### PR TITLE
fix: return full memory content when verbose=true (fixes #8)

### DIFF
--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -115,7 +115,9 @@ export async function executeRecall(input: RecallInput): Promise<{
 export function formatMemory(memory: Memory, verbose: boolean = false): string {
   const lines = [
     `[${memory.id}] **${memory.title}**`,
-    `    ${memory.content.slice(0, 200)}${memory.content.length > 200 ? '...' : ''}`,
+    verbose
+      ? `    ${memory.content}`
+      : `    ${memory.content.slice(0, 200)}${memory.content.length > 200 ? '...' : ''}`,
   ];
 
   if (verbose) {


### PR DESCRIPTION
## Summary

Fixes #8 — Memory content was always truncated at 200 characters, even when explicitly recalled or fetched by ID.

## Root Cause

`formatMemory()` in `src/tools/recall.ts` had a hardcoded `.slice(0, 200)` that applied unconditionally. The `verbose` parameter only controlled metadata display (tags, category, etc.) but never affected content length.

## Fix

Made content truncation conditional on the `verbose` flag:
- **`verbose=true`** → full content returned (for `recall` and `get_memory` MCP tools)
- **`verbose=false`** → 200-char preview preserved (for summary/list views)

Both MCP tool call sites already pass `verbose=true`, so this fix works immediately with no schema changes.

## Tests

All 352 tests pass, 0 failures.