### PR TITLE
fix: include openclaw.plugin.json manifest in plugin install (fixes #10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "type": "module",
   "scripts": {
     "postinstall": "node scripts/postinstall.mjs",
-    "build": "tsc",
+    "build": "tsc && cp plugins/openclaw/openclaw.plugin.json plugins/openclaw/dist/",
     "build:dashboard": "cd dashboard && npm run build && (cp -r .next/static .next/standalone/dashboard/.next/ 2>/dev/null || true) && (cp -r public .next/standalone/dashboard/ 2>/dev/null || true)",
     "build:all": "npm run build && npm run build:dashboard",
     "start": "node dist/index.js",

--- a/plugins/openclaw/dist/openclaw.plugin.json
+++ b/plugins/openclaw/dist/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "shieldcortex-realtime",
+  "name": "ShieldCortex Real-time Scanner",
+  "description": "Real-time defence scanning on LLM input and memory extraction on LLM output.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "shieldcortex-realtime",
+  "name": "ShieldCortex Real-time Scanner",
+  "description": "Real-time defence scanning on LLM input and memory extraction on LLM output.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -235,11 +235,18 @@ function installPlugin(): boolean {
   try {
     fs.mkdirSync(destDir, { recursive: true });
 
-    for (const file of ['index.js', 'openclaw.plugin.json']) {
+    const requiredFiles = ['index.js', 'openclaw.plugin.json'];
+    for (const file of requiredFiles) {
       const src = path.join(PLUGIN_SOURCE, file);
       const dest = path.join(destDir, file);
       if (fs.existsSync(src)) {
         fs.copyFileSync(src, dest);
+      } else {
+        console.warn(`  Warning: ${file} not found in plugin source (${PLUGIN_SOURCE})`);
+        if (file === 'openclaw.plugin.json') {
+          console.warn('  OpenClaw will fail to load the plugin without this manifest.');
+          console.warn('  This is a build issue — try rebuilding with: npm run build');
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

`shieldcortex openclaw install` copies `index.js` to `~/.openclaw/extensions/shieldcortex-realtime/` but the `openclaw.plugin.json` manifest was never built into `plugins/openclaw/dist/`, so the install silently skipped it.

This caused OpenClaw to fail config validation on startup:
```
plugin manifest not found: ~/.openclaw/extensions/shieldcortex-realtime/openclaw.plugin.json
```

**Impact:** Broke TARS (and any fresh OpenClaw install running ShieldCortex).

## Root Cause

The build script was just `tsc`, which compiled `index.ts → dist/index.js` but had no step to copy static assets (the manifest JSON) into `dist/`.

The install code in `src/setup/openclaw.ts` checked for the file but silently skipped when missing — no warning, no error.

## Fix

1. **Added** `plugins/openclaw/openclaw.plugin.json` (source of truth)
2. **Updated build script** to copy manifest into `dist/` after tsc
3. **Added warning** in install code if manifest is missing (fail loud, not silent)

## Testing

- Verified `plugins/openclaw/dist/` now contains both `index.js` and `openclaw.plugin.json` after build
- Confirmed OpenClaw loads the plugin cleanly after install (tested on TARS)
- Pre-existing test failures (42 Jest/Vitest config conflicts) are unchanged

Closes #10