### PR TITLE
v4.10.6: ship scripts/lib so prompt-recall-hook actually runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.10.6 — 22 April 2026
+
+**Ship the shared helper Tars added in v4.10.5** — fixes silent fleet-wide amnesia.
+
+- **`scripts/lib/project-key.mjs` was missing from the npm tarball** — v4.10.5 introduced the shared helper to unify project-key derivation across `session-start-hook.mjs` and `prompt-recall-hook.mjs`, but `package.json` `files` only listed the individual `scripts/*.mjs` files by name. The `scripts/lib` directory was excluded from published packages, so every install of 4.10.5 had both hooks crashing on startup with `ERR_MODULE_NOT_FOUND` and exit code 0 (silent failure).
+- **Impact on OpenClaw fleets** — Claude Code fires `UserPromptSubmit → prompt-recall` on every user turn. With the hook broken, no prior-turn context was injected, so Opus 4.7 (which refuses to confabulate the way 4.6 did) replied "I don't have context for what you're replying to — this looks like the start of our conversation" to every Telegram message. Surfaced on the Jarvis / Edith / Tars fleet right after the Opus 4.7 switch; masked the packaging bug as a model-behaviour complaint.
+- **Fix** — added `scripts/lib` to the `files` array in `package.json` so the whole directory ships with the npm tarball. Verified by `npm pack --dry-run` listing `scripts/lib/project-key.mjs`.
+
 ## v4.10.5 — 22 April 2026
 
 **Session-start hook fixes** — stops the v4.10.4 "amnesia every resume" complaint.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.10.5",
+  "version": "4.10.6",
   "description": "Trustworthy memory and security for AI agents. Recall debugging, review queue, OpenClaw session capture, and memory poisoning defence for Claude Code, Codex, OpenClaw, LangChain, and MCP agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -145,6 +145,7 @@
     "scripts/session-start-hook.mjs",
     "scripts/stop-hook.mjs",
     "scripts/prompt-recall-hook.mjs",
+    "scripts/lib",
     "dashboard/.next/standalone"
   ]
 }


### PR DESCRIPTION
## Summary

Fixes a packaging bug introduced in v4.10.5 where `scripts/lib/project-key.mjs` was not included in the published npm tarball. Both `prompt-recall-hook.mjs` and `session-start-hook.mjs` import this helper, so every user install of 4.10.5 had both hooks crashing on every invocation with `ERR_MODULE_NOT_FOUND` (silent, exit code 0).

## Impact

- **UserPromptSubmit → prompt-recall**: dead on every turn. No cross-turn memory injection.
- **SessionStart → session-start-hook**: dead on every boot. No project-context preamble.
- **Fleet-visible symptom**: after upgrading to ShieldCortex 4.10.5 and switching to Opus 4.7, agents replied "I don't have context for what you're replying to — this looks like the start of our conversation" to every Telegram message. Opus 4.6 had been confabulating context from workspace files; 4.7 refuses to, so the broken hook became user-visible. Symptom was investigated across OpenClaw configs (envelope timestamps, Memory Search, memoryFlush thresholds, session key formats) before being traced to the packaging issue.

## Fix

```diff
     "scripts/prompt-recall-hook.mjs",
+    "scripts/lib",
     "dashboard/.next/standalone"
```

Verified with `npm pack --dry-run` — `scripts/lib/project-key.mjs` (4.7kB) now appears in the output.

## Test plan

- [x] `npm pack --dry-run` lists `scripts/lib/project-key.mjs`
- [ ] After publish, `npm install -g shieldcortex@4.10.6 && echo '{"prompt":"test"}' | shieldcortex hook prompt-recall` exits cleanly (no module-not-found)
- [ ] On fleet agent after upgrade, Telegram conversation continuity returns (validate with consecutive messages referencing prior turns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)