### PR TITLE
feat(uninstall,doctor): deep OpenClaw residue purge + detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+**New: `shieldcortex uninstall --deep` and `shieldcortex doctor` residue check** — closes the "partial uninstall" gap that left ~9 orphan config entries across `~/.openclaw/openclaw.json`, `~/.openclaw/workspace/.clawhub/lock.json`, and stale hook/extension directories after every version bump or manual cleanup (incident 2026-04-23/24: five-host fleet residue took several hours of hand-scripted `jq` surgery to purge).
+
+### What's new
+
+- **`shieldcortex uninstall --deep`** — after the normal uninstall, scans 15 known residue locations (plugins.installs / entries / allow / load.paths, hooks.shieldcortex, hooks.internal.installs/entries/allow, clawhub skills lock, legacy hook dirs, extensions dir) and surgically removes any ShieldCortex references while preserving sibling keys. Then best-effort restarts the OpenClaw gateway (`systemctl --user restart openclaw-gateway` on Linux, `launchctl kickstart` on macOS) so the purge takes effect. `--no-gateway-restart` opts out.
+- **`shieldcortex doctor`** now runs an OpenClaw residue check that reports how many of the 15 locations are dirty and points at `uninstall --deep` as the fix. Skipped cleanly on non-OpenClaw hosts.
+- **New module `src/setup/deep-clean.ts`** exposes `scanForResidue()`, `cleanResidue()`, and `runDeepClean()` for programmatic use. Each location is declared once with its own `Removal` spec (delete-config-key / filter-config-array / delete-directory), so adding a new residue path is a single-item append.
+
+### Why it matters
+
+The existing `uninstallPlugin()` only cleans config entries when the extension directory still exists on disk. In the field we saw hosts where files had been removed manually (or wiped by a failed update) but config entries remained, producing recurring "plugin references without files" warnings and load-time errors. Deep-clean scans independently of disk state, so orphan entries get purged even when the on-disk artefacts are already gone.
+
+### Tests
+
+Eight new tests in `src/__tests__/deep-clean.test.ts` cover: zero-residue baseline, full-residue detection (all 15 locations), surgical removal with sibling preservation, idempotency, dryRun, orphan-entry cleanup (the incident case), malformed-JSON tolerance, and `runDeepClean` structured return.
+
 ## v4.11.1 — 22 April 2026
 
 **Fleet-critical fix: MCP registration no longer uses `npx -y` as the command** — it now resolves and pins the installed `shieldcortex` binary path (falls back to `npx -y` only when no global install exists). This closes a silent session-wipe loop that was hitting every production OpenClaw install.

--- a/src/__tests__/deep-clean.test.ts
+++ b/src/__tests__/deep-clean.test.ts
@@ -1,0 +1,228 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+describe('deep-clean — OpenClaw residue purge', () => {
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const originalSudoUser = process.env.SUDO_USER;
+  let tempHome: string;
+  let homedirSpy: jest.SpiedFunction<typeof os.homedir>;
+
+  beforeEach(() => {
+    jest.resetModules();
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'shieldcortex-deep-clean-'));
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    delete process.env.SUDO_USER;
+
+    fs.mkdirSync(path.join(tempHome, '.openclaw'), { recursive: true });
+    homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(tempHome);
+  });
+
+  afterEach(() => {
+    homedirSpy.mockRestore();
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    if (originalSudoUser === undefined) delete process.env.SUDO_USER;
+    else process.env.SUDO_USER = originalSudoUser;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  const openclawJsonPath = () => path.join(tempHome, '.openclaw', 'openclaw.json');
+  const clawhubLockPath = () => path.join(tempHome, '.openclaw', 'workspace', '.clawhub', 'lock.json');
+
+  async function loadModule() {
+    return import('../setup/deep-clean.js');
+  }
+
+  function writeOpenClawJson(data: unknown): void {
+    fs.writeFileSync(openclawJsonPath(), JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  function writeClawhubLock(data: unknown): void {
+    fs.mkdirSync(path.dirname(clawhubLockPath()), { recursive: true });
+    fs.writeFileSync(clawhubLockPath(), JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  it('reports zero residue when config is absent and no directories exist', async () => {
+    const { scanForResidue } = await loadModule();
+    const report = scanForResidue();
+    expect(report.dirtyCount).toBe(0);
+    expect(report.paths.every((p) => !p.present)).toBe(true);
+    // Should cover all the residue locations we care about
+    expect(report.paths.length).toBeGreaterThanOrEqual(14);
+  });
+
+  it('detects every known residue location when populated', async () => {
+    // Populate all config-level residue
+    writeOpenClawJson({
+      plugins: {
+        installs: { 'shieldcortex-realtime': { source: 'path', version: '4.10.5' }, 'other-plugin': { source: 'npm' } },
+        entries: { 'shieldcortex-realtime': { enabled: true }, 'other-plugin': { enabled: true } },
+        allow: ['shieldcortex-realtime', 'other-plugin'],
+        load: { paths: ['/tmp/shieldcortex-realtime/index.js', '/tmp/other-plugin'] },
+      },
+      hooks: {
+        shieldcortex: { enabled: true },
+        internal: {
+          installs: { shieldcortex: { version: '3.4.37' } },
+          entries: { shieldcortex: { enabled: true } },
+          allow: ['shieldcortex', 'other-hook'],
+        },
+      },
+    });
+    writeClawhubLock({ skills: { shieldcortex: { version: '4.10.5' }, other: { version: '1.0.0' } } });
+
+    // Populate filesystem residue
+    const dirs = [
+      path.join(tempHome, '.openclaw', 'hooks', 'cortex-memory'),
+      path.join(tempHome, '.openclaw', 'hooks', 'internal', 'cortex-memory'),
+      path.join(tempHome, '.openclaw', 'hooks', 'shieldcortex'),
+      path.join(tempHome, '.claude', 'hooks', 'cortex-memory'),
+      path.join(tempHome, '.claude', 'hooks', 'internal', 'cortex-memory'),
+      path.join(tempHome, '.openclaw', 'extensions', 'shieldcortex-realtime'),
+    ];
+    for (const d of dirs) fs.mkdirSync(d, { recursive: true });
+
+    const { scanForResidue } = await loadModule();
+    const report = scanForResidue();
+    const dirty = report.paths.filter((p) => p.present).map((p) => p.description);
+
+    // Every configured residue path should be detected
+    expect(dirty).toContain('openclaw.json: .plugins.installs["shieldcortex-realtime"]');
+    expect(dirty).toContain('openclaw.json: .plugins.entries["shieldcortex-realtime"]');
+    expect(dirty).toContain('openclaw.json: .plugins.allow[] contains "shieldcortex-realtime"');
+    expect(dirty).toContain('openclaw.json: .plugins.load.paths[] contains "shieldcortex-realtime"');
+    expect(dirty).toContain('openclaw.json: .hooks.shieldcortex');
+    expect(dirty).toContain('openclaw.json: .hooks.internal.installs.shieldcortex');
+    expect(dirty).toContain('openclaw.json: .hooks.internal.entries.shieldcortex');
+    expect(dirty).toContain('openclaw.json: .hooks.internal.allow[] contains "shieldcortex"');
+    expect(dirty).toContain('clawhub/lock.json: .skills.shieldcortex');
+    for (const d of dirs) expect(dirty).toContain(d);
+
+    expect(report.dirtyCount).toBeGreaterThanOrEqual(15);
+  });
+
+  it('surgically removes only ShieldCortex entries and preserves siblings', async () => {
+    writeOpenClawJson({
+      plugins: {
+        installs: { 'shieldcortex-realtime': { source: 'path' }, 'other-plugin': { source: 'npm' } },
+        entries: { 'shieldcortex-realtime': { enabled: true }, 'other-plugin': { enabled: true } },
+        allow: ['shieldcortex-realtime', 'other-plugin', '/abs/path/shieldcortex-realtime/index.js'],
+        load: { paths: ['/abs/shieldcortex-realtime/index.js', '/abs/other-plugin'] },
+      },
+      hooks: {
+        shieldcortex: { enabled: true },
+        'custom-hook': { enabled: true },
+        internal: {
+          installs: { shieldcortex: {}, 'other-hook': {} },
+          entries: { shieldcortex: {}, 'other-hook': {} },
+          allow: ['shieldcortex', 'shieldcortex-legacy', 'other-hook'],
+        },
+      },
+      otherTopLevel: { preserved: true },
+    });
+    writeClawhubLock({ skills: { shieldcortex: { version: '4.10.5' }, 'genuine-skill': { version: '1.0.0' } } });
+
+    const { scanForResidue, cleanResidue } = await loadModule();
+    const report = scanForResidue();
+    const result = cleanResidue(report);
+
+    expect(result.errors).toEqual([]);
+    expect(result.removed.length).toBeGreaterThanOrEqual(9);
+
+    // Verify siblings preserved
+    const cfg = JSON.parse(fs.readFileSync(openclawJsonPath(), 'utf-8'));
+    expect(cfg.plugins.installs['shieldcortex-realtime']).toBeUndefined();
+    expect(cfg.plugins.installs['other-plugin']).toEqual({ source: 'npm' });
+    expect(cfg.plugins.entries['shieldcortex-realtime']).toBeUndefined();
+    expect(cfg.plugins.entries['other-plugin']).toEqual({ enabled: true });
+    expect(cfg.plugins.allow).toEqual(['other-plugin']);
+    expect(cfg.plugins.load.paths).toEqual(['/abs/other-plugin']);
+    expect(cfg.hooks.shieldcortex).toBeUndefined();
+    expect(cfg.hooks['custom-hook']).toEqual({ enabled: true });
+    expect(cfg.hooks.internal.installs.shieldcortex).toBeUndefined();
+    expect(cfg.hooks.internal.installs['other-hook']).toEqual({});
+    expect(cfg.hooks.internal.entries.shieldcortex).toBeUndefined();
+    expect(cfg.hooks.internal.allow).toEqual(['other-hook']);
+    expect(cfg.otherTopLevel).toEqual({ preserved: true });
+
+    const lock = JSON.parse(fs.readFileSync(clawhubLockPath(), 'utf-8'));
+    expect(lock.skills.shieldcortex).toBeUndefined();
+    expect(lock.skills['genuine-skill']).toEqual({ version: '1.0.0' });
+  });
+
+  it('is idempotent — second run finds nothing to clean', async () => {
+    writeOpenClawJson({
+      plugins: { installs: { 'shieldcortex-realtime': { source: 'path' } } },
+    });
+
+    const { scanForResidue, cleanResidue } = await loadModule();
+    const first = cleanResidue(scanForResidue());
+    expect(first.removed.length).toBe(1);
+
+    const second = cleanResidue(scanForResidue());
+    expect(second.removed.length).toBe(0);
+    expect(second.errors).toEqual([]);
+  });
+
+  it('dryRun leaves config untouched', async () => {
+    writeOpenClawJson({ plugins: { installs: { 'shieldcortex-realtime': { source: 'path' } } } });
+
+    const { scanForResidue, cleanResidue } = await loadModule();
+    const before = fs.readFileSync(openclawJsonPath(), 'utf-8');
+    const result = cleanResidue(scanForResidue(), { dryRun: true });
+    const after = fs.readFileSync(openclawJsonPath(), 'utf-8');
+
+    expect(result.removed.length).toBeGreaterThan(0);
+    expect(before).toBe(after);
+  });
+
+  it('removes orphan config entries even when the extension directory is gone', async () => {
+    // This is the real-world incident: files were cleaned manually but config entries
+    // persisted and kept producing "references without files" warnings.
+    writeOpenClawJson({
+      plugins: {
+        installs: { 'shieldcortex-realtime': { source: 'path' } },
+        entries: { 'shieldcortex-realtime': { enabled: true } },
+        allow: ['shieldcortex-realtime'],
+      },
+    });
+    // Deliberately no filesystem residue
+
+    const { scanForResidue, cleanResidue } = await loadModule();
+    const result = cleanResidue(scanForResidue());
+
+    const cfg = JSON.parse(fs.readFileSync(openclawJsonPath(), 'utf-8'));
+    expect(cfg.plugins.installs['shieldcortex-realtime']).toBeUndefined();
+    expect(cfg.plugins.entries['shieldcortex-realtime']).toBeUndefined();
+    expect(cfg.plugins.allow).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('handles malformed JSON without throwing', async () => {
+    fs.writeFileSync(openclawJsonPath(), '{ not valid json', 'utf-8');
+
+    const { scanForResidue } = await loadModule();
+    const report = scanForResidue();
+    // Invalid JSON is treated as an empty config — no residue reported for that file
+    const configEntries = report.paths.filter((p) =>
+      p.description.startsWith('openclaw.json'),
+    );
+    expect(configEntries.every((p) => !p.present)).toBe(true);
+  });
+
+  it('runDeepClean returns structured report and skips gateway restart when nothing to do', async () => {
+    const { runDeepClean } = await loadModule();
+    const { report, result, gateway } = await runDeepClean({ restartGateway: true });
+
+    expect(report.dirtyCount).toBe(0);
+    expect(result.removed).toEqual([]);
+    // No residue → no restart attempt
+    expect(gateway).toBeUndefined();
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -461,6 +461,37 @@ async function checkLockFile(): Promise<CheckResult> {
   }
 }
 
+// ── Check 7.5: OpenClaw residue ──────────────────────────
+async function checkOpenClawResidue(): Promise<CheckResult> {
+  const env = detectEnvironment();
+  if (!env.hasOpenClaw) {
+    return { label: 'OpenClaw residue', status: 'info', message: 'skipped (OpenClaw not detected)' };
+  }
+
+  try {
+    const { scanForResidue } = await import('../setup/deep-clean.js');
+    const report = scanForResidue();
+
+    if (report.dirtyCount === 0) {
+      return { label: 'OpenClaw residue', status: 'pass', message: `clean (${report.cleanCount} locations checked)` };
+    }
+
+    const dirty = report.paths.filter((p) => p.present);
+    const first = dirty.slice(0, 3).map((p) => p.description).join('; ');
+    const suffix = dirty.length > 3 ? ` (+${dirty.length - 3} more)` : '';
+
+    return {
+      label: 'OpenClaw residue',
+      status: 'warn',
+      message: `${report.dirtyCount} residue location${report.dirtyCount === 1 ? '' : 's'} — ${first}${suffix}`,
+      fix: 'Run `shieldcortex uninstall --deep --confirm` to purge, or reinstall with `shieldcortex openclaw install`',
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { label: 'OpenClaw residue', status: 'warn', message: `check failed — ${msg}` };
+  }
+}
+
 // ── Check 8: Model cache ─────────────────────────────────
 async function checkModelCache(): Promise<CheckResult> {
   const cacheDir = path.join(os.homedir(), '.cache', 'shieldcortex', 'models', 'Xenova', 'all-MiniLM-L6-v2');
@@ -512,6 +543,7 @@ export async function runDoctor(): Promise<void> {
     checkProcesses,
     checkDiskUsage,
     checkLockFile,
+    checkOpenClawResidue,
     checkModelCache,
   ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -586,7 +586,11 @@ ${bold}DOCS${reset}
   // Handle "uninstall" subcommand
   if (process.argv[2] === 'uninstall') {
     const { uninstallAll } = await import('./setup/uninstall.js');
-    await uninstallAll({ keepLogs: process.argv.includes('--keep-logs') });
+    await uninstallAll({
+      keepLogs: process.argv.includes('--keep-logs'),
+      deep: process.argv.includes('--deep'),
+      restartGateway: !process.argv.includes('--no-gateway-restart'),
+    });
     return;
   }
 

--- a/src/setup/deep-clean.ts
+++ b/src/setup/deep-clean.ts
@@ -1,0 +1,377 @@
+/**
+ * Deep-clean / residue detection for ShieldCortex ↔ OpenClaw integration.
+ *
+ * The standard `uninstall` and `uninstallPlugin` code paths only fire when
+ * the on-disk artefacts they expected are still present. Partial uninstalls,
+ * manual cleanups, and version-to-version shape changes left orphaned config
+ * entries in `~/.openclaw/openclaw.json` and `~/.openclaw/workspace/.clawhub/lock.json`
+ * that kept producing "plugin references without files" and "missing skill file"
+ * warnings until purged by hand (see incident notes 2026-04-23/24).
+ *
+ * This module scans every known residue location once, independently of disk
+ * state, and offers a single surgical clean-up pass.
+ *
+ * Scope: read/write of JSON config files + directory removal under the user's
+ * home directory. No network, no sudo, no shell invocation.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { execSync } from 'child_process';
+
+const PLUGIN_ID = 'shieldcortex-realtime';
+const HOOK_NAME = 'cortex-memory';
+
+/**
+ * Resolve the real user's home directory (mirrors openclaw.ts behaviour so the
+ * two modules agree on which home to touch under sudo).
+ */
+function resolveHome(): string {
+  const sudoUser = process.env.SUDO_USER;
+  if (sudoUser) {
+    try {
+      const entry = execSync(`getent passwd ${sudoUser}`, {
+        encoding: 'utf-8',
+        timeout: 5000,
+      }).trim();
+      const homeDir = entry.split(':')[5];
+      if (homeDir && fs.existsSync(homeDir)) return homeDir;
+    } catch {
+      // getent not available (macOS)
+    }
+  }
+  return os.homedir();
+}
+
+type Removal =
+  | { kind: 'delete-config-key'; file: string; keyPath: string[] }
+  | { kind: 'filter-config-array'; file: string; keyPath: string[]; contains: string }
+  | { kind: 'delete-directory'; path: string };
+
+export interface ResiduePath {
+  description: string;
+  removal: Removal;
+  present: boolean;
+}
+
+export interface ResidueReport {
+  paths: ResiduePath[];
+  dirtyCount: number;
+  cleanCount: number;
+}
+
+export interface CleanOptions {
+  dryRun?: boolean;
+}
+
+export interface CleanResult {
+  removed: string[];
+  errors: Array<{ description: string; error: string }>;
+}
+
+function readJsonOrNull(file: string): Record<string, unknown> | null {
+  if (!fs.existsSync(file)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(file: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+function getPath(root: unknown, keyPath: string[]): unknown {
+  let node: unknown = root;
+  for (const key of keyPath) {
+    if (typeof node !== 'object' || node === null) return undefined;
+    node = (node as Record<string, unknown>)[key];
+  }
+  return node;
+}
+
+function deletePath(root: Record<string, unknown>, keyPath: string[]): boolean {
+  if (keyPath.length === 0) return false;
+  let node: Record<string, unknown> = root;
+  for (let i = 0; i < keyPath.length - 1; i++) {
+    const next = node[keyPath[i]];
+    if (typeof next !== 'object' || next === null) return false;
+    node = next as Record<string, unknown>;
+  }
+  const leaf = keyPath[keyPath.length - 1];
+  if (leaf in node) {
+    delete node[leaf];
+    return true;
+  }
+  return false;
+}
+
+function filterArrayAtPath(
+  root: Record<string, unknown>,
+  keyPath: string[],
+  contains: string,
+): boolean {
+  const target = getPath(root, keyPath);
+  if (!Array.isArray(target)) return false;
+  const before = target.length;
+  const filtered = target.filter(
+    (entry) => !(typeof entry === 'string' && entry.includes(contains)),
+  );
+  if (filtered.length === before) return false;
+  // Re-walk and assign back so we don't rely on aliasing
+  let node: Record<string, unknown> = root;
+  for (let i = 0; i < keyPath.length - 1; i++) {
+    node = node[keyPath[i]] as Record<string, unknown>;
+  }
+  node[keyPath[keyPath.length - 1]] = filtered;
+  return true;
+}
+
+/**
+ * Build the full list of known residue locations and whether each one is
+ * currently populated. Pure read — no mutation.
+ */
+export function scanForResidue(): ResidueReport {
+  const home = resolveHome();
+  const openclawJson = path.join(home, '.openclaw', 'openclaw.json');
+  const clawhubLock = path.join(home, '.openclaw', 'workspace', '.clawhub', 'lock.json');
+
+  const cfg = readJsonOrNull(openclawJson) ?? {};
+  const lock = readJsonOrNull(clawhubLock) ?? {};
+
+  const paths: ResiduePath[] = [];
+
+  // ── openclaw.json: plugins ─────────────────────────────
+  paths.push({
+    description: `openclaw.json: .plugins.installs["${PLUGIN_ID}"]`,
+    removal: { kind: 'delete-config-key', file: openclawJson, keyPath: ['plugins', 'installs', PLUGIN_ID] },
+    present: !!getPath(cfg, ['plugins', 'installs', PLUGIN_ID]),
+  });
+  paths.push({
+    description: `openclaw.json: .plugins.entries["${PLUGIN_ID}"]`,
+    removal: { kind: 'delete-config-key', file: openclawJson, keyPath: ['plugins', 'entries', PLUGIN_ID] },
+    present: !!getPath(cfg, ['plugins', 'entries', PLUGIN_ID]),
+  });
+  paths.push({
+    description: `openclaw.json: .plugins.allow[] contains "${PLUGIN_ID}"`,
+    removal: { kind: 'filter-config-array', file: openclawJson, keyPath: ['plugins', 'allow'], contains: PLUGIN_ID },
+    present: ((): boolean => {
+      const arr = getPath(cfg, ['plugins', 'allow']);
+      return Array.isArray(arr) && arr.some((e) => typeof e === 'string' && e.includes(PLUGIN_ID));
+    })(),
+  });
+  paths.push({
+    description: `openclaw.json: .plugins.load.paths[] contains "${PLUGIN_ID}"`,
+    removal: { kind: 'filter-config-array', file: openclawJson, keyPath: ['plugins', 'load', 'paths'], contains: PLUGIN_ID },
+    present: ((): boolean => {
+      const arr = getPath(cfg, ['plugins', 'load', 'paths']);
+      return Array.isArray(arr) && arr.some((e) => typeof e === 'string' && e.includes(PLUGIN_ID));
+    })(),
+  });
+
+  // ── openclaw.json: hooks (both modern and legacy shapes) ─
+  paths.push({
+    description: 'openclaw.json: .hooks.shieldcortex',
+    removal: { kind: 'delete-config-key', file: openclawJson, keyPath: ['hooks', 'shieldcortex'] },
+    present: !!getPath(cfg, ['hooks', 'shieldcortex']),
+  });
+  paths.push({
+    description: 'openclaw.json: .hooks.internal.installs.shieldcortex',
+    removal: { kind: 'delete-config-key', file: openclawJson, keyPath: ['hooks', 'internal', 'installs', 'shieldcortex'] },
+    present: !!getPath(cfg, ['hooks', 'internal', 'installs', 'shieldcortex']),
+  });
+  paths.push({
+    description: 'openclaw.json: .hooks.internal.entries.shieldcortex',
+    removal: { kind: 'delete-config-key', file: openclawJson, keyPath: ['hooks', 'internal', 'entries', 'shieldcortex'] },
+    present: !!getPath(cfg, ['hooks', 'internal', 'entries', 'shieldcortex']),
+  });
+  paths.push({
+    description: 'openclaw.json: .hooks.internal.allow[] contains "shieldcortex"',
+    removal: { kind: 'filter-config-array', file: openclawJson, keyPath: ['hooks', 'internal', 'allow'], contains: 'shieldcortex' },
+    present: ((): boolean => {
+      const arr = getPath(cfg, ['hooks', 'internal', 'allow']);
+      return Array.isArray(arr) && arr.some((e) => typeof e === 'string' && e.includes('shieldcortex'));
+    })(),
+  });
+
+  // ── clawhub lock ────────────────────────────────────────
+  paths.push({
+    description: 'clawhub/lock.json: .skills.shieldcortex',
+    removal: { kind: 'delete-config-key', file: clawhubLock, keyPath: ['skills', 'shieldcortex'] },
+    present: !!getPath(lock, ['skills', 'shieldcortex']),
+  });
+
+  // ── filesystem ──────────────────────────────────────────
+  const dirs = [
+    path.join(home, '.openclaw', 'hooks', HOOK_NAME),
+    path.join(home, '.openclaw', 'hooks', 'internal', HOOK_NAME),
+    path.join(home, '.openclaw', 'hooks', 'shieldcortex'),
+    path.join(home, '.claude', 'hooks', HOOK_NAME),
+    path.join(home, '.claude', 'hooks', 'internal', HOOK_NAME),
+    path.join(home, '.openclaw', 'extensions', PLUGIN_ID),
+  ];
+
+  for (const dir of dirs) {
+    paths.push({
+      description: dir,
+      removal: { kind: 'delete-directory', path: dir },
+      present: fs.existsSync(dir),
+    });
+  }
+
+  const dirtyCount = paths.filter((p) => p.present).length;
+  const cleanCount = paths.length - dirtyCount;
+  return { paths, dirtyCount, cleanCount };
+}
+
+/**
+ * Apply all pending removals from a residue report. Config mutations for the
+ * same file are batched so we write each JSON file at most once.
+ */
+export function cleanResidue(report: ResidueReport, options: CleanOptions = {}): CleanResult {
+  const result: CleanResult = { removed: [], errors: [] };
+
+  // Load each referenced config file once
+  const configCache = new Map<string, Record<string, unknown>>();
+  const loadConfig = (file: string): Record<string, unknown> => {
+    if (!configCache.has(file)) {
+      configCache.set(file, readJsonOrNull(file) ?? {});
+    }
+    return configCache.get(file)!;
+  };
+
+  const dirtyConfigFiles = new Set<string>();
+
+  for (const entry of report.paths) {
+    if (!entry.present) continue;
+
+    try {
+      const r = entry.removal;
+      if (r.kind === 'delete-directory') {
+        if (!options.dryRun) {
+          fs.rmSync(r.path, { recursive: true, force: true });
+        }
+        result.removed.push(entry.description);
+      } else if (r.kind === 'delete-config-key') {
+        const cfg = loadConfig(r.file);
+        if (deletePath(cfg, r.keyPath)) {
+          dirtyConfigFiles.add(r.file);
+          result.removed.push(entry.description);
+        }
+      } else if (r.kind === 'filter-config-array') {
+        const cfg = loadConfig(r.file);
+        if (filterArrayAtPath(cfg, r.keyPath, r.contains)) {
+          dirtyConfigFiles.add(r.file);
+          result.removed.push(entry.description);
+        }
+      }
+    } catch (err) {
+      result.errors.push({ description: entry.description, error: (err as Error).message });
+    }
+  }
+
+  if (!options.dryRun) {
+    for (const file of dirtyConfigFiles) {
+      try {
+        writeJson(file, configCache.get(file)!);
+      } catch (err) {
+        result.errors.push({ description: file, error: (err as Error).message });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Best-effort restart of the OpenClaw gateway so the purged config takes
+ * effect. Returns a structured report; never throws.
+ *
+ * Order of attempts:
+ *   - Linux:  `systemctl --user restart openclaw-gateway`
+ *   - macOS:  `launchctl kickstart -k gui/<uid>/ai.openclaw.gateway`
+ *   - Fallback: skip with info message.
+ */
+export async function restartOpenClawGateway(): Promise<{
+  attempted: boolean;
+  restarted: boolean;
+  method: string;
+  detail?: string;
+}> {
+  const platform = process.platform;
+
+  if (platform === 'linux') {
+    try {
+      execSync('systemctl --user restart openclaw-gateway', {
+        encoding: 'utf-8',
+        timeout: 10000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      return { attempted: true, restarted: true, method: 'systemctl --user' };
+    } catch (err) {
+      return {
+        attempted: true,
+        restarted: false,
+        method: 'systemctl --user',
+        detail: (err as Error).message,
+      };
+    }
+  }
+
+  if (platform === 'darwin') {
+    try {
+      const uid = process.getuid ? process.getuid() : 0;
+      execSync(`launchctl kickstart -k gui/${uid}/ai.openclaw.gateway`, {
+        encoding: 'utf-8',
+        timeout: 10000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      return { attempted: true, restarted: true, method: 'launchctl kickstart' };
+    } catch (err) {
+      return {
+        attempted: true,
+        restarted: false,
+        method: 'launchctl kickstart',
+        detail: (err as Error).message,
+      };
+    }
+  }
+
+  return {
+    attempted: false,
+    restarted: false,
+    method: 'unsupported-platform',
+    detail: `Restart not implemented for platform: ${platform}`,
+  };
+}
+
+/**
+ * High-level entry point used by `shieldcortex uninstall --deep`.
+ * Scans → cleans → (optionally) restarts gateway.
+ */
+export async function runDeepClean(options: { dryRun?: boolean; restartGateway?: boolean } = {}): Promise<{
+  report: ResidueReport;
+  result: CleanResult;
+  gateway?: Awaited<ReturnType<typeof restartOpenClawGateway>>;
+}> {
+  const report = scanForResidue();
+  const result = cleanResidue(report, { dryRun: options.dryRun });
+  let gateway: Awaited<ReturnType<typeof restartOpenClawGateway>> | undefined;
+  if (options.restartGateway && !options.dryRun && result.removed.length > 0) {
+    gateway = await restartOpenClawGateway();
+  }
+  return { report, result, gateway };
+}
+
+// Exported for tests
+export const _internals = {
+  PLUGIN_ID,
+  HOOK_NAME,
+  resolveHome,
+};

--- a/src/setup/uninstall.ts
+++ b/src/setup/uninstall.ts
@@ -186,10 +186,17 @@ export async function uninstallSetup(): Promise<void> {
   console.log('\nSetup removal complete.');
 }
 
-export async function uninstallAll(options?: { keepLogs?: boolean }): Promise<void> {
+export async function uninstallAll(options?: {
+  keepLogs?: boolean;
+  deep?: boolean;
+  restartGateway?: boolean;
+}): Promise<void> {
   if (blockAgentUninstall()) return;
 
-  const confirmed = await requireConfirmation('fully uninstall ShieldCortex');
+  const action = options?.deep
+    ? 'fully uninstall ShieldCortex and purge OpenClaw residue'
+    : 'fully uninstall ShieldCortex';
+  const confirmed = await requireConfirmation(action);
   if (!confirmed) {
     console.log('Uninstall cancelled.');
     return;
@@ -223,6 +230,42 @@ export async function uninstallAll(options?: { keepLogs?: boolean }): Promise<vo
     removeClaudeMdBlock();
   } catch (err: any) {
     console.error(`Failed to remove CLAUDE.md block: ${err.message}`);
+  }
+
+  // 5. Deep clean: purge all known OpenClaw residue locations that the
+  //    version-specific uninstall paths miss, then (best-effort) restart
+  //    the gateway so the purged config takes effect immediately.
+  if (options?.deep) {
+    try {
+      const { runDeepClean } = await import('./deep-clean.js');
+      const { report, result, gateway } = await runDeepClean({
+        restartGateway: options?.restartGateway !== false,
+      });
+      if (result.removed.length > 0) {
+        console.log(`\nDeep clean: removed ${result.removed.length} residue reference(s):`);
+        for (const r of result.removed) {
+          console.log(`  - ${r}`);
+        }
+      } else if (report.dirtyCount === 0) {
+        console.log('\nDeep clean: no OpenClaw residue detected.');
+      }
+      if (result.errors.length > 0) {
+        console.warn(`\nDeep clean: ${result.errors.length} error(s):`);
+        for (const e of result.errors) {
+          console.warn(`  - ${e.description}: ${e.error}`);
+        }
+      }
+      if (gateway) {
+        if (gateway.restarted) {
+          console.log(`\nOpenClaw gateway restarted via ${gateway.method}.`);
+        } else if (gateway.attempted) {
+          console.warn(`\nOpenClaw gateway restart via ${gateway.method} failed: ${gateway.detail ?? 'unknown'}`);
+          console.warn('Restart it manually for the cleanup to take effect.');
+        }
+      }
+    } catch (err: any) {
+      console.error(`Deep clean failed: ${err.message}`);
+    }
   }
 
   console.log('\nDatabase preserved at ~/.shieldcortex/memories.db — delete manually if desired.');


### PR DESCRIPTION
## Summary

Adds `shieldcortex uninstall --deep` and a `doctor` OpenClaw-residue check that together close the **partial-uninstall gap** that left orphan config entries in `~/.openclaw/openclaw.json` and `~/.openclaw/workspace/.clawhub/lock.json` after every version bump or manual cleanup.

The existing `uninstallPlugin()` only cleans config entries when the extension directory still exists on disk. Deep-clean scans **independently of disk state**, so orphan entries get purged even when on-disk artefacts are already gone — which is exactly the shape the fleet incident on 2026-04-23/24 took (five hosts, several hours of hand-scripted `jq` surgery to purge).

## What's new

- **`shieldcortex uninstall --deep [--no-gateway-restart]`** — after the normal uninstall, scans 15 known residue locations and surgically removes any ShieldCortex references while preserving sibling keys. Best-effort restarts the OpenClaw gateway so the purge takes effect.
- **`shieldcortex doctor`** now runs an OpenClaw residue check that reports how many of the 15 locations are dirty and points at `uninstall --deep` as the fix. Skipped cleanly on non-OpenClaw hosts.
- **`src/setup/deep-clean.ts`** (new) exposes `scanForResidue()`, `cleanResidue()`, and `runDeepClean()` for programmatic use. Each residue location is declared once with its own `Removal` spec (`delete-config-key` / `filter-config-array` / `delete-directory`), so adding a new residue path is a single-item append.

## Residue locations covered

**`openclaw.json`:**
- `.plugins.installs["shieldcortex-realtime"]`
- `.plugins.entries["shieldcortex-realtime"]`
- `.plugins.allow[]` (filters entries containing plugin id)
- `.plugins.load.paths[]` (filters entries containing plugin id)
- `.hooks.shieldcortex`
- `.hooks.internal.installs.shieldcortex`
- `.hooks.internal.entries.shieldcortex`
- `.hooks.internal.allow[]`

**`workspace/.clawhub/lock.json`:**
- `.skills.shieldcortex`

**Filesystem directories:**
- `~/.openclaw/hooks/cortex-memory/`
- `~/.openclaw/hooks/internal/cortex-memory/` (legacy)
- `~/.openclaw/hooks/shieldcortex/` (legacy)
- `~/.claude/hooks/cortex-memory/`
- `~/.claude/hooks/internal/cortex-memory/` (legacy)
- `~/.openclaw/extensions/shieldcortex-realtime/`

## Test plan

- [x] `npx jest src/__tests__/deep-clean.test.ts` — 8/8 pass
- [x] `npx tsc --noEmit` — no new type errors in changed files (pre-existing errors in `contradictions.test.ts`, `store.test.ts`, `interceptor.test.ts`, etc. are unchanged)
- [x] Full suite: 28/53 suites pass; same 25 pre-existing failures as `main` (all `import.meta.url` ESM/CJS issues unrelated to this change — confirmed by stashing the diff and re-running)
- [ ] Manual smoke: run `shieldcortex uninstall --deep --confirm` on a host with known residue and verify all 15 locations come back clean under `shieldcortex doctor`
- [ ] Manual smoke: run `shieldcortex doctor` on a clean host and verify the new check reports `pass`

## Follow-ups (not in this PR)

- Phase 2: plugin `openclaw` peer-dep migration (requires OpenClaw ≥ 2026.4.23 for [#70462](https://github.com/openclaw/openclaw/pull/70462) fix)
- Phase 2: move hook integration to OpenClaw's context-engine hook metadata API ([#70625](https://github.com/openclaw/openclaw/pull/70625))
- Phase 2: use forked `sessions_spawn` context for scan operations so they don't bloat the parent session

🤖 Generated with [Claude Code](https://claude.com/claude-code)