### PR TITLE
feat(plugin): declare openclaw as optional peer dep + engines hint

### DIFF
--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -10,6 +10,11 @@ OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory 
 
 OpenClaw is declared as an **optional** peer dependency, so installs on older OpenClaw keep working but miss the linking benefit.
 
+### Known limitations under OpenClaw 2026.4.23
+
+- **Forked subagent context is host-owned.** OpenClaw 2026.4.23 added `ContextEngine.prepareSubagentSpawn({ contextMode: "isolated" | "fork" })` on the plugin-sdk's `ContextEngine` interface, but the spawn itself is initiated by the host runtime — plugins can only react to the lifecycle, not call `sessions_spawn` directly. Work that would benefit from an isolated scratch transcript (e.g. batch scans) therefore still runs inline in the parent session. If upstream exposes a plugin-callable spawn API, scan offloading will be revisited.
+- **No public `systemPromptAddition` seam in plugin-sdk.** Hook metadata (`{ name, description }`) is typed and stable, but the SDK does not expose a structured hook for contributing to the effective system prompt. SC's bootstrap injection was disabled in v2026.2.26 for this reason (it was using private internals), and OpenClaw's native Memory Search now handles context recall at session start.
+
 ## What it does
 
 | Hook | Action |

--- a/plugins/openclaw/README.md
+++ b/plugins/openclaw/README.md
@@ -2,6 +2,14 @@
 
 OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.
 
+## Compatibility
+
+- **Node.js** — ≥ 18 required
+- **OpenClaw** — ≥ 2026.3.22 required, **≥ 2026.4.23 recommended** — 2026.4.23 added host-package linking for plugins that declare `openclaw` as a peer dependency ([#70462](https://github.com/openclaw/openclaw/pull/70462)), which lets any future `openclaw/plugin-sdk/*` imports resolve without a duplicate runtime bundle
+- **ShieldCortex** — ≥ 4.11.1 required
+
+OpenClaw is declared as an **optional** peer dependency, so installs on older OpenClaw keep working but miss the linking benefit.
+
 ## What it does
 
 | Hook | Action |

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -4,6 +4,10 @@
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,
+  "engines": {
+    "openclaw": ">=2026.3.22",
+    "recommended": ">=2026.4.23"
+  },
   "enabledByDefault": false,
   "activation": {
     "hooks": ["llm_input", "llm_output", "before_tool_call", "session_end"],

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -24,10 +24,15 @@
     "pack:verify": "npm pack --dry-run"
   },
   "peerDependencies": {
-    "shieldcortex": "^4.11.1"
+    "shieldcortex": "^4.11.1",
+    "openclaw": ">=2026.3.22"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": { "optional": true }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.0.0",
+    "openclaw": ">=2026.4.23"
   },
   "publishConfig": {
     "access": "public"

--- a/src/__tests__/plugin-manifest.test.ts
+++ b/src/__tests__/plugin-manifest.test.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * Locks in the plugin package/manifest shape that OpenClaw 2026.4.23 expects
+ * for host-package linking (#70462) and compatibility hinting. Regressions
+ * in these fields silently break peer-only SDK imports after install.
+ */
+describe('shieldcortex-realtime plugin manifest', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const pluginDir = path.join(repoRoot, 'plugins', 'openclaw');
+
+  const pkg = JSON.parse(fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf-8'));
+  const manifest = JSON.parse(fs.readFileSync(path.join(pluginDir, 'openclaw.plugin.json'), 'utf-8'));
+
+  it('declares openclaw as a peer dependency (enables 2026.4.23 host-package linking)', () => {
+    expect(pkg.peerDependencies).toBeDefined();
+    expect(pkg.peerDependencies.openclaw).toBeDefined();
+    expect(pkg.peerDependencies.openclaw).toMatch(/2026\./);
+  });
+
+  it('marks openclaw peer as optional so older installs still resolve', () => {
+    expect(pkg.peerDependenciesMeta).toBeDefined();
+    expect(pkg.peerDependenciesMeta.openclaw).toEqual({ optional: true });
+  });
+
+  it('keeps shieldcortex peer dependency intact', () => {
+    expect(pkg.peerDependencies.shieldcortex).toBeDefined();
+  });
+
+  it('records a recommended OpenClaw engine version in package.json', () => {
+    expect(pkg.engines).toBeDefined();
+    expect(pkg.engines.openclaw).toBeDefined();
+    expect(pkg.engines.openclaw).toMatch(/2026\.4\.23/);
+  });
+
+  it('records engine hints inside the OpenClaw plugin manifest', () => {
+    expect(manifest.engines).toBeDefined();
+    expect(manifest.engines.openclaw).toMatch(/2026\./);
+    expect(manifest.engines.recommended).toMatch(/2026\.4\.23/);
+  });
+
+  it('keeps id and activation hooks stable (uninstall scripts key off these)', () => {
+    expect(manifest.id).toBe('shieldcortex-realtime');
+    expect(manifest.activation.hooks).toEqual(
+      expect.arrayContaining(['llm_input', 'llm_output', 'before_tool_call', 'session_end']),
+    );
+  });
+
+  it('plugin package version matches the root package version', () => {
+    const rootPkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8'));
+    expect(pkg.version).toBe(rootPkg.version);
+    expect(manifest.version).toBe(rootPkg.version);
+  });
+});

--- a/src/__tests__/plugin-manifest.test.ts
+++ b/src/__tests__/plugin-manifest.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from '@jest/globals';
 
 /**
@@ -8,7 +9,8 @@ import { describe, expect, it } from '@jest/globals';
  * in these fields silently break peer-only SDK imports after install.
  */
 describe('shieldcortex-realtime plugin manifest', () => {
-  const repoRoot = path.resolve(__dirname, '..', '..');
+  const thisFile = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
   const pluginDir = path.join(repoRoot, 'plugins', 'openclaw');
 
   const pkg = JSON.parse(fs.readFileSync(path.join(pluginDir, 'package.json'), 'utf-8'));


### PR DESCRIPTION
## Summary

Unlocks OpenClaw 2026.4.23's [#70462](https://github.com/openclaw/openclaw/pull/70462) host-package linking for plugins that declare \`openclaw\` as a peer dependency. The plugin doesn't import from \`openclaw/plugin-sdk/*\` yet, but declaring the peer means that once it does, \`openclaw plugins install\` on ≥ 2026.4.23 will link the host package into resolution without a duplicate runtime bundle.

This is **Phase 2a** of the SC ↔ OpenClaw compatibility work (Phase 1 was #30 — deep uninstall + doctor residue check).

## What changes

- \`plugins/openclaw/package.json\`:
  - \`peerDependencies\`: add \`"openclaw": ">=2026.3.22"\` (current minimum compat floor)
  - \`peerDependenciesMeta\`: mark \`openclaw\` as \`optional\` so older installs don't fail
  - \`engines.openclaw\`: \`">=2026.4.23"\` as a forward-compat hint
- \`plugins/openclaw/openclaw.plugin.json\`: mirror \`engines\` block with required/recommended split
- \`plugins/openclaw/README.md\`: new Compatibility section documenting the version matrix
- \`src/__tests__/plugin-manifest.test.ts\` (new, 7 cases) — locks in peer-dep shape, engines block, activation hooks, plugin-version/root-version invariant

## What doesn't change

- No code imports. The plugin keeps its locally-defined structural \`PluginApi\` type until we're ready to add \`openclaw\` to devDependencies (heavy, needed for type-time resolution of \`openclaw/plugin-sdk/*\`).
- No behaviour changes in the plugin itself.

## Test plan

- [x] \`npx jest src/__tests__/plugin-manifest.test.ts\` — 7/7 pass
- [x] \`npm run build:ts\` — plugin compiles clean, manifest copied to \`plugins/openclaw/dist/\` with new \`engines\` block
- [x] \`npx tsc -p tsconfig.openclaw-plugin.json --noEmit\` — clean
- [ ] Manual smoke: \`openclaw plugins install @drakon-systems/shieldcortex-realtime\` on OpenClaw 2026.4.23 and confirm no "unknown field" warnings, and that host-package linking hook fires

## Context — what's left in Phase 2

- **2b**: Hash-stable hook invocation test + doc cleanup. Context injection was already disabled in v2026.2.26 (native OpenClaw Memory Search handles recall), so the main goal is to lock in that behaviour with a test and update HOOK.md to reflect reality.
- **2c**: Forked \`sessions_spawn\` for scan operations. Not feasible in 2026.4.23 — the SDK exposes \`ContextEngine.prepareSubagentSpawn({ contextMode: "isolated" | "fork" })\` but spawn management is owned by the host runtime; plugins can only react to subagent lifecycle, not initiate spawns. Will document the finding and close as "upstream dependency".

🤖 Generated with [Claude Code](https://claude.com/claude-code)