### PR TITLE
feat(hooks): lock in system-prompt hash stability + correct stale HOOK.md

### DIFF
--- a/hooks/openclaw/cortex-memory/HOOK.md
+++ b/hooks/openclaw/cortex-memory/HOOK.md
@@ -28,9 +28,9 @@ When `openclawAutoMemory` is enabled:
 5. Skips exact and near-duplicate memories using novelty filtering
 
 ### On Session Start (Agent Bootstrap)
-1. Calls Cortex `get_context` to retrieve relevant memories
-2. Injects them into the agent's bootstrap context
-3. Agent starts with knowledge of past sessions
+Bootstrap context injection was **disabled in v2026.2.26**. OpenClaw's native Memory Search now handles context recall at session start, so the hook no longer pushes memories into the system prompt (which was producing ~40× duplication of CORTEX_MEMORY.md and eating most of the context window).
+
+The hook still fires on `agent:bootstrap` for lifecycle wiring (warning-bootstrap-file handoff, etc.) but contributes nothing to the system prompt. This keeps `extraSystemPromptHash` stable across turns and prevents the session-binding reset loop documented in `src/setup/claude-md.ts`.
 
 ### Keyword Triggers
 

--- a/src/__tests__/hook-hash-stability.test.ts
+++ b/src/__tests__/hook-hash-stability.test.ts
@@ -1,0 +1,104 @@
+import fs from 'fs';
+import path from 'path';
+import { createHash } from 'crypto';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * OpenClaw's claude-cli session binding tracks `extraSystemPromptHash` — the
+ * SHA over everything that feeds into the system prompt. If that hash flips
+ * between turns, the binding resets (reason=system-prompt) and the session
+ * loses context mid-flight.
+ *
+ * SC contributes to the system prompt through exactly one artefact:
+ * the ~/.claude/CLAUDE.md block installed by `setupClaudeCode()`. As long as
+ * that text is deterministic (no timestamps, no env-dependent values, no
+ * random nonces), re-running the installer on the same SC version produces
+ * identical bytes — and the system-prompt hash stays stable.
+ *
+ * These tests lock in that invariant through static source analysis, so they
+ * catch dynamic content regressions even without running the installer.
+ * (Runtime invocation isn't viable here because setupClaudeMd imports the
+ * OpenClaw setup module, which trips the baseline ESM/CJS issue in Jest.)
+ */
+describe('ShieldCortex system-prompt hash stability', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const claudeMdSource = path.join(repoRoot, 'src', 'setup', 'claude-md.ts');
+  const hookDir = path.join(repoRoot, 'hooks', 'openclaw', 'cortex-memory');
+
+  function readSource(): string {
+    return fs.readFileSync(claudeMdSource, 'utf-8');
+  }
+
+  function hashFile(file: string): string {
+    return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+  }
+
+  it('CLAUDE.md INSTRUCTIONS block has no runtime-dependent interpolations', () => {
+    const source = readSource();
+    const instructionsMatch = source.match(/const INSTRUCTIONS = `([\s\S]*?)`;/);
+    expect(instructionsMatch).not.toBeNull();
+
+    const body = instructionsMatch![1];
+    const interpolations = body.match(/\$\{[^}]+\}/g) ?? [];
+
+    // Only allow interpolations of module-level UPPER_SNAKE_CASE constants.
+    // Anything else — Date, randomUUID, process.env, function calls — flips
+    // the file bytes between installs and resets the binding hash.
+    for (const interp of interpolations) {
+      expect(interp).toMatch(/^\$\{[A-Z_][A-Z0-9_]*\}$/);
+    }
+  });
+
+  it('claude-md.ts does not import Date, randomUUID, or other time/nonce sources at module scope', () => {
+    const source = readSource();
+    // Strip strings and comments to avoid false positives, then scan for
+    // forbidden identifiers at the file level.
+    const stripped = source
+      .replace(/`[\s\S]*?`/g, '""')   // template strings
+      .replace(/"[^"]*"/g, '""')       // double-quoted
+      .replace(/'[^']*'/g, "''")       // single-quoted
+      .replace(/\/\/[^\n]*/g, '')      // line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // block comments
+
+    // These are the red flags — they'd produce non-reproducible bytes.
+    const forbiddenAtModuleScope = [
+      /\brandomUUID\s*\(/,
+      /\bDate\s*\.\s*now\s*\(/,
+      /\bnew\s+Date\s*\(/,
+      /\bMath\s*\.\s*random\s*\(/,
+    ];
+    for (const pattern of forbiddenAtModuleScope) {
+      expect(stripped).not.toMatch(pattern);
+    }
+  });
+
+  it('all hook files exist on disk and hash deterministically', () => {
+    const files = ['HOOK.md', 'handler.ts', 'runtime.mjs'];
+    for (const file of files) {
+      const full = path.join(hookDir, file);
+      expect(fs.existsSync(full)).toBe(true);
+      // Hash twice — if the filesystem returned different bytes the second
+      // time (e.g. somebody regenerated on read), this fails.
+      expect(hashFile(full)).toBe(hashFile(full));
+    }
+  });
+
+  it('HOOK.md documents that bootstrap context injection is disabled (matches handler.ts behaviour)', () => {
+    // handler.ts line ~500 comment states injection was disabled in v2026.2.26
+    // because it caused 40x duplication of CORTEX_MEMORY.md in the system prompt.
+    // HOOK.md must not claim injection still happens or operators will
+    // misconfigure their setups.
+    const hookMd = fs.readFileSync(path.join(hookDir, 'HOOK.md'), 'utf-8');
+    const handlerSource = fs.readFileSync(path.join(hookDir, 'handler.ts'), 'utf-8');
+
+    // Handler keeps its disabled-injection note; that's the source of truth.
+    expect(handlerSource).toMatch(/Context injection disabled as of v2026\.2\.26/);
+
+    // If HOOK.md still promises injection happens, fail.
+    const bootstrapSection = hookMd.match(/### On Session Start[\s\S]*?(?=\n## |\n### )/);
+    if (bootstrapSection) {
+      const text = bootstrapSection[0];
+      expect(text).not.toMatch(/Injects them into the agent's bootstrap context/);
+    }
+  });
+});

--- a/src/__tests__/hook-hash-stability.test.ts
+++ b/src/__tests__/hook-hash-stability.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { createHash } from 'crypto';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from '@jest/globals';
 
 /**
@@ -21,7 +22,8 @@ import { describe, expect, it } from '@jest/globals';
  * OpenClaw setup module, which trips the baseline ESM/CJS issue in Jest.)
  */
 describe('ShieldCortex system-prompt hash stability', () => {
-  const repoRoot = path.resolve(__dirname, '..', '..');
+  const thisFile = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
   const claudeMdSource = path.join(repoRoot, 'src', 'setup', 'claude-md.ts');
   const hookDir = path.join(repoRoot, 'hooks', 'openclaw', 'cortex-memory');
 


### PR DESCRIPTION
## Summary

OpenClaw's claude-cli binding hashes everything that feeds into the system prompt (\`extraSystemPromptHash\`). When that hash flips between turns, the binding resets with \`reason=system-prompt\` and the session loses context mid-flight.

SC contributes exactly one artefact to that hash: the \`~/.claude/CLAUDE.md\` block installed by \`setupClaudeCode()\`. If that block ever picks up runtime-dependent content (timestamps, UUIDs, env reads), every install flips the hash and every fleet session starts wiping. This is **Phase 2b** of the OpenClaw compat work — locks in the "no dynamic content" invariant with tests, and fixes the HOOK.md docs that still claimed bootstrap context injection happens.

## What changes

- **\`src/__tests__/hook-hash-stability.test.ts\`** (new, 4 cases):
  - INSTRUCTIONS template has no runtime-dependent interpolations — only UPPER_SNAKE_CASE module-level constants allowed
  - \`claude-md.ts\` module scope never references \`Date.now\`, \`new Date()\`, \`randomUUID\`, or \`Math.random\`
  - All three hook files (HOOK.md, handler.ts, runtime.mjs) exist and hash deterministically
  - HOOK.md's "On Session Start (Agent Bootstrap)" section no longer promises injection — matches \`handler.ts\`'s note that injection was disabled in v2026.2.26
- **\`hooks/openclaw/cortex-memory/HOOK.md\`**: replace the stale "Injects them into the agent's bootstrap context" three-step list with a corrected note that bootstrap injection was disabled in v2026.2.26 (native OpenClaw Memory Search now handles recall)

## Why static analysis instead of runtime

\`setupClaudeMd()\` imports the OpenClaw setup module, which trips the baseline ESM/CJS issue Jest has on this repo (\`Identifier '__filename' has already been declared\`). Static source analysis catches the real regression shape — dynamic content landing in the INSTRUCTIONS template — without needing to execute the module. If we fix the Jest ESM issue later, adding a runtime idempotency test is straightforward.

## Test plan

- [x] \`npx jest src/__tests__/hook-hash-stability.test.ts\` — 4/4 pass
- [x] Red/green: confirmed the HOOK.md test failed before the doc fix, passes after
- [ ] Optional follow-up: if the Jest ESM issue gets resolved, add a runtime test that invokes \`setupClaudeMd()\` twice and asserts byte-identical output

## Context — Phase 2 progress

- Phase 2a (PR #31): openclaw peer dep + engines hint — **done**
- Phase 2b (this PR): hash stability + doc cleanup — **done**
- Phase 2c: forked \`sessions_spawn\` for scans — **documenting as infeasible next** (plugin SDK in 2026.4.23 exposes \`ContextEngine.prepareSubagentSpawn\` but spawn management is host-owned, not plugin-initiable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)