### PR TITLE
fix(doctor): distinguish legitimate install state from orphan residue (v4.12.1)

### DIFF
--- a/src/__tests__/deep-clean.test.ts
+++ b/src/__tests__/deep-clean.test.ts
@@ -226,3 +226,172 @@ describe('deep-clean — OpenClaw residue purge', () => {
     expect(gateway).toBeUndefined();
   });
 });
+
+describe('deep-clean — orphan detection (doctor path)', () => {
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const originalSudoUser = process.env.SUDO_USER;
+  let tempHome: string;
+  let homedirSpy: jest.SpiedFunction<typeof os.homedir>;
+
+  beforeEach(() => {
+    jest.resetModules();
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'shieldcortex-orphans-'));
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    delete process.env.SUDO_USER;
+    fs.mkdirSync(path.join(tempHome, '.openclaw'), { recursive: true });
+    homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(tempHome);
+  });
+
+  afterEach(() => {
+    homedirSpy.mockRestore();
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    if (originalSudoUser === undefined) delete process.env.SUDO_USER;
+    else process.env.SUDO_USER = originalSudoUser;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  async function loadModule() {
+    return import('../setup/deep-clean.js');
+  }
+
+  function installPluginDir(): void {
+    const extDir = path.join(tempHome, '.openclaw', 'extensions', 'shieldcortex-realtime');
+    fs.mkdirSync(extDir, { recursive: true });
+    fs.writeFileSync(path.join(extDir, 'openclaw.plugin.json'), '{"id":"shieldcortex-realtime","version":"4.12.1"}\n', 'utf-8');
+    fs.writeFileSync(path.join(extDir, 'index.ts'), 'export default {};\n', 'utf-8');
+  }
+
+  function installHookDir(): void {
+    fs.mkdirSync(path.join(tempHome, '.openclaw', 'hooks', 'cortex-memory'), { recursive: true });
+  }
+
+  function writeHealthyInstallConfig(): void {
+    fs.writeFileSync(
+      path.join(tempHome, '.openclaw', 'openclaw.json'),
+      JSON.stringify({
+        plugins: {
+          installs: { 'shieldcortex-realtime': { source: 'npm', version: '4.12.1' } },
+          entries: { 'shieldcortex-realtime': { enabled: true } },
+          allow: ['shieldcortex-realtime'],
+        },
+        hooks: {
+          internal: {
+            installs: { shieldcortex: { version: '4.12.1' } },
+            entries: { shieldcortex: { enabled: true } },
+            allow: ['shieldcortex'],
+          },
+        },
+      }, null, 2),
+      'utf-8',
+    );
+  }
+
+  it('reports zero orphans when plugin+hook are installed and config references them (v4.12.0 bug fix)', async () => {
+    // Reproduces the fleet scenario: `shieldcortex openclaw install` on Case
+    // populated config entries AND copied the plugin/hook to disk. The v4.12.0
+    // doctor flagged all the config entries as "residue"; it should not have.
+    installPluginDir();
+    installHookDir();
+    writeHealthyInstallConfig();
+
+    const { scanForOrphans } = await loadModule();
+    const report = scanForOrphans();
+
+    expect(report.orphanCount).toBe(0);
+    expect(report.installState.pluginInstalled).toBe(true);
+    expect(report.installState.hookInstalled).toBe(true);
+  });
+
+  it('flags plugin-config entries as orphans when the plugin dir is gone', async () => {
+    // Partial uninstall — config still references the plugin but the dir is gone.
+    writeHealthyInstallConfig();
+    installHookDir(); // keep hook installed to isolate plugin-config detection
+
+    const { scanForOrphans } = await loadModule();
+    const report = scanForOrphans();
+
+    expect(report.orphanCount).toBeGreaterThanOrEqual(3); // installs, entries, allow
+    expect(report.paths.every((p) => p.category !== 'hook-config')).toBe(true);
+    expect(report.paths.some((p) => p.category === 'plugin-config')).toBe(true);
+  });
+
+  it('flags hook-config entries as orphans when no hook dir exists', async () => {
+    writeHealthyInstallConfig();
+    installPluginDir(); // keep plugin installed to isolate hook-config detection
+
+    const { scanForOrphans } = await loadModule();
+    const report = scanForOrphans();
+
+    expect(report.paths.some((p) => p.category === 'hook-config')).toBe(true);
+    expect(report.paths.every((p) => p.category !== 'plugin-config')).toBe(true);
+  });
+
+  it('flags legacy hook dirs as orphans even when current install is healthy', async () => {
+    installPluginDir();
+    installHookDir();
+    writeHealthyInstallConfig();
+
+    // Also drop a legacy hook dir that should have been migrated off
+    const legacyDir = path.join(tempHome, '.openclaw', 'hooks', 'internal', 'cortex-memory');
+    fs.mkdirSync(legacyDir, { recursive: true });
+
+    const { scanForOrphans } = await loadModule();
+    const report = scanForOrphans();
+
+    expect(report.orphanCount).toBeGreaterThanOrEqual(1);
+    expect(report.paths.some((p) => p.category === 'legacy-hook-dir' && p.description === legacyDir)).toBe(true);
+  });
+
+  it('flags clawhub skill lock as orphan (SC does not manage skills automatically)', async () => {
+    installPluginDir();
+    installHookDir();
+    writeHealthyInstallConfig();
+
+    const lockPath = path.join(tempHome, '.openclaw', 'workspace', '.clawhub', 'lock.json');
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify({ skills: { shieldcortex: { version: '4.10.5' } } }, null, 2), 'utf-8');
+
+    const { scanForOrphans } = await loadModule();
+    const report = scanForOrphans();
+
+    expect(report.paths.some((p) => p.category === 'clawhub-skill-lock')).toBe(true);
+  });
+
+  it('does NOT flag the plugin extensions dir or the current hook dir themselves as orphans', async () => {
+    installPluginDir();
+    installHookDir();
+    writeHealthyInstallConfig();
+
+    const { scanForOrphans } = await loadModule();
+    const report = scanForOrphans();
+
+    expect(report.paths.some((p) => p.category === 'plugin-dir')).toBe(false);
+    expect(report.paths.some((p) => p.category === 'hook-dir')).toBe(false);
+  });
+
+  it('tags every residue path with a category (migration regression guard)', async () => {
+    writeHealthyInstallConfig();
+    installPluginDir();
+    installHookDir();
+
+    const { scanForResidue } = await loadModule();
+    const report = scanForResidue();
+
+    for (const p of report.paths) {
+      expect(p.category).toBeDefined();
+      expect([
+        'plugin-config',
+        'hook-config',
+        'clawhub-skill-lock',
+        'plugin-dir',
+        'hook-dir',
+        'legacy-hook-dir',
+      ]).toContain(p.category);
+    }
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -461,7 +461,7 @@ async function checkLockFile(): Promise<CheckResult> {
   }
 }
 
-// ── Check 7.5: OpenClaw residue ──────────────────────────
+// ── Check 7.5: OpenClaw residue (orphans only) ───────────
 async function checkOpenClawResidue(): Promise<CheckResult> {
   const env = detectEnvironment();
   if (!env.hasOpenClaw) {
@@ -469,21 +469,30 @@ async function checkOpenClawResidue(): Promise<CheckResult> {
   }
 
   try {
-    const { scanForResidue } = await import('../setup/deep-clean.js');
-    const report = scanForResidue();
+    const { scanForOrphans } = await import('../setup/deep-clean.js');
+    const report = scanForOrphans();
 
-    if (report.dirtyCount === 0) {
-      return { label: 'OpenClaw residue', status: 'pass', message: `clean (${report.cleanCount} locations checked)` };
+    if (report.orphanCount === 0) {
+      // Legitimate install state is not flagged — a fresh `openclaw install`
+      // writes plugin config entries that SHOULD be there, and those are not
+      // reported as residue.
+      const summary = report.installState.pluginInstalled && report.installState.hookInstalled
+        ? 'clean (plugin + hook installed, config aligned)'
+        : report.installState.pluginInstalled
+          ? 'clean (plugin installed, hook absent but non-orphaned)'
+          : report.installState.hookInstalled
+            ? 'clean (hook installed, plugin absent but non-orphaned)'
+            : 'clean (no ShieldCortex artefacts detected)';
+      return { label: 'OpenClaw residue', status: 'pass', message: summary };
     }
 
-    const dirty = report.paths.filter((p) => p.present);
-    const first = dirty.slice(0, 3).map((p) => p.description).join('; ');
-    const suffix = dirty.length > 3 ? ` (+${dirty.length - 3} more)` : '';
+    const first = report.paths.slice(0, 3).map((p) => p.description).join('; ');
+    const suffix = report.paths.length > 3 ? ` (+${report.paths.length - 3} more)` : '';
 
     return {
       label: 'OpenClaw residue',
       status: 'warn',
-      message: `${report.dirtyCount} residue location${report.dirtyCount === 1 ? '' : 's'} — ${first}${suffix}`,
+      message: `${report.orphanCount} orphan${report.orphanCount === 1 ? '' : 's'} — ${first}${suffix}`,
       fix: 'Run `shieldcortex uninstall --deep --confirm` to purge, or reinstall with `shieldcortex openclaw install`',
     };
   } catch (err: unknown) {

--- a/src/setup/deep-clean.ts
+++ b/src/setup/deep-clean.ts
@@ -49,16 +49,40 @@ type Removal =
   | { kind: 'filter-config-array'; file: string; keyPath: string[]; contains: string }
   | { kind: 'delete-directory'; path: string };
 
+/**
+ * Classification of residue paths. Drives orphan detection: a `plugin-config`
+ * entry is legitimate (not an orphan) while the plugin extension dir is on disk;
+ * a `legacy-hook-dir` is always an orphan because the current install uses a
+ * different path.
+ */
+export type ResidueCategory =
+  | 'plugin-config'         // .plugins.{installs|entries|allow|load.paths} referencing the plugin id
+  | 'hook-config'           // .hooks.* entries referencing shieldcortex
+  | 'clawhub-skill-lock'    // .clawhub/lock.json: .skills.shieldcortex
+  | 'plugin-dir'            // current extensions dir (the install itself)
+  | 'hook-dir'              // current cortex-memory hook dir (the install itself)
+  | 'legacy-hook-dir';      // pre-v4.x hook paths kept around for migration cleanup only
+
 export interface ResiduePath {
   description: string;
   removal: Removal;
   present: boolean;
+  category: ResidueCategory;
 }
 
 export interface ResidueReport {
   paths: ResiduePath[];
   dirtyCount: number;
   cleanCount: number;
+}
+
+export interface OrphanReport {
+  paths: ResiduePath[];
+  orphanCount: number;
+  installState: {
+    pluginInstalled: boolean;
+    hookInstalled: boolean;
+  };
 }
 
 export interface CleanOptions {
@@ -152,11 +176,13 @@ export function scanForResidue(): ResidueReport {
     description: `openclaw.json: .plugins.installs["${PLUGIN_ID}"]`,
     removal: { kind: 'delete-config-key', file: openclawJson, keyPath: ['plugins', 'installs', PLUGIN_ID] },
     present: !!getPath(cfg, ['plugins', 'installs', PLUGIN_ID]),
+    category: 'plugin-config',
   });
   paths.push({
     description: `openclaw.json: .plugins.entries["${PLUGIN_ID}"]`,
     removal: { kind: 'delete-config-key', file: openclawJson, keyPath: ['plugins', 'entries', PLUGIN_ID] },
     present: !!getPath(cfg, ['plugins', 'entries', PLUGIN_ID]),
+    category: 'plugin-config',
   });
   paths.push({
     description: `openclaw.json: .plugins.allow[] contains "${PLUGIN_ID}"`,
@@ -165,6 +191,7 @@ export function scanForResidue(): ResidueReport {
       const arr = getPath(cfg, ['plugins', 'allow']);
       return Array.isArray(arr) && arr.some((e) => typeof e === 'string' && e.includes(PLUGIN_ID));
     })(),
+    category: 'plugin-config',
   });
   paths.push({
     description: `openclaw.json: .plugins.load.paths[] contains "${PLUGIN_ID}"`,
@@ -173,6 +200,7 @@ export function scanForResidue(): ResidueReport {
       const arr = getPath(cfg, ['plugins', 'load', 'paths']);
       return Array.isArray(arr) && arr.some((e) => typeof e === 'string' && e.includes(PLUGIN_ID));
     })(),
+    category: 'plugin-config',
   });
 
   // ── openclaw.json: hooks (both modern and legacy shapes) ─
@@ -180,16 +208,19 @@ export function scanForResidue(): ResidueReport {
     description: 'openclaw.json: .hooks.shieldcortex',
     removal: { kind: 'delete-config-key', file: openclawJson, keyPath: ['hooks', 'shieldcortex'] },
     present: !!getPath(cfg, ['hooks', 'shieldcortex']),
+    category: 'hook-config',
   });
   paths.push({
     description: 'openclaw.json: .hooks.internal.installs.shieldcortex',
     removal: { kind: 'delete-config-key', file: openclawJson, keyPath: ['hooks', 'internal', 'installs', 'shieldcortex'] },
     present: !!getPath(cfg, ['hooks', 'internal', 'installs', 'shieldcortex']),
+    category: 'hook-config',
   });
   paths.push({
     description: 'openclaw.json: .hooks.internal.entries.shieldcortex',
     removal: { kind: 'delete-config-key', file: openclawJson, keyPath: ['hooks', 'internal', 'entries', 'shieldcortex'] },
     present: !!getPath(cfg, ['hooks', 'internal', 'entries', 'shieldcortex']),
+    category: 'hook-config',
   });
   paths.push({
     description: 'openclaw.json: .hooks.internal.allow[] contains "shieldcortex"',
@@ -198,6 +229,7 @@ export function scanForResidue(): ResidueReport {
       const arr = getPath(cfg, ['hooks', 'internal', 'allow']);
       return Array.isArray(arr) && arr.some((e) => typeof e === 'string' && e.includes('shieldcortex'));
     })(),
+    category: 'hook-config',
   });
 
   // ── clawhub lock ────────────────────────────────────────
@@ -205,29 +237,100 @@ export function scanForResidue(): ResidueReport {
     description: 'clawhub/lock.json: .skills.shieldcortex',
     removal: { kind: 'delete-config-key', file: clawhubLock, keyPath: ['skills', 'shieldcortex'] },
     present: !!getPath(lock, ['skills', 'shieldcortex']),
+    category: 'clawhub-skill-lock',
   });
 
   // ── filesystem ──────────────────────────────────────────
-  const dirs = [
-    path.join(home, '.openclaw', 'hooks', HOOK_NAME),
-    path.join(home, '.openclaw', 'hooks', 'internal', HOOK_NAME),
-    path.join(home, '.openclaw', 'hooks', 'shieldcortex'),
-    path.join(home, '.claude', 'hooks', HOOK_NAME),
-    path.join(home, '.claude', 'hooks', 'internal', HOOK_NAME),
-    path.join(home, '.openclaw', 'extensions', PLUGIN_ID),
+  const dirEntries: Array<{ dir: string; category: ResidueCategory }> = [
+    // Current canonical paths (these ARE the install when present)
+    { dir: path.join(home, '.openclaw', 'hooks', HOOK_NAME), category: 'hook-dir' },
+    { dir: path.join(home, '.claude', 'hooks', HOOK_NAME), category: 'hook-dir' },
+    { dir: path.join(home, '.openclaw', 'extensions', PLUGIN_ID), category: 'plugin-dir' },
+    // Legacy paths — always orphaned when present (migrations should remove them)
+    { dir: path.join(home, '.openclaw', 'hooks', 'internal', HOOK_NAME), category: 'legacy-hook-dir' },
+    { dir: path.join(home, '.openclaw', 'hooks', 'shieldcortex'), category: 'legacy-hook-dir' },
+    { dir: path.join(home, '.claude', 'hooks', 'internal', HOOK_NAME), category: 'legacy-hook-dir' },
   ];
 
-  for (const dir of dirs) {
+  for (const { dir, category } of dirEntries) {
     paths.push({
       description: dir,
       removal: { kind: 'delete-directory', path: dir },
       present: fs.existsSync(dir),
+      category,
     });
   }
 
   const dirtyCount = paths.filter((p) => p.present).length;
   const cleanCount = paths.length - dirtyCount;
   return { paths, dirtyCount, cleanCount };
+}
+
+/**
+ * Detect whether the SC plugin / hook are currently installed on disk.
+ * Used by `scanForOrphans()` to tell legitimate install state from true orphans.
+ */
+function detectInstallState(): { pluginInstalled: boolean; hookInstalled: boolean } {
+  const home = resolveHome();
+  const pluginManifest = path.join(home, '.openclaw', 'extensions', PLUGIN_ID, 'openclaw.plugin.json');
+  const pluginInstalled = fs.existsSync(pluginManifest);
+
+  const hookCandidates = [
+    path.join(home, '.openclaw', 'hooks', HOOK_NAME),
+    path.join(home, '.claude', 'hooks', HOOK_NAME),
+  ];
+  const hookInstalled = hookCandidates.some((d) => fs.existsSync(d));
+
+  return { pluginInstalled, hookInstalled };
+}
+
+/**
+ * Return only residue entries that are TRUE ORPHANS — meaning the config /
+ * lock-file entry references a ShieldCortex artefact that is NOT currently
+ * installed on disk, OR it's a legacy path that shouldn't exist anymore.
+ *
+ * This is what `shieldcortex doctor` wants: it should flag partial-uninstall
+ * wreckage without flagging every legitimate install as "residue" (which was
+ * the v4.12.0 bug — the doctor couldn't tell a healthy install from a leftover).
+ *
+ * The `--deep` purge path continues to use `scanForResidue()` because its job
+ * is to remove ALL traces unconditionally, not just orphans.
+ */
+export function scanForOrphans(): OrphanReport {
+  const installState = detectInstallState();
+  const report = scanForResidue();
+
+  const orphans = report.paths.filter((p): boolean => {
+    if (!p.present) return false;
+    switch (p.category) {
+      case 'plugin-config':
+        // Config entry is legitimate iff the plugin dir is installed.
+        return !installState.pluginInstalled;
+      case 'hook-config':
+        // Config entry is legitimate iff any current hook dir is installed.
+        return !installState.hookInstalled;
+      case 'plugin-dir':
+      case 'hook-dir':
+        // These ARE the install when present — never orphaned.
+        return false;
+      case 'legacy-hook-dir':
+        // Legacy paths should have been migrated off; always flag.
+        return true;
+      case 'clawhub-skill-lock':
+        // SC's openclaw install wrapper doesn't manage the skill. If the entry
+        // is present it was written by `openclaw skills install shieldcortex`
+        // and is either a matching live skill or an orphan. We can't confirm
+        // which without knowing where OpenClaw keeps skill artefacts, so we
+        // conservatively flag it so the operator can decide (purge or reinstall).
+        return true;
+    }
+  });
+
+  return {
+    paths: orphans,
+    orphanCount: orphans.length,
+    installState,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

v4.12.0 shipped a broken \`doctor\` OpenClaw residue check. After a clean \`shieldcortex openclaw install\`, OpenClaw legitimately writes \`.plugins.installs\`, \`.plugins.entries\`, \`.plugins.allow\`, and matching \`.hooks.*\` entries — these are **expected** config state, not residue. The doctor was unconditionally flagging any presence of SC entries as "residue", so a freshly-installed host showed 6–7 warnings and pointed users at \`uninstall --deep\` to "purge" a healthy install.

Reproduced on aiquant/Case after fleet rollout: fresh v4.12.0 install → \`shieldcortex openclaw install\` → \`shieldcortex doctor\` → 7 false positives.

## Fix

- Tag every \`ResiduePath\` with a new \`category\` field: \`plugin-config | hook-config | clawhub-skill-lock | plugin-dir | hook-dir | legacy-hook-dir\`.
- New \`scanForOrphans()\` applies presence-aware filtering:
  - \`plugin-config\` → orphan only if the plugin extensions dir is absent
  - \`hook-config\` → orphan only if no cortex-memory hook dir exists
  - \`plugin-dir\` / \`hook-dir\` → never orphaned (the dir IS the install)
  - \`legacy-hook-dir\` → always orphaned (paths kept for migration cleanup only)
  - \`clawhub-skill-lock\` → always flagged (SC doesn't manage skills)
- \`doctor\` now uses \`scanForOrphans()\` and tailors its "clean" message to install state: _"plugin + hook installed, config aligned"_ instead of a generic "clean" line.

## What doesn't change

- \`scanForResidue()\` / \`cleanResidue()\` / \`runDeepClean()\` — their job is total purge for the \`uninstall --deep\` path, so they still flag and remove ALL traces regardless of install state. This is intentional.

## Tests

7 new tests in a second describe block (\`deep-clean — orphan detection (doctor path)\`):

- Reports zero orphans when plugin + hook are installed (the v4.12.0 bug)
- Flags plugin-config entries as orphans when plugin dir is gone
- Flags hook-config entries as orphans when no hook dir exists
- Flags legacy hook dirs as orphans even with healthy install
- Flags clawhub skill lock as orphan
- Does NOT flag the current plugin/hook dirs as orphans
- Migration regression guard: every residue path has a valid category

All 15 tests (8 original + 7 new) pass. \`tsc --noEmit\` clean, \`npm run build:ts\` clean.

## Release plan

Ships as **v4.12.1**. After merge:
- Fleet hosts currently showing false-positive residue warnings will flip to green on upgrade
- Existing \`uninstall --deep\` behaviour unchanged — purge still removes everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)