### PR TITLE
fix(doctor): suggest scan "init" for DB creation, not quickstart (v4.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.12.2 — 24 April 2026
+
+**Fix: `shieldcortex doctor` no longer suggests `quickstart` to initialise the database.**
+
+v4.12.1 doctor's "Database: not found" suggested-fix message read _"Start the MCP server or run `shieldcortex quickstart` to initialise the database"_ — but `quickstart` only configures hooks/MCP, it does not touch the database. On TARS during fleet rollout this caused a loop: `quickstart` → `doctor` (still complains) → `quickstart` again.
+
+### Fix
+
+- `checkDatabase()` now suggests `shieldcortex scan "init"` as the explicit one-shot init command (works on every install shape — Claude+OpenClaw, OpenClaw-only, headless).
+- On Claude+OpenClaw hosts, the message also mentions the lazy-init alternative: starting a Claude Code session, where the MCP server creates the DB on first memory call.
+- 3 new tests in `src/__tests__/doctor-db-init-hint.test.ts` lock the corrected guidance in: no `quickstart` reference, explicit `scan "init"` reference, and the MCP lazy-init mention preserved for Claude+OpenClaw hosts.
+
+### Why it matters
+
+Doctor's job is to tell operators what to do. A suggested fix that doesn't fix the thing wastes their time and erodes trust in the tool. This is a docs-shaped bug — same severity as the v4.12.0 false-positive residue check that v4.12.1 closed.
+
 ## v4.12.1 — 24 April 2026
 
 **Fix: `shieldcortex doctor` no longer reports false-positive residue on healthy installs.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.12.1",
+      "version": "4.12.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "description": "Trustworthy memory and security for AI agents. Recall debugging, review queue, OpenClaw session capture, and memory poisoning defence for Claude Code, Codex, OpenClaw, LangChain, and MCP agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "index.ts",
@@ -24,7 +24,7 @@
     "pack:verify": "npm pack --dry-run"
   },
   "peerDependencies": {
-    "shieldcortex": "^4.12.1",
+    "shieldcortex": "^4.12.2",
     "openclaw": ">=2026.3.22"
   },
   "peerDependenciesMeta": {

--- a/src/__tests__/doctor-db-init-hint.test.ts
+++ b/src/__tests__/doctor-db-init-hint.test.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * Lock in the corrected DB-init hint. v4.12.1 doctor pointed users at
+ * `shieldcortex quickstart` to "initialise the database" — but quickstart
+ * only configures hooks/MCP and doesn't touch the DB. Caused the user to
+ * loop on quickstart → doctor → quickstart on TARS during fleet rollout.
+ *
+ * The reliable one-shot init paths are `shieldcortex scan "..."` (any
+ * install shape) or starting an MCP-bound session (Claude Code).
+ */
+describe('doctor — database-not-found hint', () => {
+  const thisFile = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
+  const doctorSource = fs.readFileSync(path.join(repoRoot, 'src', 'cli', 'doctor.ts'), 'utf-8');
+
+  it('does not suggest `shieldcortex quickstart` as a way to initialise the database', () => {
+    const checkDatabaseFn = doctorSource.match(/async function checkDatabase\(\)[\s\S]*?\n\}/);
+    expect(checkDatabaseFn).not.toBeNull();
+    expect(checkDatabaseFn![0]).not.toMatch(/quickstart.*?initialise the database/i);
+    expect(checkDatabaseFn![0]).not.toMatch(/run `shieldcortex quickstart`/);
+  });
+
+  it('suggests `shieldcortex scan` as the explicit init command', () => {
+    const checkDatabaseFn = doctorSource.match(/async function checkDatabase\(\)[\s\S]*?\n\}/);
+    expect(checkDatabaseFn![0]).toMatch(/shieldcortex scan ["']init["']/);
+  });
+
+  it('still mentions the Claude Code MCP-server lazy-init path on Claude+OpenClaw hosts', () => {
+    const checkDatabaseFn = doctorSource.match(/async function checkDatabase\(\)[\s\S]*?\n\}/);
+    expect(checkDatabaseFn![0]).toMatch(/Claude Code session/i);
+    expect(checkDatabaseFn![0]).toMatch(/lazy-init|MCP server/i);
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -92,10 +92,15 @@ async function checkDatabase(): Promise<CheckResult> {
   const dbPath = getDbPath();
 
   if (!fs.existsSync(dbPath)) {
+    // The database is created lazily on the first memory operation.
+    // `quickstart` only configures hooks/MCP — it does NOT touch the DB.
+    // The reliable one-shot init paths are: `shieldcortex scan "..."`
+    // (works on every install shape) or starting an MCP-bound session
+    // (Claude Code) which lazy-inits via the MCP server.
     const env = detectEnvironment();
-    const fix = env.hasOpenClaw && !env.hasClaude
-      ? 'Run `shieldcortex scan "test"` to initialise the database (OpenClaw-only setup detected)'
-      : 'Start the MCP server or run `shieldcortex quickstart` to initialise the database';
+    const fix = env.hasClaude
+      ? 'Run `shieldcortex scan "init"` to create the database now, or start a Claude Code session — the MCP server will lazy-init on first memory call'
+      : 'Run `shieldcortex scan "init"` to create the database now (OpenClaw-only / headless install)';
     return {
       label: 'Database',
       status: 'fail',


### PR DESCRIPTION
## Summary

v4.12.1 doctor suggested \`shieldcortex quickstart\` as the way to initialise the database. \`quickstart\` only configures hooks/MCP — it does **not** touch the DB. On TARS during fleet rollout this caused a loop: \`quickstart\` → \`doctor\` (still complains) → \`quickstart\` again, with no progress.

## Fix

- \`checkDatabase()\` now suggests \`shieldcortex scan "init"\` as the explicit one-shot init command (works on every install shape — Claude+OpenClaw, OpenClaw-only, headless).
- On Claude+OpenClaw hosts, the message also mentions the lazy-init alternative: starting a Claude Code session, where the MCP server creates the DB on first memory call.

## Tests

3 new in \`src/__tests__/doctor-db-init-hint.test.ts\`:
- No \`quickstart\` reference inside \`checkDatabase()\`
- Explicit \`scan "init"\` reference present
- MCP lazy-init mention preserved for Claude+OpenClaw hosts

All 29 release-track tests green: 8 deep-clean + 7 deep-clean orphan + 7 plugin-manifest + 4 hook-hash-stability + 3 doctor-db-init-hint.

## Release plan

Ships as **v4.12.2**. After merge: bump versions, tag, push — CI auto-publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)