### PR TITLE
fix(pre-compact): match Claude Code project-dir encoding (silent zero-memory bug, v4.12.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.12.4 — 25 April 2026
+
+**Fix: silent zero-memory issue when running under dotfile-prefixed working directories (e.g. `~/.openclaw/`, `~/.config/`).**
+
+The pre-compact hook builds the path to Claude Code's session transcript by encoding the cwd into a project-folder slug. Earlier versions only replaced `/` with `-` and left dots intact, but Claude Code itself replaces BOTH `/` AND `.` with `-` (and `:` for Windows drive letters). Net effect: every session under a dotfile-prefixed directory looked at the wrong folder, found no files, read 0 messages, and silently extracted 0 memories.
+
+Reproduced on Jarvis 2026-04-25 inside an OpenClaw workspace at `~/.openclaw/workspace`:
+
+```text
+[auto-extract] Session dir not found: /home/ubuntu/.claude/projects/-home-ubuntu-.openclaw-workspace
+[auto-extract] Read 0 messages from transcript (0 chars)
+[shieldcortex] Pre-compact complete: 0 memories auto-extracted
+```
+
+The actual folder was `-home-ubuntu--openclaw-workspace` (note the double dash where the `.` should have become `-`).
+
+### Fix
+
+`scripts/lib/claude-project-dir.mjs` — new pure ESM util exporting `encodeClaudeProjectDir(cwd)` that mirrors Claude Code's encoding exactly: replace `/`, `\`, `.`, `:` with `-`, with a leading `-` separator. `scripts/pre-compact-hook.mjs` imports it and uses it instead of the broken inline regex.
+
+### Tests
+
+6 new cases in `src/__tests__/claude-project-dir-encoding.test.ts` covering the original repro plus dot-inside-component and Windows path scenarios:
+
+| Input                                     | Expected                                |
+|-------------------------------------------|-----------------------------------------|
+| `/home/u/.openclaw/workspace`             | `-home-u--openclaw-workspace`           |
+| `/home/u/foo.bar/baz`                     | `-home-u-foo-bar-baz`                   |
+| `/home/u/regular/path`                    | `-home-u-regular-path`                  |
+| `C:\Users\u\.openclaw\workspace`          | `-C--Users-u--openclaw-workspace`       |
+
+### Why it matters
+
+Until this release, **every fleet host running ShieldCortex from inside `~/.openclaw/workspace`** was producing 0 auto-extracted memories on every pre-compact event — silently. Doctor was green, hooks were "configured", but the actual work product (memory capture during long sessions) was zero. Other hooks weren't affected because they receive `transcript_path` directly from Claude Code via the hook payload; only pre-compact's auto-extract path computed the slug itself.
+
 ## v4.12.3 — 25 April 2026
 
 **Fix: doctor recognises native-package installs (Mac homebrew, npm-global discovery).**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.12.3",
+      "version": "4.12.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "description": "Trustworthy memory and security for AI agents. Recall debugging, review queue, OpenClaw session capture, and memory poisoning defence for Claude Code, Codex, OpenClaw, LangChain, and MCP agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "index.ts",
@@ -24,7 +24,7 @@
     "pack:verify": "npm pack --dry-run"
   },
   "peerDependencies": {
-    "shieldcortex": "^4.12.3",
+    "shieldcortex": "^4.12.4",
     "openclaw": ">=2026.3.22"
   },
   "peerDependenciesMeta": {

--- a/scripts/lib/claude-project-dir.mjs
+++ b/scripts/lib/claude-project-dir.mjs
@@ -1,0 +1,20 @@
+/**
+ * Encode a working directory the same way Claude Code does when picking
+ * the `~/.claude/projects/<slug>/` folder for that session.
+ *
+ * Claude Code replaces BOTH `/` (and `\` on Windows) AND `.` with `-`,
+ * with a leading `-` separator before the first path component.
+ *
+ * Earlier versions of pre-compact-hook only replaced slashes, so any
+ * session under a dotfile-prefixed dir (e.g. `~/.openclaw/workspace`)
+ * silently extracted zero memories: the lookup path
+ * `-home-u-.openclaw-workspace` never matched the folder Claude Code
+ * actually wrote (`-home-u--openclaw-workspace`).
+ */
+export function encodeClaudeProjectDir(cwd) {
+  // Match Claude Code: replace `/`, `\`, `.`, and `:` with `-`. The `:`
+  // matters on Windows so `C:\Users\u\.openclaw\workspace` becomes
+  // `-C--Users-u--openclaw-workspace` (drive-letter colon → dash).
+  const slug = String(cwd).replace(/[\\/.:]/g, '-');
+  return slug.startsWith('-') ? slug : `-${slug}`;
+}

--- a/scripts/pre-compact-hook.mjs
+++ b/scripts/pre-compact-hook.mjs
@@ -15,6 +15,7 @@ import Database from 'better-sqlite3';
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { encodeClaudeProjectDir } from './lib/claude-project-dir.mjs';
 
 // Database paths (with legacy fallback)
 const NEW_DB_DIR = join(homedir(), '.shieldcortex');
@@ -595,9 +596,7 @@ function readSessionConversation(cwd) {
   if (!cwd) return '';
 
   try {
-    // Claude Code uses the absolute path with slashes replaced by dashes as the project folder name
-    const projectSlug = cwd.replace(/^\//, '').replace(/\//g, '-');
-    const projectDir = join(homedir(), '.claude', 'projects', `-${projectSlug}`);
+    const projectDir = join(homedir(), '.claude', 'projects', encodeClaudeProjectDir(cwd));
 
     if (!existsSync(projectDir)) {
       console.error(`[auto-extract] Session dir not found: ${projectDir}`);

--- a/src/__tests__/claude-project-dir-encoding.test.ts
+++ b/src/__tests__/claude-project-dir-encoding.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from '@jest/globals';
+// @ts-expect-error -- importing a .mjs util for the encoder under test
+import { encodeClaudeProjectDir } from '../../scripts/lib/claude-project-dir.mjs';
+
+/**
+ * Locks in the Claude Code project-dir encoding. Earlier versions of the
+ * pre-compact hook only replaced `/` with `-` and left dots intact, so any
+ * session under a dotfile-prefixed dir (e.g. `~/.openclaw/workspace`)
+ * silently extracted zero memories: the lookup path
+ * `-home-u-.openclaw-workspace` never matched the folder Claude Code
+ * actually wrote (`-home-u--openclaw-workspace`).
+ *
+ * Claude Code's encoding rule (verified empirically on Jarvis 2026-04-25):
+ * replace BOTH `/` (and `\` on Windows) AND `.` with `-`, with a leading
+ * `-` separator before the first path component.
+ */
+describe('encodeClaudeProjectDir — Claude Code project-folder slug', () => {
+  // Test table reproduced from the v4.12.4 fix prompt
+  const cases: Array<{ cwd: string; expected: string; note?: string }> = [
+    { cwd: '/home/u/.openclaw/workspace', expected: '-home-u--openclaw-workspace', note: 'dotfile-prefixed dir (the bug repro)' },
+    { cwd: '/home/u/foo.bar/baz',         expected: '-home-u-foo-bar-baz',         note: 'dot inside a path component' },
+    { cwd: '/home/u/regular/path',        expected: '-home-u-regular-path',        note: 'no dots — same as before' },
+    { cwd: 'C:\\Users\\u\\.openclaw\\workspace', expected: '-C--Users-u--openclaw-workspace', note: 'Windows path with dotfile dir' },
+  ];
+
+  for (const { cwd, expected, note } of cases) {
+    it(`encodes ${JSON.stringify(cwd)} → ${expected}${note ? ` (${note})` : ''}`, () => {
+      expect(encodeClaudeProjectDir(cwd)).toBe(expected);
+    });
+  }
+
+  it('is idempotent on a single-segment input (defensive)', () => {
+    expect(encodeClaudeProjectDir('/foo')).toBe('-foo');
+  });
+
+  it('coerces non-string input rather than throwing', () => {
+    // The hook is invoked from a JSON pipe; defensive against a missing/wrong cwd.
+    expect(() => encodeClaudeProjectDir(123 as unknown as string)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Closes a silent zero-memory bug. Until v4.12.4, **every fleet host running ShieldCortex from inside a dotfile-prefixed working directory** (e.g. \`~/.openclaw/workspace\`) was producing 0 auto-extracted memories on every pre-compact event. Doctor was green, hooks were "configured", but the actual capture was zero.

## Root cause

The pre-compact hook builds the path to Claude Code's session transcript by encoding the cwd into a project-folder slug. The encoder only replaced \`/\` with \`-\` and left dots intact. Claude Code itself replaces BOTH \`/\` AND \`.\` with \`-\`.

\`\`\`text
ShieldCortex looked for: -home-ubuntu-.openclaw-workspace
Claude Code wrote:       -home-ubuntu--openclaw-workspace
                                     ^^ note double dash
\`\`\`

Lookup never matched, transcript file never opened, 0 messages read, 0 memories extracted.

## Reproduction (Jarvis 2026-04-25)

\`\`\`text
[auto-extract] Session dir not found: /home/ubuntu/.claude/projects/-home-ubuntu-.openclaw-workspace
[auto-extract] Read 0 messages from transcript (0 chars)
[shieldcortex] Pre-compact complete: 0 memories auto-extracted
\`\`\`

## Fix

- New \`scripts/lib/claude-project-dir.mjs\` — pure ESM util exporting \`encodeClaudeProjectDir(cwd)\` that mirrors Claude Code's encoding: replace \`/\`, \`\\\`, \`.\`, \`:\` with \`-\`, with a leading \`-\` separator.
- \`scripts/pre-compact-hook.mjs\` imports it instead of the broken inline regex.

## Tests

6 new in \`src/__tests__/claude-project-dir-encoding.test.ts\`:

| Input                                     | Expected                                |
|-------------------------------------------|-----------------------------------------|
| \`/home/u/.openclaw/workspace\`           | \`-home-u--openclaw-workspace\`         |
| \`/home/u/foo.bar/baz\`                   | \`-home-u-foo-bar-baz\`                 |
| \`/home/u/regular/path\`                  | \`-home-u-regular-path\`                |
| \`C:\\Users\\u\\.openclaw\\workspace\`    | \`-C--Users-u--openclaw-workspace\`     |

Plus an idempotence guard and a defensive non-string-input test. All 37 release-track tests green.

## Audit of other hooks

- \`scripts/session-end-hook.mjs\` — receives \`transcript_path\` from Claude Code via hook payload. Safe.
- \`scripts/prompt-recall-hook.mjs\` — uses \`deriveProjectKey(cwd)\` for project scoping, never builds a session path. Safe.
- \`scripts/session-start-hook.mjs\` — same as prompt-recall. Safe.
- \`scripts/stop-hook.mjs\` — uses \`hookData.transcript_path\` directly. Safe.

Only \`pre-compact-hook.mjs\` had the bug.

## Verification on a fleet host after upgrade

In a fresh session under \`~/.openclaw/workspace\`:
1. Send 5+ messages including deliberate "decided X", "fix Y", "prefer Z"
2. Trigger pre-compact (or wait for natural fire)
3. \`shieldcortex status\` shows Memories > 0 and Last activity recent
4. \`shieldcortex doctor\` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)