### PR TITLE
feat(openclaw): auto-restart gateway after install (Edith fix, v4.12.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.12.6 — 25 April 2026
+
+**Fix: `shieldcortex openclaw install` now auto-restarts the OpenClaw gateway** so freshly-copied plugin/hook files take effect immediately without manual intervention. Symmetric with `uninstall --deep`'s gateway-restart, which has been live since v4.12.0.
+
+### Why this matters
+
+Reproduced on Edith 2026-04-25 during the v4.12.5 fleet rollout: the npm package upgraded cleanly to 4.12.5, but OpenClaw still showed the plugin loaded as v4.12.2 in memory. Result: `shieldcortex status` reported 0 memories / `Last activity: never` despite a successful upgrade. Fixing this required a manual `systemctl --user restart openclaw-gateway`. With this release the install command does it for you.
+
+### What changed
+
+- `OpenClawInstallOptions` adds `restartGateway?: boolean` (default `true`).
+- `installOpenClawHook()` calls the existing `restartOpenClawGateway()` helper from `src/setup/deep-clean.ts` after install completes — only when something actually landed (avoids wasting a restart on `--no-hooks --no-plugins` no-op runs).
+- `shieldcortex openclaw install` accepts a new `--no-gateway-restart` flag for cases where the operator wants to defer the restart (CI, scripted multi-step installs, or when the gateway will be restarted later as part of a larger orchestration).
+- On restart failure, the install output prints platform-specific manual restart instructions (`systemctl --user restart openclaw-gateway` on Linux, `launchctl kickstart -k gui/$UID/ai.openclaw.gateway` on macOS).
+
+### Tests
+
+8 new in `src/__tests__/openclaw-install-gateway-restart.test.ts` lock in the wiring: option declared, CLI flag parsed and passed through, default-true gating, "only restart when something installed" guard, usage block advertises the flag, restart helper reused (not duplicated), and platform-specific manual fallback messages.
+
+50/50 release-track tests green.
+
 ## v4.12.5 — 25 April 2026
 
 **Fix: auto-extracted memories were silently failing every INSERT with `NOT NULL constraint failed: memories.uuid`.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.12.5",
+  "version": "4.12.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.12.5",
+      "version": "4.12.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.12.5",
+  "version": "4.12.6",
   "description": "Trustworthy memory and security for AI agents. Recall debugging, review queue, OpenClaw session capture, and memory poisoning defence for Claude Code, Codex, OpenClaw, LangChain, and MCP agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.12.5",
+  "version": "4.12.6",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.12.5",
+  "version": "4.12.6",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "index.ts",
@@ -24,7 +24,7 @@
     "pack:verify": "npm pack --dry-run"
   },
   "peerDependencies": {
-    "shieldcortex": "^4.12.5",
+    "shieldcortex": "^4.12.6",
     "openclaw": ">=2026.3.22"
   },
   "peerDependenciesMeta": {

--- a/src/__tests__/openclaw-install-gateway-restart.test.ts
+++ b/src/__tests__/openclaw-install-gateway-restart.test.ts
@@ -1,0 +1,73 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * v4.12.6 makes `shieldcortex openclaw install` auto-restart the OpenClaw
+ * gateway after install (with `--no-gateway-restart` opt-out), symmetric
+ * with `uninstall --deep`. Without this, an upgrade of the npm package
+ * leaves the running gateway with the old plugin in memory until something
+ * else triggers a restart — observed on Edith 2026-04-25 where the npm
+ * package was on 4.12.5 but the loaded plugin was still 4.12.2, silently
+ * producing zero memories.
+ *
+ * Runtime invocation isn't viable here because src/setup/openclaw.ts
+ * trips the baseline ESM/CJS issue Jest has on this repo (same reason
+ * hook-hash-stability uses source analysis). We assert source-level
+ * invariants instead.
+ */
+describe('openclaw install — auto gateway restart (v4.12.6)', () => {
+  const thisFile = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
+  const openclawSource = fs.readFileSync(path.join(repoRoot, 'src', 'setup', 'openclaw.ts'), 'utf-8');
+
+  it('OpenClawInstallOptions declares restartGateway', () => {
+    expect(openclawSource).toMatch(/restartGateway\?:\s*boolean/);
+  });
+
+  it('handleOpenClawCommand parses --no-gateway-restart and inverts it', () => {
+    expect(openclawSource).toMatch(/extraArgs\.includes\(['"]--no-gateway-restart['"]\)/);
+    expect(openclawSource).toMatch(/restartGateway\s*=\s*!extraArgs\.includes/);
+  });
+
+  it('handleOpenClawCommand passes restartGateway to installOpenClawHook', () => {
+    const installCase = openclawSource.match(
+      /case\s+['"]install['"]:\s*\n[\s\S]*?installOpenClawHook\(([^)]*)\)/,
+    );
+    expect(installCase).not.toBeNull();
+    expect(installCase![1]).toMatch(/restartGateway/);
+  });
+
+  it('installOpenClawHook gates the restart behind options.restartGateway !== false (default true)', () => {
+    // Restart fires by default; only an explicit `false` opts out.
+    expect(openclawSource).toMatch(/options\.restartGateway\s*!==\s*false/);
+  });
+
+  it('installOpenClawHook only restarts when something was actually installed', () => {
+    // Don't waste a restart when both --no-hooks and --no-plugins are passed
+    // and nothing landed on disk.
+    expect(openclawSource).toMatch(/didInstallSomething\s*=\s*installed\s*>\s*0\s*\|\|\s*pluginInstallMode\s*!==\s*['"]skipped['"]/);
+  });
+
+  it('install advertises --no-gateway-restart in the usage block', () => {
+    expect(openclawSource).toMatch(/--no-gateway-restart/);
+    const usageBlock = openclawSource.match(/Install options:[\s\S]*?process\.exit\(1\)/);
+    expect(usageBlock).not.toBeNull();
+    expect(usageBlock![0]).toMatch(/--no-gateway-restart/);
+  });
+
+  it('reuses restartOpenClawGateway from deep-clean (does not duplicate the implementation)', () => {
+    // Accept either a static `import ... from './deep-clean.js'`
+    // or a dynamic `await import('./deep-clean.js')`.
+    expect(openclawSource).toMatch(/(?:from|import\s*\()\s*['"]\.\/deep-clean(?:\.js)?['"]/);
+    expect(openclawSource).toMatch(/restartOpenClawGateway/);
+  });
+
+  it('on restart failure, prints platform-specific manual restart instructions', () => {
+    // Linux hosts get systemctl, macOS gets launchctl. Edith would have
+    // benefited from this clear next-step.
+    expect(openclawSource).toMatch(/systemctl --user restart openclaw-gateway/);
+    expect(openclawSource).toMatch(/launchctl kickstart -k gui\/\$UID\/ai\.openclaw\.gateway/);
+  });
+});

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -730,6 +730,20 @@ export interface OpenClawInstallOptions {
   noHooks?: boolean;
   /** Skip plugin installation (--no-plugins flag) */
   noPlugins?: boolean;
+  /**
+   * Best-effort restart of the OpenClaw gateway after install so the freshly
+   * copied hook + plugin files are picked up without manual intervention.
+   * Defaults to true. Set to false (or pass `--no-gateway-restart` from the
+   * CLI) to skip the restart.
+   *
+   * Symmetric with `uninstall --deep`'s gateway-restart, which has been live
+   * since v4.12.0. Without this on the install side, an upgrade of the npm
+   * package leaves the running gateway with the old plugin in memory until
+   * something else triggers a restart — observed on Edith 2026-04-25 where
+   * the npm package was on 4.12.5 but the plugin loaded was still 4.12.2,
+   * silently producing zero memories.
+   */
+  restartGateway?: boolean;
 }
 
 export async function installOpenClawHook(options: OpenClawInstallOptions = {}): Promise<void> {
@@ -868,8 +882,32 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
   console.log('Native OpenClaw install is also supported:');
   console.log('  openclaw skills install shieldcortex');
   console.log('  openclaw plugins install @drakon-systems/shieldcortex-realtime');
-  console.log('');
-  console.log('Restart your agent to activate.');
+
+  // Best-effort gateway restart so the new plugin/hook are picked up
+  // immediately. Skipped only when the caller explicitly opts out, both
+  // capability paths skipped (--no-hooks AND --no-plugins), or no work
+  // landed (installed === 0 AND plugin skipped).
+  const didInstallSomething = installed > 0 || pluginInstallMode !== 'skipped';
+  const restartRequested = options.restartGateway !== false;
+  if (restartRequested && didInstallSomething) {
+    const { restartOpenClawGateway } = await import('./deep-clean.js');
+    const result = await restartOpenClawGateway();
+    console.log('');
+    if (result.restarted) {
+      console.log(`OpenClaw gateway restarted via ${result.method}.`);
+    } else if (result.attempted) {
+      console.warn(`OpenClaw gateway restart via ${result.method} failed: ${result.detail ?? 'unknown'}`);
+      console.warn('Restart it manually so the new plugin/hook take effect:');
+      console.warn(process.platform === 'linux'
+        ? '  systemctl --user restart openclaw-gateway'
+        : '  launchctl kickstart -k gui/$UID/ai.openclaw.gateway');
+    } else {
+      console.log('Restart your agent / OpenClaw gateway to activate.');
+    }
+  } else {
+    console.log('');
+    console.log('Restart your agent to activate.');
+  }
 }
 
 export async function uninstallOpenClawHook(): Promise<void> {
@@ -973,10 +1011,11 @@ export async function openClawHookStatus(): Promise<void> {
 export async function handleOpenClawCommand(subcommand: string, extraArgs: string[] = []): Promise<void> {
   const noHooks = extraArgs.includes('--no-hooks');
   const noPlugins = extraArgs.includes('--no-plugins');
+  const restartGateway = !extraArgs.includes('--no-gateway-restart');
 
   switch (subcommand) {
     case 'install':
-      await installOpenClawHook({ noHooks, noPlugins });
+      await installOpenClawHook({ noHooks, noPlugins, restartGateway });
       break;
     case 'uninstall':
       await uninstallOpenClawHook();
@@ -988,8 +1027,9 @@ export async function handleOpenClawCommand(subcommand: string, extraArgs: strin
       console.log('Usage: shieldcortex openclaw <install|uninstall|status>');
       console.log('');
       console.log('Install options:');
-      console.log('  --no-hooks     Skip hook installation (useful in Docker/CI)');
-      console.log('  --no-plugins   Skip plugin installation (useful in Docker/CI)');
+      console.log('  --no-hooks              Skip hook installation (useful in Docker/CI)');
+      console.log('  --no-plugins            Skip plugin installation (useful in Docker/CI)');
+      console.log('  --no-gateway-restart    Skip the auto gateway restart after install');
       process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

Closes the install/uninstall asymmetry that bit Edith during v4.12.5 fleet rollout. \`uninstall --deep\` has restarted the gateway since v4.12.0, but \`openclaw install\` did not. After a clean \`npm install -g shieldcortex@4.12.5\` followed by \`shieldcortex openclaw install\`, Edith's gateway kept running the v4.12.2 plugin in memory. Result: \`shieldcortex status\` reported 0 memories / \`Last activity: never\` despite a successful upgrade. Fix required a manual \`systemctl --user restart openclaw-gateway\`.

## What changes

- \`OpenClawInstallOptions\` adds \`restartGateway?: boolean\` (default \`true\`).
- \`installOpenClawHook()\` calls the existing \`restartOpenClawGateway()\` helper from \`src/setup/deep-clean.ts\` after install completes — only when something actually landed (avoids wasting a restart on \`--no-hooks --no-plugins\` no-op runs).
- \`shieldcortex openclaw install\` accepts \`--no-gateway-restart\` for cases where the operator wants to defer the restart.
- On restart failure, the install output prints platform-specific manual restart instructions (\`systemctl --user restart openclaw-gateway\` on Linux, \`launchctl kickstart -k gui/\$UID/ai.openclaw.gateway\` on macOS).

## Tests

8 new in \`src/__tests__/openclaw-install-gateway-restart.test.ts\`:

- \`OpenClawInstallOptions\` declares \`restartGateway\`
- \`handleOpenClawCommand\` parses \`--no-gateway-restart\` and inverts it
- CLI passes \`restartGateway\` through to \`installOpenClawHook\`
- Default-true gating (\`options.restartGateway !== false\`)
- Only restart when something installed (\`installed > 0 || pluginInstallMode !== 'skipped'\`)
- Usage block advertises the new flag
- Reuses \`restartOpenClawGateway\` from deep-clean (no duplication)
- Restart-failure output mentions both platform-specific manual commands

50/50 release-track tests green.

## Verification on a fleet host after upgrade

\`\`\`bash
npm install -g shieldcortex@4.12.6
shieldcortex openclaw install   # should print "OpenClaw gateway restarted via ..."
shieldcortex doctor             # should show OpenClaw residue: clean (plugin + hook installed, config aligned)
\`\`\`

This unblocks the next fleet upgrade — no manual restart step needed after \`shieldcortex openclaw install\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)