### PR TITLE
fix(openclaw): record correct installPath for native-package installs / Mac homebrew (v4.12.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## v4.12.7 — 25 April 2026
+
+**Fix: false-positive doctor "orphans" on Mac homebrew installs (root cause of the v4.12.3–v4.12.6 Mac regression).**
+
+Reproduced on Friday/mikes-mac on every release v4.12.3 → v4.12.6: `shieldcortex install` succeeded, plugin landed on disk, hooks installed, but `shieldcortex doctor` kept flagging `.plugins.installs/entries/allow["shieldcortex-realtime"]` as orphans. Linux fleet hosts never hit it.
+
+### Root cause
+
+`installPlugin()`'s native-package code path (the one that fires when npm-global lives in OpenClaw's search path — i.e. `/opt/homebrew/lib/node_modules` on Mac) recorded the WRONG `installPath` in `openclaw.json`:
+
+```text
+path.dirname(path.dirname(globalPluginPath))   ← package root  (wrong)
+path.dirname(globalPluginPath)                 ← dist dir      (right — manifest's parent)
+```
+
+The `trusted-local-copy` code path used the correct convention; only native-package was off. `detectInstallState()` checked `installPath/openclaw.plugin.json`, found nothing (the manifest is in `dist/`), and returned `pluginInstalled = false` → false-positive orphans every time.
+
+### Fix
+
+- `src/setup/openclaw.ts` — `installPlugin()`'s native-package branch now passes `pluginDir = path.dirname(globalPluginPath)` to `trustLocalPlugin()`. Matches the convention used by every other code path. Same value is logged to the user as is recorded in config — no install/log mismatch any more.
+- `src/setup/deep-clean.ts` — `detectInstallState()` now also checks `installPath/dist/openclaw.plugin.json` as a fallback. This means fleet hosts that already have the bad `installPath` written from v4.12.3–v4.12.6 stop false-flagging on the next doctor run, even before they re-install.
+
+### Tests
+
+4 new cases:
+
+- `src/__tests__/deep-clean.test.ts` — "honours installPath/dist fallback" reproduces the Friday scenario with the wrong-path config and asserts `pluginInstalled = true`, `orphanCount = 0`.
+- `src/__tests__/openclaw-install-path.test.ts` (new file, 3 cases) — locks in that the writer passes `pluginDir` to `trustLocalPlugin`, never the double-dirname pattern, and the logged path matches the recorded path.
+
+54/54 release-track tests green.
+
 ## v4.12.6 — 25 April 2026
 
 **Fix: `shieldcortex openclaw install` now auto-restarts the OpenClaw gateway** so freshly-copied plugin/hook files take effect immediately without manual intervention. Symmetric with `uninstall --deep`'s gateway-restart, which has been live since v4.12.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.12.6",
+  "version": "4.12.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.12.6",
+      "version": "4.12.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.12.6",
+  "version": "4.12.7",
   "description": "Trustworthy memory and security for AI agents. Recall debugging, review queue, OpenClaw session capture, and memory poisoning defence for Claude Code, Codex, OpenClaw, LangChain, and MCP agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.12.6",
+  "version": "4.12.7",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.12.6",
+  "version": "4.12.7",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "index.ts",
@@ -24,7 +24,7 @@
     "pack:verify": "npm pack --dry-run"
   },
   "peerDependencies": {
-    "shieldcortex": "^4.12.6",
+    "shieldcortex": "^4.12.7",
     "openclaw": ">=2026.3.22"
   },
   "peerDependenciesMeta": {

--- a/src/__tests__/deep-clean.test.ts
+++ b/src/__tests__/deep-clean.test.ts
@@ -465,4 +465,50 @@ describe('deep-clean — orphan detection (doctor path)', () => {
     expect(report.installState.pluginInstalled).toBe(true);
     expect(report.orphanCount).toBe(0);
   });
+
+  it('honours installPath/dist/openclaw.plugin.json fallback (pre-v4.12.7 wrong-path bug)', async () => {
+    // Reproduces Friday/mikes-mac (Mac homebrew) on v4.12.3–v4.12.6.
+    // The native-package install code wrote `installPath = .../plugins/openclaw`
+    // (the package root, one level too high), but the manifest lives at
+    // `.../plugins/openclaw/dist/openclaw.plugin.json`. detectInstallState
+    // checked only `installPath/openclaw.plugin.json` and returned false
+    // → false-positive orphans on every Mac install.
+    //
+    // v4.12.7 fixes the writer AND adds the dist/ fallback so existing
+    // fleet hosts with the bad installPath stop false-flagging on next
+    // doctor run, even before re-installing.
+    const wrongInstallPath = path.join(tempHome, 'fake-homebrew', 'shieldcortex', 'plugins', 'openclaw');
+    const realManifestDir = path.join(wrongInstallPath, 'dist');
+    fs.mkdirSync(realManifestDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(realManifestDir, 'openclaw.plugin.json'),
+      '{"id":"shieldcortex-realtime","version":"4.12.6"}\n',
+      'utf-8',
+    );
+
+    fs.writeFileSync(
+      path.join(tempHome, '.openclaw', 'openclaw.json'),
+      JSON.stringify({
+        plugins: {
+          installs: {
+            'shieldcortex-realtime': {
+              source: 'path',
+              installPath: wrongInstallPath, // package root, NOT the dist dir
+              version: '4.12.6',
+            },
+          },
+          entries: { 'shieldcortex-realtime': { enabled: true } },
+          allow: ['shieldcortex-realtime'],
+        },
+      }, null, 2),
+      'utf-8',
+    );
+    installHookDir();
+
+    const { scanForOrphans } = await loadModule();
+    const report = scanForOrphans();
+
+    expect(report.installState.pluginInstalled).toBe(true);
+    expect(report.orphanCount).toBe(0);
+  });
 });

--- a/src/__tests__/openclaw-install-path.test.ts
+++ b/src/__tests__/openclaw-install-path.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * v4.12.3-v4.12.6's native-package install code recorded the wrong
+ * `installPath` in `openclaw.json`:
+ *
+ *   path.dirname(path.dirname(globalPluginPath))   ← package root
+ *   path.dirname(globalPluginPath)                 ← dist dir (the manifest's parent)
+ *
+ * Only the second one is the dir that contains `openclaw.plugin.json`,
+ * which is the convention `detectInstallState()` checks. v4.12.7 fixes
+ * the writer so the recorded path matches the convention used by every
+ * other code path (trusted-local-copy passes the dest dir directly).
+ */
+describe('installPlugin — native-package installPath (v4.12.7)', () => {
+  const thisFile = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
+  const openclawSource = fs.readFileSync(
+    path.join(repoRoot, 'src', 'setup', 'openclaw.ts'),
+    'utf-8',
+  );
+
+  it('passes path.dirname(globalPluginPath) to trustLocalPlugin (the dist dir)', () => {
+    const nativePackageBlock = openclawSource.match(
+      /isInOpenClawSearchPath[\s\S]*?return\s+['"]native-package['"];/,
+    );
+    expect(nativePackageBlock).not.toBeNull();
+    expect(nativePackageBlock![0]).toMatch(/trustLocalPlugin\(\s*pluginDir/);
+  });
+
+  it('does NOT pass path.dirname(path.dirname(globalPluginPath)) — that was the bug', () => {
+    const nativePackageBlock = openclawSource.match(
+      /isInOpenClawSearchPath[\s\S]*?return\s+['"]native-package['"];/,
+    );
+    expect(nativePackageBlock).not.toBeNull();
+    // Strip comments (the buggy pattern is intentionally referenced in the
+    // explanatory comment block) before checking the actual code.
+    const codeOnly = nativePackageBlock![0]
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+    expect(codeOnly).not.toMatch(/path\.dirname\(\s*path\.dirname\(/);
+  });
+
+  it('logs the same dir to the user as it records to config (no install/log mismatch)', () => {
+    // Earlier code printed `path.dirname(globalPluginPath)` ("Installed to .../dist")
+    // while writing `path.dirname(path.dirname(...))` to config — confusing
+    // any operator who tried to verify by hand. Both should now use pluginDir.
+    const nativePackageBlock = openclawSource.match(
+      /isInOpenClawSearchPath[\s\S]*?return\s+['"]native-package['"];/,
+    );
+    expect(nativePackageBlock).not.toBeNull();
+    expect(nativePackageBlock![0]).toMatch(/Installed real-time plugin to \$\{pluginDir\}/);
+    expect(nativePackageBlock![0]).toMatch(/trustLocalPlugin\(\s*pluginDir/);
+  });
+});

--- a/src/setup/deep-clean.ts
+++ b/src/setup/deep-clean.ts
@@ -288,13 +288,20 @@ function detectInstallState(): { pluginInstalled: boolean; hookInstalled: boolea
   const home = resolveHome();
 
   // 1. Honour whatever path the installer recorded in openclaw.json.
+  //    Defensive: also check `installPath/dist/openclaw.plugin.json` because
+  //    pre-v4.12.7 native-package installs (Mac homebrew) recorded the
+  //    package root instead of the dir containing the manifest. Without this
+  //    fallback, fleet hosts with the bad installPath continue to false-flag
+  //    until their next `shieldcortex openclaw install` overwrites it.
   const cfg = readJsonOrNull(path.join(home, '.openclaw', 'openclaw.json')) ?? {};
   const recorded = getPath(cfg, ['plugins', 'installs', PLUGIN_ID]);
   let pluginInstalled = false;
   if (recorded && typeof recorded === 'object') {
     const installPath = (recorded as Record<string, unknown>).installPath;
     if (typeof installPath === 'string' && installPath.length > 0) {
-      pluginInstalled = fs.existsSync(path.join(installPath, 'openclaw.plugin.json'));
+      pluginInstalled =
+        fs.existsSync(path.join(installPath, 'openclaw.plugin.json')) ||
+        fs.existsSync(path.join(installPath, 'dist', 'openclaw.plugin.json'));
     }
   }
 

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -500,8 +500,17 @@ function installPlugin(options: { noPlugins?: boolean } = {}): PluginInstallMode
             fs.rmSync(staleDir, { recursive: true, force: true });
           }
         }
-        console.log(`Installed real-time plugin to ${path.dirname(globalPluginPath)}`);
-        trustLocalPlugin(path.dirname(path.dirname(globalPluginPath)), '');
+        // Record the dir that ACTUALLY contains the manifest as `installPath`
+        // — that's the convention the trusted-local-copy path uses, and what
+        // `detectInstallState()` in deep-clean.ts checks. Earlier versions
+        // wrote `path.dirname(path.dirname(globalPluginPath))` (the package
+        // root, one level too high), so the manifest existence check failed
+        // and doctor flagged the legitimate config entries as orphans on
+        // every Mac homebrew install. Reproduced on Friday/mikes-mac on
+        // every release v4.12.3 → v4.12.6.
+        const pluginDir = path.dirname(globalPluginPath);
+        console.log(`Installed real-time plugin to ${pluginDir}`);
+        trustLocalPlugin(pluginDir, '');
         return 'native-package';
       }
     } catch { /* npm not available or no global install — fall through */ }


### PR DESCRIPTION
## Summary

Closes the v4.12.3–v4.12.6 Mac regression. Reproduced on Friday/mikes-mac on every release: \`shieldcortex install\` succeeded, plugin landed on disk, hooks installed, but \`shieldcortex doctor\` kept flagging \`.plugins.installs/entries/allow["shieldcortex-realtime"]\` as orphans. Linux fleet hosts never hit it.

## Root cause

\`installPlugin()\`'s native-package code path (the one that fires when npm-global lives in OpenClaw's search path — \`/opt/homebrew/lib/node_modules\` on Mac) recorded the WRONG \`installPath\` in \`openclaw.json\`:

\`\`\`text
path.dirname(path.dirname(globalPluginPath))   ← package root  (wrong)
path.dirname(globalPluginPath)                 ← dist dir      (right — manifest's parent)
\`\`\`

The \`trusted-local-copy\` code path used the correct convention; only native-package was off. \`detectInstallState()\` checked \`installPath/openclaw.plugin.json\`, found nothing (manifest is in \`dist/\`), and returned \`pluginInstalled = false\` → false-positive orphans every time.

## Fix

- **\`src/setup/openclaw.ts\`** — native-package branch now passes \`pluginDir = path.dirname(globalPluginPath)\` to \`trustLocalPlugin\`. Same value is logged to the user as is recorded in config.
- **\`src/setup/deep-clean.ts\`** — \`detectInstallState()\` now also checks \`installPath/dist/openclaw.plugin.json\` as a fallback. Fleet hosts that already have the bad \`installPath\` written from v4.12.3–v4.12.6 stop false-flagging on the next doctor run, even before they re-install.

## Tests

- \`src/__tests__/deep-clean.test.ts\` — new "honours installPath/dist fallback" test reproduces the Friday scenario with the wrong-path config and asserts \`pluginInstalled = true\`, \`orphanCount = 0\`.
- \`src/__tests__/openclaw-install-path.test.ts\` (new file, 3 cases) — locks in that the writer passes \`pluginDir\` to \`trustLocalPlugin\`, never the double-dirname pattern, and the logged path matches the recorded path.

54/54 release-track tests green.

## Verification on Mac after upgrade

\`\`\`bash
npm install -g shieldcortex@4.12.7
shieldcortex openclaw install
shieldcortex doctor   # should show "OpenClaw residue: clean (plugin + hook installed, config aligned)"
\`\`\`

The defensive \`installPath/dist\` fallback means the doctor will report clean immediately after upgrading, without needing to re-run \`openclaw install\` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)