### PR TITLE
release: v4.24.1 — fix Free-tier cloud audit sync (was gated behind Team)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.24.1] - 2026-05-26
+
+**Hotfix: Free-tier audit sync to ShieldCortex Cloud was incorrectly gated behind Team tier — every Free-tier install was silently dropping audit data.**
+
+The defence pipeline's "audit metadata" sync (the one that feeds the Cloud dashboard's scan counts, threat timeline, and device list) was gated on `isFeatureEnabled('cloud_sync')` — but `cloud_sync` is a Team-tier feature in `FEATURE_TIERS`. So even with a valid cloud API key set, Free-tier installs never sent anything. The Cloud dashboard appeared stuck on the "No scan data yet" empty state for every Free-tier user.
+
+This contradicts the published Free-tier offer (500 scans/month + 7-day audit retention on `api.shieldcortex.ai`).
+
+### Fixed
+
+- **Split the single `cloud_sync` flag into two narrower features** ([`src/license/gate.ts`](src/license/gate.ts)):
+  - `cloud_audit_sync` (Free) — sync audit metadata only, no content. Matches the Free-tier promise on the SaaS pricing page.
+  - `cloud_sync` (Team) — full bi-directional sync: memories, knowledge graph, and quarantine *content*. Unchanged tier.
+- **Re-gate the audit-ingest call** ([`src/defence/pipeline.ts:261`](src/defence/pipeline.ts#L261)) on the new `cloud_audit_sync` feature. Free-tier installs with a configured cloud API key now actually fire `POST /v1/audit/ingest` on each scan, as the dashboard has always expected.
+- **Quarantine content sync stays on `cloud_sync` (Team)** ([`src/defence/pipeline.ts:270`](src/defence/pipeline.ts#L270)) — this sends `original_content` + `original_title`, so it correctly remains Team-tier.
+
+### Migration
+
+No action required for users — `npm i -g shieldcortex@4.24.1` is enough. Existing cloud API keys keep working. The cloud dashboard's "No scan data yet" state will clear within a few scans once devices upgrade.
+
 ## [4.24.0] - 2026-05-25
 
 **Gentle Pro-tier upsell — doctor footer + dashboard banner. Three triggers, all gated on `tier === 'free'`, muteable, throttled.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.24.0",
+  "version": "4.24.1",
   "description": "Trustworthy memory and security for AI agents. Recall debugging, review queue, OpenClaw session capture, and memory poisoning defence for Claude Code, Codex, OpenClaw, LangChain, and MCP agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.24.0",
+  "version": "4.24.1",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.24.0",
+  "version": "4.24.1",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/defence/pipeline.ts
+++ b/src/defence/pipeline.ts
@@ -257,8 +257,9 @@ export function runDefencePipeline(
       auditId,
     };
 
-    // 8. Sync audit data to cloud (fire-and-forget, never blocks)
-    if (isFeatureEnabled('cloud_sync')) {
+    // 8. Sync audit data to cloud (fire-and-forget, never blocks).
+    // Gated on `cloud_audit_sync` (Free tier) — metadata only, no content.
+    if (isFeatureEnabled('cloud_audit_sync')) {
       try {
         syncToCloud(pipelineResult, source, durationMs);
       } catch {
@@ -266,7 +267,8 @@ export function runDefencePipeline(
       }
     }
 
-    // 9. Sync quarantine content to cloud (fire-and-forget)
+    // 9. Sync quarantine *content* to cloud (fire-and-forget). Gated on
+    // `cloud_sync` (Team tier) because this sends original content + title.
     if (isFeatureEnabled('cloud_sync') && firewall.result === 'QUARANTINE') {
       try {
         const indicators = firewall.threatIndicators.map(t =>

--- a/src/license/__tests__/feature-gating.test.ts
+++ b/src/license/__tests__/feature-gating.test.ts
@@ -137,6 +137,20 @@ describe('Feature Gating', () => {
       expect(getRequiredTier('cloud_sync')).toBe('team');
       expect(getRequiredTier('team_management')).toBe('team');
     });
+
+    it('cloud_audit_sync is a Free-tier feature (audit metadata only)', async () => {
+      // Regression: v4.24.0 and earlier gated audit-ingest behind `cloud_sync` (Team),
+      // so every Free-tier install silently dropped data despite a valid cloud API key.
+      // The published Free tier is "500 scans/month + 7-day audit retention" — that
+      // requires the audit-ingest path to work on Free. cloud_audit_sync covers
+      // metadata-only ingest; cloud_sync stays Team for full memory + quarantine content.
+      const { getRequiredTier, isFeatureEnabled } = await import('../gate.js');
+      expect(getRequiredTier('cloud_audit_sync')).toBe('free');
+      expect(getRequiredTier('cloud_sync')).toBe('team');
+      // Free tier: audit ingest enabled, full sync gated.
+      expect(isFeatureEnabled('cloud_audit_sync')).toBe(true);
+      expect(isFeatureEnabled('cloud_sync')).toBe(false);
+    });
   });
 
   describe('listFeatures', () => {

--- a/src/license/gate.ts
+++ b/src/license/gate.ts
@@ -17,6 +17,7 @@ export type GatedFeature =
   | 'custom_firewall_rules'
   | 'audit_export'
   | 'skill_scanner_deep'
+  | 'cloud_audit_sync'
   | 'cloud_sync'
   | 'team_management'
   | 'shared_patterns'
@@ -41,6 +42,7 @@ const FEATURE_TIERS: Record<GatedFeature, LicenseTier> = {
   custom_firewall_rules: 'pro',
   audit_export: 'pro',
   skill_scanner_deep: 'pro',
+  cloud_audit_sync: 'free',
   cloud_sync: 'team',
   team_management: 'team',
   shared_patterns: 'team',
@@ -66,7 +68,8 @@ const FEATURE_DESCRIPTIONS: Record<GatedFeature, string> = {
   custom_firewall_rules: 'Add custom firewall rules to block or allow specific content patterns.',
   audit_export: 'Export your full audit trail as JSON or CSV for compliance reporting.',
   skill_scanner_deep: 'Deep skill scanning with multi-file analysis and semantic intent detection.',
-  cloud_sync: 'Sync audit data across devices for centralised team visibility.',
+  cloud_audit_sync: 'Sync audit metadata (no content) to ShieldCortex Cloud for centralised visibility — included on Free tier (500 scans/month, 7-day retention).',
+  cloud_sync: 'Full bi-directional cloud sync — memories, knowledge graph, and quarantine content. Required for cross-device team workflows.',
   team_management: 'Manage team members, invites, and shared security policies.',
   shared_patterns: 'Share custom injection patterns and policies across your team.',
   cortex_learning: 'Systematic mistake learning with pre-flight checks, pattern detection, and rule graduation.',


### PR DESCRIPTION
## Summary

Hotfix for a real bug discovered while investigating why the Cloud dashboard at `api.shieldcortex.ai` showed "No scan data yet" across a 5-machine fleet (Edith, Jarvis, Tars-on-Hermes, Friday, plus the primary Mac) even with a valid cloud API key configured on each.

### The bug

In [`src/defence/pipeline.ts:261`](src/defence/pipeline.ts#L261), the audit-metadata sync to Cloud was gated on `isFeatureEnabled('cloud_sync')`. But `cloud_sync` is declared as a **Team-tier** feature in [`src/license/gate.ts`](src/license/gate.ts):

```ts
const FEATURE_TIERS = {
  // ...
  cloud_sync: 'team',  // ← gates BOTH metadata audit AND full content sync
  // ...
};
```

So every Free-tier install silently dropped audit data, no matter how the cloud API key was configured. The dashboard's "No scan data yet" empty state was the only symptom — no errors, no warnings, no log lines.

This contradicts the published Free-tier offer: **500 scans/month + 7-day audit retention** at `api.shieldcortex.ai`. The dashboard was designed assuming Free-tier installs would send audit metadata.

### The fix

Split the single `cloud_sync` flag into two narrower features:

| Feature | Tier | What it gates |
|---|---|---|
| `cloud_audit_sync` (new) | Free | Audit metadata only — no content. Matches the published Free-tier promise. |
| `cloud_sync` (unchanged) | Team | Full bi-directional sync: memories, knowledge graph, quarantine *content*. |

`pipeline.ts:261` (audit ingest) now gates on `cloud_audit_sync`. `pipeline.ts:270` (quarantine content sync) stays on `cloud_sync` — that path sends `original_content` + `original_title`, which is correctly Team-tier.

Locked down with a regression test in [`src/license/__tests__/feature-gating.test.ts`](src/license/__tests__/feature-gating.test.ts) so the "everything behind Team" regression can't return silently:

```ts
it('cloud_audit_sync is a Free-tier feature (audit metadata only)', async () => {
  expect(getRequiredTier('cloud_audit_sync')).toBe('free');
  expect(getRequiredTier('cloud_sync')).toBe('team');
  expect(isFeatureEnabled('cloud_audit_sync')).toBe(true);  // free tier
  expect(isFeatureEnabled('cloud_sync')).toBe(false);
});
```

## Migration

No action required for users beyond upgrading:

```bash
npm i -g shieldcortex@4.24.1
```

Existing cloud API keys keep working. The Cloud dashboard's "No scan data yet" empty state clears within a few scans once devices upgrade.

## Test plan

- [x] `npm run build` — green (TS + dashboard standalone)
- [x] `npm test` — 1232/1235 pass. Regression test for the new gate passes. The single failing test (`mcp-registration › idempotent`) is a pre-existing flaky timeout — also fails on `main` (verified independently)
- [x] `npx tsc --noEmit` — clean
- [ ] After publish: install `shieldcortex@4.24.1` on a Free-tier machine, run `npx shieldcortex scan "ping"`, confirm the audit row lands at `api.shieldcortex.ai/audit` within a few seconds

## Affected versions

`v4.24.0` and earlier. The gate has been wrong since `cloud_sync` was introduced — this is the first time it's been investigated end-to-end with a real Free-tier fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)