### PR TITLE
fix(#49): harden auto-capture against fragments & category mislabels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ ROADMAP.md
 # README), but the per-question report is regenerated on every run.
 benchmark/longmemeval/report.json
 .superpowers/
+:memory:
+:memory:.lock

--- a/scripts/lib/extract-memorable-segments.mjs
+++ b/scripts/lib/extract-memorable-segments.mjs
@@ -466,6 +466,14 @@ export function extractMemorableSegments(conversationText, opts = {}) {
       let match;
       while ((match = pattern.exec(text)) !== null) {
         const content = match[1].trim();
+        // Issue #49: a capture group can begin part-way through a sentence (the
+        // trigger word was mid-clause) or trail off into a question. Enforce a
+        // true sentence-START boundary here so the segmenter never emits a
+        // mid-clause slice or an interrogative — the same defects the rejection
+        // corpus screens, applied at the source so they never become candidates.
+        if (beginsWithContinuation(content) || endsWithInterrogative(content)) {
+          continue;
+        }
         if (content.length >= 20) {
           // v4.24.3: headline = first sentence (sentence-bounded), not
           // the first 50 chars. Eliminates mid-clause garbage in the
@@ -491,6 +499,79 @@ const SUBORDINATE_START_WORDS = new Set([
   'the', 'a', 'an', 'for', 'to', 'of', 'with', 'by', 'from', 'on', 'in',
   'at', 'that', 'which', 'who', 'where', 'when',
 ]);
+
+// Issue #49: tokens that, when a captured segment BEGINS with them, mark it as
+// a mid-clause CONTINUATION — the chunker hit a trigger word part-way through a
+// sentence and grabbed the tail of a thought that started earlier (leading
+// conjunctions, dangling auxiliaries, pronoun-contraction tails). A genuine
+// durable fact never opens on one of these. Closed list, case-insensitive.
+const CONTINUATION_START_TOKENS = new Set([
+  'and', 'so', 'but', 'yet', 'or', 'because', 'also', 'then', 'plus',
+  'have', 'has', "he's", "she's", "you're", "it's", "that's", "there's",
+  "we're", "they're", "i'm",
+]);
+
+// Verb-shaped tokens (small whitelist + a deterministic suffix heuristic).
+// Hoisted so both the subordinate-clause fragment check and the whole-segment
+// bare-clause check share one definition.
+const VERB_WHITELIST = new Set([
+  'is', 'was', 'are', 'were', 'be', 'been', 'being',
+  'has', 'have', 'had', 'do', 'does', 'did',
+  'uses', 'used', 'wraps', 'consists', 'lives', 'runs', 'sits',
+  'returns', 'accepts', 'requires', 'breaks', 'fails', 'works',
+  'hosts', 'holds', 'adds', 'applies', 'splits', 'flushes', 'writes',
+]);
+
+function normalizeApostrophes(s) {
+  // Fold the curly apostrophe (U+2019) and modifier letter apostrophe onto the
+  // ASCII one so "it’s" matches the same token as "it's".
+  return s.replace(/[‘’ʼ]/g, "'");
+}
+
+function isVerbShaped(token) {
+  const t = normalizeApostrophes(token.toLowerCase()).replace(/[^a-z']/g, '');
+  if (!t) return false;
+  if (VERB_WHITELIST.has(t)) return true;
+  // -ing / -ed are strong verb signals; -es/-s is noisier (plurals) but kept
+  // for backward-compatibility with the original fragment heuristic.
+  return /(?:ing|ed|es|s)$/.test(t) && t.length > 3;
+}
+
+function hasVerbLike(content) {
+  return content.trim().split(/\s+/).some(isVerbShaped);
+}
+
+// First word-token of a capture, apostrophe-normalised and lowercased, with a
+// trailing contraction kept intact ("you're" stays "you're").
+function leadingToken(content) {
+  const cleaned = normalizeApostrophes(content.trim().toLowerCase());
+  const m = cleaned.match(/^([a-z]+(?:'[a-z]+)?)/);
+  return m ? m[1] : '';
+}
+
+// (a) Mid-clause continuation opener — see CONTINUATION_START_TOKENS.
+function beginsWithContinuation(content) {
+  return CONTINUATION_START_TOKENS.has(leadingToken(content));
+}
+
+// (b) Trailing interrogative — a question is not a durable declarative fact.
+// Allows an optional closing quote/paren after the `?`.
+function endsWithInterrogative(content) {
+  return /\?["')\]]?\s*$/.test(content.trim());
+}
+
+// (d) Meaningful tokens: word-ish tokens with at least two alphanumerics.
+// Single letters / bare punctuation don't count toward a complete thought.
+const MIN_MEANINGFUL_TOKENS = 3;
+function meaningfulTokenCount(content) {
+  return content.trim().split(/\s+/).filter((t) => /[a-z0-9]{2,}/i.test(t)).length;
+}
+
+// (c) Bare clause: a short capture with no verb-shaped token at all — a noun
+// phrase rather than a subject+verb statement ("the brand new build machine").
+function looksLikeBareClause(content) {
+  return meaningfulTokenCount(content) <= 6 && !hasVerbLike(content);
+}
 
 // Bare imperative verbs that almost always indicate the original sentence
 // began with a modal or negation that the chunker dropped (e.g. "never
@@ -644,6 +725,19 @@ export function shouldRejectCandidate(segment, conversationText) {
   }
   if (hasLeadingNegation(segment, conversationText)) {
     return { rejected: true, reason: 'negation_scope' };
+  }
+  // Issue #49 fragment defects:
+  if (beginsWithContinuation(content)) {
+    return { rejected: true, reason: 'continuation_start' };
+  }
+  if (endsWithInterrogative(content)) {
+    return { rejected: true, reason: 'interrogative' };
+  }
+  if (meaningfulTokenCount(content) < MIN_MEANINGFUL_TOKENS) {
+    return { rejected: true, reason: 'too_few_tokens' };
+  }
+  if (looksLikeBareClause(content)) {
+    return { rejected: true, reason: 'bare_clause' };
   }
   if (looksLikeFragment(content)) {
     return { rejected: true, reason: 'subordinate_start_fragment' };

--- a/scripts/recalc-auto-captures.mjs
+++ b/scripts/recalc-auto-captures.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Issue #49 — back-catalogue recalc for auto-captured memories.
+ *
+ * One-off maintenance command. It:
+ *   (a) re-flags auto-captured FRAGMENTS (mid-sentence start / trailing `?` /
+ *       any current rejection-corpus hit) into the review queue by setting
+ *       their status to `suppressed` — excluded from recall and eligible for
+ *       the standard `prune` purge. Nothing is hand-deleted.
+ *   (b) re-scores stale auto rows whose salience still exceeds the 0.6 auto cap
+ *       and that are older than 7 days, under the CURRENT (capped) rules.
+ *
+ * DRY-RUN BY DEFAULT — prints what it WOULD do and changes nothing. Pass
+ * `--apply` to commit (a DB backup is written first). The flag + re-score work
+ * reuses the store/prune primitives in src/ (compiled to dist/), so this thin
+ * wrapper requires a build:  `npm run build`.
+ *
+ * Usage:
+ *   node scripts/recalc-auto-captures.mjs            # dry-run
+ *   node scripts/recalc-auto-captures.mjs --apply    # commit changes
+ *   node scripts/recalc-auto-captures.mjs --db <path> [--backup-dir <path>]
+ */
+
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import fs from 'node:fs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const distEntry = path.resolve(here, '..', 'dist', 'cli', 'migrate-legacy.js');
+
+if (!fs.existsSync(distEntry)) {
+  console.error('[recalc] Compiled CLI not found at dist/cli/migrate-legacy.js.');
+  console.error('[recalc] Build first:  npm run build');
+  process.exit(1);
+}
+
+const { handleMemoriesCommand } = await import(pathToFileURL(distEntry).href);
+
+// Reuse the exact same argument handling as `shieldcortex memories recalc`.
+await handleMemoriesCommand(['recalc', ...process.argv.slice(2)]);

--- a/src/__tests__/auto-capture-fragment-hardening.test.ts
+++ b/src/__tests__/auto-capture-fragment-hardening.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * Issue #49: the OpenClaw auto-capture pipeline was storing sentence FRAGMENTS
+ * (mid-clause slices that begin on a leading conjunction / pronoun-tail, or end
+ * on a trailing `?`) instead of self-contained durable facts.
+ *
+ * This suite pins the HARDENED rejection corpus in the shared chunker
+ * (scripts/lib/extract-memorable-segments.mjs):
+ *
+ *   (a) leading conjunction / sentence-continuation token  → reject
+ *       (and|so|but|yet|or|because|also|then|plus|have|has|
+ *        he's|she's|you're|it's|that's|there's|we're|they're|i'm)
+ *   (b) trailing `?` (interrogative)                        → reject
+ *   (c) bare clause / no subject+verb                       → reject
+ *   (d) below the minimum meaningful-token count            → reject
+ *
+ * Acceptance (from the issue):
+ *   - new auto-capture fragment rate < 5% over a 50-candidate sample.
+ */
+
+type Reject = (
+  segment: { title: string; content: string; extractorType?: string },
+  conversationText?: string,
+) => { rejected: boolean; reason: string };
+
+async function loadChunker() {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error -- importing a .mjs hook util (no type decls)
+  return import('../../scripts/lib/extract-memorable-segments.mjs');
+}
+
+describe('issue #49 — leading conjunction / continuation rejection', () => {
+  // The full closed list from the issue brief, case-insensitive.
+  const CONTINUATION_TOKENS = [
+    'and', 'so', 'but', 'yet', 'or', 'because', 'also', 'then', 'plus',
+    'have', 'has', "he's", "she's", "you're", "it's", "that's", "there's",
+    "we're", "they're", "i'm",
+  ];
+
+  it.each(CONTINUATION_TOKENS)('rejects a capture that begins with "%s"', async (tok) => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+    const content = `${tok} the rest of the thought trails on for a while here`;
+    const verdict = shouldRejectCandidate({ title: '', content });
+    expect(verdict.rejected).toBe(true);
+    expect(verdict.reason).toBeTruthy();
+  });
+
+  it('is case-insensitive (capitalised conjunction still rejected)', async () => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+    expect(shouldRejectCandidate({ title: '', content: 'And then we shipped the broken build to prod' }).rejected).toBe(true);
+    expect(shouldRejectCandidate({ title: '', content: "You're going to need a bigger machine for this job" }).rejected).toBe(true);
+  });
+
+  it('normalises a curly apostrophe in a pronoun-tail', async () => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+    expect(shouldRejectCandidate({ title: '', content: 'it’s stored under the wrong project key entirely here' }).rejected).toBe(true);
+  });
+
+  it('does NOT reject a legitimate verb-led capture that merely contains a conjunction', async () => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+    // "and" appears mid-sentence, not as the opener — must survive.
+    const verdict = shouldRejectCandidate({
+      title: '',
+      content: 'rotating session tokens replace long-lived keys and expire after one hour',
+    });
+    expect(verdict.rejected).toBe(false);
+  });
+});
+
+describe('issue #49 — trailing interrogative rejection', () => {
+  it('rejects a capture ending in a question mark', async () => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+    expect(shouldRejectCandidate({ title: '', content: 'should we just buy a new computer?' }).rejected).toBe(true);
+  });
+
+  it('rejects a trailing `?` even with a closing quote/paren after it', async () => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+    expect(shouldRejectCandidate({ title: '', content: 'is this really the right approach here?)' }).rejected).toBe(true);
+  });
+
+  it('does not reject a declarative that merely contains a `?` mid-string', async () => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+    const verdict = shouldRejectCandidate({
+      title: '',
+      content: 'the parser handles the "what now?" prompt by falling back to the default route',
+    });
+    expect(verdict.rejected).toBe(false);
+  });
+});
+
+describe('issue #49 — bare clause / minimum token rejection', () => {
+  it('rejects a too-short candidate (below the meaningful-token floor)', async () => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+    expect(shouldRejectCandidate({ title: '', content: 'new box' }).rejected).toBe(true);
+  });
+
+  it('rejects a bare noun-phrase clause with no verb', async () => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+    expect(shouldRejectCandidate({ title: '', content: 'the brand new build machine' }).rejected).toBe(true);
+  });
+
+  it('keeps a complete clause that has a verb', async () => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+    expect(shouldRejectCandidate({ title: '', content: 'the staging rack hosts the nightly build agents' }).rejected).toBe(false);
+  });
+});
+
+describe('issue #49 — sentence-start enforcement in the segmenter', () => {
+  it('extractMemorableSegments never emits a capture that opens on a continuation token', async () => {
+    const { extractMemorableSegments } = (await loadChunker()) as {
+      extractMemorableSegments: (t: string) => Array<{ content: string }>;
+    };
+    // The decision regex `decided\s+(?:to\s+)?(...)` would otherwise capture
+    // "and then ship it" out of "...we decided and then ship it tomorrow".
+    const text = 'Honestly we decided and then ship it tomorrow to the whole fleet at once.';
+    const segments = extractMemorableSegments(text);
+    for (const s of segments) {
+      expect(/^(and|so|but|yet|or|because|also|then|plus|have|has)\b/i.test(s.content.trim())).toBe(false);
+    }
+  });
+
+  it('extractMemorableSegments never emits an interrogative capture', async () => {
+    const { extractMemorableSegments } = (await loadChunker()) as {
+      extractMemorableSegments: (t: string) => Array<{ content: string }>;
+    };
+    const text = 'So the bug is in the date parser, is it not really clear at all?';
+    const segments = extractMemorableSegments(text);
+    for (const s of segments) {
+      expect(/\?["')\]]?\s*$/.test(s.content.trim())).toBe(false);
+    }
+  });
+});
+
+describe('issue #49 — fragment rate < 5% over a 50-candidate sample', () => {
+  // A representative mix mirroring the live store: 25 genuine fragments
+  // (must be rejected) + 25 self-contained facts (must survive).
+  const FRAGMENTS: string[] = [
+    'and so the whole pipeline stalled until the gateway came back online',
+    'so they sit at project equals null until the next reconciliation pass',
+    'but that means the cache never warms before the first real request',
+    'yet nobody noticed the regression until the weekly report went out',
+    'or maybe we should just roll the change back before friday afternoon',
+    'because the migration ran twice against the same shard last night',
+    'also the dashboard kept rendering the stale figure for ten minutes',
+    'then the worker exited zero without flushing the pending batch first',
+    'plus the retries stacked up behind the lock and timed the request out',
+    'have you actually confirmed the backup restored cleanly this morning',
+    'has the new key already been rotated into the production secret store',
+    "he's still waiting on the review before he can merge the hotfix branch",
+    "she's convinced the flake is in the date parser not the network layer",
+    "you're going to want a bigger instance before you replay that backlog",
+    "it's stored under the wrong project key across every one of the rows",
+    "that's the third time the heartbeat job has silently skipped a night",
+    "there's no index on the created_at column so the scan goes full table",
+    "we're capping salience at zero point six for all auto extracted rows",
+    "they're filed as preference even though the line is plainly a question",
+    "i'm fairly sure the regex grabbed the tail of the previous sentence",
+    'should we just buy a brand new development computer for the team?',
+    'is the apostrophe really splitting into two separate sub tokens?',
+    'do you want me to flip the primary back to opus permanently now?',
+    'and nobody re-ran the verification after the gateway finally recovered',
+    'is the heartbeat marker even being written on a successful nightly run?',
+  ];
+
+  const FACTS: string[] = [
+    'the deploy key rotates every ninety days and must be rotated by an admin',
+    'we migrated the billing service onto Postgres for stronger write consistency',
+    'the salience cap holds at zero point six for every auto-extracted memory row',
+    'rotating session tokens replace the long-lived keys and expire after one hour',
+    'the defence pipeline applies sanitisation before trust scoring on every write',
+    'the FTS5 tokenizer splits apostrophes into separate sub-tokens during indexing',
+    'the worker flushes the pending batch before it exits to avoid losing events',
+    'the heartbeat job writes a marker row to the audit table on every successful run',
+    'the dashboard caches the figure for ten seconds to smooth the websocket updates',
+    'the migration adds a composite index on the project and created_at columns',
+    'the gateway restarts gracefully and drains in-flight requests before exiting',
+    'the backup script verifies the restore against a checksum before rotating files',
+    'the recall ranker blends vector similarity with recency using a weighted sum',
+    'the quarantine queue holds blocked content until an operator approves the row',
+    'the sync queue retries failed uploads with exponential backoff up to five times',
+    'the chunker pins category from the extractor type rather than rescanning text',
+    'the prune job excludes pinned and suppressed rows from the deletion candidate set',
+    'the installer rebuilds the native module whenever the node runtime version changes',
+    'the api server holds an open connection in WAL mode for the dashboard reads',
+    'the trust score reflects the human approval once the operator clears the item',
+    'the novelty gate deduplicates a candidate against the most recent captured rows',
+    'the embedding cache reuses a vector when the content hash already exists in store',
+    'the firewall fails closed on a non-allow verdict during the update content path',
+    'the session hook extracts at most five memories from one conversation transcript',
+    'the cloud sync excludes any row that carries the cloud-excluded flag on upload',
+  ];
+
+  it('rejects every genuine fragment and keeps the facts (< 5% accepted-fragment rate)', async () => {
+    const { shouldRejectCandidate } = (await loadChunker()) as { shouldRejectCandidate: Reject };
+
+    const candidates = [
+      ...FRAGMENTS.map((content) => ({ content, isFragment: true })),
+      ...FACTS.map((content) => ({ content, isFragment: false })),
+    ];
+    expect(candidates).toHaveLength(50);
+
+    const accepted = candidates.filter((c) => !shouldRejectCandidate({ title: '', content: c.content }).rejected);
+    const acceptedFragments = accepted.filter((c) => c.isFragment);
+
+    // No fragment should survive — fragment rate among accepted captures < 5%.
+    const fragmentRate = accepted.length === 0 ? 0 : acceptedFragments.length / accepted.length;
+    expect(fragmentRate).toBeLessThan(0.05);
+
+    // Sanity: the gate must not be nuking everything — most real facts survive.
+    const acceptedFacts = accepted.filter((c) => !c.isFragment);
+    expect(acceptedFacts.length).toBeGreaterThanOrEqual(23); // >= 23/25 facts kept
+  });
+});

--- a/src/__tests__/chunker-rejection-corpus.test.ts
+++ b/src/__tests__/chunker-rejection-corpus.test.ts
@@ -113,4 +113,26 @@ describe('Defect 3: chunker rejection corpus from fixture', () => {
     const mod = await import('../../scripts/lib/extract-memorable-segments.mjs');
     expect(mod.AUTO_EXTRACT_SALIENCE_CAP).toBe(0.6);
   });
+
+  // Issue #49: the corpus is extended with the live fragment-capture defects —
+  // conjunction-led / pronoun-tail openers and trailing interrogatives — that
+  // the original six rules did not cover.
+  it('rejects conjunction-led and interrogative fragments (issue #49)', async () => {
+    const mod = await import('../../scripts/lib/extract-memorable-segments.mjs');
+    const reject: (segment: { title: string; content: string }) => { rejected: boolean; reason: string } = mod.shouldRejectCandidate;
+
+    const fragments = [
+      'and so they sit at project equals null until reconciliation runs',
+      "you're going to need a much bigger instance for that replay job",
+      "it's filed under the wrong project key across every single row",
+      'should we just buy a brand new development computer for the team?',
+      'is the apostrophe really splitting into two separate sub tokens?',
+    ];
+
+    for (const content of fragments) {
+      const verdict = reject({ title: '', content });
+      expect(verdict.rejected).toBe(true);
+      expect(verdict.reason).toBeTruthy();
+    }
+  });
 });

--- a/src/__tests__/salience-fact-gate.test.ts
+++ b/src/__tests__/salience-fact-gate.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from '@jest/globals';
+import { isDurableFact, classifyCategory, suggestCategory } from '../memory/salience.js';
+import type { MemoryCategory } from '../memory/types.js';
+
+/**
+ * Issue #49 (task 3): a fact gate must run BEFORE keyword classification in
+ * salience.ts. A candidate that is not a declarative durable statement
+ * (interrogative, conjunction-led fragment, or a sub-clause below the
+ * meaningful-token floor) is dropped — `classifyCategory` returns null rather
+ * than forcing a (usually wrong) category. `suggestCategory` keeps its non-null
+ * contract by falling back to 'note' for non-facts, so the manual MCP path
+ * never mislabels a question as a `preference`.
+ *
+ * Acceptance: 20-sample category precision >= 18/20 correct-or-correctly-rejected.
+ */
+
+describe('isDurableFact', () => {
+  it('accepts a declarative durable statement', () => {
+    expect(isDurableFact({ title: '', content: 'We migrated the billing service onto Postgres for consistency' })).toBe(true);
+  });
+
+  it('rejects an interrogative', () => {
+    expect(isDurableFact({ title: '', content: 'should we just buy a new computer?' })).toBe(false);
+  });
+
+  it('rejects a conjunction-led fragment', () => {
+    expect(isDurableFact({ title: '', content: 'and so they sit at project null for now' })).toBe(false);
+    expect(isDurableFact({ title: '', content: "you're going to need a bigger machine" })).toBe(false);
+  });
+
+  it('rejects a sub-clause below the meaningful-token floor', () => {
+    expect(isDurableFact({ title: '', content: 'new box' })).toBe(false);
+  });
+});
+
+describe('classifyCategory — fact gate before classification', () => {
+  it('returns null for a non-fact instead of forcing a category', () => {
+    // The OLD keyword scan filed this question under `preference` (it contains
+    // "should"). The gate must drop it to null.
+    expect(classifyCategory({ title: '', content: 'should we always rebuild the cache?' })).toBeNull();
+  });
+
+  it('classifies a real preference', () => {
+    expect(classifyCategory({ title: '', content: 'the team prefers TypeScript strict mode on every package' })).toBe('preference');
+  });
+
+  it('classifies a real error resolution', () => {
+    expect(classifyCategory({ title: '', content: 'the crash was caused by a null pointer in the date parser' })).toBe('error');
+  });
+});
+
+describe('suggestCategory — non-destructive fallback', () => {
+  it('falls back to note for a non-fact (never a confidently-wrong label)', () => {
+    expect(suggestCategory({ title: '', content: 'should we always rebuild the cache?' })).toBe('note');
+  });
+
+  it('still classifies a genuine architecture fact', () => {
+    expect(suggestCategory({ title: 'System Design', content: 'Using microservices architecture with an API gateway' })).toBe('architecture');
+  });
+});
+
+describe('issue #49 — 20-sample category precision >= 18/20', () => {
+  interface Sample {
+    content: string;
+    expected: MemoryCategory | null; // null == should be correctly rejected as a non-fact
+  }
+
+  const SAMPLES: Sample[] = [
+    // --- valid declarative facts (expected category) ---
+    { content: 'the system uses a microservices architecture behind an API gateway', expected: 'architecture' },
+    { content: 'the database schema models each tenant as a separate row-level scope', expected: 'architecture' },
+    { content: 'the crash was caused by a null pointer exception in the date parser', expected: 'error' },
+    { content: 'the bug was fixed by adding a busy_timeout and enabling WAL mode', expected: 'error' },
+    { content: 'the team prefers TypeScript strict mode on every package in the repo', expected: 'preference' },
+    { content: 'we should always run the build before pushing changes to the main branch', expected: 'preference' },
+    { content: 'the recommended approach uses a retry strategy with exponential backoff', expected: 'pattern' },
+    { content: 'the default workflow runs the linter then the unit test suite in order', expected: 'pattern' },
+    { content: 'todo: rotate the deploy key every ninety days before the certificate expires', expected: 'todo' },
+    { content: 'the parser depends on the shared tokenizer module for its input stage', expected: 'relationship' },
+    // --- non-facts that must be correctly REJECTED (null) ---
+    { content: 'should we just buy a brand new development computer for the team?', expected: null },
+    { content: 'is the apostrophe really splitting into two separate sub-tokens?', expected: null },
+    { content: 'do you want me to flip the primary back to opus permanently now?', expected: null },
+    { content: 'and so they sit at project null until the next reconciliation pass', expected: null },
+    { content: "you're going to want a bigger instance before that backlog replay", expected: null },
+    { content: "it's stored under the wrong project key across every single row", expected: null },
+    { content: "that's the third night the heartbeat job has silently skipped", expected: null },
+    { content: 'because the migration ran twice against the same shard last night', expected: null },
+    { content: 'new box', expected: null },
+    { content: 'plus a couple of stray edge cases slipped through the net last week', expected: null },
+  ];
+
+  it('scores at least 18/20 correct-or-correctly-rejected', () => {
+    expect(SAMPLES).toHaveLength(20);
+    let correct = 0;
+    const misses: Array<{ content: string; expected: MemoryCategory | null; got: MemoryCategory | null }> = [];
+    for (const s of SAMPLES) {
+      const got = classifyCategory({ title: '', content: s.content });
+      if (got === s.expected) correct++;
+      else misses.push({ content: s.content, expected: s.expected, got });
+    }
+    if (correct < 18) {
+      // Surface the misclassifications for a fast diagnosis if this regresses.
+      // eslint-disable-next-line no-console
+      console.error('category misses:', JSON.stringify(misses, null, 2));
+    }
+    expect(correct).toBeGreaterThanOrEqual(18);
+  });
+});

--- a/src/cli/__tests__/recalc-auto-captures.test.ts
+++ b/src/cli/__tests__/recalc-auto-captures.test.ts
@@ -1,0 +1,146 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { initDatabase, getDatabase, closeDatabase } from '../../database/init.js';
+import { recalcAutoCaptures } from '../migrate-legacy.js';
+
+/**
+ * Issue #49 (task 4): a one-off back-catalogue maintenance command that
+ *   (a) re-flags auto-captured FRAGMENTS (mid-sentence start / trailing `?`)
+ *       into the review queue (status='suppressed') so they can be purged, and
+ *   (b) re-scores stale salience>0.6 auto rows older than 7 days under the
+ *       current (0.6-capped) rules.
+ *
+ * It MUST default to dry-run and only mutate with an explicit apply flag, and
+ * it must reuse the store/review primitives (no hand-deletes / raw mutation).
+ */
+
+interface SeedRow {
+  title: string;
+  content: string;
+  tags: string[];
+  salience: number;
+  createdAt: string;
+  /** Drives the historical flat-clamp migration; defaults to 'auto'. */
+  captureMethod?: string;
+  status?: string;
+}
+
+function seed(dbPath: string, rows: SeedRow[]): number[] {
+  initDatabase(dbPath);
+  const db = getDatabase();
+  const insert = db.prepare(
+    `INSERT INTO memories (uuid, type, category, title, content, project, tags, salience, created_at, updated_at, status, source_kind, capture_method)
+     VALUES (?, 'long_term', 'note', ?, ?, 'demo', ?, ?, ?, ?, ?, 'hook', ?)`,
+  );
+  const ids: number[] = [];
+  for (const r of rows) {
+    const info = insert.run(
+      randomUUID(),
+      r.title,
+      r.content,
+      JSON.stringify(r.tags),
+      r.salience,
+      r.createdAt,
+      r.createdAt,
+      r.status ?? 'active',
+      r.captureMethod ?? 'auto',
+    );
+    ids.push(Number(info.lastInsertRowid));
+  }
+  closeDatabase();
+  return ids;
+}
+
+function readRow(dbPath: string, id: number): { salience: number; status: string } {
+  initDatabase(dbPath);
+  const row = getDatabase().prepare('SELECT salience, status FROM memories WHERE id = ?').get(id) as {
+    salience: number;
+    status: string;
+  };
+  closeDatabase();
+  return row;
+}
+
+const OLD = '2020-01-01T00:00:00.000Z'; // > 7 days old
+const NOW = new Date().toISOString();
+
+describe('recalcAutoCaptures (issue #49 back-catalogue cleanup)', () => {
+  let tempDir: string;
+  let dbPath: string;
+  let fragmentId: number;
+  let interrogativeId: number;
+  let cleanAutoId: number;
+  let staleInflatedId: number;
+  let manualInflatedId: number;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shieldcortex-recalc-'));
+    dbPath = path.join(tempDir, 'memories.db');
+    [fragmentId, interrogativeId, cleanAutoId, staleInflatedId, manualInflatedId] = seed(dbPath, [
+      // auto-captured conjunction-led fragment → should be flagged for purge
+      { title: 'Note: and so they sit at null', content: 'and so they sit at project null until reconciliation runs', tags: ['auto-extracted'], salience: 0.6, createdAt: NOW },
+      // auto-captured interrogative → flagged
+      { title: 'Pref: should we', content: 'should we just buy a brand new development computer?', tags: ['auto-extracted'], salience: 0.6, createdAt: NOW },
+      // clean auto fact → never flagged, salience already within cap
+      { title: 'Note: deploy key', content: 'the deploy key rotates every ninety days across all environments', tags: ['auto-extracted'], salience: 0.6, createdAt: NOW },
+      // stale inflated auto-extracted row (salience 1.0, > 7d) that ESCAPED the
+      // historical flat-clamp migration (capture_method outside auto/legacy/plugin)
+      // → re-scored DOWN to its true value under the current 0.6-capped rules.
+      { title: 'Note: build speed', content: 'the build now runs in under two minutes on the CI runners', tags: ['auto-extracted'], salience: 1.0, createdAt: OLD, captureMethod: 'hook' },
+      // manual inflated row (NOT auto-extracted) → untouched
+      { title: 'Manual', content: 'the manual note that a human wrote and pinned deliberately here', tags: [], salience: 1.0, createdAt: OLD, captureMethod: 'manual' },
+    ]);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('dry-run reports planned changes but mutates nothing', async () => {
+    const report = await recalcAutoCaptures({ dbPath, apply: false });
+
+    expect(report.apply).toBe(false);
+    expect(report.flagged.map((f) => f.id).sort((a, b) => a - b)).toEqual([fragmentId, interrogativeId].sort((a, b) => a - b));
+    expect(report.rescored.map((r) => r.id)).toEqual([staleInflatedId]);
+
+    // Nothing changed on disk.
+    expect(readRow(dbPath, fragmentId).status).toBe('active');
+    expect(readRow(dbPath, interrogativeId).status).toBe('active');
+    expect(readRow(dbPath, staleInflatedId).salience).toBe(1.0);
+    expect(readRow(dbPath, manualInflatedId).salience).toBe(1.0);
+  });
+
+  it('apply flags fragments for purge and re-scores stale inflated auto rows', async () => {
+    const report = await recalcAutoCaptures({ dbPath, apply: true });
+
+    expect(report.apply).toBe(true);
+
+    // Fragments are moved into the review queue (suppressed → excluded from
+    // recall + eligible for the standard prune purge), not hand-deleted.
+    expect(readRow(dbPath, fragmentId).status).toBe('suppressed');
+    expect(readRow(dbPath, interrogativeId).status).toBe('suppressed');
+
+    // The clean auto fact is left active and untouched.
+    expect(readRow(dbPath, cleanAutoId).status).toBe('active');
+
+    // The stale inflated auto row is re-scored DOWN to the auto cap (<= 0.6).
+    const rescored = readRow(dbPath, staleInflatedId);
+    expect(rescored.salience).toBeLessThanOrEqual(0.6);
+    expect(rescored.salience).toBeLessThan(1.0);
+    expect(rescored.status).toBe('active'); // a valid fact, not a fragment
+
+    // The manual (non-auto) inflated row is NEVER touched by this command.
+    expect(readRow(dbPath, manualInflatedId).salience).toBe(1.0);
+    expect(readRow(dbPath, manualInflatedId).status).toBe('active');
+  });
+
+  it('defaults to dry-run when apply is omitted', async () => {
+    const report = await recalcAutoCaptures({ dbPath });
+    expect(report.apply).toBe(false);
+    expect(readRow(dbPath, fragmentId).status).toBe('active');
+  });
+});

--- a/src/cli/migrate-legacy.ts
+++ b/src/cli/migrate-legacy.ts
@@ -366,6 +366,13 @@ function printUsage(): void {
   console.log('      body bleed, path-label fragments, etc. Use --dry-run to');
   console.log('      preview matches; --execute writes a full DB copy to the');
   console.log('      backup dir (default ~/.shieldcortex/backups/) before delete.');
+  console.log('');
+  console.log('  recalc [--apply] [--db <path>] [--backup-dir <path>]');
+  console.log('      Back-catalogue cleanup (#49): re-flag auto-captured fragments');
+  console.log('      (mid-sentence start / trailing `?`) into the review queue as');
+  console.log('      suppressed, and re-score stale salience>0.6 auto rows (>7d) under');
+  console.log('      current rules. DRY-RUN BY DEFAULT — pass --apply to commit.');
+  console.log('      Backup auto-saved before any change; purge later with `prune`.');
 }
 
 export async function handleMemoriesCommand(args: string[]): Promise<void> {
@@ -394,6 +401,10 @@ export async function handleMemoriesCommand(args: string[]): Promise<void> {
   }
   if (sub === 'purge') {
     await runPurge(args.slice(1));
+    return;
+  }
+  if (sub === 'recalc') {
+    await runRecalc(args.slice(1));
     return;
   }
   printUsage();
@@ -481,6 +492,179 @@ export async function purgeMalformed(opts: PurgeMalformedOptions): Promise<Purge
     return report;
   } finally {
     db.close();
+  }
+}
+
+// ============================================================
+// recalc auto-captures (issue #49 back-catalogue cleanup)
+// ============================================================
+
+interface RecalcOptions {
+  /** Path to memories.db (defaults to ~/.shieldcortex/memories.db). */
+  dbPath?: string;
+  /** Default false → dry-run. Only true mutates the DB. */
+  apply?: boolean;
+  /** Where to write the pre-apply backup. Defaults next to the DB. */
+  backupDir?: string;
+}
+
+interface RecalcFlag {
+  id: number;
+  title: string;
+  reason: string;
+}
+
+interface RecalcRescore {
+  id: number;
+  title: string;
+  oldSalience: number;
+  newSalience: number;
+}
+
+export interface RecalcReport {
+  apply: boolean;
+  scanned: number;
+  flagged: RecalcFlag[];
+  rescored: RecalcRescore[];
+  backupPath?: string;
+}
+
+// Auto-extracted rows are stamped with the `auto-extracted` tag by the shared
+// chunker (extractTags). Re-scoring only touches rows whose stored salience
+// still sits ABOVE the auto cap (the historical 1.0 inflation) and that are
+// older than this many days — recent rows are left for the live pipeline.
+const RECALC_STALE_AGE_DAYS = 7;
+
+/**
+ * One-off back-catalogue maintenance for issue #49:
+ *   (a) re-flag auto-captured FRAGMENTS (mid-sentence start / trailing `?` /
+ *       any current rejection-corpus hit) into the review queue by setting
+ *       status='suppressed' via the store `updateMemory` primitive — excluded
+ *       from recall and eligible for the standard `prune` purge. No hand-delete.
+ *   (b) re-score stale auto rows whose salience exceeds the 0.6 auto cap and
+ *       that are older than 7 days, under the CURRENT (capped) rules.
+ *
+ * Defaults to dry-run; only `apply: true` mutates. Manual (non-auto) rows are
+ * never touched.
+ */
+export async function recalcAutoCaptures(opts: RecalcOptions): Promise<RecalcReport> {
+  const dbPath = opts.dbPath ?? DEFAULT_TARGET;
+  const apply = opts.apply === true;
+
+  if (!fs.existsSync(dbPath)) {
+    throw new Error(`memories DB not found at ${dbPath}`);
+  }
+
+  // @ts-expect-error -- importing a .mjs hook util (no type decls)
+  const mod = await import('../../scripts/lib/extract-memorable-segments.mjs');
+  const shouldRejectCandidate = mod.shouldRejectCandidate as (
+    seg: { title: string; content: string },
+  ) => { rejected: boolean; reason: string };
+  const calcSalience = mod.calculateSalience as (text: string, o?: { autoExtractMode?: boolean }) => number;
+  const completenessAdjustment = mod.completenessAdjustment as (content: string) => number;
+  const AUTO_CAP = mod.AUTO_EXTRACT_SALIENCE_CAP as number;
+
+  const { initDatabase, getDatabase, closeDatabase } = await import('../database/init.js');
+  const { updateMemory } = await import('../memory/store.js');
+
+  initDatabase(dbPath);
+
+  const report: RecalcReport = { apply, scanned: 0, flagged: [], rescored: [] };
+
+  try {
+    const db = getDatabase();
+    const rows = db
+      .prepare(
+        `SELECT id, title, content, salience,
+                (julianday('now') - julianday(created_at)) AS age_days
+           FROM memories
+          WHERE tags LIKE '%auto-extracted%'
+            AND COALESCE(status, 'active') = 'active'`,
+      )
+      .all() as Array<{ id: number; title: string; content: string; salience: number; age_days: number }>;
+
+    report.scanned = rows.length;
+
+    for (const row of rows) {
+      const verdict = shouldRejectCandidate({ title: row.title ?? '', content: row.content ?? '' });
+      if (verdict.rejected) {
+        report.flagged.push({ id: row.id, title: row.title ?? '', reason: verdict.reason });
+        continue;
+      }
+      // Not a fragment — consider re-scoring an inflated stale row.
+      if (row.salience > AUTO_CAP && row.age_days >= RECALC_STALE_AGE_DAYS) {
+        const base = calcSalience(`${row.title ?? ''} ${row.content ?? ''}`, { autoExtractMode: true });
+        const adjusted = Math.max(0, Math.min(AUTO_CAP, base) + completenessAdjustment(row.content ?? ''));
+        const newSalience = Math.round(adjusted * 1000) / 1000;
+        report.rescored.push({ id: row.id, title: row.title ?? '', oldSalience: row.salience, newSalience });
+      }
+    }
+
+    if (!apply || (report.flagged.length === 0 && report.rescored.length === 0)) {
+      return report;
+    }
+
+    // Snapshot the DB before any mutation (mirrors backupMemoriesDb; written
+    // next to the DB so a custom --db stays self-contained).
+    const backupDir = opts.backupDir ?? path.join(path.dirname(dbPath), 'backups');
+    fs.mkdirSync(backupDir, { recursive: true });
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const backupPath = path.join(backupDir, `memories-recalc-${stamp}.db`);
+    await db.backup(backupPath);
+    report.backupPath = backupPath;
+
+    // Reuse the store review primitive — never a raw DELETE / UPDATE.
+    for (const f of report.flagged) {
+      updateMemory(f.id, { status: 'suppressed', reviewedBy: 'maintenance:recalc-issue-49' });
+    }
+    for (const r of report.rescored) {
+      updateMemory(r.id, { salience: r.newSalience });
+    }
+
+    return report;
+  } finally {
+    closeDatabase();
+  }
+}
+
+async function runRecalc(args: string[]): Promise<void> {
+  const apply = args.includes('--apply');
+  const backupDir = flagValue(args, '--backup-dir');
+  const dbPath = flagValue(args, '--db');
+
+  const report = await recalcAutoCaptures({ apply, backupDir, dbPath });
+
+  const banner = report.apply ? '' : '[DRY RUN] ';
+  console.log(`${banner}Recalc auto-captures (issue #49) — scanned ${report.scanned} auto-extracted rows.`);
+  console.log(`  Fragments to flag for purge: ${report.flagged.length}`);
+  console.log(`  Stale inflated rows to re-score: ${report.rescored.length}`);
+
+  if (report.flagged.length > 0) {
+    console.log('');
+    console.log('Flag (→ suppressed, review/purge queue):');
+    for (const f of report.flagged.slice(0, 50)) {
+      console.log(`  #${String(f.id).padStart(5)}  ${f.reason.padEnd(20)}  ${f.title.slice(0, 70)}`);
+    }
+    if (report.flagged.length > 50) console.log(`  … and ${report.flagged.length - 50} more`);
+  }
+
+  if (report.rescored.length > 0) {
+    console.log('');
+    console.log('Re-score (inflated → current 0.6-capped rules):');
+    for (const r of report.rescored.slice(0, 50)) {
+      console.log(`  #${String(r.id).padStart(5)}  ${r.oldSalience.toFixed(2)} → ${r.newSalience.toFixed(2)}  ${r.title.slice(0, 60)}`);
+    }
+    if (report.rescored.length > 50) console.log(`  … and ${report.rescored.length - 50} more`);
+  }
+
+  if (!report.apply && (report.flagged.length > 0 || report.rescored.length > 0)) {
+    console.log('');
+    console.log('Re-run with --apply to commit (a DB backup is written first).');
+    console.log('Then purge the suppressed fragments with: shieldcortex memories prune --execute');
+  } else if (report.apply) {
+    console.log('');
+    console.log(`Applied. Flagged ${report.flagged.length}, re-scored ${report.rescored.length}.`);
+    if (report.backupPath) console.log(`Backup: ${report.backupPath}`);
   }
 }
 

--- a/src/memory/salience.ts
+++ b/src/memory/salience.ts
@@ -143,10 +143,50 @@ function detectCodeReferences(content: string): boolean {
   return CODE_REFERENCE_PATTERNS.some(pattern => pattern.test(content));
 }
 
+// Issue #49: tokens that mark a candidate as a mid-clause CONTINUATION rather
+// than the start of a self-contained statement (leading conjunctions, dangling
+// auxiliaries, pronoun-contraction tails). Mirrors the chunker's list in
+// scripts/lib/extract-memorable-segments.mjs.
+const CONTINUATION_START_TOKENS = new Set([
+  'and', 'so', 'but', 'yet', 'or', 'because', 'also', 'then', 'plus',
+  'have', 'has', "he's", "she's", "you're", "it's", "that's", "there's",
+  "we're", "they're", "i'm",
+]);
+
+function leadingToken(text: string): string {
+  const cleaned = text.trim().toLowerCase().replace(/[‘’ʼ]/g, "'");
+  const m = cleaned.match(/^([a-z]+(?:'[a-z]+)?)/);
+  return m ? m[1] : '';
+}
+
 /**
- * Suggest a category based on content analysis
+ * Issue #49 — fact gate. A candidate is a DURABLE DECLARATIVE statement only if
+ * it is not interrogative, does not open on a sentence-continuation token, and
+ * carries enough meaningful tokens to be a complete thought. This runs BEFORE
+ * keyword classification so a question or a conjunction-led fragment is never
+ * forced into a (usually wrong) category.
  */
-export function suggestCategory(input: MemoryInput): MemoryCategory {
+export function isDurableFact(input: MemoryInput): boolean {
+  const content = (input.content ?? input.title ?? '').trim();
+  if (!content) return false;
+  // (b) interrogative
+  if (/\?["')\]]?\s*$/.test(content)) return false;
+  // (a) conjunction / continuation-led opener
+  if (CONTINUATION_START_TOKENS.has(leadingToken(content))) return false;
+  // (d) minimum meaningful-token count
+  const meaningful = content.split(/\s+/).filter((t) => /[a-z0-9]{2,}/i.test(t));
+  if (meaningful.length < 3) return false;
+  return true;
+}
+
+/**
+ * Classify a candidate, or return null when it is not a durable fact. This is
+ * the gated entry point: callers that must drop non-facts use this and treat
+ * null as "reject". `suggestCategory` wraps it with a non-null fallback.
+ */
+export function classifyCategory(input: MemoryInput): MemoryCategory | null {
+  if (!isDurableFact(input)) return null;
+
   const text = `${input.title} ${input.content}`.toLowerCase();
 
   if (detectKeywords(text, ARCHITECTURE_KEYWORDS)) return 'architecture';
@@ -165,6 +205,18 @@ export function suggestCategory(input: MemoryInput): MemoryCategory {
 
   // Default to note
   return 'note';
+}
+
+/**
+ * Suggest a category based on content analysis.
+ *
+ * Non-destructive wrapper over the gated `classifyCategory`: a non-fact falls
+ * back to 'note' rather than a confidently-wrong specific label (issue #49 — a
+ * question must not be filed as a `preference`). The manual MCP remember path
+ * still keeps the memory; it just stops mislabelling it.
+ */
+export function suggestCategory(input: MemoryInput): MemoryCategory {
+  return classifyCategory(input) ?? 'note';
 }
 
 /**


### PR DESCRIPTION
Closes #49

## Problem
Auto-capture was storing **sentence fragments**, **mislabelling categories**, and (historically) over-pinning salience. Evidence from a live 105-memory store: 72% of recent auto-captures were mid-sentence tails (`"he's next at a desktop."`), trailing questions, or conjunction-leads, and several were filed under confidently-wrong categories (a question stored as a `preference`).

## Fix
- **Chunker hardening** (`scripts/lib/extract-memorable-segments.mjs`): reject leading-conjunction / continuation starts (`and/so/but/yet/or/because/also/then/plus`), pronoun-contraction tails (`he's/she's/you're/it's/that's/there's/we're/they're/i'm`), bare auxiliaries (`have/has`), and trailing interrogatives. Enforce real sentence-start boundaries + a meaningful-token floor. Negation-scope aware.
- **Fact-gate before classification** (`src/memory/salience.ts`): `isDurableFact()` runs *before* `classifyCategory()`; a non-fact returns `null` (or falls back to `note`) instead of being forced into a confidently-wrong category. Default capture salience cap stays calibrated at **0.6**, not 1.0.
- **Back-catalogue cleanup** (`scripts/recalc-auto-captures.mjs`): re-scores / purges polluted legacy rows. **Dry-run by default** — changes nothing unless `--apply` is passed, and writes a DB backup first.
- **Legacy migrate command** (`src/cli/migrate-legacy.ts`).

## Verification (local, pre-CI)
- `tsc -p tsconfig.build.json` → **exit 0**
- `tsc -p tsconfig.openclaw-plugin.json` → **exit 0**
- Targeted suites → **51 passed / 51 total** across 4 files:
  - `auto-capture-fragment-hardening.test.ts`
  - `chunker-rejection-corpus.test.ts`
  - `salience-fact-gate.test.ts`
  - `recalc-auto-captures.test.ts`

Full regression suite runs here via CI (`npm test`).

> Branch commit is labelled `WIP` — that label is stale; the work above is complete and verified. Squash-merging will clean the history.
