### PR TITLE
P1/WS1: Action Guard — dangerous tier enforces by default

### DIFF
--- a/docs/CLAIMS-PROOF.md
+++ b/docs/CLAIMS-PROOF.md
@@ -27,12 +27,15 @@ npm test -- claims-proof
 | 8 | RESTRICTED isolation + own-only for low-trust callers, applied before recall reaches the agent | SKILL "trust/ACL-filters recalled memory (RESTRICTED isolation, own-only…) before it reaches the agent" | B·claim 8 — source trust scoring, ACL `checkAccess`, the MCP `get_memory` tool, related-recall, and the recall path all exclude RESTRICTED / low-trust | ✅ |
 | 9 | Dashboard API + WebSocket never emit RESTRICTED content | SKILL "the bundled dashboard never renders RESTRICTED content … redacts before it reaches the browser" | B·claim 9 — REST and WebSocket payloads carry the placeholder content, masked titles, and metadata only | ✅ |
 | 10 | Iron Dome Action Guard hard-blocks catastrophic tool calls out of the box | README Iron Dome; SKILL "Iron Dome kill-switch can block operations" | C·claim 10 — `rm -rf /`, fork bomb, and delete-root all return `decision=block, severity=catastrophic` | ✅ |
+| 10a | `dangerous` tier is gated by default (require_approval, never silent-allow) with benign precision | P1/WS1 — internal posture proof; OpenClaw interceptor enforces-by-default on this verdict (core-wide default flip still pending) | C·claim 10 (gating) — broad `rm`, `sudo`, force-push all return `require_approval/dangerous` with a firing signal; (precision) — benign shell/read stay `allow` | ✅ |
 | 11 | Environment Firewall detects hidden web injection; enforce mode redacts before the model sees it (advisory by default) | README Environment Firewall | D·claim 11 — advisory passes content through (flagged, not blocked); enforce withholds/redacts; a clean page is not flagged in either mode | ✅ |
 | 12 | Provenance ledger records read/write/delete with content hashes | SKILL "a provenance ledger recording read/write/delete operations with content hashes" | E·claim 12 — ledger rows written for each operation, each carrying a content hash | ✅ |
 
 ## Verdict
 
 **12 / 12 public claims proven by a firing adversarial test. 0 gaps, 0 unwired claims.**
+
+_P1/WS1 adds internal posture proof **10a** (dangerous-tier gated by default + benign precision). Not counted as a new public claim: it hardens the posture behind claim 10 rather than asserting a new marketing line._
 
 The pillars aren't just documented — they hold under attack, and now there's one runnable
 file that proves it.

--- a/plugins/openclaw/__tests__/action-guard.test.ts
+++ b/plugins/openclaw/__tests__/action-guard.test.ts
@@ -42,9 +42,30 @@ describe('interceptor — Action Guard wiring', () => {
     await expect(i.handleToolCall({ toolName: 'Bash', arguments: { command: 'ls -la && npm test' } })).resolves.toBeUndefined();
   });
 
-  it('warn mode (default) surfaces dangerous ops but does NOT block', async () => {
+  it('enforce-by-default: an unattended dangerous op is fail-closed (denied)', async () => {
+    // Default config now enforces (P1/WS1). With no approver present — an
+    // unattended agent (cron/heartbeat) — a recognised-dangerous op must be
+    // denied, not warned-and-allowed.
     const i = makeInterceptor();
-    await expect(i.handleToolCall({ toolName: 'Bash', arguments: { command: 'sudo systemctl stop ssh' } })).resolves.toBeUndefined();
+    await expect(
+      i.handleToolCall({ toolName: 'Bash', arguments: { command: 'sudo systemctl stop ssh' } }),
+    ).rejects.toThrow(/blocked|deny/i);
+  });
+
+  it('autoApprove: an unattended dangerous op on the per-agent allowlist passes', async () => {
+    // The escape hatch that keeps enforce-by-default from breaking unattended
+    // agents doing legitimate dangerous work (matches family/action/signal).
+    const i = makeInterceptor({ actionGuard: { enabled: true, enforce: true, autoApprove: ['file-delete'] } });
+    await expect(
+      i.handleToolCall({ toolName: 'Bash', arguments: { command: 'rm /home/u/notes.txt' } }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('advisory opt-down: enforce:false restores warn-and-allow for dangerous ops', async () => {
+    const i = makeInterceptor({ actionGuard: { enabled: true, enforce: false } });
+    await expect(
+      i.handleToolCall({ toolName: 'Bash', arguments: { command: 'sudo systemctl stop ssh' } }),
+    ).resolves.toBeUndefined();
   });
 
   it('enforce mode: a DENIED dangerous op throws', async () => {

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -880,7 +880,7 @@ export default {
             enabled: rawInterceptorConfig.enabled ?? DEFAULT_INTERCEPTOR_CONFIG.enabled,
             severityActions: { ...DEFAULT_INTERCEPTOR_CONFIG.severityActions, ...rawInterceptorConfig.severityActions },
             failurePolicy: { ...DEFAULT_INTERCEPTOR_CONFIG.failurePolicy, ...rawInterceptorConfig.failurePolicy },
-            actionGuard: { ...(DEFAULT_INTERCEPTOR_CONFIG.actionGuard ?? { enabled: true, enforce: false }), ...(rawInterceptorConfig.actionGuard ?? {}) },
+            actionGuard: { ...(DEFAULT_INTERCEPTOR_CONFIG.actionGuard ?? { enabled: true, enforce: true, autoApprove: [] }), ...(rawInterceptorConfig.actionGuard ?? {}) },
           } : {}),
           logger: { info: api.logger?.info ?? console.log, warn: (api.logger as any)?.warn ?? console.warn },
         };

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -10,14 +10,22 @@ export type FailureAction = 'allow' | 'deny';
 /**
  * Action Guard config — gates what the agent DOES (shell/file/network/git),
  * not just what it remembers. Catastrophic operations (rm -rf /, fork bombs,
- * disk wipes, secret exfil) are always blocked when `enabled`; recognised
- * dangerous ops require approval when `enforce` is set, otherwise they are
- * surfaced (warn + audit) but allowed through — so the guard never nags on
- * routine work by default.
+ * disk wipes, secret exfil) are always blocked when `enabled`.
+ *
+ * Recognised-dangerous ops (`rm <path>`, `sudo`, force-push, external egress,
+ * touching secret paths) are ENFORCED by default (P1/WS1): with an approver in
+ * the loop they prompt; unattended (no approver) they fail closed on the failure
+ * policy. `enforce:false` opts back down to warn-and-allow (advisory).
+ *
+ * `autoApprove` is the per-agent escape hatch: a dangerous op whose family,
+ * action, or signal matches an entry passes without gating — so enforce-by-default
+ * does not break unattended agents doing legitimate dangerous work. It NEVER
+ * relaxes catastrophic ops (those hard-block regardless).
  */
 export interface ActionGuardConfig {
   enabled: boolean;
   enforce: boolean;
+  autoApprove?: string[];
 }
 
 /** Structural shape of a Tool Action Guard verdict (kept local to avoid a
@@ -91,10 +99,14 @@ const DEFAULT_CONFIG: InterceptorConfig = {
     critical: 'deny',
   },
   // Action Guard on by default: catastrophic ops are blocked out of the box;
-  // dangerous ops are surfaced (warn+audit) but allowed unless `enforce` is set.
+  // recognised-dangerous ops are ENFORCED by default (P1/WS1) — attended → prompt,
+  // unattended → fail closed on failurePolicy. Populate `autoApprove` per agent to
+  // pre-approve the dangerous ops it legitimately needs unattended; set
+  // `enforce:false` to opt back down to warn-and-allow.
   actionGuard: {
     enabled: true,
-    enforce: false,
+    enforce: true,
+    autoApprove: [],
   },
 };
 
@@ -421,7 +433,26 @@ export function createInterceptor(
       throw new Error(`ShieldCortex: tool call blocked — ${v.reason}`);
     }
 
-    // require_approval — warn-only by default (never nags), prompt when enforcing.
+    // Per-agent autoApprove allowlist: a recognised-dangerous op whose family,
+    // action, or signal is pre-approved passes without gating. This is the escape
+    // hatch that lets enforce-by-default coexist with unattended agents doing
+    // legitimate dangerous work. It NEVER applies to catastrophic ops — those
+    // hard-block above, before this branch is reached.
+    const autoApprove = actionGuardCfg.autoApprove ?? [];
+    if (autoApprove.length > 0) {
+      const hay = [v.family, v.action, ...v.signals].map(s => String(s).toLowerCase());
+      const matched = autoApprove.some(a => {
+        const n = a.toLowerCase();
+        return hay.some(h => h === n || h.includes(n));
+      });
+      if (matched) {
+        emitAudit({ ...base, action: 'require_approval', outcome: 'approved' });
+        return;
+      }
+    }
+
+    // require_approval — ENFORCED by default (P1/WS1). `enforce:false` opts back
+    // down to warn-and-allow (advisory) for operators who want the old behaviour.
     if (!actionGuardCfg.enforce) {
       log.warn(`[shieldcortex] ⚠️ Action Guard: ${context.toolName} — ${v.reason}`);
       emitAudit({ ...base, action: 'warn', outcome: 'warned' });
@@ -429,9 +460,14 @@ export function createInterceptor(
     }
 
     if (typeof context.requireApproval !== 'function') {
+      // Unattended (no approver, e.g. cron/heartbeat): fail closed on the failure
+      // policy. High-severity dangerous defaults to deny — surfaced loudly to the
+      // gateway log so an operator sees it, because a silent no-op is exactly the
+      // failure mode we are eliminating.
       const failAction = config.failurePolicy[severity];
       emitAudit({ ...base, action: 'require_approval', outcome: failAction === 'deny' ? 'failure_denied' : 'failure_allowed' });
       if (failAction === 'deny') {
+        log.warn(`[shieldcortex] action-guard DENIED (unattended, no approver) ${context.toolName}: ${v.reason} [${v.signals.join(", ")}]`);
         throw new Error(`ShieldCortex: tool call blocked — ${v.reason} (no approver, failure policy: deny)`);
       }
       return;

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -384,7 +384,7 @@ export function createInterceptor(
   const rateLimiter = new RateLimiter(options?.maxPromptsPerMinute ?? 5);
   const log = config.logger ?? { info: console.log, warn: console.warn };
   const onAuditEntry = options?.onAuditEntry;
-  const actionGuardCfg: ActionGuardConfig = config.actionGuard ?? { enabled: true, enforce: false };
+  const actionGuardCfg: ActionGuardConfig = config.actionGuard ?? { enabled: true, enforce: true, autoApprove: [] };
   const evaluateToolCall = options?.evaluateToolCall;
 
   function emitAudit(entry: InterceptAuditEntry): void {

--- a/src/__tests__/claims-proof.test.ts
+++ b/src/__tests__/claims-proof.test.ts
@@ -427,6 +427,33 @@ describe('C. Iron Dome (what it does)', () => {
     // Structured (non-shell) delete of root is blocked too.
     expect(evaluateToolCall('delete_file', { path: '/' }).decision).toBe('block');
   });
+
+  it('claim 10 (gating): a representative dangerous op is gated — require_approval, never silent-allow', () => {
+    // P1/WS1 — the `dangerous` tier must be gated by default, not advisory
+    // pass-through. Prove the classification the enforce-by-default posture
+    // rests on: broad delete, privilege escalation, and history-rewriting push
+    // all resolve to `require_approval` (dangerous) with a firing signal — so a
+    // runtime that honours the verdict (OpenClaw interceptor: enforce-by-default)
+    // gates them and can never silently allow them.
+    const dangerous = [
+      'rm /home/u/notes.txt',
+      'sudo systemctl stop ssh',
+      'git push --force origin main',
+    ];
+    for (const command of dangerous) {
+      const v = evaluateToolCall('Bash', { command });
+      expect(v.decision).toBe('require_approval');
+      expect(v.severity).toBe('dangerous');
+      expect(v.signals.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('claim 10 (precision): a benign op is untouched — no over-blocking on the newly-enforcing tier', () => {
+    // The false-positive guard for enforce-by-default: ordinary work must stay
+    // `allow`, or promoting `dangerous` to enforce would nag on routine actions.
+    expect(evaluateToolCall('Bash', { command: 'ls -la && npm test' }).decision).toBe('allow');
+    expect(evaluateToolCall('Read', { file_path: '/etc/hosts' }).decision).toBe('allow');
+  });
 });
 
 // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What

Promotes the Action Guard's `dangerous` tier from warn-and-allow to **enforce-by-default**. Closes the gap where broad `rm`, `sudo`, force-push etc. sailed through with only an advisory log line.

## Behaviour

| Context | Before | After |
|---|---|---|
| Attended (approver in loop) | warn + allow | **prompt for approval** |
| Unattended (cron/heartbeat) | warn + allow | **fail closed** |
| `enforce: false` set | advisory | advisory (explicit opt-down) |
| Catastrophic tier | always blocked | always blocked — `autoApprove` can never relax it |

New per-agent `autoApprove` allowlist is the escape hatch for legitimate unattended dangerous ops (matched by family, never wildcard-catastrophic).

## Evidence

- action-guard suite 12/12
- claims-proof 16/16 (2 new WS1 entries fire)
- full OpenClaw plugin suite 40/40
- second commit aligns the two stale `enforce: false` dead-code fallbacks with the new contract

## ⚠️ Release gate — do not publish on merge

This is a fleet-wide behaviour change. Any unattended agent that legitimately runs dangerous ops fail-closes on upgrade until its `autoApprove` list is populated. Release is held until the fleet autoApprove pass is done (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)