### PR TITLE
fix(setup): tests must never restart the live OpenClaw gateway

### DIFF
--- a/src/__tests__/openclaw-install-gateway-restart.test.ts
+++ b/src/__tests__/openclaw-install-gateway-restart.test.ts
@@ -71,3 +71,34 @@ describe('openclaw install — auto gateway restart (v4.12.6)', () => {
     expect(openclawSource).toMatch(/launchctl kickstart -k gui\/\$UID\/ai\.openclaw\.gateway/);
   });
 });
+
+describe('restartOpenClawGateway — never fires from a test runner', () => {
+  // Unmocked install-path tests were restarting the LIVE gateway on the host
+  // during `npm test` (Jarvis 2026-07-02: 8 live bounces in one morning, each
+  // killing every in-flight agent turn). The implementation must refuse to
+  // exec when running under Jest, regardless of what any test passes in.
+  it('returns skipped under JEST_WORKER_ID without exec-ing anything', async () => {
+    const { restartOpenClawGateway } = await import('../setup/deep-clean.js');
+    expect(process.env.JEST_WORKER_ID).toBeDefined();
+    const result = await restartOpenClawGateway();
+    expect(result.attempted).toBe(false);
+    expect(result.restarted).toBe(false);
+    expect(result.method).toBe('skipped');
+  });
+
+  it('source guards on JEST_WORKER_ID, NODE_ENV=test, and the manual escape hatch', () => {
+    const thisFile = fileURLToPath(import.meta.url);
+    const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
+    const deepCleanSource = fs.readFileSync(
+      path.join(repoRoot, 'src', 'setup', 'deep-clean.ts'),
+      'utf-8',
+    );
+    const guard = deepCleanSource.match(
+      /restartOpenClawGateway[\s\S]{0,800}?JEST_WORKER_ID[\s\S]{0,300}?SHIELDCORTEX_SKIP_GATEWAY_RESTART/,
+    );
+    expect(guard).not.toBeNull();
+    // The guard must come before the first execSync in the function body.
+    const fnBody = deepCleanSource.slice(deepCleanSource.indexOf('export async function restartOpenClawGateway'));
+    expect(fnBody.indexOf('JEST_WORKER_ID')).toBeLessThan(fnBody.indexOf('execSync'));
+  });
+});

--- a/src/setup/deep-clean.ts
+++ b/src/setup/deep-clean.ts
@@ -484,6 +484,22 @@ export async function restartOpenClawGateway(): Promise<{
   method: string;
   detail?: string;
 }> {
+  // Restarting the gateway kills every in-flight agent turn on the host, so
+  // this must never fire from a test runner — unmocked install-path tests were
+  // bouncing live gateways during `npm test`.
+  if (
+    process.env.JEST_WORKER_ID !== undefined ||
+    process.env.NODE_ENV === 'test' ||
+    process.env.SHIELDCORTEX_SKIP_GATEWAY_RESTART === '1'
+  ) {
+    return {
+      attempted: false,
+      restarted: false,
+      method: 'skipped',
+      detail: 'gateway restart suppressed (test runner or SHIELDCORTEX_SKIP_GATEWAY_RESTART=1)',
+    };
+  }
+
   const platform = process.platform;
 
   if (platform === 'linux') {


### PR DESCRIPTION
## Problem
`openclaw-setup.test.ts` calls the real `installOpenClawHook()` with nothing mocked. That function ends by calling `restartOpenClawGateway()`, which `execSync`s `systemctl --user restart openclaw-gateway` **on the host**. Every `npm test` run bounced the live gateway — 8 live restarts on Jarvis's box on the morning of 2026-07-02 (restart-log ancestry: jest-worker → sh -c systemctl), each one killing every in-flight agent turn.

## Fix
Hard guard at the top of `restartOpenClawGateway()`: refuse when `JEST_WORKER_ID` is set, `NODE_ENV=test`, or `SHIELDCORTEX_SKIP_GATEWAY_RESTART=1` (manual escape hatch). Defence-in-depth at the implementation, so any current or future unmocked test is covered — not just this file.

## Verification
- New regression tests: runtime check that the guard returns `skipped` under Jest, plus a source-level check pinning the guard ahead of the first `execSync`.
- `node scripts/run-jest.mjs openclaw-install-gateway-restart openclaw-setup deep-clean` → 43/43 pass, and `gateway-restarts.log` shows zero new restarts during the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)