### PR TITLE
feat(host-safety): never break the gateway or the agent — no implicit restarts headless + zeroth-law invariant

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -24,6 +24,31 @@ beside the memory — it *is* what makes the memory usable in production.
 
 ---
 
+## 1a. The zeroth law — never break the host
+
+Standing directive (Michael, 2026-07-02): **ShieldCortex must never break the OpenClaw
+gateway or the agent it protects.** A protection layer that can take down its own host is
+worse than none. Concretely:
+
+- **No implicit gateway restarts.** `restartOpenClawGateway()` is the single choke point:
+  it refuses under any test runner (`JEST_WORKER_ID` / `NODE_ENV=test`), and in any
+  non-interactive session unless `SHIELDCORTEX_ALLOW_GATEWAY_RESTART=1` is set —
+  deliberate automation only (e.g. a fleet-upgrade runbook that has checked for in-flight
+  work). A restart kills every in-flight agent turn on the host, frequently including the
+  agent that ran the install. A human at a TTY keeps the normal setup behaviour.
+- **Tests never touch live services** (PR #64) — guard plus regression tests pin it.
+- **The realtime plugin fails open.** A plugin crash or scan timeout degrades to
+  advisory/no-op; it must never stall or kill the gateway.
+- **Hooks stay bounded.** Claude Code hooks run with canonical timeouts (doctor verifies);
+  a hung hook must never wedge an agent turn.
+- **Enforcement must not strand unattended agents.** Fail-closed changes (P1/WS1) ship
+  only after the fleet autoApprove audit, so no legitimate unattended job starts failing
+  on upgrade.
+
+Violations of this section are release-blockers regardless of what else a change delivers.
+
+---
+
 ## 2. The one-organism model
 
 Two systems sharing one data path. The brain thinks; the immune system guards every surface

--- a/src/__tests__/openclaw-install-gateway-restart.test.ts
+++ b/src/__tests__/openclaw-install-gateway-restart.test.ts
@@ -102,3 +102,79 @@ describe('restartOpenClawGateway — never fires from a test runner', () => {
     expect(fnBody.indexOf('JEST_WORKER_ID')).toBeLessThan(fnBody.indexOf('execSync'));
   });
 });
+
+describe('restartOpenClawGateway — host-safety invariant: no implicit restart headless', () => {
+  // Directive (Michael, 2026-07-02): ShieldCortex must never break the
+  // gateway or the agent. The remaining auto-vector after PR #64 was
+  // `shieldcortex setup`/`update` run headless (agent, cron, SSH exec):
+  // installOpenClawHook ends with a best-effort gateway restart that would
+  // kill every in-flight turn on the host — including the agent running
+  // the install. Non-TTY sessions now require the explicit
+  // SHIELDCORTEX_ALLOW_GATEWAY_RESTART=1 consent to restart.
+  function withEnv(patch: Record<string, string | undefined>, fn: () => Promise<void>): Promise<void> {
+    const saved = new Map<string, string | undefined>();
+    for (const key of Object.keys(patch)) saved.set(key, process.env[key]);
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    return fn().finally(() => {
+      for (const [key, value] of saved) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    });
+  }
+
+  it('non-TTY without consent env returns the non-interactive skip (never reaches exec)', async () => {
+    const originalIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true });
+    try {
+      await withEnv(
+        { JEST_WORKER_ID: undefined, NODE_ENV: 'production', SHIELDCORTEX_SKIP_GATEWAY_RESTART: undefined, SHIELDCORTEX_ALLOW_GATEWAY_RESTART: undefined },
+        async () => {
+          const { restartOpenClawGateway } = await import('../setup/deep-clean.js');
+          const result = await restartOpenClawGateway();
+          expect(result.attempted).toBe(false);
+          expect(result.restarted).toBe(false);
+          expect(result.method).toBe('skipped');
+          expect(result.detail).toMatch(/non-interactive/);
+        },
+      );
+    } finally {
+      if (originalIsTTY) Object.defineProperty(process.stdin, 'isTTY', originalIsTTY);
+      else Reflect.deleteProperty(process.stdin, 'isTTY');
+    }
+  });
+
+  it('consent env cannot bypass the test-runner guard (ordering)', async () => {
+    await withEnv({ SHIELDCORTEX_ALLOW_GATEWAY_RESTART: '1' }, async () => {
+      const { restartOpenClawGateway } = await import('../setup/deep-clean.js');
+      expect(process.env.JEST_WORKER_ID).toBeDefined();
+      const result = await restartOpenClawGateway();
+      expect(result.attempted).toBe(false);
+      expect(result.detail).toMatch(/test runner/);
+    });
+  });
+
+  it('source shape: consent gate sits after the test-runner guard and before execSync', () => {
+    const thisFile = fileURLToPath(import.meta.url);
+    const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
+    const deepCleanSource = fs.readFileSync(
+      path.join(repoRoot, 'src', 'setup', 'deep-clean.ts'),
+      'utf-8',
+    );
+    const fnBody = deepCleanSource.slice(
+      deepCleanSource.indexOf('export async function restartOpenClawGateway'),
+    );
+    const jestGuard = fnBody.indexOf('JEST_WORKER_ID');
+    const consentGate = fnBody.indexOf('SHIELDCORTEX_ALLOW_GATEWAY_RESTART');
+    const ttyCheck = fnBody.indexOf('process.stdin.isTTY');
+    const firstExec = fnBody.indexOf('execSync');
+    expect(jestGuard).toBeGreaterThan(-1);
+    expect(consentGate).toBeGreaterThan(jestGuard);
+    expect(ttyCheck).toBeGreaterThan(jestGuard);
+    expect(firstExec).toBeGreaterThan(consentGate);
+    expect(firstExec).toBeGreaterThan(ttyCheck);
+  });
+});

--- a/src/setup/deep-clean.ts
+++ b/src/setup/deep-clean.ts
@@ -500,6 +500,24 @@ export async function restartOpenClawGateway(): Promise<{
     };
   }
 
+  // Host-safety invariant (2026-07-02): ShieldCortex must never break the
+  // gateway or the agent it protects. Headless callers — agents, cron, CI,
+  // SSH exec — get no implicit restart, because they are frequently running
+  // *inside* the very gateway this would kill, along with every other
+  // in-flight turn on the host. Consent is a human at a TTY, or an explicit
+  // SHIELDCORTEX_ALLOW_GATEWAY_RESTART=1 from deliberate automation
+  // (e.g. a fleet-upgrade runbook that has checked for in-flight work).
+  if (process.env.SHIELDCORTEX_ALLOW_GATEWAY_RESTART !== '1' && !process.stdin.isTTY) {
+    return {
+      attempted: false,
+      restarted: false,
+      method: 'skipped',
+      detail:
+        'non-interactive session — gateway restart skipped (it kills every in-flight agent turn on this host). ' +
+        'Restart manually when ready, or set SHIELDCORTEX_ALLOW_GATEWAY_RESTART=1 for deliberate automation.',
+    };
+  }
+
   const platform = process.platform;
 
   if (platform === 'linux') {


### PR DESCRIPTION
## Directive

> "I don't want ShieldCortex breaking the gateway or the agent." — Michael, 2026-07-02

This PR makes that structural rather than situational, after this morning's restart storm (test suite bouncing the live gateway 7+ times, each bounce killing the in-flight agent turns investigating it — see PR #64).

## What was still open after #64

#64 stopped **tests** from restarting the live gateway. One auto-vector remained: `shieldcortex setup` / `update` run **headless**. `installOpenClawHook()` ends with a best-effort gateway restart so new hooks/plugins take effect — correct UX for a human at a terminal, but when an agent, cron job, or SSH-exec runs the install, that restart kills every in-flight agent turn on the host, frequently including the agent doing the installing.

## The fix

`restartOpenClawGateway()` is the single choke point for all gateway restarts (install path and `uninstall --deep` both route through it). It now refuses in any non-interactive session unless `SHIELDCORTEX_ALLOW_GATEWAY_RESTART=1` is explicitly set:

- **Human at a TTY** → unchanged: install restarts the gateway and says so.
- **Headless without consent** → skip + clear message: restart manually when ready, or set the env var for deliberate automation.
- **Headless with `SHIELDCORTEX_ALLOW_GATEWAY_RESTART=1`** → restart proceeds (fleet-upgrade runbooks that have checked for in-flight work).
- **Any test runner** → still hard-refused (#64 guard, checked first; the consent env cannot bypass it).

Callers already handle the skip result and print platform-specific manual restart instructions, so no call-site changes were needed.

## The invariant, codified

`SCOPE.md` gains **"1a. The zeroth law — never break the host"**: no implicit gateway restarts, tests never touch live services, the realtime plugin fails open, hooks stay bounded by timeouts, and fail-closed enforcement changes ship only after the fleet autoApprove audit. Violations of the section are release-blockers regardless of what else a change delivers.

## Tests

- New behavioural: non-TTY + no consent env → `skipped` with the non-interactive message (env + isTTY restored around the assertion).
- New ordering: consent env set under Jest → the test-runner guard still wins.
- New source-shape: consent gate pinned after the test guard and before the first `execSync`.
- Guard file 13/13; **full suite 235 suites / 2189 tests green with zero gateway bounces during the run** — the first clean full-suite run on this host today, proving both this and #64 in production conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
