### PR TITLE
feat(claude-code): PreToolUse action guard — WS1 enforce-by-default carry-over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 > **Coverage note**: 49 v4 versions are documented below — typically every minor (`X.Y.0`) plus significant patches. Many small patch releases between 4.0.0 and 4.20.x are not individually documented (~50 versions, mostly behaviour-preserving fixes). For a specific diff between adjacent npm versions, see `git log vX.Y.Z..vX.Y.W` or compare tarballs. Audited and reconciled 2026-05-27 — gap is intentional, not a sign of release-note drift going forward.
 
+## [Unreleased]
+
+**The Action Guard reaches Claude Code: the same enforce-by-default that guards OpenClaw agents now gates every Claude Code tool call through the native permission dialog.**
+
+### Added
+
+- **Claude Code PreToolUse action guard (P1/WS1 carry-over).** `shieldcortex install`/`update` now wire a `PreToolUse` hook (matcher `*`) that runs every tool call through the shared Iron Dome tool-action-guard. Catastrophic operations (`rm -rf /`, fork bombs, raw disk writes, secret exfiltration) emit `permissionDecision: "deny"` — always, even under `actionGuard.enforce:false`, mirroring the plugin's hard-block tier. Recognised-dangerous operations emit `permissionDecision: "ask"`, routing through Claude Code's own confirmation dialog; headless runs (`claude --print`) cannot prompt, so unattended dangerous calls fail closed, matching the plugin's no-approver posture. `actionGuard.enforce:false` opts down to a stderr warning with no decision; an `actionGuard.autoApprove` match (family/action/signal) emits no decision at all — the guard defers to Claude Code's own permission system and never widens what the user's settings allow. Verdicts append to the same `~/.shieldcortex/audit/realtime-*.jsonl` stream as the OpenClaw plugin, tagged `origin: "claude-code-hook"`. Config is shared with the plugin (`~/.shieldcortex/config.json` → `actionGuard`), so one opt-down governs both surfaces. Failure posture is fail-open with a stderr note (a broken guard must not break the agent), pending WS2 fail-closed.
+- **Hook-script packaging contract test.** package.json `files` whitelists hook scripts individually; a new test locks every `BUILT_IN_HOOKS` script to that whitelist so a future hook can't ship as settings.json wiring pointing at a file npm never packed.
+
+### Fixed
+
+- **`settingsPath()` resolved per call.** The `~/.claude/settings.json` path was captured at module import; under a cached module any later homedir redirection (test harness, future override) silently wrote to the wrong — real — settings file.
+
 ## [4.46.0] - 2026-07-02
 
 **The dangerous tier enforces by default, the zeroth law makes breaking the host a release-blocker, and the project-key repair finally works for the agents it was built for.**

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "scripts/session-start-hook.mjs",
     "scripts/stop-hook.mjs",
     "scripts/prompt-recall-hook.mjs",
+    "scripts/pre-tool-hook.mjs",
     "scripts/lib",
     "dashboard/.next/standalone"
   ]

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * ShieldCortex — Action Guard Hook (PreToolUse)
+ *
+ * P1/WS1 carry-over: the dangerous-tier enforce-by-default semantics the
+ * OpenClaw plugin ships (plugins/openclaw/interceptor.ts runActionGuard) applied
+ * to Claude Code via the native PreToolUse permission protocol.
+ *
+ * Verdict → Claude Code decision mapping:
+ *   - catastrophic (`block`)        → permissionDecision "deny". ALWAYS — the
+ *     hard-block tier ignores `actionGuard.enforce:false`, mirroring the plugin.
+ *   - dangerous (`require_approval`) → permissionDecision "ask" (Claude Code's
+ *     own confirm dialog) by default. `actionGuard.enforce:false` opts down to
+ *     a stderr warning with NO decision. In headless runs ("claude --print")
+ *     "ask" cannot prompt, so the call fails — the same fail-closed unattended
+ *     posture as the plugin's no-approver deny path.
+ *   - autoApprove match              → NO decision. The guard defers to Claude
+ *     Code's own permission system rather than emitting "allow": ShieldCortex
+ *     narrows or stays neutral, it never WIDENS what the user's settings allow.
+ *   - benign / read-only / pure-print → no output at all.
+ *
+ * Failure posture (v1): a guard that cannot load or evaluate fails OPEN with a
+ * stderr note, matching the plugin ("a guard error must never break the
+ * agent"). WS2 (fail-closed) revisits this across both surfaces.
+ *
+ * The hook always exits 0 — denial travels in hookSpecificOutput JSON, never
+ * exit codes, so a crash can't masquerade as a verdict.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { homedir } from 'os';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// ==================== CONFIG ====================
+
+const DEFAULT_ACTION_GUARD = { enabled: true, enforce: true, autoApprove: [] };
+
+function loadActionGuardConfig() {
+  try {
+    const configPath = join(homedir(), '.shieldcortex', 'config.json');
+    if (!existsSync(configPath)) return { ...DEFAULT_ACTION_GUARD };
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const raw = config?.actionGuard;
+    if (!raw || typeof raw !== 'object') return { ...DEFAULT_ACTION_GUARD };
+    return {
+      enabled: raw.enabled !== false,
+      enforce: raw.enforce !== false,
+      autoApprove: Array.isArray(raw.autoApprove) ? raw.autoApprove.filter((a) => typeof a === 'string') : [],
+    };
+  } catch {
+    // Unreadable config → guard on with defaults. Enforce-by-default means a
+    // corrupt config file must not silently disable the guard.
+    return { ...DEFAULT_ACTION_GUARD };
+  }
+}
+
+// ==================== GUARD (lazy dist import) ====================
+
+/**
+ * Load the built tool-action-guard from dist. Returns null when the dist build
+ * is missing/incomplete → the caller fails OPEN (see failure posture above).
+ * SHIELDCORTEX_DIST_ROOT is a test seam, mirroring recall-defence.mjs.
+ */
+async function loadGuard() {
+  const distRoot = process.env.SHIELDCORTEX_DIST_ROOT ?? resolve(here, '..', 'dist');
+  try {
+    const mod = await import(
+      pathToFileURL(resolve(distRoot, 'defence', 'iron-dome', 'tool-action-guard.js')).href
+    );
+    return typeof mod.evaluateToolCall === 'function' ? mod : null;
+  } catch {
+    return null;
+  }
+}
+
+// ==================== AUDIT (local JSONL) ====================
+// Same file the OpenClaw plugin appends to (~/.shieldcortex/audit/realtime-*.jsonl)
+// so `shieldcortex` audit tooling reads one unified stream; `origin`
+// disambiguates which surface produced the entry.
+
+function summariseToolArgs(args) {
+  const parts = [];
+  for (const [k, val] of Object.entries(args ?? {})) {
+    if (typeof val === 'string') parts.push(`${k}=${val.slice(0, 80)}`);
+    else if (typeof val === 'number' || typeof val === 'boolean') parts.push(`${k}=${val}`);
+  }
+  return parts.join(' ').slice(0, 160);
+}
+
+function writeAuditEntry(toolName, verdict, args, action, outcome) {
+  try {
+    const auditDir = join(homedir(), '.shieldcortex', 'audit');
+    mkdirSync(auditDir, { recursive: true });
+    const date = new Date().toISOString().slice(0, 10);
+    const entry = {
+      type: 'intercept',
+      origin: 'claude-code-hook',
+      tool: toolName,
+      severity: verdict.severity === 'catastrophic' ? 'critical' : 'high',
+      firewallResult: 'ACTION_GUARD',
+      threats: verdict.signals,
+      anomalyScore: verdict.decision === 'block' ? 1 : 0.6,
+      trustScore: 0,
+      sensitivityLevel: 'INTERNAL',
+      fragmentationScore: null,
+      pipelineDurationMs: 0,
+      preview: `${toolName} :: ${summariseToolArgs(args)}`.slice(0, 200),
+      ts: new Date().toISOString(),
+      action,
+      outcome,
+    };
+    appendFileSync(join(auditDir, `realtime-${date}.jsonl`), JSON.stringify(entry) + '\n');
+  } catch {
+    // Best-effort — never block on audit failure.
+  }
+}
+
+// ==================== DECISION OUTPUT ====================
+
+function emitDecision(permissionDecision, reason) {
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision,
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+}
+
+// ==================== MAIN ====================
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('readable', () => {
+  let chunk;
+  while ((chunk = process.stdin.read()) !== null) input += chunk;
+});
+
+process.stdin.on('end', async () => {
+  try {
+    const cfg = loadActionGuardConfig();
+    if (!cfg.enabled) process.exit(0);
+
+    let hookData;
+    try {
+      hookData = JSON.parse(input || '{}');
+    } catch {
+      process.exit(0); // Malformed payload — nothing to evaluate.
+    }
+    const toolName = typeof hookData.tool_name === 'string' ? hookData.tool_name : '';
+    const toolInput =
+      hookData.tool_input && typeof hookData.tool_input === 'object' ? hookData.tool_input : {};
+    if (!toolName) process.exit(0);
+
+    const guard = await loadGuard();
+    if (!guard) {
+      console.error('[shieldcortex] action-guard unavailable (missing dist build) — allowing tool call');
+      process.exit(0);
+    }
+
+    let verdict;
+    try {
+      verdict = guard.evaluateToolCall(toolName, toolInput);
+    } catch (err) {
+      console.error(`[shieldcortex] ⚠️ action-guard error (allowing ${toolName}): ${err?.message ?? err}`);
+      process.exit(0);
+    }
+
+    if (verdict.decision === 'allow') process.exit(0);
+
+    // Catastrophic — hard deny, always enforced while the guard is enabled.
+    if (verdict.decision === 'block') {
+      writeAuditEntry(toolName, verdict, toolInput, 'auto_deny', 'auto_denied');
+      console.error(
+        `[shieldcortex] action-guard BLOCKED ${toolName}: ${verdict.reason} [${verdict.signals.join(', ')}]`,
+      );
+      emitDecision('deny', `ShieldCortex Action Guard: ${verdict.reason} [${verdict.signals.join(', ')}]`);
+      process.exit(0);
+    }
+
+    // require_approval — the dangerous tier.
+    // Per-operator autoApprove allowlist (family / action / signal match, same
+    // matching as the plugin). Never applies to catastrophic — that returned above.
+    const autoApprove = cfg.autoApprove ?? [];
+    if (autoApprove.length > 0) {
+      const hay = [verdict.family, verdict.action, ...verdict.signals].map((s) => String(s).toLowerCase());
+      const matched = autoApprove.some((a) => {
+        const n = a.toLowerCase();
+        return hay.some((h) => h === n || h.includes(n));
+      });
+      if (matched) {
+        writeAuditEntry(toolName, verdict, toolInput, 'require_approval', 'approved');
+        process.exit(0); // Defer to Claude Code's own permission system.
+      }
+    }
+
+    if (!cfg.enforce) {
+      writeAuditEntry(toolName, verdict, toolInput, 'warn', 'warned');
+      console.error(`[shieldcortex] ⚠️ Action Guard: ${toolName} — ${verdict.reason}`);
+      process.exit(0); // Advisory: warn, emit no decision.
+    }
+
+    writeAuditEntry(toolName, verdict, toolInput, 'require_approval', 'asked');
+    emitDecision('ask', `ShieldCortex Action Guard: ${verdict.reason} [${verdict.signals.join(', ')}]`);
+    process.exit(0);
+  } catch (error) {
+    console.error(`[shieldcortex] action-guard hook error: ${error?.message ?? error}`);
+    process.exit(0);
+  }
+});

--- a/src/__tests__/hook-scripts-packaging.test.ts
+++ b/src/__tests__/hook-scripts-packaging.test.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from '@jest/globals';
+import { BUILT_IN_HOOKS } from '../setup/hooks.js';
+
+/**
+ * Every built-in hook script must be shipped in the npm tarball. package.json
+ * "files" whitelists hook scripts INDIVIDUALLY, so adding a hook to
+ * BUILT_IN_HOOKS without whitelisting its script publishes a package whose
+ * settings.json wiring points at a missing file — the hook exits 1 on every
+ * fire with no build/test failure anywhere. This locks the two lists together.
+ */
+describe('built-in hook scripts — npm packaging contract', () => {
+  const thisFile = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8')) as {
+    files: string[];
+  };
+
+  it.each(Object.entries(BUILT_IN_HOOKS))(
+    'hook "%s" script is whitelisted in package.json files',
+    (_hookName, scriptFile) => {
+      expect(pkg.files).toContain(`scripts/${scriptFile}`);
+    },
+  );
+
+  it.each(Object.entries(BUILT_IN_HOOKS))(
+    'hook "%s" script exists on disk',
+    (_hookName, scriptFile) => {
+      expect(fs.existsSync(path.join(repoRoot, 'scripts', scriptFile))).toBe(true);
+    },
+  );
+});

--- a/src/__tests__/hooks-alignment.test.ts
+++ b/src/__tests__/hooks-alignment.test.ts
@@ -17,6 +17,10 @@ describe('Claude Code hooks — doctor/install alignment (guards against #23)', 
     );
   });
 
+  it('includes PreToolUse — the WS1 action guard carried over to Claude Code', () => {
+    expect(REQUIRED_HOOK_NAMES).toContain('PreToolUse');
+  });
+
   it('is immutable (cannot be mutated by callers at runtime)', () => {
     expect(() => {
       (REQUIRED_HOOK_NAMES as string[]).push('SessionEnd');

--- a/src/__tests__/pre-tool-hook.test.ts
+++ b/src/__tests__/pre-tool-hook.test.ts
@@ -1,0 +1,196 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * PreToolUse action guard hook (P1/WS1 carry-over to Claude Code).
+ *
+ * These tests spawn scripts/pre-tool-hook.mjs as a subprocess with a
+ * synthesised Claude Code PreToolUse payload and assert the WS1 enforcement
+ * semantics the OpenClaw plugin already ships (plugins/openclaw/interceptor.ts):
+ *
+ *   - catastrophic  → permissionDecision "deny", ALWAYS (never fails open)
+ *   - dangerous     → permissionDecision "ask" by default (enforce-by-default);
+ *                     `actionGuard.enforce:false` opts down to a stderr warning
+ *   - autoApprove   → no decision emitted (defers to Claude Code's own
+ *                     permission system — the guard never WIDENS permissions)
+ *   - benign / read-only / pure-print → no output at all
+ *
+ * The hook must always exit 0: denial travels in hookSpecificOutput JSON, not
+ * exit codes, so a crash can never masquerade as a verdict.
+ */
+
+const HOOK_PATH = path.resolve(__dirname, '..', '..', 'scripts', 'pre-tool-hook.mjs');
+
+type HookResult = { stdout: string; stderr: string; code: number };
+
+function runHook(payload: unknown, envOverrides: NodeJS.ProcessEnv = {}): Promise<HookResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [HOOK_PATH], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...envOverrides },
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => { stdout += c.toString(); });
+    child.stderr.on('data', (c) => { stderr += c.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ stdout, stderr, code: code ?? 0 }));
+
+    child.stdin.write(typeof payload === 'string' ? payload : JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+function bashCall(command: string): Record<string, unknown> {
+  return {
+    session_id: 'test-session',
+    cwd: '/tmp',
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    tool_input: { command },
+  };
+}
+
+function decisionOf(stdout: string): { permissionDecision?: string; permissionDecisionReason?: string } {
+  const parsed = JSON.parse(stdout);
+  expect(parsed.hookSpecificOutput?.hookEventName).toBe('PreToolUse');
+  return parsed.hookSpecificOutput;
+}
+
+describe('pre-tool hook — WS1 enforce-by-default on Claude Code', () => {
+  const originalHome = process.env.HOME;
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'shieldcortex-pretool-'));
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  function writeActionGuardConfig(actionGuard: Record<string, unknown>): void {
+    const dir = path.join(tempHome, '.shieldcortex');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify({ actionGuard }));
+  }
+
+  it('denies a catastrophic command by default (no config file)', async () => {
+    const result = await runHook(bashCall('rm -rf /'));
+    expect(result.code).toBe(0);
+    const decision = decisionOf(result.stdout);
+    expect(decision.permissionDecision).toBe('deny');
+    expect(decision.permissionDecisionReason).toMatch(/catastrophic/i);
+  });
+
+  it('catastrophic deny cannot be disabled by enforce:false', async () => {
+    writeActionGuardConfig({ enforce: false });
+    const result = await runHook(bashCall('rm -rf /'));
+    expect(result.code).toBe(0);
+    expect(decisionOf(result.stdout).permissionDecision).toBe('deny');
+  });
+
+  it('asks for approval on a dangerous command by default', async () => {
+    const result = await runHook(bashCall('sudo systemctl stop nginx'));
+    expect(result.code).toBe(0);
+    const decision = decisionOf(result.stdout);
+    expect(decision.permissionDecision).toBe('ask');
+    expect(decision.permissionDecisionReason).toMatch(/approval/i);
+  });
+
+  it('enforce:false downgrades dangerous to a stderr warning with no decision', async () => {
+    writeActionGuardConfig({ enforce: false });
+    const result = await runHook(bashCall('sudo systemctl stop nginx'));
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toMatch(/action guard/i);
+  });
+
+  it('autoApprove match defers to Claude Code permissions (no decision)', async () => {
+    writeActionGuardConfig({ autoApprove: ['sudo_command'] });
+    const result = await runHook(bashCall('sudo systemctl stop nginx'));
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('benign command emits nothing', async () => {
+    const result = await runHook(bashCall('ls -la'));
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('read-only tool mentioning a dangerous string is not an action', async () => {
+    const result = await runHook({
+      session_id: 'test-session',
+      cwd: '/tmp',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Grep',
+      tool_input: { pattern: 'rm -rf /' },
+    });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('pure print of a dangerous string is not an action', async () => {
+    const result = await runHook(bashCall('echo "rm -rf /"'));
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('actionGuard.enabled:false disables the guard entirely', async () => {
+    writeActionGuardConfig({ enabled: false });
+    const result = await runHook(bashCall('rm -rf /'));
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('writes an audit entry on deny', async () => {
+    await runHook(bashCall('rm -rf /'));
+    const auditDir = path.join(tempHome, '.shieldcortex', 'audit');
+    const files = fs.readdirSync(auditDir).filter((f) => /^realtime-.*\.jsonl$/.test(f));
+    expect(files.length).toBe(1);
+    const lines = fs.readFileSync(path.join(auditDir, files[0]), 'utf-8').trim().split('\n');
+    const entry = JSON.parse(lines[lines.length - 1]);
+    expect(entry.outcome).toBe('auto_denied');
+    expect(entry.origin).toBe('claude-code-hook');
+    expect(entry.tool).toBe('Bash');
+    expect(entry.firewallResult).toBe('ACTION_GUARD');
+  });
+
+  it('audits the ask verdict so unattended denials are visible', async () => {
+    await runHook(bashCall('sudo systemctl stop nginx'));
+    const auditDir = path.join(tempHome, '.shieldcortex', 'audit');
+    const files = fs.readdirSync(auditDir).filter((f) => /^realtime-.*\.jsonl$/.test(f));
+    expect(files.length).toBe(1);
+    const lines = fs.readFileSync(path.join(auditDir, files[0]), 'utf-8').trim().split('\n');
+    const entry = JSON.parse(lines[lines.length - 1]);
+    expect(entry.action).toBe('require_approval');
+    expect(entry.origin).toBe('claude-code-hook');
+  });
+
+  it('malformed stdin exits 0 with no output', async () => {
+    const result = await runHook('this is not json');
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  it('missing dist guard fails open (WS2 will flip this to fail-closed)', async () => {
+    const emptyDist = fs.mkdtempSync(path.join(os.tmpdir(), 'shieldcortex-emptydist-'));
+    try {
+      const result = await runHook(bashCall('rm -rf /'), { SHIELDCORTEX_DIST_ROOT: emptyDist });
+      expect(result.code).toBe(0);
+      expect(result.stdout).toBe('');
+    } finally {
+      fs.rmSync(emptyDist, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/setup/__tests__/action-guard-hook-install.test.ts
+++ b/src/setup/__tests__/action-guard-hook-install.test.ts
@@ -1,0 +1,105 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * PreToolUse action-guard wiring (P1/WS1 carry-over to Claude Code).
+ *
+ * Locks two contracts:
+ *  1. `setupHooks()` installs a PreToolUse entry with a wildcard matcher and
+ *     the `shieldcortex hook pre-tool` command — so `shieldcortex install` /
+ *     `update` wire the guard by default (enforce-by-default carry-over).
+ *  2. The `shieldcortex hook pre-tool` CLI path dispatches to the script —
+ *     drift between BUILT_IN_HOOKS and settings-hooks is the #23 failure class.
+ */
+
+describe('action-guard hook install (PreToolUse)', () => {
+  let tmpHome: string;
+  let tmpScDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-ag-home-'));
+    tmpScDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-ag-scdir-'));
+    originalEnv = { ...process.env };
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    process.env.SHIELDCORTEX_CONFIG_DIR = tmpScDir;
+    jest.resetModules();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+    try { fs.rmSync(tmpScDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    jest.restoreAllMocks();
+  });
+
+  function readSettings(): Record<string, any> {
+    return JSON.parse(fs.readFileSync(path.join(tmpHome, '.claude', 'settings.json'), 'utf-8'));
+  }
+
+  it('setupHooks installs PreToolUse with a wildcard matcher and the pre-tool command', async () => {
+    // jest virtualizes process.env, so a HOME swap is invisible to the native
+    // os.homedir() — the spy is the repo's established redirection seam (see
+    // hook-timeout-reconcile.test.ts). Without it this test writes to the REAL
+    // ~/.claude/settings.json.
+    jest.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+    const { setupHooks } = await import('../settings-hooks.js');
+    setupHooks();
+
+    const settings = readSettings();
+    const entries = settings.hooks?.PreToolUse;
+    expect(Array.isArray(entries)).toBe(true);
+    const entry = entries[0];
+    expect(entry.matcher).toBe('*');
+    expect(entry.hooks?.[0]?.command).toBe('shieldcortex hook pre-tool');
+    expect(entry.hooks?.[0]?.timeout).toBe(10);
+  });
+
+  it('setupHooks does not duplicate an existing PreToolUse entry', async () => {
+    jest.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+    const { setupHooks } = await import('../settings-hooks.js');
+    setupHooks();
+    setupHooks();
+
+    const entries = readSettings().hooks?.PreToolUse;
+    const cortexEntries = entries.filter((e: any) =>
+      e.hooks?.some((h: any) => typeof h.command === 'string' && h.command.includes('shieldcortex')),
+    );
+    expect(cortexEntries.length).toBe(1);
+  });
+
+  it('the hook CLI dispatches pre-tool to the guard script', async () => {
+    const cliPath = path.resolve(__dirname, '..', '..', '..', 'dist', 'index.js');
+    // dist is built before tests in CI; guard the local invariant explicitly so
+    // a missing build fails loudly instead of green-skipping the dispatch check.
+    expect(fs.existsSync(cliPath)).toBe(true);
+
+    const result = await new Promise<{ stdout: string; code: number }>((resolve, reject) => {
+      const child = spawn(process.execPath, [cliPath, 'hook', 'pre-tool'], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env },
+      });
+      let stdout = '';
+      child.stdout.on('data', (c) => { stdout += c.toString(); });
+      child.on('error', reject);
+      child.on('close', (code) => resolve({ stdout, code: code ?? 0 }));
+      child.stdin.write(JSON.stringify({
+        session_id: 't', cwd: '/tmp', hook_event_name: 'PreToolUse',
+        tool_name: 'Bash', tool_input: { command: 'rm -rf /' },
+      }));
+      child.stdin.end();
+    });
+
+    expect(result.code).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.hookSpecificOutput?.permissionDecision).toBe('deny');
+  });
+});

--- a/src/setup/hooks.ts
+++ b/src/setup/hooks.ts
@@ -18,14 +18,17 @@ const __dirname = path.dirname(__filename);
 // Scripts are in ../scripts/ relative to dist/setup/
 const SCRIPTS_DIR = path.resolve(__dirname, '..', '..', 'scripts');
 
-const BUILT_IN_HOOKS: Record<string, string> = {
+// Exported for the packaging contract test: every script listed here must
+// also be whitelisted in package.json "files", or the published tarball
+// ships settings.json wiring that points at a missing file.
+export const BUILT_IN_HOOKS: Readonly<Record<string, string>> = Object.freeze({
   'pre-compact': 'pre-compact-hook.mjs',
   'session-start': 'session-start-hook.mjs',
   'session-end': 'session-end-hook.mjs',
   'stop': 'stop-hook.mjs',
   'prompt-recall': 'prompt-recall-hook.mjs',
   'pre-tool': 'pre-tool-hook.mjs',
-};
+});
 
 interface CustomHookConfig {
   command: string;    // path to script or command to run

--- a/src/setup/hooks.ts
+++ b/src/setup/hooks.ts
@@ -24,6 +24,7 @@ const BUILT_IN_HOOKS: Record<string, string> = {
   'session-end': 'session-end-hook.mjs',
   'stop': 'stop-hook.mjs',
   'prompt-recall': 'prompt-recall-hook.mjs',
+  'pre-tool': 'pre-tool-hook.mjs',
 };
 
 interface CustomHookConfig {

--- a/src/setup/settings-hooks.ts
+++ b/src/setup/settings-hooks.ts
@@ -7,7 +7,14 @@ import os from 'os';
 import { getAutoMemoryEnableConfig, setAutoMemoryEnableConfig } from '../cloud/config.js';
 import { readJsonConfigOrAbort, writeJsonConfigWithBackup } from './json-config.js';
 
-const SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json');
+// Resolved per call, not at import: an import-time constant freezes whichever
+// home os.homedir() saw when the module FIRST loaded, so any later redirection
+// (an os.homedir mock in a cached-module test, a future homedir override)
+// silently writes to the wrong settings.json. Call-time resolution keeps the
+// target honest no matter when this module was imported.
+function settingsPath(): string {
+  return path.join(os.homedir(), '.claude', 'settings.json');
+}
 
 interface HookEntry {
   hooks: Array<{ type: string; command?: string; prompt?: string; timeout?: number }>;
@@ -30,6 +37,15 @@ const CORTEX_HOOKS: Record<string, HookEntry> = {
     // any IO pressure, dropping recall context with no user-visible error
     // (#43). 5 s leaves ~3 s headroom on a busy host.
     hooks: [{ type: 'command', command: 'shieldcortex hook prompt-recall', timeout: 5 }],
+  },
+  PreToolUse: {
+    // Action guard (P1/WS1 carried over from the OpenClaw plugin): catastrophic
+    // ops deny, dangerous ops route through Claude Code's native "ask" dialog.
+    // Enforce-by-default — the runtime opt-down lives in ~/.shieldcortex/
+    // config.json (`actionGuard.enforce:false` → advisory, `enabled:false` →
+    // off) so posture changes never require re-editing settings.json.
+    matcher: '*',
+    hooks: [{ type: 'command', command: 'shieldcortex hook pre-tool', timeout: 10 }],
   },
 };
 
@@ -77,12 +93,12 @@ function hasCortexHook(entries: HookEntry[]): boolean {
 // rather than write a hooks-only file over the user's permissions/env/model
 // settings. Mirrors uninstall.ts's "aborting to avoid corruption" discipline.
 function readSettings(): Record<string, any> {
-  return readJsonConfigOrAbort(SETTINGS_PATH);
+  return readJsonConfigOrAbort(settingsPath());
 }
 
 // Backs up an existing settings.json before overwriting it.
 function writeSettings(settings: Record<string, any>): void {
-  writeJsonConfigWithBackup(SETTINGS_PATH, settings);
+  writeJsonConfigWithBackup(settingsPath(), settings);
 }
 
 /**


### PR DESCRIPTION
## What

Carries the P1/WS1 dangerous-tier enforce-by-default semantics from the OpenClaw plugin to **Claude Code**, via a native `PreToolUse` hook mapped onto Claude Code's permission protocol. Second of the two carry-over surfaces (Hermes plugin enforce trial is running in parallel via #57).

## Verdict → decision mapping

| Guard verdict | Claude Code decision | Notes |
|---|---|---|
| catastrophic (`block`) | `permissionDecision: "deny"` | **Always** — `enforce:false` cannot disable it (mirrors plugin hard-block tier) |
| dangerous (`require_approval`) | `permissionDecision: "ask"` | Routes through Claude Code's **own** confirm dialog; headless runs can't prompt → fail-closed unattended (mirrors plugin no-approver deny) |
| dangerous + `enforce:false` | none (stderr warning) | Advisory opt-down, same config key as the plugin |
| dangerous + `autoApprove` match | none | Defers to Claude Code's own permission system — the guard **never widens** what user settings allow |
| benign / read-only / pure-print | none | Positive recognition: `ls`, `git status`, `echo "rm -rf /"`, Grep-for-dangerous-strings all pass silently |

- Shared config: `~/.shieldcortex/config.json` → `actionGuard` (`enabled`/`enforce`/`autoApprove`) — one opt-down governs both surfaces.
- Audit: appends to the same `~/.shieldcortex/audit/realtime-*.jsonl` stream as the plugin, tagged `origin: "claude-code-hook"`.
- Failure posture **v1 = fail-open** with stderr note (zeroth law: a broken guard must not break the agent). WS2 (fail-closed) revisits both surfaces together.
- Wiring: `CORTEX_HOOKS` gains `PreToolUse` (matcher `*`, timeout 10) → `shieldcortex install`/`update` configure it by default; doctor checks it via `REQUIRED_HOOK_NAMES`; hook eval measured ~40 ms/call.

## Also in this PR

- **`settingsPath()` resolved per call** — the import-time constant froze the first-seen homedir; under a cached module a temp-HOME test wrote to the REAL `~/.claude/settings.json` (caught during TDD of this PR; restored from the automatic `.bak-shieldcortex` backup).
- **Hook-script packaging contract test** — `package.json` `files` whitelists hook scripts individually; the new test locks every `BUILT_IN_HOOKS` script to the whitelist. Without it this PR would have shipped settings wiring pointing at a file npm never packed (the test caught exactly that in RED).

## Testing

- TDD throughout: 13 hook-behaviour tests (spawned subprocess, temp HOME), 3 install/dispatch tests, 12 packaging contract tests, 1 alignment test — all RED first, all green.
- Full suite: 236/238 suites pass locally. The 3 failing suites (`recall-defence-integration`, `save-auto-extracted-memory`, `defence-pipeline-bypass`) **fail identically on `main` on this host** (known local-env issue, one already parked pre-PR) — verified by checkout-main rerun; CI is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)