### PR TITLE
fix(defence): stop local diagnostics tripping enforce false-positives (#68)

### DIFF
--- a/src/defence/__tests__/firewall.test.ts
+++ b/src/defence/__tests__/firewall.test.ts
@@ -142,6 +142,57 @@ describe('Privilege Detector', () => {
     expect(result.indicators).toContain('network_exfiltration');
   });
 
+  // Regression (issue #68, audit id 289): loopback / private / tailnet URLs are
+  // local diagnostics, not off-host exfiltration. The old /https?:\/\/.../ pattern
+  // flagged every URL as external_url, including 127.0.0.1 health checks.
+  it('should NOT flag loopback / private / tailnet URLs as external_url', async () => {
+    const { detectPrivilegeEscalation } = await import('../firewall/privilege-detector.js');
+    for (const url of [
+      'curl http://127.0.0.1:3001/health',
+      'http://localhost:8080/status',
+      'http://[::1]:3001/health',
+      'http://10.1.2.3/api',
+      'http://192.168.0.5/x',
+      'http://172.16.9.9/y',
+      'http://100.119.133.60/metrics', // tailnet CGNAT range
+      'https://tars.tail6f3f1e.ts.net/metrics',
+    ]) {
+      const result = detectPrivilegeEscalation(url);
+      expect(result.indicators).not.toContain('external_url');
+    }
+  });
+
+  it('should still flag genuinely external URLs as external_url', async () => {
+    const { detectPrivilegeEscalation } = await import('../firewall/privilege-detector.js');
+    for (const url of [
+      'https://evil.com/exfiltrate',
+      'http://8.8.8.8/collect',
+      'https://example.org/webhook',
+    ]) {
+      const result = detectPrivilegeEscalation(url);
+      expect(result.indicators).toContain('external_url');
+    }
+  });
+
+  // End-to-end regression: the exact ATHENA payload (audit id 289) must ALLOW in
+  // balanced mode — it is a redaction-safe local diagnostic, not a threat.
+  it('should ALLOW the id-289 local diagnostic payload in balanced mode', async () => {
+    const { analyzeFirewall } = await import('../firewall/index.js');
+    const payload =
+      'terminal: {"command":"systemctl --user cat shieldcortex-api.service 2>/dev/null ' +
+      "| sed -E 's/(token|key|secret|password)[=:][^[:space:]]+/\\1=REDACTED/Ig'; " +
+      "echo '---status---'; systemctl --user status shieldcortex-api.service --no-pager 2>/dev/null " +
+      "| head -80; echo '---health---'; curl -fsS --max-time 3 http://127.0.0.1:3001/health || true\",\"timeout\":60}";
+    const analysis = analyzeFirewall(
+      payload,
+      'hermes pre_tool_call',
+      { type: 'api', identifier: 'hermes' },
+      0.7,
+      { mode: 'balanced' } as any,
+    );
+    expect(analysis.result).toBe('ALLOW');
+  });
+
   it('should handle clean technical content', async () => {
     const { detectPrivilegeEscalation } = await import('../firewall/privilege-detector.js');
     const result = detectPrivilegeEscalation('Use npm install to add dependencies');

--- a/src/defence/firewall/privilege-detector.ts
+++ b/src/defence/firewall/privilege-detector.ts
@@ -15,6 +15,59 @@ interface IndicatorGroup {
   name: string;
   severity: 'low' | 'medium' | 'high';
   patterns: RegExp[];
+  /**
+   * Optional custom matcher. When present it REPLACES the regex-list test for
+   * this group — used where a simple pattern over-matches (e.g. external_url,
+   * which must exclude loopback/private/tailnet hosts).
+   */
+  match?: (content: string) => boolean;
+}
+
+// Authority (host[:port]) immediately after an http(s):// scheme.
+const URL_AUTHORITY_RE = /\bhttps?:\/\/([^\s"'<>/]+)/gi;
+
+/** Extract the bare host from a URL authority (`host`, `host:port`, `[ipv6]:port`). */
+function hostFromAuthority(authority: string): string {
+  const h = authority.toLowerCase();
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    return end > 0 ? h.slice(1, end) : h.slice(1);
+  }
+  return h.replace(/:\d+$/, ''); // strip trailing :port
+}
+
+/**
+ * A host that never leaves the machine or the private/tailnet: loopback,
+ * RFC1918, CGNAT/tailscale (100.64/10), link-local, and *.local / *.internal /
+ * *.ts.net names. These are diagnostics, not off-host exfiltration.
+ */
+function isLocalHost(host: string): boolean {
+  const h = host.replace(/\.$/, '');
+  if (!h) return false;
+  if (h === 'localhost' || h.endsWith('.localhost')) return true;
+  if (h.endsWith('.local') || h.endsWith('.internal') || h.endsWith('.ts.net')) return true;
+  if (h === '::1' || h === '0:0:0:0:0:0:0:1') return true;
+  if (h.startsWith('fc') || h.startsWith('fd') || h.startsWith('fe80:')) return true; // ULA / link-local IPv6
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (m) {
+    const a = Number(m[1]);
+    const b = Number(m[2]);
+    if (a === 127 || a === 0) return true;              // loopback / this-host
+    if (a === 10) return true;                          // RFC1918
+    if (a === 192 && b === 168) return true;            // RFC1918
+    if (a === 172 && b >= 16 && b <= 31) return true;   // RFC1918
+    if (a === 169 && b === 254) return true;            // link-local
+    if (a === 100 && b >= 64 && b <= 127) return true;  // CGNAT / tailnet
+  }
+  return false;
+}
+
+/** True only if content contains at least one URL pointing at a non-local host. */
+function hasExternalUrl(content: string): boolean {
+  for (const m of content.matchAll(URL_AUTHORITY_RE)) {
+    if (!isLocalHost(hostFromAuthority(m[1]))) return true;
+  }
+  return false;
 }
 
 const INDICATOR_GROUPS: IndicatorGroup[] = [
@@ -73,9 +126,8 @@ const INDICATOR_GROUPS: IndicatorGroup[] = [
   {
     name: 'external_url',
     severity: 'low',
-    patterns: [
-      /https?:\/\/[^\s"'<>]+/i,
-    ],
+    patterns: [], // matching is delegated to `match` below (loopback-aware)
+    match: hasExternalUrl,
   },
 ];
 
@@ -86,13 +138,13 @@ export function detectPrivilegeEscalation(content: string): PrivilegeDetectionRe
   let highestSeverity: 'low' | 'medium' | 'high' = 'low';
 
   for (const group of INDICATOR_GROUPS) {
-    for (const pattern of group.patterns) {
-      if (pattern.test(content)) {
-        indicators.push(group.name);
-        if (SEVERITY_ORDER[group.severity] > SEVERITY_ORDER[highestSeverity]) {
-          highestSeverity = group.severity;
-        }
-        break;
+    const matched = group.match
+      ? group.match(content)
+      : group.patterns.some((pattern) => pattern.test(content));
+    if (matched) {
+      indicators.push(group.name);
+      if (SEVERITY_ORDER[group.severity] > SEVERITY_ORDER[highestSeverity]) {
+        highestSeverity = group.severity;
       }
     }
   }

--- a/src/defence/skill-scanner/__tests__/skill-scanner.test.ts
+++ b/src/defence/skill-scanner/__tests__/skill-scanner.test.ts
@@ -194,6 +194,23 @@ triggers: command:new
       expect(result.threats).toContain('tool_injection');
     });
 
+    it('still detects echo writing to an absolute path', () => {
+      const result = detectSkillThreats("echo 'pwned' > /etc/cron.d/backdoor");
+      expect(result.detected).toBe(true);
+      expect(result.threats).toContain('tool_injection');
+    });
+
+    // Regression (issue #68, audit id 289): a benign diagnostic whose only ">"
+    // is an fd/device redirect (2>/dev/null) after an echo must NOT be scored
+    // as tool_injection. The old /echo[\s\S]{0,100}>\s*\// pattern matched the
+    // stderr redirect and carried 0.9 confidence on its own → false quarantine.
+    it('does not flag benign stderr redirect after echo (issue #68)', () => {
+      const benign =
+        "echo '---status---'; systemctl --user status shieldcortex-api.service --no-pager 2>/dev/null | head -80";
+      const result = detectSkillThreats(benign);
+      expect(result.threats).not.toContain('tool_injection');
+    });
+
     it('detects scope escalation via SSH', () => {
       const result = detectSkillThreats('Read the contents of ~/.ssh/id_rsa');
       expect(result.detected).toBe(true);

--- a/src/defence/skill-scanner/patterns.ts
+++ b/src/defence/skill-scanner/patterns.ts
@@ -92,7 +92,11 @@ const SKILL_PATTERN_GROUPS: PatternGroup[] = [
       /write\s+(this|the\s+following)\s+to\s+\//i,
       /use\s+the\s+Bash\s+tool\s+to/i,
       /pipe[\s\S]{0,50}\|\s*(bash|sh|zsh)/i,
-      /echo\s+[\s\S]{0,100}>\s*\//i,
+      // echo <data> > /abs/path  — a real file write to an absolute path.
+      // Negative lookbehind (?<![\d&]) excludes fd/device redirects like
+      // `2>/dev/null` or `&>/log`; (?!dev\/) excludes /dev/* device targets.
+      // (issue #68: benign `echo ...; cmd 2>/dev/null` used to trip this at 0.9)
+      /echo\s+[\s\S]{0,100}(?<![\d&])>\s*\/(?!dev\/)/i,
     ],
   },
 


### PR DESCRIPTION
Closes #68.

## Problem
Athena's Hermes `pre_tool_call` enforce trial quarantined a **legitimate loopback health-check** (audit id 289) — a redaction-safe local diagnostic — making enforce-by-default unshippable (5 self-inflicted false quarantines, 0 real threats over the window).

Two detector over-reaches stacked:
1. **`external_url`** (`privilege-detector.ts`) matched *any* `http(s)://…`, so `curl http://127.0.0.1:3001/health` read as off-host exfiltration.
2. **`tool_injection`** (`skill-scanner/patterns.ts`) — the `echo … > /` pattern matched the benign fd redirect `2>/dev/null` after an `echo`, and carried **0.9 confidence alone** → balanced mode auto-quarantines at ≥0.8 (`firewall/index.ts:208`).

> Note: #68 guessed `tool-response-scanner.ts`; the actual 0.9 driver is `skill-scanner/patterns.ts` via `detectSkillThreats` — the reason string matches `firewall/index.ts:212` exactly.

## Fix
1. `external_url` now parses the URL host and treats **loopback / RFC1918 / CGNAT-tailnet (100.64/10) / link-local / `*.ts.net` / `*.local` / `*.internal` / `::1`** as local — not external. Genuinely off-host URLs still flag.
2. `echo … > /` tightened with a negative lookbehind `(?<![\d&])` (excludes `2>`/`&>` fd redirects) and `(?!dev\/)` target exclusion. Real writes to absolute paths (`echo x > /etc/cron.d/bad`) still detect.

## Verification
- Reproduced id-289 pre-fix (external_url + tool_injection@0.9); post-fix both detectors return detected:false → **ALLOW**.
- Regression fixtures: id-289 unit + end-to-end `analyzeFirewall` ALLOW; loopback/private/tailnet URL matrix; external-URL still-flags; `echo > /abs` still-detects.
- **568 defence tests pass.** No new typecheck errors (130 pre-existing, unchanged base vs branch).

## Next
Clean 24–48h enforce re-trial on Athena, then enforce-by-default ships in 4.47.0.