### PR TITLE
fix: pluginStatus() detects managed npm project installs (#77)

### DIFF
--- a/src/__tests__/openclaw-setup.test.ts
+++ b/src/__tests__/openclaw-setup.test.ts
@@ -268,4 +268,96 @@ describe('OpenClaw setup', () => {
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('config references'));
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('no files on disk'));
   });
+
+  // Issue #77: `pluginStatus()` only path-probed the legacy
+  // ~/.openclaw/extensions/shieldcortex-realtime dir, so managed npm project
+  // installs (~/.openclaw/npm/projects/drakon-systems-shieldcortex-realtime-*/)
+  // reported "config references ... but no files on disk" while the runtime was
+  // demonstrably loaded (field evidence from aiquant, 2026-07-12).
+  function writeManagedProjectInstall(version: string): string {
+    const installPath = path.join(
+      tempHome, '.openclaw', 'npm', 'projects',
+      'drakon-systems-shieldcortex-realtime-abc123',
+      'node_modules', '@drakon-systems', 'shieldcortex-realtime',
+    );
+    fs.mkdirSync(installPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(installPath, 'package.json'),
+      JSON.stringify({ name: '@drakon-systems/shieldcortex-realtime', version }, null, 2),
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(installPath, 'openclaw.plugin.json'),
+      JSON.stringify({ id: 'shieldcortex-realtime', version }, null, 2),
+      'utf-8',
+    );
+    const pluginsDir = path.join(tempHome, '.openclaw', 'plugins');
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginsDir, 'installs.json'),
+      JSON.stringify({
+        installRecords: {
+          'shieldcortex-realtime': { source: 'npm', version, installPath },
+        },
+      }, null, 2),
+      'utf-8',
+    );
+    return installPath;
+  }
+
+  it('reports plugin as installed for a managed npm project install with no extensions/ dir (#77)', async () => {
+    const { openClawHookStatus } = await loadOpenClawModule();
+    // The field case: OpenClaw's `plugins install` put the package under a
+    // managed npm project (not extensions/), the roster shows it loaded, and
+    // openclaw.json references it — but the legacy extensions/ dir is empty.
+    const installPath = writeManagedProjectInstall('4.47.3');
+    fs.writeFileSync(openClawConfigPath(), JSON.stringify({
+      plugins: {
+        allow: ['shieldcortex-realtime'],
+        installs: { 'shieldcortex-realtime': { source: 'npm', version: '4.47.3' } },
+        entries: { 'shieldcortex-realtime': { enabled: true } },
+      },
+    }, null, 2), 'utf-8');
+
+    await openClawHookStatus();
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Real-time plugin: installed'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(installPath));
+    // Must NOT emit the false-negative drift line when files are present.
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('no files on disk'));
+  });
+
+  it('does not false-positive: reports "no files on disk" when the managed install record points at a missing path (#77)', async () => {
+    const { openClawHookStatus } = await loadOpenClawModule();
+    // Registry references a managed install, but the package dir is gone —
+    // genuinely absent, must still report truthfully.
+    const ghostPath = path.join(
+      tempHome, '.openclaw', 'npm', 'projects',
+      'drakon-systems-shieldcortex-realtime-ghost',
+      'node_modules', '@drakon-systems', 'shieldcortex-realtime',
+    );
+    const pluginsDir = path.join(tempHome, '.openclaw', 'plugins');
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginsDir, 'installs.json'),
+      JSON.stringify({
+        installRecords: {
+          'shieldcortex-realtime': { source: 'npm', version: '4.47.3', installPath: ghostPath },
+        },
+      }, null, 2),
+      'utf-8',
+    );
+    fs.writeFileSync(openClawConfigPath(), JSON.stringify({
+      plugins: {
+        allow: ['shieldcortex-realtime'],
+        installs: { 'shieldcortex-realtime': { source: 'npm', version: '4.47.3' } },
+        entries: { 'shieldcortex-realtime': { enabled: true } },
+      },
+    }, null, 2), 'utf-8');
+
+    await openClawHookStatus();
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('config references'));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('no files on disk'));
+  });
 });

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -12,6 +12,7 @@ import os from 'os';
 import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
 import {
+  resolveRealtimePluginInstallPath,
   resolveRealtimeProjectDir,
   readRealtimeProjectManifest,
   findEoverrideRiskPins,
@@ -827,19 +828,33 @@ function uninstallPlugin(): boolean {
  * caused `status` to report "not installed" immediately after a successful
  * `openclaw plugins install`.
  */
-function pluginStatus(): { installed: boolean; path?: string; entry?: 'index.ts' | 'index.js' } {
+function pluginStatus(): { installed: boolean; path?: string; entry?: 'index.ts' | 'index.js'; source?: 'extensions' | 'managed-project' } {
   const extensionsDir = findExtensionsDir();
-  if (!extensionsDir) return { installed: false };
+  if (extensionsDir) {
+    const destDir = path.join(extensionsDir, PLUGIN_DIR_NAME);
+    const manifestPath = path.join(destDir, 'openclaw.plugin.json');
+    if (fs.existsSync(manifestPath)) {
+      const jsEntry = path.join(destDir, 'index.js');
+      const tsEntry = path.join(destDir, 'index.ts');
+      if (fs.existsSync(jsEntry)) return { installed: true, path: destDir, entry: 'index.js', source: 'extensions' };
+      if (fs.existsSync(tsEntry)) return { installed: true, path: destDir, entry: 'index.ts', source: 'extensions' };
+      // Manifest present but no recognised entry — treat as broken install, not hidden.
+    }
+  }
 
-  const destDir = path.join(extensionsDir, PLUGIN_DIR_NAME);
-  const manifestPath = path.join(destDir, 'openclaw.plugin.json');
-  if (!fs.existsSync(manifestPath)) return { installed: false };
+  // Managed npm project install (OpenClaw >= 2026.6.x): the package lives under
+  // ~/.openclaw/npm/projects/drakon-systems-shieldcortex-realtime-*/ rather than
+  // extensions/. Reuse the canonical install-discovery helper the #74/#75
+  // reconciler work introduced so status agrees with the roster/plugins-list
+  // view instead of inventing a second path heuristic (issue #77).
+  const managedPath = resolveRealtimePluginInstallPath(resolveUserHome());
+  if (managedPath) {
+    const jsEntry = path.join(managedPath, 'index.js');
+    const tsEntry = path.join(managedPath, 'index.ts');
+    const entry = fs.existsSync(jsEntry) ? 'index.js' : fs.existsSync(tsEntry) ? 'index.ts' : undefined;
+    return { installed: true, path: managedPath, entry, source: 'managed-project' };
+  }
 
-  const jsEntry = path.join(destDir, 'index.js');
-  const tsEntry = path.join(destDir, 'index.ts');
-  if (fs.existsSync(jsEntry)) return { installed: true, path: destDir, entry: 'index.js' };
-  if (fs.existsSync(tsEntry)) return { installed: true, path: destDir, entry: 'index.ts' };
-  // Manifest present but no recognised entry — treat as broken install, not hidden.
   return { installed: false };
 }
 
@@ -1203,7 +1218,8 @@ export async function openClawHookStatus(): Promise<void> {
         ? 'local install not yet trusted'
         : 'native or unknown trust source';
   const entrySuffix = plugin.entry ? ` [${plugin.entry}]` : '';
-  console.log(`  Real-time plugin: installed (${plugin.path})${entrySuffix} — ${trustSuffix}`);
+  const sourceSuffix = plugin.source === 'managed-project' ? ' (managed npm project)' : '';
+  console.log(`  Real-time plugin: installed (${plugin.path})${sourceSuffix}${entrySuffix} — ${trustSuffix}`);
 
   // Surface any config/disk drift even when installed. A legacy `installs`
   // entry alone is not sufficient for OpenClaw to load the plugin — it needs


### PR DESCRIPTION
## Summary
`shieldcortex openclaw status` reported `config references ... but no files on disk` for managed npm project installs even though the plugin was loaded and enforcing. `pluginStatus()` only path-probed the legacy `~/.openclaw/extensions/shieldcortex-realtime` dir and was blind to the canonical managed-project path (`~/.openclaw/npm/projects/drakon-systems-shieldcortex-realtime-*/`).

**Field context (aiquant, 2026-07-12, 4.47.3 rc→release verification):** roster (`plugins list --json`), `plugins info`, doctor and the reconciler all agreed loaded/v4.47.3, and Action Guard blocked a live recursive-force-delete post-restart — runtime healthy; only the status command lied. Exactly the config-vs-disk-vs-loaded trap our fleet doctrine warns about.

## Approach
Reuse the canonical install-discovery helper `resolveRealtimePluginInstallPath()` from the #74/#75 reconciler work (which reads `installs.json` `installRecords[].installPath` and falls back to scanning `~/.openclaw/npm/projects/`) — **no second path heuristic invented**. `pluginStatus()` now:

1. Checks the legacy `extensions/` dir first (unchanged behaviour, `source: 'extensions'`).
2. Falls back to the managed-project helper (`source: 'managed-project'`), which only resolves when the package dir actually has a `package.json` on disk.
3. Returns `installed: false` when neither resolves — so the genuinely-missing case still reports truthfully.

Status now agrees with the roster/plugins-list view across both install shapes; the status line gains a `(managed npm project)` marker for the new shape.

## Tests (strict TDD — failing test first)
- **New:** managed npm project install with no `extensions/` dir → reports `installed`, prints the resolved path, does **not** emit the false-negative drift line.
- **New:** managed install record pointing at a missing package dir → still reports `config references ... no files on disk` (no false-positive).
- **Preserved:** legacy `index.ts`-only extensions install; genuinely-missing (#20) drift case.

## Test evidence
`openclaw-setup` suite (all 11 green, incl. the 2 new #77 tests):
```
Tests:       11 passed, 11 total
```

Full `npm test` on this box: **2315 passed / 17 failed**. The 17 failures are pre-existing and unrelated — clean `origin/main` (a48917a) produces the **identical** 4 failed suites / 17 failed tests (`save-auto-extracted-memory`, `save-memory-near-dup-dedup`, `defence-pipeline-bypass`, `recall-defence-integration`) — a DB test-isolation/embedding-skip issue on this environment. This branch's delta is **+2 passing, 0 new failures**; the affected suites pass when run in a small group.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)