### PR TITLE
fix: MCP startup self-heal on ABI mismatch, loud failure, PATH-immune setup entries (#76)

### DIFF
--- a/src/__tests__/codex-setup.test.ts
+++ b/src/__tests__/codex-setup.test.ts
@@ -1,29 +1,15 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { execSync } from 'child_process';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { installCodex, uninstallCodex } from '../setup/codex.js';
 
 /**
- * codex install resolves the MCP command via `which shieldcortex` (the v4.11.1
- * stable-binary fix). Under `npm test` a shieldcortex binary usually exists on
- * PATH; use that resolved path as the expected command rather than fighting to
- * mock execSync across jest workers (same approach as mcp-registration.test.ts).
- * If nothing is on PATH the resolver falls back to `node <dist/index.js>`.
+ * codex install resolves a PATH-immune MCP command (issue #76): the ABSOLUTE
+ * node binary (`process.execPath`) + the ABSOLUTE `dist/index.js`. Never the
+ * shebang `shieldcortex` bin (dies when node isn't on the spawn PATH → bare
+ * -32000) and never `npx -y` (hash-thrash).
  */
-function resolvedShieldCortexBinary(): string | null {
-  try {
-    const whichCmd = process.platform === 'win32' ? 'where' : 'which';
-    const out = execSync(`${whichCmd} shieldcortex`, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] })
-      .trim()
-      .split('\n')[0]
-      .trim();
-    return out && fs.existsSync(out) ? out : null;
-  } catch {
-    return null;
-  }
-}
 
 describe('Codex setup', () => {
   const originalHome = process.env.HOME;
@@ -107,19 +93,11 @@ describe('Codex setup', () => {
     expect(matches).toHaveLength(1);
     expect(content).toContain('[mcp_servers.other]');
     expect(content).toContain('shieldcortex');
-    // The resolved command is either the absolute global binary or
-    // `node <dist/index.js>` — never `npx -y` (the hash-thrash class).
+    // PATH-immune (#76): absolute node binary + absolute dist/index.js — never
+    // `npx -y` (hash-thrash) and never a bare shebang bin.
     expect(content).not.toContain('npx');
-    const ambient = resolvedShieldCortexBinary();
-    if (ambient) {
-      // v4.11.1: prefer the absolute global binary, invoked directly (no args).
-      expect(content).toContain(`command = "${ambient}"`);
-      expect(content).toContain('args = []');
-    } else {
-      // Fallback: node + the absolute bundled dist entry.
-      expect(content).toContain('command = "node"');
-      expect(content).toContain('index.js');
-    }
+    expect(content).toContain(`command = "${process.execPath}"`);
+    expect(content).toContain('index.js');
     expect(content).not.toContain('/tmp/dev.js');
     expect(content).not.toContain('/tmp/global.js');
   });
@@ -144,15 +122,11 @@ describe('Codex setup', () => {
     const content = readConfig();
     const matches = content.match(/\[mcp_servers\.shieldcortex-memory\]/g) ?? [];
     expect(matches).toHaveLength(1);
-    // Stale npx form must be gone; replaced by an absolute resolved command.
+    // Stale npx form must be gone; replaced by the PATH-immune absolute-node +
+    // absolute dist/index.js command (#76).
     expect(content).not.toContain('command = "npx"');
-    const ambient = resolvedShieldCortexBinary();
-    if (ambient) {
-      expect(content).toContain(`command = "${ambient}"`);
-    } else {
-      expect(content).toContain('command = "node"');
-      expect(content).toContain('index.js');
-    }
+    expect(content).toContain(`command = "${process.execPath}"`);
+    expect(content).toContain('index.js');
   });
 
   it('removes only the shieldcortex MCP block on uninstall', async () => {

--- a/src/__tests__/copilot-setup.test.ts
+++ b/src/__tests__/copilot-setup.test.ts
@@ -1,35 +1,19 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { execSync } from 'child_process';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { installCopilot } from '../setup/copilot.js';
 
 /**
- * copilot install resolves the MCP command via `which shieldcortex` (the
- * v4.11.1 stable-binary fix). Under `npm test` a shieldcortex binary usually
- * exists on PATH; use that as the expected command. Fallback is
- * `node <dist/index.js>`. Either way it must NEVER be `npx -y` (hash-thrash).
+ * copilot install resolves a PATH-immune MCP command (issue #76): the ABSOLUTE
+ * node binary (`process.execPath`) plus the ABSOLUTE `dist/index.js`. It must
+ * NEVER be the shebang `shieldcortex` bin (dies when node isn't on the spawn
+ * PATH → bare -32000) and NEVER `npx -y` (hash-thrash).
  */
-function resolvedShieldCortexBinary(): string | null {
-  try {
-    const whichCmd = process.platform === 'win32' ? 'where' : 'which';
-    const out = execSync(`${whichCmd} shieldcortex`, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] })
-      .trim()
-      .split('\n')[0]
-      .trim();
-    return out && fs.existsSync(out) ? out : null;
-  } catch {
-    return null;
-  }
-}
 
 /** Expected command/args the resolver should produce in this environment. */
 function expectedCommand(): { command: string; argsLengthAtLeast: number } {
-  const ambient = resolvedShieldCortexBinary();
-  return ambient
-    ? { command: ambient, argsLengthAtLeast: 0 }
-    : { command: 'node', argsLengthAtLeast: 1 };
+  return { command: process.execPath, argsLengthAtLeast: 1 };
 }
 
 // VS Code (darwin) lives under ~/Library/Application Support/Code/User; Cursor

--- a/src/__tests__/mcp-path-immune-config.test.ts
+++ b/src/__tests__/mcp-path-immune-config.test.ts
@@ -1,0 +1,57 @@
+import path from 'path';
+import { describe, expect, it } from '@jest/globals';
+import { resolveMcpServerCommand } from '../setup/json-config.js';
+import { resolveMcpCommand } from '../setup/claude-md.js';
+
+/**
+ * Issue #76: setup writers emitted PATH-fragile MCP server entries —
+ * `command: <shieldcortex bin>` relying on `#!/usr/bin/env node`, so
+ * GUI/launchd spawn environments that lack the node prefix on PATH kill the
+ * process before the MCP handshake and the operator sees only a bare -32000.
+ *
+ * The fix: emit an ABSOLUTE node binary + ABSOLUTE dist/index.js, resolved at
+ * setup time, so the entry never depends on PATH.
+ */
+describe('PATH-immune MCP config writers (#76)', () => {
+  const distEntry = '/opt/shieldcortex/dist/index.js';
+
+  it('resolveMcpServerCommand emits an absolute node binary as the command', () => {
+    const { command } = resolveMcpServerCommand(distEntry);
+    // Must be the running node's absolute path — never `node`/`npx`/a shebang bin.
+    expect(command).toBe(process.execPath);
+    expect(path.isAbsolute(command)).toBe(true);
+    expect(command).not.toBe('node');
+    expect(command).not.toBe('npx');
+  });
+
+  it('resolveMcpServerCommand runs dist/index.js via an absolute path argument', () => {
+    const { args } = resolveMcpServerCommand(distEntry);
+    expect(Array.isArray(args)).toBe(true);
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    const entry = args[args.length - 1];
+    expect(path.isAbsolute(entry)).toBe(true);
+    expect(path.basename(entry)).toBe('index.js');
+    // No PATH-relative or npx re-resolution anywhere in the argv.
+    expect(JSON.stringify(args)).not.toContain('npx');
+  });
+
+  it('falls back to the passed dist entry when no global binary resolves', () => {
+    // Even with a global install absent, the command stays absolute-node and the
+    // arg stays an absolute index.js path (never `npx`, never a bare shebang bin).
+    const { command, args } = resolveMcpServerCommand(distEntry);
+    expect(command).toBe(process.execPath);
+    expect(path.isAbsolute(args[args.length - 1])).toBe(true);
+    expect(path.basename(args[args.length - 1])).toBe('index.js');
+  });
+
+  it('resolveMcpCommand (Claude Code writer) is PATH-immune: absolute node + absolute index.js, never npx', () => {
+    const { command, args } = resolveMcpCommand();
+    expect(command).toBe(process.execPath);
+    expect(command).not.toBe('npx');
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    const entry = args[args.length - 1];
+    expect(path.isAbsolute(entry)).toBe(true);
+    expect(path.basename(entry)).toBe('index.js');
+    expect(JSON.stringify(args)).not.toContain('npx');
+  });
+});

--- a/src/__tests__/mcp-registration.test.ts
+++ b/src/__tests__/mcp-registration.test.ts
@@ -1,30 +1,15 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { execSync } from 'child_process';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 /**
- * The resolver under test shells out to `which shieldcortex` (or `where` on
- * Windows). When these tests run under `npm test`, a shieldcortex binary
- * usually exists on PATH — we use *that* resolved path as the expected value
- * instead of fighting to mock exec calls across jest workers.
- *
- * If no shieldcortex binary exists on PATH at all, the "global install"
- * tests are skipped with a clear reason; the fallback test still runs via
- * a PATH override that we know clears the lookup.
+ * The MCP registration is now PATH-immune (issue #76): it always emits the
+ * ABSOLUTE node binary (`process.execPath`) + the ABSOLUTE `dist/index.js`,
+ * regardless of whether a `shieldcortex` binary is on PATH. It never emits the
+ * shebang bin as the command (which dies when node isn't on the spawn PATH →
+ * bare -32000) and never `npx -y` (hash-thrash).
  */
-function resolvedShieldCortexBinary(): string | null {
-  try {
-    const whichCmd = process.platform === 'win32' ? 'where' : 'which';
-    const out = execSync(`${whichCmd} shieldcortex`, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] })
-      .trim()
-      .split('\n')[0];
-    return out && fs.existsSync(out) ? out : null;
-  } catch {
-    return null;
-  }
-}
 
 describe('MCP global server registration (guards against npx-y hash thrash)', () => {
   const originalHome = process.env.HOME;
@@ -69,22 +54,23 @@ describe('MCP global server registration (guards against npx-y hash thrash)', ()
     setupGlobalMcp();
   }
 
-  const ambientBinary = resolvedShieldCortexBinary();
-  const describeIfBinary = ambientBinary ? describe : describe.skip;
-
-  describeIfBinary('when shieldcortex is on PATH', () => {
-    it('prefers resolved binary path over npx -y', async () => {
+  describe('PATH-immune registration (#76)', () => {
+    it('writes an absolute node binary + absolute dist/index.js (never a shebang bin, never npx)', async () => {
       await runSetup();
 
       const written = JSON.parse(fs.readFileSync(mcpPath(), 'utf-8'));
-      expect(written.mcpServers.memory).toEqual({
-        type: 'stdio',
-        command: ambientBinary,
-        args: [],
-      });
+      const entry = written.mcpServers.memory;
+      expect(entry.type).toBe('stdio');
+      expect(entry.command).toBe(process.execPath);
+      expect(entry.command).not.toBe('npx');
+      expect(Array.isArray(entry.args)).toBe(true);
+      expect(entry.args.length).toBeGreaterThanOrEqual(1);
+      const script = entry.args[entry.args.length - 1];
+      expect(path.isAbsolute(script)).toBe(true);
+      expect(path.basename(script)).toBe('index.js');
     });
 
-    it('upgrades a stale `npx -y shieldcortex` registration to the stable binary path', async () => {
+    it('upgrades a stale `npx -y shieldcortex` registration to the PATH-immune command', async () => {
       fs.writeFileSync(
         mcpPath(),
         JSON.stringify({
@@ -98,12 +84,13 @@ describe('MCP global server registration (guards against npx-y hash thrash)', ()
       await runSetup();
 
       const written = JSON.parse(fs.readFileSync(mcpPath(), 'utf-8'));
-      expect(written.mcpServers.memory.command).toBe(ambientBinary);
-      expect(written.mcpServers.memory.args).toEqual([]);
+      expect(written.mcpServers.memory.command).toBe(process.execPath);
+      expect(written.mcpServers.memory.command).not.toBe('npx');
+      expect(path.basename(written.mcpServers.memory.args.at(-1))).toBe('index.js');
       expect(written.otherUserField).toBe('preserve-me');
     });
 
-    it('is idempotent — running setup twice with a stable binary does not rewrite', async () => {
+    it('is idempotent — running setup twice does not rewrite', async () => {
       await runSetup();
       const firstMtime = fs.statSync(mcpPath()).mtimeMs;
 
@@ -117,13 +104,4 @@ describe('MCP global server registration (guards against npx-y hash thrash)', ()
       expect(secondMtime).toBe(firstMtime);
     });
   });
-
-  // Note: the "falls back to npx -y when no global binary is on PATH" scenario
-  // is not covered by a jest test because `npm test` injects its own PATH into
-  // the child process at a level below `process.env.PATH = …`, making it
-  // impossible to stage a "nothing on PATH" environment here. The fallback
-  // branch in resolveMcpCommand() is covered by inspection: three lines, an
-  // execSync-in-try/catch that on any throw returns {command: 'npx', args:
-  // ['-y', 'shieldcortex']}. If that branch ever grows non-trivial, move it
-  // into a unit-testable helper with explicit env injection.
 });

--- a/src/__tests__/mcp-startup-selfheal.test.ts
+++ b/src/__tests__/mcp-startup-selfheal.test.ts
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import {
+  selfHealMcpNativeBinding,
+  formatMcpSpawnError,
+  MCP_SPAWN_ERROR_LOG,
+} from '../setup/mcp-self-heal.js';
+import type { EnsureResult } from '../setup/native-binding.js';
+
+/**
+ * Issue #76: the MCP server dies with a bare JSON-RPC `-32000` when
+ * better-sqlite3's native binding is ABI-mismatched (e.g. an npm version bump
+ * without `shieldcortex repair`). The process spawns and dies before the MCP
+ * handshake, and the operator — whose MCP server was spawned by a GUI app —
+ * sees only `-32000`, no explanation.
+ *
+ * The fix: at MCP start, attempt the documented repair (reusing the
+ * `shieldcortex repair` machinery, `ensureNativeBinding`); if it can't heal,
+ * fail LOUDLY with a message naming the exact fix command + drop a breadcrumb.
+ */
+describe('MCP startup self-heal (#76)', () => {
+  let logsDir: string;
+  const installDir = '/opt/shieldcortex';
+
+  beforeEach(() => {
+    logsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-mcp-selfheal-'));
+  });
+  afterEach(() => {
+    fs.rmSync(logsDir, { recursive: true, force: true });
+  });
+
+  const deps = (ensureResult: EnsureResult) => ({
+    ensure: async () => ensureResult,
+    installDir: () => installDir,
+    logsDir: () => logsDir,
+    now: () => '2026-07-12T00:00:00.000Z',
+  });
+
+  it('returns ok without a breadcrumb when the binding loads first try', async () => {
+    const out = await selfHealMcpNativeBinding(deps({ status: 'ok' }));
+    expect(out.ok).toBe(true);
+    expect(out.healed).toBe(false);
+    expect(fs.existsSync(path.join(logsDir, MCP_SPAWN_ERROR_LOG))).toBe(false);
+  });
+
+  it('self-heals (reusing the repair machinery) and reports healed, no breadcrumb', async () => {
+    const out = await selfHealMcpNativeBinding(deps({ status: 'healed', rebuildOutput: 'built ok' }));
+    expect(out.ok).toBe(true);
+    expect(out.healed).toBe(true);
+    expect(fs.existsSync(path.join(logsDir, MCP_SPAWN_ERROR_LOG))).toBe(false);
+  });
+
+  it('fails LOUDLY when heal is impossible: message names the exact fix command, never a bare -32000', async () => {
+    const out = await selfHealMcpNativeBinding(
+      deps({ status: 'failed', error: 'NODE_MODULE_VERSION mismatch', remediation: 'cd .../better-sqlite3 && npm run build-release' }),
+    );
+    expect(out.ok).toBe(false);
+    expect(out.healed).toBe(false);
+    expect(out.message).toBeDefined();
+    // The whole point: a diagnosable message, not an opaque -32000.
+    expect(out.message).not.toBe('-32000');
+    expect(out.message).toContain('shieldcortex repair');
+    expect(out.message).toContain(installDir);
+  });
+
+  it('drops a breadcrumb naming the install path and repair command on failure', async () => {
+    const out = await selfHealMcpNativeBinding(
+      deps({ status: 'failed', error: 'could not locate the bindings file', remediation: 'cd x && npm run build-release' }),
+    );
+    const crumb = path.join(logsDir, MCP_SPAWN_ERROR_LOG);
+    expect(out.breadcrumbPath).toBe(crumb);
+    expect(fs.existsSync(crumb)).toBe(true);
+    const body = fs.readFileSync(crumb, 'utf-8');
+    expect(body).toContain(installDir);
+    expect(body).toContain('shieldcortex repair');
+    // The underlying error is preserved for diagnosis.
+    expect(body).toContain('could not locate the bindings file');
+  });
+
+  it('formatMcpSpawnError produces an actionable, non-opaque message', () => {
+    const msg = formatMcpSpawnError(installDir, 'NODE_MODULE_VERSION 127 vs 108');
+    expect(msg).toContain('shieldcortex repair');
+    expect(msg).toContain(installDir);
+    expect(msg).not.toBe('-32000');
+    expect(msg.toLowerCase()).toContain('database engine');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,21 @@ async function startMcpServer(dbPath?: string): Promise<void> {
   // stays clean even if a future code path forgets.
   console.log = (...args: unknown[]): void => { console.error(...args); };
 
+  // Startup self-heal (#76): before we touch the database, make sure the
+  // better-sqlite3 native binding actually loads. On an ABI mismatch (npm
+  // version bump without `shieldcortex repair`) it wouldn't, and `createServer`
+  // → `initDatabase` would throw, killing the process before the MCP handshake
+  // — the client sees only a bare `-32000`. Attempt the documented repair
+  // (reusing the `shieldcortex repair` machinery); if it can't heal, fail LOUDLY
+  // to stderr + a breadcrumb naming the exact fix command, never a silent death.
+  const { selfHealMcpNativeBinding } = await import('./setup/mcp-self-heal.js');
+  const heal = await selfHealMcpNativeBinding();
+  if (!heal.ok) {
+    console.error(heal.message);
+    if (heal.breadcrumbPath) console.error(`\nDetails written to: ${heal.breadcrumbPath}`);
+    process.exit(1);
+  }
+
   // Lazy-load heavy server/worker/embedding modules — only the actual MCP
   // server path needs them, so they stay out of fast CLI/hook startup.
   const { createServer } = await import('./server.js');

--- a/src/setup/claude-md.ts
+++ b/src/setup/claude-md.ts
@@ -12,10 +12,13 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
 import { installOpenClawHook, findAllHooksDirs } from './openclaw.js';
 import { setupHooks } from './settings-hooks.js';
-import { readJsonConfigOrAbort, writeJsonConfigWithBackup, looksLikeShieldcortex } from './json-config.js';
+import { readJsonConfigOrAbort, writeJsonConfigWithBackup, looksLikeShieldcortex, resolveMcpServerCommand } from './json-config.js';
+
+// MCP entry point: dist/index.js — one level up from dist/setup/ (this module).
+const MCP_ENTRY = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'index.js');
 
 const MARKER = '# ShieldCortex — Memory System';
 
@@ -97,36 +100,22 @@ interface McpCommand {
 }
 
 /**
- * Resolve the best shieldcortex command for the MCP stdio registration.
+ * Resolve the shieldcortex command for the MCP stdio registration.
  *
- * Prefers an installed global binary over `npx -y shieldcortex`. Reason:
- * Claude Code / OpenClaw hash the effective MCP config to decide whether
- * to reset the active CLI session. `npx -y` resolves dynamically on every
- * invocation — when the npm cache shifts (version drift, fresh publish,
- * cache miss), the resolved command changes, the hash changes, and the
- * active CLI session is silently reset. Every reset wipes conversation
- * context mid-flight. On TARS (v4.10.x install on Oracle ARM) this fired
- * every ~30 minutes and surfaced as the fleet "Fresh session, no prior
- * context" bug on 2026-04-22.
+ * PATH-immune (issue #76): delegates to the shared resolver so the entry is an
+ * ABSOLUTE node binary (`process.execPath`) + the ABSOLUTE `dist/index.js` — it
+ * never emits the `shieldcortex` shebang bin (which relies on `#!/usr/bin/env
+ * node` finding node on PATH; GUI/launchd spawns often lack it, killing the
+ * server before the MCP handshake with a bare -32000).
  *
- * If no global binary exists (single-shot `npx shieldcortex setup`),
- * falls back to `npx -y shieldcortex` — which still works, just trades
- * stability for availability in ephemeral installs.
+ * Also never `npx -y shieldcortex`: `npx` re-resolves on every spawn, so a cache
+ * shift changes the effective command; Claude Code / OpenClaw hash the MCP
+ * config and reset the active CLI session on any change, wiping conversation
+ * context mid-flight (TARS, 2026-04-22 fleet "Fresh session" bug). Two absolute
+ * paths never drift.
  */
-function resolveMcpCommand(): McpCommand {
-  try {
-    const whichCmd = process.platform === 'win32' ? 'where' : 'which';
-    const resolved = execSync(`${whichCmd} shieldcortex`, {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim().split('\n')[0];
-    if (resolved && fs.existsSync(resolved)) {
-      return { command: resolved, args: [] };
-    }
-  } catch {
-    // No global install on PATH.
-  }
-  return { command: 'npx', args: ['-y', 'shieldcortex'] };
+export function resolveMcpCommand(): McpCommand {
+  return resolveMcpServerCommand(MCP_ENTRY);
 }
 
 function isIdealMcpEntry(entry: unknown, ideal: McpCommand): boolean {

--- a/src/setup/json-config.ts
+++ b/src/setup/json-config.ts
@@ -132,28 +132,19 @@ export interface McpServerCommand {
 }
 
 /**
- * Resolve the stdio command an editor (Codex / VS Code Copilot / Cursor) should
- * launch to start the ShieldCortex MCP server.
+ * Resolve the ABSOLUTE `dist/index.js` the MCP server should run. Prefers the
+ * globally-installed package's entry (so an editor points at the user's real
+ * install, not a transient npx/local checkout), falling back to the caller's
+ * bundled entry.
  *
- * Mirrors `claude-md.ts setupGlobalMcp`'s v4.11.1 fix: prefer the installed
- * GLOBAL binary, resolved to an ABSOLUTE path via `which`/`where`, and invoke
- * it directly. The hazard being avoided is `npx -y shieldcortex` as the MCP
- * command — `npx` re-resolves dynamically on every spawn, so a cache shift
- * (version drift / fresh publish / cache miss) silently changes the effective
- * command. Editors hash their MCP config; a changed command changes the hash
- * and resets the active session, wiping context (the 2026-04-22 fleet "fresh
- * session" bug). An absolute path never drifts.
+ * The global `shieldcortex` bin IS `dist/index.js` (package.json `bin` maps it
+ * directly), so `realpath`-ing the resolved bin yields that install's absolute
+ * entry file — no layout guessing.
  *
- * Fallback when no global binary is on PATH: `node <absoluteDistEntry>` — the
- * bundled `dist/index.js` resolved to an absolute path from this module's
- * location. That is ALSO stable (a fixed absolute path, not `npx`), so a
- * single-shot install without a global binary still gets a hash-stable command
- * rather than re-introducing the npx hash-thrash class.
- *
- * @param distEntry Absolute path to the package's `dist/index.js` (the caller
- *   resolves it from its own `__dirname` so we don't guess the layout).
+ * @param distEntry Absolute path to this package's `dist/index.js` (the caller
+ *   resolves it from its own `__dirname`), used when no global install resolves.
  */
-export function resolveMcpServerCommand(distEntry: string): McpServerCommand {
+export function resolveMcpEntryPath(distEntry: string): string {
   try {
     const whichCmd = process.platform === 'win32' ? 'where' : 'which';
     const resolved = execSync(`${whichCmd} shieldcortex`, {
@@ -164,10 +155,41 @@ export function resolveMcpServerCommand(distEntry: string): McpServerCommand {
       .split('\n')[0]
       .trim();
     if (resolved && fs.existsSync(resolved)) {
-      return { command: resolved, args: [] };
+      // The bin is a symlink/wrapper to the install's dist/index.js — follow it
+      // to the real absolute entry file.
+      const real = fs.realpathSync(resolved);
+      if (real && path.basename(real) === 'index.js' && fs.existsSync(real)) {
+        return real;
+      }
     }
   } catch {
     // No global install on PATH — fall through to the bundled entry.
   }
-  return { command: 'node', args: [distEntry] };
+  return distEntry;
+}
+
+/**
+ * Resolve the stdio command an editor (Codex / VS Code Copilot / Cursor) should
+ * launch to start the ShieldCortex MCP server.
+ *
+ * PATH-IMMUNE by construction (issue #76): emits the ABSOLUTE node binary
+ * (`process.execPath`) plus the ABSOLUTE `dist/index.js`. It never emits the
+ * `shieldcortex` shebang bin as the command — that relies on `#!/usr/bin/env
+ * node` finding `node` on PATH, and GUI/launchd spawn environments (VS Code,
+ * Claude Code's own launcher) frequently lack the node prefix, so the process
+ * dies before the MCP handshake and the operator sees only a bare JSON-RPC
+ * `-32000` with no explanation. An absolute-node + absolute-script argv has no
+ * PATH dependency at all.
+ *
+ * Also never `npx -y shieldcortex`: `npx` re-resolves dynamically on every
+ * spawn, so a cache shift (version drift / fresh publish / cache miss) silently
+ * changes the effective command. Editors hash their MCP config; a changed
+ * command changes the hash and resets the active session, wiping context (the
+ * 2026-04-22 fleet "fresh session" bug). Two absolute paths never drift.
+ *
+ * @param distEntry Absolute path to this package's `dist/index.js` (the caller
+ *   resolves it from its own `__dirname` so we don't guess the layout).
+ */
+export function resolveMcpServerCommand(distEntry: string): McpServerCommand {
+  return { command: process.execPath, args: [resolveMcpEntryPath(distEntry)] };
 }

--- a/src/setup/mcp-self-heal.ts
+++ b/src/setup/mcp-self-heal.ts
@@ -1,0 +1,133 @@
+/**
+ * MCP-server startup self-heal for the better-sqlite3 native binding (issue #76).
+ *
+ * When the MCP server is spawned by a GUI app (Claude Code, VS Code, launchd)
+ * and better-sqlite3's native binding is ABI-mismatched — the classic
+ * "npm version bump without `shieldcortex repair`" trap — the process dies
+ * before the MCP handshake and the operator sees only a bare JSON-RPC `-32000`
+ * with no explanation.
+ *
+ * This module makes MCP startup:
+ *   1. SELF-HEAL: attempt the documented repair programmatically, REUSING the
+ *      `shieldcortex repair` machinery (`ensureNativeBinding`) — never a second
+ *      rebuild implementation.
+ *   2. FAIL LOUDLY: if the heal is impossible, produce a one-line actionable
+ *      message naming the exact fix command (`shieldcortex repair`) AND drop a
+ *      breadcrumb file (`~/.shieldcortex/logs/mcp-spawn-error.log`) naming the
+ *      exact install path + repair command — so `-32000` is diagnosable in
+ *      seconds instead of being opaque.
+ *
+ * Pure/injectable so both outcomes are unit-testable without a real ABI break.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  ensureNativeBinding,
+  resolveSelfInstallDir,
+  type EnsureResult,
+} from './native-binding.js';
+
+/** Breadcrumb filename dropped under the logs dir on an unrecoverable failure. */
+export const MCP_SPAWN_ERROR_LOG = 'mcp-spawn-error.log';
+
+/** Injection seam so the self-heal orchestration is testable without a real
+ * native failure or touching the real logs dir. */
+export interface McpSelfHealDeps {
+  /** The repair machinery — verify → rebuild → re-verify. */
+  ensure: () => Promise<EnsureResult>;
+  /** The running install's root dir (contains node_modules/better-sqlite3). */
+  installDir: () => string;
+  /** Where the breadcrumb is written (default ~/.shieldcortex/logs). */
+  logsDir: () => string;
+  /** ISO timestamp source (injectable for deterministic tests). */
+  now: () => string;
+}
+
+export interface McpSelfHealOutcome {
+  /** True when the binding is loadable (either it always was, or heal fixed it). */
+  ok: boolean;
+  /** True when a rebuild was needed and succeeded. */
+  healed: boolean;
+  /** Loud, actionable message — present only when `ok` is false. Names the exact
+   * fix command; NEVER a bare `-32000`. */
+  message?: string;
+  /** Absolute path of the breadcrumb written on failure, if any. */
+  breadcrumbPath?: string;
+}
+
+function defaultLogsDir(): string {
+  return path.join(os.homedir(), '.shieldcortex', 'logs');
+}
+
+/**
+ * Build the loud, actionable startup-failure message. Pure so it can be printed
+ * to stderr AND embedded in the breadcrumb, and unit-tested directly.
+ *
+ * The contract: it must name the exact fix command and the install path, and it
+ * must NEVER be an opaque `-32000` — that opacity is the whole bug.
+ */
+export function formatMcpSpawnError(installDir: string, underlying: string): string {
+  return [
+    'ShieldCortex MCP server failed to start: the database engine (better-sqlite3)',
+    'could not be loaded and an automatic rebuild did not fix it (native-module',
+    'ABI mismatch — typically an npm version bump without a repair).',
+    '',
+    `Install: ${installDir}`,
+    '',
+    'Fix it with:',
+    '  shieldcortex repair',
+    `  (or: cd "${path.join(installDir, 'node_modules', 'better-sqlite3')}" && npm run build-release)`,
+    'Then restart the app that launches this MCP server.',
+    '',
+    `Underlying error: ${underlying}`,
+  ].join('\n');
+}
+
+/**
+ * Verify + heal the native binding for MCP startup; on unrecoverable failure,
+ * write a breadcrumb and return a loud, actionable message. Never throws.
+ *
+ * REUSES `ensureNativeBinding` (the `shieldcortex repair` machinery) — no second
+ * rebuild path. The caller (the MCP entry point) prints `message` to stderr and
+ * exits non-zero when `ok` is false, so the client never just sees `-32000`.
+ */
+export async function selfHealMcpNativeBinding(
+  deps: Partial<McpSelfHealDeps> = {},
+): Promise<McpSelfHealOutcome> {
+  const ensure = deps.ensure ?? ensureNativeBinding;
+  const installDir = deps.installDir ?? resolveSelfInstallDir;
+  const logsDir = deps.logsDir ?? defaultLogsDir;
+  const now = deps.now ?? (() => new Date().toISOString());
+
+  const result = await ensure();
+
+  if (result.status === 'ok') return { ok: true, healed: false };
+  if (result.status === 'healed') return { ok: true, healed: true };
+
+  // status === 'failed' — heal impossible. Fail loudly.
+  const dir = installDir();
+  const underlying = result.error ?? 'unknown native-module load failure';
+  const message = formatMcpSpawnError(dir, underlying);
+
+  let breadcrumbPath: string | undefined;
+  try {
+    const target = logsDir();
+    fs.mkdirSync(target, { recursive: true });
+    breadcrumbPath = path.join(target, MCP_SPAWN_ERROR_LOG);
+    const body = [
+      `[${now()}] ShieldCortex MCP server spawn failed (better-sqlite3 native-module load).`,
+      message,
+      result.remediation ? `\nRemediation:\n${result.remediation}` : '',
+      result.rebuildOutput ? `\nRebuild output (tail):\n${result.rebuildOutput.split('\n').slice(-12).join('\n')}` : '',
+      '',
+    ].join('\n');
+    fs.writeFileSync(breadcrumbPath, body, 'utf-8');
+  } catch {
+    // A breadcrumb-write failure must not mask the (already loud) message.
+    breadcrumbPath = undefined;
+  }
+
+  return { ok: false, healed: false, message, breadcrumbPath };
+}


### PR DESCRIPTION
## Summary
The MCP server died with a bare JSON-RPC `-32000` when better-sqlite3's native binding was ABI-mismatched (an npm version bump without `shieldcortex repair`): the process spawned and died before the MCP handshake, and an operator whose MCP server was launched by a GUI app saw only `-32000` — no explanation.

**Field context (Friday's Mac, 2026-07-11, 4.47.2 fleet bump):** Claude Code's `mcpServers.memory` entry failed with `-32000`; entry shape was correct (verified healthy on a control host). Two product-hardenable causes: (1) better-sqlite3 ABI mismatch, (2) PATH-fragile shebang entries in GUI/launchd spawn environments.

## Approach
Three fixes, all reusing existing machinery (no forked rebuild path):

1. **Startup self-heal** — `src/setup/mcp-self-heal.ts`, wired into `startMcpServer` *before* the DB is touched. Verifies the native binding and, on failure, attempts the documented repair by **reusing `ensureNativeBinding`** (the `shieldcortex repair` machinery). Returns `{ok, healed}`.

2. **Loud failure** — when self-heal is impossible, `formatMcpSpawnError()` produces a one-line actionable message naming the exact fix command (`shieldcortex repair`) + the install path, and a breadcrumb is dropped at `~/.shieldcortex/logs/mcp-spawn-error.log` (install path + repair command + rebuild tail). The MCP entry prints it to **stderr** (stdout stays pure JSON-RPC) and exits non-zero — never a bare `-32000`.

3. **PATH-immune config writers** — `resolveMcpServerCommand` is now the single PATH-immune resolver: it emits `process.execPath` (absolute node) + the absolute `dist/index.js` (resolved from the global bin via `realpath`, else the bundled entry). It no longer emits the `shieldcortex` shebang bin (relies on `#!/usr/bin/env node` finding node on PATH — GUI/launchd spawns often lack it) nor `npx -y` (hash-thrash). `claude-md.ts`'s `resolveMcpCommand` delegates to it. Codex/Copilot/Cursor already routed through it.

Note: issue #76 also lists a 4th item (repair covers every install on multi-install hosts) — out of scope for this PR's three deliverables; can follow up.

## Tests (strict TDD — failing test first)
- `mcp-startup-selfheal.test.ts`: stubbed `EnsureResult` drives all three outcomes — ok (no breadcrumb), healed (no breadcrumb), failed (loud message names `shieldcortex repair` + install path, is **not** `-32000`; breadcrumb written with install path + repair command + underlying error).
- `mcp-path-immune-config.test.ts`: `resolveMcpServerCommand` / `resolveMcpCommand` emit `process.execPath` + an absolute `index.js`, never `node`/`npx`/a shebang bin.
- Existing writer tests (`copilot-setup`, `codex-setup`, `mcp-registration`) migrated to the new PATH-immune contract; `mcp-stdout-purity` confirms the self-heal wiring doesn't pollute the JSON-RPC channel.

## Test evidence
Item-2 suites (all green):
```
Test Suites: 10 passed, 10 total
Tests:       55 passed, 55 total
```
Full `npm test`: **2325 passed / 17 failed**. The 17 failures are pre-existing and unrelated — clean `origin/main` (a48917a) produces the **identical** 4 failed suites / 17 failed tests (`save-auto-extracted-memory`, `save-memory-near-dup-dedup`, `defence-pipeline-bypass`, `recall-defence-integration`) — a DB test-isolation/embedding-skip issue on this environment. This branch's delta is **+12 passing, 0 new failures**.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)