### PR TITLE
feat: consent-gated active canary dispatch in openclaw-selfcheck (Closes #81)

### DIFF
--- a/src/__tests__/openclaw-canary-dispatch.test.ts
+++ b/src/__tests__/openclaw-canary-dispatch.test.ts
@@ -1,0 +1,156 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { evaluateToolCall } from '../defence/iron-dome/tool-action-guard.js';
+import {
+  buildSyntheticCanaryOp,
+  dispatchCanaryThroughInstalledInterceptor,
+  defaultTriggerSyntheticOp,
+  findFreshEnforcementEntry,
+  CANARY_MARKER,
+  type ActiveDispatchDeps,
+} from '../setup/openclaw-selfcheck.js';
+
+/**
+ * Item 3 (#74 follow-up): wire the REAL consent-gated active canary in
+ * openclaw-selfcheck. `defaultTriggerSyntheticOp` shipped deliberately unwired
+ * in 4.47.3 — it reported "roster proof stands; enforcement not actively proven"
+ * rather than fabricating a live-dispatch pass. This wires the actual dispatch:
+ * a harmless synthetic op driven through the live interceptor path, whose real
+ * deny + audit entry the existing observe logic then confirms.
+ *
+ * Fail-closed contract (non-negotiable):
+ *  - No consent → identical to today (honest "not actively proven").
+ *  - Dispatch attempted but unobservable/failed → reported loudly as NOT proven;
+ *    never fabricate a pass.
+ *  - The synthetic op is provably harmless + clearly canary-tagged.
+ */
+
+describe('buildSyntheticCanaryOp — provably harmless, known-bad, canary-tagged', () => {
+  it('is genuinely denied by the REAL Action Guard evaluator (catastrophic block)', () => {
+    const op = buildSyntheticCanaryOp('sc-canary-NONCE1');
+    const v = evaluateToolCall(op.toolName, op.arguments);
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('catastrophic');
+  });
+
+  it('is provably harmless: targets a synthetic /tmp canary path (a no-op even if it ran)', () => {
+    const op = buildSyntheticCanaryOp('sc-canary-NONCE1');
+    const command = String(op.arguments.command);
+    expect(command).toContain('/tmp/');
+    // Never a real/root/home target — the delete surface is a synthetic path only.
+    expect(command).not.toMatch(/\srm\b[^\n]*\s(?:\/|~|\$HOME)(?:\s|$)/);
+  });
+
+  it('carries the nonce and the canary marker so the audit entry is unmistakable', () => {
+    const op = buildSyntheticCanaryOp('sc-canary-NONCE1');
+    const blob = JSON.stringify(op.arguments);
+    expect(blob).toContain('sc-canary-NONCE1');
+    expect(blob).toContain(CANARY_MARKER);
+  });
+});
+
+describe('dispatchCanaryThroughInstalledInterceptor — fail-closed orchestration', () => {
+  const evaluator = evaluateToolCall as unknown as ActiveDispatchDeps['evaluator'];
+
+  it('reports NOT dispatched (loudly) when the realtime plugin is not found on disk', async () => {
+    const r = await dispatchCanaryThroughInstalledInterceptor('/home/x', 'p', 'sc-canary-N', {
+      resolveInstallPath: () => null,
+      loadInterceptorModule: async () => { throw new Error('should not be called'); },
+      evaluator,
+    });
+    expect(r.dispatched).toBe(false);
+    expect(r.detail).toMatch(/not found|could not|cannot/i);
+  });
+
+  it('reports NOT dispatched when the installed interceptor module cannot be loaded', async () => {
+    const r = await dispatchCanaryThroughInstalledInterceptor('/home/x', 'p', 'sc-canary-N', {
+      resolveInstallPath: () => '/opt/plugin',
+      loadInterceptorModule: async () => null,
+      evaluator,
+    });
+    expect(r.dispatched).toBe(false);
+    expect(r.detail).toMatch(/interceptor|module|cannot/i);
+  });
+
+  it('reports NOT dispatched when constructing the interceptor throws (never fabricates a pass)', async () => {
+    const r = await dispatchCanaryThroughInstalledInterceptor('/home/x', 'p', 'sc-canary-N', {
+      resolveInstallPath: () => '/opt/plugin',
+      loadInterceptorModule: async () => ({
+        createInterceptor: () => { throw new Error('boom'); },
+        DEFAULT_CONFIG: {},
+      }),
+      evaluator,
+    });
+    expect(r.dispatched).toBe(false);
+    expect(r.detail).toMatch(/interceptor|construct|failed/i);
+  });
+
+  it('dispatches the exact synthetic canary op through the interceptor, with the evaluator wired', async () => {
+    let received: { toolName: string; arguments: Record<string, unknown> } | undefined;
+    let evaluatorWired = false;
+    const r = await dispatchCanaryThroughInstalledInterceptor('/home/x', 'p', 'sc-canary-N', {
+      resolveInstallPath: () => '/opt/plugin',
+      loadInterceptorModule: async () => ({
+        createInterceptor: (_cfg: unknown, _pipe: unknown, opts: { evaluateToolCall?: unknown }) => {
+          evaluatorWired = typeof opts?.evaluateToolCall === 'function';
+          return {
+            handleToolCall: async (ctx: { toolName: string; arguments: Record<string, unknown> }) => {
+              received = ctx;
+              // A real block throws after auditing — mimic that so the catch path is exercised.
+              throw new Error('ShieldCortex: tool call blocked — canary');
+            },
+            resetSession: () => {},
+          };
+        },
+        DEFAULT_CONFIG: {},
+      }),
+      evaluator,
+    });
+    expect(r.dispatched).toBe(true);
+    expect(evaluatorWired).toBe(true);
+    expect(received).toEqual(buildSyntheticCanaryOp('sc-canary-N'));
+  });
+});
+
+describe('active canary end-to-end through the REAL interceptor (hermetic, no gateway)', () => {
+  let home: string;
+  let homedirSpy: jest.SpiedFunction<typeof os.homedir>;
+
+  beforeEach(() => {
+    jest.resetModules();
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-canary-e2e-'));
+    homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(home);
+  });
+  afterEach(() => {
+    homedirSpy.mockRestore();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('the real interceptor denies + audits the synthetic op; findFresh confirms a fresh nonce-matched deny', async () => {
+    const nonce = 'sc-canary-E2E-UNIQUE';
+    const sinceMs = Date.now() - 1000;
+    // Load the ACTUAL plugin interceptor (its AUDIT_DIR resolves under the mocked
+    // home) and drive the synthetic op through it via the real defence evaluator.
+    const interceptorMod = await import('../../plugins/openclaw/interceptor.js');
+    const r = await dispatchCanaryThroughInstalledInterceptor(home, 'shieldcortex-realtime', nonce, {
+      resolveInstallPath: () => '/unused-real-module-injected',
+      loadInterceptorModule: async () => interceptorMod as unknown as Awaited<ReturnType<ActiveDispatchDeps['loadInterceptorModule']>>,
+      evaluator: evaluateToolCall as unknown as ActiveDispatchDeps['evaluator'],
+    });
+    expect(r.dispatched).toBe(true);
+
+    // The observe half of the canary: a FRESH audit deny carrying our nonce.
+    const fresh = findFreshEnforcementEntry(home, { nonce, sinceMs });
+    expect(fresh.found).toBe(true);
+  });
+});
+
+describe('defaultTriggerSyntheticOp — fail-closed guards preserved', () => {
+  it('is skipped under the test runner (JEST_WORKER_ID guard preserved — never dispatches in tests)', async () => {
+    const r = await defaultTriggerSyntheticOp('/home/x', 'shieldcortex-realtime', 'sc-canary-N');
+    expect(r.dispatched).toBe(false);
+    expect(r.detail).toMatch(/test runner/i);
+  });
+});

--- a/src/setup/openclaw-selfcheck.ts
+++ b/src/setup/openclaw-selfcheck.ts
@@ -1,13 +1,18 @@
 import fs from 'fs';
 import path from 'path';
 import { randomUUID } from 'crypto';
+import { pathToFileURL } from 'url';
 import semver from 'semver';
 import {
   readPluginInstallIndex,
   REALTIME_PLUGIN_ID,
   type PluginIndexRow,
 } from '../integrations/openclaw-plugin-index.js';
-import { readInstalledRealtimePluginVersion } from '../integrations/openclaw-plugin-state.js';
+import {
+  readInstalledRealtimePluginVersion,
+  resolveRealtimePluginInstallPath,
+} from '../integrations/openclaw-plugin-state.js';
+import { evaluateToolCall } from '../defence/iron-dome/tool-action-guard.js';
 
 /**
  * Honest-state post-install/enable self-check (#74 deliverable 2).
@@ -223,17 +228,171 @@ export async function defaultCanaryProbe(home: string, pluginId: string): Promis
   });
 }
 
+/** Marker embedded in the synthetic op so its audit entry is unmistakably a
+ * canary probe (not a real agent action) to anyone tailing the audit log. */
+export const CANARY_MARKER = 'SHIELDCORTEX-CANARY';
+
+/** The synthetic operation the active canary drives through the interceptor. */
+export interface SyntheticCanaryOp {
+  toolName: string;
+  arguments: Record<string, unknown>;
+}
+
 /**
- * The guarded live dispatch seam. Refuses to drive a real gateway operation
- * under a Jest worker or without the explicit `SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1`
- * consent env. Returns `dispatched:false` when it cannot run so the probe fails
- * closed. The actual active synthetic dispatch is performed on the sacrificial
- * rollout env per the #74 plan; this box (frozen toggle) never dispatches.
+ * Build the synthetic canary operation, tagged with the probe `nonce`.
+ *
+ * It is a known-bad SHAPE — a recursive-force-delete, which the Action Guard
+ * hard-blocks as `catastrophic` — so a live interceptor MUST deny it. Yet it is
+ * PROVABLY HARMLESS: the delete surface is a synthetic, non-existent `/tmp`
+ * path, so even in the failure mode this canary exists to detect (enforcement
+ * OFF, the op actually executes) `rm -rf` on a missing path is a no-op. The
+ * nonce uniquely identifies this probe's audit entry; {@link CANARY_MARKER}
+ * makes its purpose unmistakable to an operator reading the log.
+ */
+export function buildSyntheticCanaryOp(nonce: string): SyntheticCanaryOp {
+  return {
+    toolName: 'Bash',
+    arguments: {
+      command: `rm -rf /tmp/${nonce}`,
+      description: `${CANARY_MARKER} synthetic enforcement probe ${nonce} — never executed`,
+    },
+  };
+}
+
+/** The subset of the plugin's compiled interceptor module the canary needs. */
+export interface InterceptorLikeModule {
+  createInterceptor: (
+    config: unknown,
+    pipeline: unknown,
+    options?: { evaluateToolCall?: unknown },
+  ) => { handleToolCall: (ctx: SyntheticCanaryOp) => Promise<void>; resetSession?: () => void };
+  DEFAULT_CONFIG: unknown;
+}
+
+/** Injectable seams for the active synthetic dispatch, so the wiring is unit-
+ * tested without a live gateway or a real ABI/install on disk. */
+export interface ActiveDispatchDeps {
+  /** Resolve the installed realtime plugin dir (the live interceptor code). */
+  resolveInstallPath: (home: string) => string | null;
+  /** Load the installed plugin's compiled interceptor module, or null. */
+  loadInterceptorModule: (installPath: string) => Promise<InterceptorLikeModule | null>;
+  /** The real Tool Action Guard evaluator (`shieldcortex/defence`). */
+  evaluator: (toolName: string, args: Record<string, unknown>) => unknown;
+}
+
+/** A benign pipeline stub for the memory path — never invoked for the Bash
+ * canary op (non-memory tools route to the Action Guard), but createInterceptor
+ * requires one. */
+const benignPipeline = () => ({
+  allowed: true,
+  firewall: { result: 'ALLOW' as const, reason: 'canary', threatIndicators: [], anomalyScore: 0, blockedPatterns: [] },
+  trust: { score: 1 },
+  sensitivity: { level: 'INTERNAL' },
+  fragmentation: null,
+  auditId: 0,
+});
+
+/**
+ * Drive the synthetic canary op through the INSTALLED plugin's real interceptor
+ * — the same code the gateway loads — so the deny + audit entry are produced by
+ * the genuine enforcement path, not a stub. Reuses the installed interceptor
+ * (no forked implementation) and the real defence evaluator.
+ *
+ * Fail-closed at every step: a missing install, an unloadable module, or a
+ * construction failure returns `dispatched:false` with a loud, honest detail —
+ * never a fabricated pass. `dispatched:true` means only that the op passed
+ * through the interceptor; whether it was actually DENIED + AUDITED is confirmed
+ * separately by {@link findFreshEnforcementEntry} (the fresh nonce gate).
+ *
+ * Harmless by construction: the interceptor evaluates + audits BEFORE any
+ * execution, and the op itself is a no-op even if it ran (see
+ * {@link buildSyntheticCanaryOp}). Nothing here touches the running gateway.
+ */
+export async function dispatchCanaryThroughInstalledInterceptor(
+  home: string,
+  _pluginId: string,
+  nonce: string,
+  deps: ActiveDispatchDeps,
+): Promise<{ dispatched: boolean; detail?: string }> {
+  const installPath = deps.resolveInstallPath(home);
+  if (!installPath) {
+    return { dispatched: false, detail: 'realtime plugin not found on disk — cannot dispatch through the live interceptor' };
+  }
+
+  let mod: InterceptorLikeModule | null;
+  try {
+    mod = await deps.loadInterceptorModule(installPath);
+  } catch (err) {
+    return { dispatched: false, detail: `could not load the installed interceptor module: ${errMsg(err)}` };
+  }
+  if (!mod || typeof mod.createInterceptor !== 'function' || mod.DEFAULT_CONFIG == null) {
+    return { dispatched: false, detail: 'installed interceptor module missing createInterceptor/DEFAULT_CONFIG — cannot actively probe' };
+  }
+
+  let interceptor: ReturnType<InterceptorLikeModule['createInterceptor']>;
+  try {
+    interceptor = mod.createInterceptor(mod.DEFAULT_CONFIG, benignPipeline, { evaluateToolCall: deps.evaluator });
+  } catch (err) {
+    return { dispatched: false, detail: `failed to construct the installed interceptor: ${errMsg(err)}` };
+  }
+
+  const op = buildSyntheticCanaryOp(nonce);
+  try {
+    await interceptor.handleToolCall(op);
+    // No throw ⇒ the interceptor did NOT block. The op WAS dispatched, but the
+    // absence of a deny is surfaced by findFresh (denied:false → loud fail).
+  } catch {
+    // A block throws AFTER writing the audit entry — the enforcement firing IS
+    // the success signal here; swallow it and let findFresh confirm the deny.
+  }
+  return { dispatched: true, detail: `synthetic canary (nonce ${nonce}) dispatched through the installed interceptor at ${installPath}` };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Default active-dispatch seams: the installed-plugin discovery helper (#77),
+ * a filesystem import of the installed interceptor, and the real evaluator. */
+const defaultActiveDispatchDeps: ActiveDispatchDeps = {
+  resolveInstallPath: (home) => resolveRealtimePluginInstallPath(home),
+  loadInterceptorModule: defaultLoadInterceptorModule,
+  evaluator: (toolName, args) => evaluateToolCall(toolName, args),
+};
+
+/** Import the installed plugin's compiled interceptor from its package dir.
+ * Best-effort across the shipped layouts (`dist/interceptor.js`, root
+ * `interceptor.js`); returns null when none resolves so dispatch fails closed. */
+async function defaultLoadInterceptorModule(installPath: string): Promise<InterceptorLikeModule | null> {
+  const candidates = [
+    path.join(installPath, 'dist', 'interceptor.js'),
+    path.join(installPath, 'interceptor.js'),
+  ];
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) continue;
+    const mod = (await import(pathToFileURL(candidate).href)) as Partial<InterceptorLikeModule>;
+    if (typeof mod.createInterceptor === 'function' && mod.DEFAULT_CONFIG != null) {
+      return mod as InterceptorLikeModule;
+    }
+  }
+  return null;
+}
+
+/**
+ * The guarded live dispatch seam. Fail-closed by design:
+ *   - Under a Jest worker → never dispatches (`ran:false` upstream).
+ *   - Without the explicit `SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1` consent env →
+ *     identical to the 4.47.3 behaviour: honest "roster proof stands;
+ *     enforcement not actively proven".
+ *   - With consent → drives the harmless synthetic op through the INSTALLED
+ *     interceptor (the real enforcement path) and reports whether it dispatched;
+ *     the deny/audit is then confirmed by the fresh nonce gate. A dispatch that
+ *     fails or is unobservable is reported loudly as NOT proven — never faked.
  */
 export async function defaultTriggerSyntheticOp(
-  _home: string,
-  _pluginId: string,
-  _nonce: string,
+  home: string,
+  pluginId: string,
+  nonce: string,
 ): Promise<{ dispatched: boolean; detail?: string }> {
   if (process.env.JEST_WORKER_ID !== undefined) {
     return { dispatched: false, detail: 'skipped under test runner' };
@@ -241,15 +400,12 @@ export async function defaultTriggerSyntheticOp(
   if (process.env.SHIELDCORTEX_ALLOW_GATEWAY_CANARY !== '1') {
     return {
       dispatched: false,
-      detail: 'live canary requires SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1 (drives a real gateway tool call)',
+      detail: 'live canary requires SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1 (drives a synthetic op through the live interceptor) — roster proof stands; enforcement not actively proven',
     };
   }
-  // Consent given: the active synthetic dispatch is wired on the sacrificial
-  // rollout env, not here — never fabricate a dispatch on an unproven path.
-  return {
-    dispatched: false,
-    detail: 'active synthetic-op dispatch is not wired in this build — roster proof stands; enforcement not actively proven',
-  };
+  // Consent given: perform the real active dispatch through the installed
+  // interceptor. Never fabricate — on any failure this returns dispatched:false.
+  return dispatchCanaryThroughInstalledInterceptor(home, pluginId, nonce, defaultActiveDispatchDeps);
 }
 
 export interface FreshEnforcementQuery {


### PR DESCRIPTION
## Summary
Wires the **real consent-gated active canary** in `src/setup/openclaw-selfcheck.ts`. In v4.47.3 (#74), `defaultTriggerSyntheticOp` shipped **deliberately unwired** — the self-check reported *"roster proof stands; enforcement not actively proven"* rather than fabricating a live-dispatch pass, while the dangerous states (roster-absent silent-drop, version-regressed downgrade) hard-fail exit 1. This PR wires the actual dispatch **while preserving that fail-closed contract**.

Tracking issue: #81.

## Fail-closed contract (the feature)
- **No consent → identical to today.** Guards unchanged: `JEST_WORKER_ID` (tests never dispatch) + `SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1`. Without consent, the honest *"roster proof stands; enforcement not actively proven"* report is returned verbatim.
- **Dispatch failed/unobservable → reported loudly as NOT proven; never a fabricated pass.** Every failure path (missing install, unloadable module, construction failure) returns `dispatched:false` with a loud detail; a dispatched-but-not-denied op is caught by the existing fresh nonce gate (`denied:false` → hard fail).
- **Dangerous-state exit codes unchanged** — roster-absent / version-regressed still hard-fail via `evaluateSelfCheck` (untouched).

## Approach
- **`buildSyntheticCanaryOp(nonce)`** — a recursive-force-delete SHAPE, which the Action Guard hard-blocks as `catastrophic` (so a live interceptor MUST deny it), targeting a synthetic non-existent `/tmp/<nonce>` path. **Provably harmless:** even in the exact failure mode this canary detects (enforcement OFF → the op actually runs), `rm -rf` on a missing path is a no-op. Tagged with the nonce + a `SHIELDCORTEX-CANARY` marker so the audit entry is unmistakable.
- **`dispatchCanaryThroughInstalledInterceptor()`** — drives the op through the **installed** plugin's real interceptor (`createInterceptor().handleToolCall`), the same code the gateway loads, discovered via the #77 install-discovery helper (`resolveRealtimePluginInstallPath`). Reuses the interceptor (no forked rebuild) and the real `evaluateToolCall`; the interceptor's own audit write lands in `~/.shieldcortex/audit/realtime-*.jsonl` where `findFreshEnforcementEntry` already reads. Nothing touches the running gateway — the dispatch is in-process through the installed interceptor code.
- **`defaultTriggerSyntheticOp`** — guards preserved; on consent it performs the real dispatch.

## Tests (strict TDD — failing test first)
- The synthetic op is **genuinely block-classified by the REAL evaluator** (`decision:'block'`, `severity:'catastrophic'`), harmless (`/tmp` target only), and canary-tagged (nonce + marker).
- The dispatch orchestration is **fail-closed** on every path (no install / null module / construction throw → `dispatched:false` loud) and dispatches the **exact** op with the evaluator wired.
- **End-to-end**: drives the op through the REAL plugin interceptor into a temp-home audit dir; `findFreshEnforcementEntry` confirms a **fresh nonce-matched deny** — the real "observe the actual deny" half.
- The `JEST_WORKER_ID` guard is preserved (never dispatches under the test runner).

## Test evidence
Self-check suites (all green):
```
Test Suites: 4 passed, 4 total
Tests:       39 passed, 39 total
```
Full `npm test`: **2322 passed / 17 failed**. The 17 failures are pre-existing and unrelated — clean `origin/main` (a48917a) produces the **identical** 4 failed suites / 17 failed tests (`save-auto-extracted-memory`, `save-memory-near-dup-dedup`, `defence-pipeline-bypass`, `recall-defence-integration`) — a DB test-isolation/embedding-skip issue on this environment. This branch's delta is **+9 passing, 0 new failures**.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)