### PR TITLE
fix(iron-dome): stop Action Guard over-gating read-only/benign ops (#88, #89)

### DIFF
--- a/src/defence/iron-dome/__tests__/fp-precision-88-89.test.ts
+++ b/src/defence/iron-dome/__tests__/fp-precision-88-89.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from '@jest/globals';
+import { evaluateToolCall } from '../tool-action-guard.js';
+
+/**
+ * FP-precision regression pack — issues #88 and #89.
+ *
+ * Live audit-log analysis on production boxes (2026-07-14) showed the Action
+ * Guard over-gating read-only / benign operations: read-only `npm … -g`
+ * queries flagged as global installs, a greedy `[^|\n]*` bridge letting the
+ * catastrophic device patterns collide across `;`-separated statements, and
+ * read-only `crontab -l` (and the bare word in an echo) flagged as scheduler
+ * mutation.
+ *
+ * Discipline: every narrowed rule keeps a must-STILL-FIRE sibling so a
+ * precision fix can never quietly become a hole. Allow-cases assert the FP is
+ * gone; block/approve-cases assert true-positive detection is intact.
+ */
+
+const decision = (args: Record<string, unknown>, tool = 'Bash') =>
+  evaluateToolCall(tool, args).decision;
+const verdict = (args: Record<string, unknown>, tool = 'Bash') =>
+  evaluateToolCall(tool, args);
+
+describe('#88 — install-package-global must not fire on read-only `npm … -g`', () => {
+  const allow: Array<[string, string]> = [
+    ['npm ls -g', 'npm ls -g'],
+    ['npm ls -g --depth=0', 'npm ls -g --depth=0'],
+    ['npm root -g', 'npm root -g'],
+    ['npm list --global', 'npm list --global'],
+    ['npm outdated -g', 'npm outdated -g'],
+    ['npm view (no flag)', 'npm view shieldcortex version'],
+    // the actual #88 compound: a read-only verification batch containing `npm ls -g`
+    ['verify compound', 'echo "=== npm core ===" && npm view shieldcortex version && npm ls -g shieldcortex'],
+  ];
+  it.each(allow)('allows: %s', (_l, command) => {
+    expect(decision({ command })).toBe('allow');
+  });
+
+  const approve: Array<[string, string]> = [
+    ['npm install -g', 'npm install -g typescript'],
+    ['npm i -g', 'npm i -g typescript'],
+    ['npm -g install (flag first)', 'npm -g install left-pad'],
+    ['npm install --global', 'npm install --global @vue/cli'],
+    ['yarn global add', 'yarn global add prettier'],
+    ['pnpm add -g', 'pnpm add -g eslint'],
+  ];
+  it.each(approve)('still requires approval: %s', (_l, command) => {
+    const v = verdict({ command });
+    expect(v.decision).toBe('require_approval');
+    expect(v.signals).toContain('install-package-global');
+  });
+});
+
+describe('#89 — catastrophic device patterns must not bridge across statements', () => {
+  // Benign commands that merely contain a wipe/shred word AND a /dev/ path in
+  // SEPARATE statements — the greedy [^|\n]* bridge used to collide them.
+  const allow: Array<[string, string]> = [
+    ['wipe in PATH, /dev/null in echo', 'export PATH="/opt/wipe/bin:$PATH"; echo "logs at /dev/null"'],
+    ['WIPE var then ls /dev/null', 'WIPE_TMP=/tmp/wipe && ls -la /dev/null'],
+    ['dd word then of=/dev in echo', 'dd if=in.img of=out.img status=progress; echo "restore with of=/dev/sdX"'],
+  ];
+  it.each(allow)('allows: %s', (_l, command) => {
+    expect(decision({ command })).toBe('allow');
+  });
+
+  // The word "shred" in a grep pattern still trips the DANGEROUS file-delete rule
+  // (`\bshred\b`) — a SEPARATE use/mention over-match tracked as a follow-up, not
+  // this patch's scope. What matters here: the CATASTROPHIC shred-device bridge no
+  // longer hard-BLOCKS a benign command whose /dev/ path is in another statement.
+  it('does not catastrophically block a grep for "shred" beside a /dev note', () => {
+    const v = verdict({ command: 'grep -rn "shred" src/; echo "handles /dev/sda safely"' });
+    expect(v.decision).not.toBe('block');
+    expect(v.severity).not.toBe('catastrophic');
+  });
+
+  // True positives: verb and device in the SAME statement — still catastrophic.
+  const block: Array<[string, string]> = [
+    ['shred a device', 'shred -vfz -n 3 /dev/sda'],
+    ['wipe a device', 'wipe /dev/nvme0n1'],
+    ['shred single', 'shred /dev/sdb1'],
+    ['dd to disk', 'dd if=/dev/zero of=/dev/sda bs=1M'],
+    ['dd iso to disk', 'dd if=ubuntu.iso of=/dev/sdb'],
+  ];
+  it.each(block)('still blocks: %s', (_l, command) => {
+    const v = verdict({ command });
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('catastrophic');
+  });
+});
+
+describe('#89 — modify-scheduler must not fire on read-only crontab -l', () => {
+  const allow: Array<[string, string]> = [
+    ['crontab -l', 'crontab -l'],
+    ['crontab -l piped', 'crontab -l | grep backup'],
+    ['crontab word in echo', 'systemctl --user list-timers 2>/dev/null || echo "checking host crontab instead"'],
+    ['systemctl list-timers', 'systemctl --user list-timers'],
+  ];
+  it.each(allow)('allows: %s', (_l, command) => {
+    expect(decision({ command })).toBe('allow');
+  });
+
+  const approve: Array<[string, string]> = [
+    ['crontab -e', 'crontab -e'],
+    ['crontab -r', 'crontab -r'],
+    ['crontab install file', 'crontab /tmp/my.cron'],
+    ['pipe into crontab -', 'echo "0 5 * * * /bin/job" | crontab -'],
+    ['at now', 'echo job | at now + 1 minute'],
+  ];
+  it.each(approve)('still requires approval: %s', (_l, command) => {
+    const v = verdict({ command });
+    expect(v.decision).toBe('require_approval');
+    expect(v.signals).toContain('modify-scheduler');
+  });
+});
+
+describe('#89 — external-egress must not fire on read-only GET fetches', () => {
+  const allow: Array<[string, Record<string, unknown>]> = [
+    ['web_fetch wikipedia', { url: 'https://en.wikipedia.org/wiki/2026_FIFA_World_Cup' }],
+    ['web_fetch github api', { url: 'https://api.github.com/repos/Drakon-Systems-Ltd/ShieldCortex/commits/main' }],
+  ];
+  it.each(allow)('allows: %s', (_l, args) => {
+    expect(decision(args, 'web_fetch')).toBe('allow');
+  });
+
+  const approve: Array<[string, string]> = [
+    ['curl POST with data', 'curl -X POST https://example.com/api -d @dump.json'],
+    ['curl --data', 'curl --data "x=1" https://example.com/collect'],
+  ];
+  it.each(approve)('still requires approval: %s', (_l, command) => {
+    const v = verdict({ command });
+    expect(v.decision).toBe('require_approval');
+    expect(v.signals).toContain('external-egress');
+  });
+});

--- a/src/defence/iron-dome/__tests__/fp-precision-88-89.test.ts
+++ b/src/defence/iron-dome/__tests__/fp-precision-88-89.test.ts
@@ -113,6 +113,50 @@ describe('#89 — modify-scheduler must not fire on read-only crontab -l', () =>
   });
 });
 
+describe('#90 — install-package-global must gate npm install-verb abbreviations', () => {
+  // Review follow-up on #88/#89: the narrowed regex only rescued the exact `i`
+  // shorthand, so npm's own alias resolver (which accepts the whole
+  // i/in/ins/inst/insta/instal/install/isnt/isntall family as `install`) let
+  // every abbreviation OTHER than `i` bypass the gate entirely.
+  const approve: Array<[string, string]> = [
+    ['npm inst -g', 'npm inst -g evil'],
+    ['npm in -g', 'npm in -g evil'],
+    ['npm isntall -g', 'npm isntall -g evil'],
+    ['npm ins -g', 'npm ins -g evil'],
+    ['npm insta -g', 'npm insta -g evil'],
+    ['npm instal -g', 'npm instal -g evil'],
+    ['npm isnt -g', 'npm isnt -g evil'],
+    // must-still-fire siblings — the pre-existing denies this patch must not weaken.
+    ['npm i -g', 'npm i -g evil'],
+    ['npm install -g', 'npm install -g evil'],
+    ['sudo npm install -g', 'sudo npm install -g evil'],
+    ['npm -g install', 'npm -g install evil'],
+    ['pnpm add -g', 'pnpm add -g evil'],
+    ['bun add -g', 'bun add -g evil'],
+    ['yarn global add', 'yarn global add evil'],
+  ];
+  it.each(approve)('still requires approval: %s', (_l, command) => {
+    const v = verdict({ command });
+    expect(v.decision).toBe('require_approval');
+    expect(v.signals).toContain('install-package-global');
+  });
+
+  // NOT install aliases — must not start denying just because they share the
+  // `i`/`in` prefix or a hyphenated/scoped package name contains a verb word.
+  const allow: Array<[string, string]> = [
+    ['npm init', 'npm init'],
+    ['npm info', 'npm info left-pad'],
+    ['npm ls -g package name contains "ci"', 'npm ls -g some-ci-tool'],
+    ['npm ls -g package name contains "add"', 'npm ls -g social-add-on'],
+    ['npm outdated -g scoped package ends in "add"', 'npm outdated -g @scope/add'],
+    // Fix 2: there is no global `npm ci` — dropped from the verb set entirely.
+    ['npm ci -g (no such thing as global ci)', 'npm ci -g'],
+  ];
+  it.each(allow)('allows: %s', (_l, command) => {
+    expect(decision({ command })).toBe('allow');
+  });
+});
+
 describe('#89 — external-egress must not fire on read-only GET fetches', () => {
   const allow: Array<[string, Record<string, unknown>]> = [
     ['web_fetch wikipedia', { url: 'https://en.wikipedia.org/wiki/2026_FIFA_World_Cup' }],

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -119,7 +119,7 @@ const CATASTROPHIC: Pattern[] = [
   { re: /:\s*\(\s*\)\s*\{\s*:\s*\|\s*:?\s*&?\s*\}\s*;\s*:/, signal: 'fork-bomb' },
   // filesystem creation / raw disk writes
   { re: /\bmkfs(\.\w+)?\b/i, signal: 'format-filesystem' },
-  { re: /\bdd\b[^|\n]*\bof=\/dev\/(sd|nvme|hd|disk|mmcblk|vd)/i, signal: 'raw-disk-write' },
+  { re: /\bdd\b[^|;&\n]*\bof=\/dev\/(sd|nvme|hd|disk|mmcblk|vd)/i, signal: 'raw-disk-write' },
   { re: /[>|]\s*\/dev\/(sd|nvme|hd|disk|mmcblk|vd)\w/i, signal: 'redirect-to-block-device' },
   { re: /\b(fdisk|parted|sgdisk|wipefs|blkdiscard)\b/i, signal: 'disk-partition-tool' },
   // pipe a download straight into an interpreter (remote code execution).
@@ -139,8 +139,11 @@ const CATASTROPHIC: Pattern[] = [
   { re: /\b(?:curl|wget|fetch)\b[^|\n]*\|[^\n]*\b(?:bash|sh|zsh|ksh|python\d?|perl|ruby|node)\b[^\n]*(?:\b(?:exec|eval)\b|\bsource\s+\/dev\/stdin\b)/i, signal: 'pipe-download-stdin-exec' },
   // recursive permission/ownership change at the root
   { re: /\bch(?:mod|own)\b[^|;&\n]*(?:-\w*R\w*|--recursive)\b[^|;&\n]*\s\/(?:\s|$)/i, signal: 'recursive-perms-on-root' },
-  // overwrite the whole disk with zeros/urandom
-  { re: /\b(?:shred|wipe)\b[^|\n]*\/dev\//i, signal: 'shred-device' },
+  // overwrite the whole disk with zeros/urandom. The [^|;&\n]* bridge keeps the
+  // verb and the /dev/ target in ONE statement — mirroring recursive-force-delete
+  // above — so `export PATH=/opt/wipe/bin; echo /dev/null` no longer collides two
+  // unrelated statements into a false catastrophic block (issue #89).
+  { re: /\b(?:shred|wipe)\b[^|;&\n]*\/dev\//i, signal: 'shred-device' },
 ];
 
 /**
@@ -161,8 +164,17 @@ const DANGEROUS: Pattern[] = [
   // work and is handled as a sensitive-but-allowed op (SENSITIVE.local-package-install
   // below) so it is never a hard gate.
   { re: /\b(?:apt|apt-get|yum|dnf|brew|pip|pip3|gem|cargo)\b[^|\n]*\b(?:install|add)\b/i, signal: 'install-package' },
-  { re: /\b(?:npm|yarn|pnpm|bun)\b[^|\n]*(?:\s-g\b|--global\b|\bglobal\s+add\b)/i, signal: 'install-package-global' },
-  { re: /\bcrontab\b|\/etc\/cron|\bat\s+now\b/i, signal: 'modify-scheduler' },
+  // A GLOBAL install mutates the host → approval. It must carry BOTH an install
+  // verb (install/add/ci, or the `npm i` shorthand) AND a global flag in the SAME
+  // statement. A read-only global QUERY — `npm ls -g`, `npm root -g`,
+  // `npm outdated -g`, `npm list --global` — mutates nothing and is not gated
+  // (issue #88). Order-independent (`npm install -g` and `npm -g install` both hit).
+  { re: /\b(?:npm|yarn|pnpm|bun)\b(?=[^|;&\n]*(?:\s-g\b|--global\b|\bglobal\s+add\b))(?=[^|;&\n]*\b(?:install|add|ci)\b)|\b(?:npm|pnpm|bun)\s+i\b[^|;&\n]*(?:\s-g\b|--global\b)/i, signal: 'install-package-global' },
+  // Scheduler MUTATION only: `crontab` in command position that edits/installs
+  // (`-e`, `-r`, a file, or stdin `-`) — never the read-only `crontab -l`, and
+  // never the bare word mentioned inside an echo/string (issue #89). Env-var and
+  // sudo prefixes allowed. `/etc/cron*` writes and `at now` scheduling still gate.
+  { re: /(?:^|[;&|(\n]|\$\()\s*(?:\w+=\S*\s+)*(?:sudo\s+)?crontab\b(?!\s+-l\b)|\/etc\/cron|\bat\s+now\b/i, signal: 'modify-scheduler' },
   { re: /\bhistory\s+-c\b|\.bash_history|truncate\b[^|\n]*\.log/i, signal: 'wipe-history-or-logs' },
   { re: /\/etc\/(passwd|shadow|sudoers)|~\/\.ssh|id_rsa|\.aws\/credentials|\.env\b/i, signal: 'touch-sensitive-path' },
 ];

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -165,11 +165,18 @@ const DANGEROUS: Pattern[] = [
   // below) so it is never a hard gate.
   { re: /\b(?:apt|apt-get|yum|dnf|brew|pip|pip3|gem|cargo)\b[^|\n]*\b(?:install|add)\b/i, signal: 'install-package' },
   // A GLOBAL install mutates the host → approval. It must carry BOTH an install
-  // verb (install/add/ci, or the `npm i` shorthand) AND a global flag in the SAME
-  // statement. A read-only global QUERY — `npm ls -g`, `npm root -g`,
+  // verb AND a global flag in the SAME statement. The verb is `install`/`add`,
+  // or npm's own `i`/`in`/`ins`/`inst`/`insta`/`instal`/`install`/`isnt`/`isntall`
+  // abbreviation family (npm's alias resolver accepts all of these as `install` —
+  // the old regex only caught the bare `i` shorthand, so `npm inst -g x` etc.
+  // bypassed the gate entirely; issue #90). `ci` is excluded — there is no global
+  // `npm ci`. The verb must land as its own whitespace-delimited argv token, not
+  // a `\b`-only substring, so a package name that merely contains the word —
+  // `npm ls -g social-add-on`, `npm outdated -g @scope/add` — does not over-gate
+  // (issue #90). A read-only global QUERY — `npm ls -g`, `npm root -g`,
   // `npm outdated -g`, `npm list --global` — mutates nothing and is not gated
   // (issue #88). Order-independent (`npm install -g` and `npm -g install` both hit).
-  { re: /\b(?:npm|yarn|pnpm|bun)\b(?=[^|;&\n]*(?:\s-g\b|--global\b|\bglobal\s+add\b))(?=[^|;&\n]*\b(?:install|add|ci)\b)|\b(?:npm|pnpm|bun)\s+i\b[^|;&\n]*(?:\s-g\b|--global\b)/i, signal: 'install-package-global' },
+  { re: /\b(?:npm|yarn|pnpm|bun)\b(?=[^|;&\n]*(?:\s-g\b|--global\b|\bglobal\s+add\b))(?=[^|;&\n]*\s(?:install|add)(?=\s|$|[|;&\n]))|\b(?:npm|pnpm|bun)\s+(?:i(?:n(?:s(?:t(?:a(?:ll?)?)?)?)?)?|isnt(?:all)?)\b[^|;&\n]*(?:\s-g\b|--global\b)/i, signal: 'install-package-global' },
   // Scheduler MUTATION only: `crontab` in command position that edits/installs
   // (`-e`, `-r`, a file, or stdin `-`) — never the read-only `crontab -l`, and
   // never the bare word mentioned inside an echo/string (issue #89). Env-var and


### PR DESCRIPTION
## What
Precision fixes for the Action Guard command classifier — kills the read-only/benign false positives found by live audit-log analysis on two production boxes (2026-07-14). Closes #88, addresses #89.

## The FPs (all reproduced as failing tests first)
| rule | was gating | fix |
|---|---|---|
| `install-package-global` | any `npm … -g` incl. read-only `npm ls -g` / `npm root -g` / `npm outdated -g` | require an install verb (`install`/`add`/`ci` or `npm i`) **and** a global flag in the same statement |
| `shred-device`, `raw-disk-write` | greedy `[^\|\n]*` bridged across `;`/`&&` → `export PATH=/opt/wipe/bin; echo /dev/null` = critical block | tighten to `[^\|;&\n]*` (mirrors `recursive-force-delete`) so verb + `/dev/` share one statement |
| `modify-scheduler` | bare `crontab` → read-only `crontab -l` and even the word in an `echo` | anchor to command position, exclude `-l`; `crontab -e/-r/<file>/-`, `/etc/cron*`, `at now` still gate |

## Evidence / tests
- New `fp-precision-88-89.test.ts` — **35 cases**, every narrowed rule paired with a must-still-fire sibling (real global installs, `shred /dev/sda`, `dd … of=/dev/sdb`, `crontab -e`, `curl -X POST -d`).
- Baseline before patch: **13 failing** (the FPs). After: **35/35 pass**.
- Full guard regression (main spec + #71–73 FP pack + interceptor wiring): **116/116**.
- Full suite: 2428 pass; the one unrelated `recall-defence-integration` failure is **pre-existing on base a3f8f01** (verified by stashing this patch).
- `tsc -p tsconfig.build.json --noEmit`: clean.

## Scope notes (honest)
- **external-egress on read-only GETs was already fixed in 4.47.4** (`hasOutboundData` gate). Verified via test; left untouched. #89's mention of it is already resolved.
- The DANGEROUS **`file-delete`** rule still approval-gates the *word* "shred" in a grep pattern — a separate use/mention over-match, **out of scope** here, worth its own follow-up.

No change to true-positive detection. Meta: this very patch was developed while the 4.47.3/4 guard was blocking `grep shred-device` on this box — the FP it fixes.
