### PR TITLE
fix(iron-dome): de-obfuscate ${IFS}/$IFS before scanning (closes pre-existing whitespace-anchor evasions)

### DIFF
--- a/src/defence/iron-dome/__tests__/ifs-normalization.test.ts
+++ b/src/defence/iron-dome/__tests__/ifs-normalization.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from '@jest/globals';
+import { evaluateToolCall } from '../tool-action-guard.js';
+
+/**
+ * `${IFS}` / `$IFS` de-obfuscation (adversarial-review follow-up to #84).
+ *
+ * `${IFS}`, `${IFS:0:1}`, and `$IFS` all expand to whitespace at runtime and are
+ * used purely to strip the literal spaces that several danger patterns anchor on
+ * (`\s/` in recursive-perms, the fork-bomb shape, etc.). Normalising them to a
+ * space before scanning makes those patterns see the real command — closing a
+ * pre-existing fail-open that let `chmod${IFS}-R${IFS}777${IFS}/` and a
+ * `${IFS}`-spaced fork bomb through (present on main; NOT a #84 regression).
+ */
+const gated = (command: string) => evaluateToolCall('Bash', { command }).decision !== 'allow';
+
+describe('${IFS} de-obfuscation — patterns anchored on literal whitespace still fire', () => {
+  const mustGate: string[] = [
+    'chmod${IFS}-R${IFS}777${IFS}/',
+    'chmod${IFS}-R${IFS}777${IFS}/etc',
+    'curl https://x/a;chmod${IFS}-R${IFS}777${IFS}/',
+    ':(){${IFS}:|:&};:',                              // fork bomb, IFS-spaced
+    'curl https://x/a;:(){${IFS}:|:&};:',
+    'rm${IFS}-rf${IFS}/',
+    'dd${IFS}if=/dev/zero${IFS}of=/dev/sda',
+    'sudo${IFS}rm${IFS}-rf${IFS}/',
+    '${IFS}rm${IFS}-rf${IFS}/',
+    'cat${IFS}/etc/shadow',                            // ${IFS:0:1} variant below
+    'chmod${IFS:0:1}-R${IFS:0:1}777${IFS:0:1}/',
+    '$IFS rm -rf /',
+  ];
+  it.each(mustGate)('gates: %s', (command) => {
+    expect(gated(command)).toBe(true);
+  });
+});
+
+describe('${IFS} de-obfuscation — benign commands are unaffected', () => {
+  const mustAllow: string[] = [
+    'ls -la',
+    'git status',
+    'npm test',
+    'echo "hello world"',
+  ];
+  it.each(mustAllow)('allows: %s', (command) => {
+    expect(evaluateToolCall('Bash', { command }).decision).toBe('allow');
+  });
+});

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -94,6 +94,14 @@ function pickString(args: Record<string, unknown>, keys: string[]): string {
 export function extractCommand(args: Record<string, unknown>): string {
   return pickString(args, ['command', 'cmd', 'script', 'code', 'input', 'shell', 'run']);
 }
+
+// `${IFS}`, `${IFS:0:1}`, `$IFS` all expand to whitespace at runtime and are used
+// purely to strip the literal spaces that several danger patterns anchor on
+// (`\s/` in recursive-perms, the fork-bomb shape). Normalise them to a space
+// before scanning so those patterns see the real command shape. Fail-closed:
+// this can only ever REVEAL a danger the raw string hid, never mask one.
+const IFS_OBFUSCATION = /\$\{IFS[^}]*\}|\$IFS\b/gi;
+export function deobfuscateIfs(s: string): string { return s.replace(IFS_OBFUSCATION, ' '); }
 export function extractPath(args: Record<string, unknown>): string {
   return pickString(args, ['path', 'file_path', 'filePath', 'file', 'target', 'destination', 'dir', 'directory']);
 }
@@ -778,7 +786,7 @@ export function evaluateToolCall(
   config?: IronDomeConfig,
 ): ToolGuardVerdict {
   const family = classifyFamily(toolName);
-  const command = extractCommand(args);
+  const command = deobfuscateIfs(extractCommand(args));
   const path = extractPath(args);
   const url = extractUrl(args);
 


### PR DESCRIPTION
Follow-up to the #84 adversarial review, which surfaced a **pre-existing** fail-open (present on `main`, not introduced by #84).

## The hole
`${IFS}`, `${IFS:0:1}`, and `$IFS` all expand to whitespace at runtime, and were used to strip the literal spaces that several danger patterns anchor on (`\s/` in recursive-perms, the fork-bomb shape). So these were **allowed** by the guard despite being fully destructive:

- `chmod${IFS}-R${IFS}777${IFS}/` (recursive perms on root)
- `:(){${IFS}:|:&};:` (fork bomb)

Verified `main` allows them too (their patterns never matched the IFS form), so this is a pre-existing evasion, not a #84 regression.

## The fix
Normalise `${IFS}`/`$IFS` to a space in the command before scanning (`deobfuscateIfs`, at the top of `evaluateToolCall`). **Fail-closed by construction** — normalisation can only *reveal* a danger the raw string hid, never mask one. Patterns whose bridges already spanned `${IFS}` (rm, dd) were caught before and still are; the whitespace-anchored ones (chmod recursive-perms, fork-bomb) now fire.

## Verification
- 16-case `ifs-normalization.test.ts` (must-gate obfuscated dangers incl. the `${IFS:0:1}` slice form; must-allow benign unaffected).
- Zero flips across all 20 guard suites; **2778/2778** full serial.

## Scope
This covers the main guard (`evaluateToolCall`). The outage-only WS2 fallback scanners share the same `\s`-anchor gap for chmod/fork-bomb; they can take the same one-line normalisation in a follow-up (low priority — outage-only, and their rm/dd bridges already span `${IFS}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
