### PR TITLE
docs(roadmap): P1 perf + false-positive budgets (#62 phase DoD)

### DIFF
--- a/docs/roadmap/P1-fp-budget.md
+++ b/docs/roadmap/P1-fp-budget.md
@@ -1,0 +1,66 @@
+# P1 — False-positive budget for the newly-enforcing tiers
+
+Phase-1 definition-of-done item: *"A documented false-positive budget for the
+newly-enforcing tiers."* This is that document.
+
+P1 moved two paths from advisory to enforced-by-default. Enforcement that
+over-fires is a real cost, so each tier ships with (a) a recoverable or
+opt-down escape hatch and (b) a CI-enforced regression bed that turns "no
+false-positive regression" into a build gate rather than a hope.
+
+## Tier 1 — Action Guard `dangerous` (WS1, enforce-by-default)
+
+**FP shape:** a legitimate dangerous-looking op is gated when it shouldn't be
+(a quoted command in a doc, a `web_fetch` URL that mentions `rm`, `git commit
+-m "remove the rm call"`).
+
+**Escape hatches (opt-down, never silent-allow):**
+- `actionGuard.enforce: false` → advisory (warn, no gate). Catastrophic still blocks.
+- `actionGuard.autoApprove: [...]` → per-operation allowlist for unattended agents.
+- `failurePolicy` → per-severity verdict when a decision can't be obtained.
+- Attended surfaces get an approval prompt; only headless + no-approver fails closed.
+
+**Budget = the must-ALLOW fixtures.** The FP rate is held at zero *against a
+curated corpus* by the regression suites, each of which pairs every must-BLOCK
+case with a must-ALLOW sibling; a new over-block flips a fixture and fails CI:
+- `fp-tune-71-73`, `fp-precision-88-89`, `guard-tune-91-89` — field-reported FP classes.
+- `span-classifier-84` — the general mention-vs-intent model (quoted data / URL
+  spans are not intent); this is the structural FP-reducer that replaced the
+  per-incident carve-outs.
+- `guard-bypasses-4475` must-still-allow siblings.
+
+**Ceiling:** zero must-ALLOW fixture may flip. New field FPs are added to the
+corpus with their fix in the same PR (the standing pattern across #71–#96).
+There is no numeric production-rate target yet — the corpus is the proxy; a
+telemetry-based rate is the natural follow-on (audit-mined allowlist, #84 rec #5).
+
+## Tier 2 — Memory write quarantine (WS3/WS4, block/quarantine-by-default)
+
+**FP shape:** a benign memory is held (quarantined) instead of stored — e.g. a
+legitimate note that trips a pattern, or a sub-agent write in the 0.5–0.7 trust
+band held for parent approval.
+
+**Why the FP cost is bounded — holds are RECOVERABLE, not lost:**
+- A false quarantine is **reviewable and re-admittable**: approving a held
+  QUARANTINE item re-enters the sanctioned funnel (`addMemory`) and re-scans,
+  so an approved item is stored with a real verdict. Nothing benign is
+  destroyed — the write-path FP is a review-queue item, not data loss.
+- A BLOCK is held (WS4) rather than dropped, so even a hard-blocked
+  false-positive is forensically recoverable at review (auto-rejected by
+  default so poison isn't laundered, but visible).
+- The sub-agent trust band is the only *new* auto-hold; it is deliberately
+  narrow (0.5–0.7) and single-sourced (`resolveDisposition`) so both runtimes
+  apply it identically.
+
+**Budget:** the group-A proof suite (`claims-proof` claims 1, 1a) pins that
+benign writes store with real provenance and only poisoning/low-trust writes are
+held — across *both* runtimes. A regression that started holding benign content
+would flip claim 1's store assertion. Quarantine has a 7-day auto-expire so a
+mistaken hold self-clears if never reviewed.
+
+## Summary
+
+| Tier | Enforced default | Opt-down / recovery | FP gate |
+|---|---|---|---|
+| Action Guard `dangerous` | require-approval / fail-closed unattended | `enforce:false`, `autoApprove`, `failurePolicy` | must-ALLOW fixtures (zero flips) |
+| Memory write | hold (quarantine) high-confidence poison + sub-agent band | review→re-admit; 7-day auto-expire | `claims-proof` group A |

--- a/docs/roadmap/P1-perf-budget.md
+++ b/docs/roadmap/P1-perf-budget.md
@@ -1,0 +1,62 @@
+# P1 — Write-pipeline hot-path performance budget
+
+Phase-1 definition-of-done item: *"Hot-path performance budget for the write
+pipeline documented and measured."* This is that document.
+
+## What the hot path is
+
+Every durable memory write goes through `runDefencePipeline(content, title,
+source)` **synchronously** before `store.ts:addMemory` inserts the row — the
+6 sync layers (input sanitisation, pattern detection, structural, behavioural,
+credential-leak) plus source trust scoring. The **semantic** layer is *not* on
+this path: it runs only on the async / deep-scan path
+(`runDefencePipelineWithVerify`), so the write hot path stays regex/heuristic
+only and CPU-bound with no model load.
+
+## Measured baseline (2026-07-20, v4.47.10 line, Apple Silicon, 2000 iterations/payload after warm-up)
+
+| Payload | Length | mean | p50 | p95 | p99 |
+|---|---|---|---|---|---|
+| short note | 51 B | 0.145 ms | 0.114 ms | 0.225 ms | 0.79 ms |
+| typical decision | 156 B | 0.150 ms | 0.122 ms | 0.223 ms | 0.43 ms |
+| long doc | 1.76 KB | 0.490 ms | 0.448 ms | 0.649 ms | 1.62 ms |
+
+The pipeline is **sub-millisecond** for typical content and scales roughly
+linearly with length (the ReDoS-bounded patterns are the dominant cost). P1's
+provenance work (WS3) adds one `defence_verdict` bind + a `BEFORE INSERT`
+trigger that evaluates three `IS NULL` checks — nanosecond-scale, below the
+measurement floor.
+
+## Budget (ceiling)
+
+For content up to **2 KB** (the 99th-percentile real write; larger content is
+truncated to 10 KB by the anti-bloat cap and separately flagged `oversized`):
+
+- **p95 ≤ 5 ms** — ~20× headroom over today's 0.22 ms, so a genuine regression
+  is caught while normal variance is not.
+- **mean ≤ 2 ms**.
+
+Rationale for the ceiling, not a tighter one: the write path runs once per
+`remember`/auto-capture, off any user-interactive loop (the OpenClaw fast loop
+uses the async recall path, not this write path), so single-digit-ms is
+imperceptible; a tight sub-ms CI gate would flake on shared runners.
+
+## How it's enforced
+
+- The measurement harness (`scratchpad/perf-measure.mjs` shape) can be run
+  ad-hoc against `dist/defence/pipeline.js`.
+- The standing guardrails that keep the path fast are the **ReDoS budgets**
+  already in CI: `guard-bypasses-4475` and the residual-evasion timing tests
+  cap individual patterns (<300 ms on 30 KB adversarial input), and the guard's
+  4 KB fallback/oversize caps bound worst-case scanning. A pattern that blew the
+  hot-path budget would first trip those ReDoS timing tests.
+- The semantic/model cost is kept off this path by construction (async-only);
+  regressing that (moving a model load onto the sync path) would be caught by
+  the `scan-only-entry` import-graph test, which asserts the light write/scan
+  entry pulls in no native/ML/DB/cloud modules.
+
+## Revisit triggers
+
+Re-measure and re-baseline if: a new synchronous layer is added to
+`runDefencePipeline`; the semantic layer is moved onto the sync path; or the
+anti-bloat content cap changes materially.


### PR DESCRIPTION
The two cross-cutting phase-DoD items for the P1 epic (#62): a measured write-pipeline **perf budget** (sub-ms hot path; p95≤5ms ceiling) and a **false-positive budget** for both newly-enforcing tiers (opt-down hatches + the CI fixture/claims gates that hold FPs at zero-flip). Completes the epic's cross-cutting DoD alongside WS1–WS4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)