### PR TITLE
fix(sessions): add session_events retention + size-pressure valve + prune CLI (#110)

### DIFF
--- a/src/__tests__/session-events-retention.test.ts
+++ b/src/__tests__/session-events-retention.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Session-events retention + size-pressure tests (issue #110).
+ *
+ * `session_events` grows on every captured turn with no DELETE anywhere —
+ * live incident (Edith box, 2026-07-21, v4.47.12): 79.6 MB DB with only 117
+ * memories, of which session_events held 62.8 MB across 29,835 rows. Doctor's
+ * suggested fixes (vacuum / memories prune) were both no-ops for that failure
+ * mode. These tests pin down the retention purge + size-pressure valve that
+ * bounds the table, mirroring the Phase 8a defence_audit valve
+ * (src/__tests__/audit-retention.test.ts).
+ *
+ * Harness: a fresh in-memory DB per test so rows never leak across cases.
+ * Rows are inserted through the real write path (recordEvent) so the ISO-8601
+ * `ts` format under test is exactly what production stores.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import type Database from 'better-sqlite3';
+import { initDatabase, closeDatabase, getDatabase } from '../database/init.js';
+import { recordEvent } from '../sessions/capture.js';
+import {
+  DEFAULT_SESSION_RETENTION_DAYS,
+  SESSION_PRESSURE_ROW_CAP,
+  resolveSessionRetentionDays,
+  purgeOldSessionEvents,
+  purgeSessionEventsOlderThan,
+  previewOldSessionEvents,
+  purgeSessionEventsUnderSizePressure,
+} from '../sessions/retention.js';
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function insertEvent(ts: string, payload: unknown = { text: 'x' }): number {
+  return recordEvent({
+    session_id: 'sess-retention-test',
+    ts,
+    kind: 'prompt',
+    payload,
+  });
+}
+
+function eventCount(db: Database.Database): number {
+  return (db.prepare('SELECT COUNT(*) AS c FROM session_events').get() as { c: number }).c;
+}
+
+describe('session_events retention (#110)', () => {
+  beforeEach(() => {
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    delete process.env.SHIELDCORTEX_SESSION_RETENTION_DAYS;
+  });
+
+  describe('purgeOldSessionEvents (age-based)', () => {
+    it('deletes only rows older than the cutoff and returns the count', () => {
+      const db = getDatabase();
+
+      // 3 old (older than 30d) + 2 recent.
+      insertEvent(daysAgo(65));
+      insertEvent(daysAgo(45));
+      insertEvent(daysAgo(31));
+      insertEvent(daysAgo(10));
+      insertEvent(daysAgo(1));
+
+      expect(eventCount(db)).toBe(5);
+
+      const deleted = purgeOldSessionEvents(30);
+
+      expect(deleted).toBe(3);
+      expect(eventCount(db)).toBe(2);
+
+      // The survivors are exactly the recent rows — every remaining ts is
+      // inside the 30-day window.
+      const remaining = db
+        .prepare('SELECT ts FROM session_events ORDER BY ts ASC')
+        .all() as { ts: string }[];
+      const cutoffMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+      for (const row of remaining) {
+        expect(new Date(row.ts).getTime()).toBeGreaterThan(cutoffMs);
+      }
+    });
+
+    it('defaults to the 30-day retention window', () => {
+      expect(DEFAULT_SESSION_RETENTION_DAYS).toBe(30);
+      const db = getDatabase();
+      insertEvent(daysAgo(31));
+      insertEvent(daysAgo(29));
+      const deleted = purgeOldSessionEvents();
+      expect(deleted).toBe(1);
+      expect(eventCount(db)).toBe(1);
+    });
+
+    it('is a no-op on an empty table', () => {
+      expect(purgeOldSessionEvents(30)).toBe(0);
+    });
+  });
+
+  describe('boundary-timestamp correctness (ISO-8601 `ts` strings)', () => {
+    // capture.ts stores caller-supplied ISO-8601 strings — in practice always
+    // `new Date().toISOString()` → 'YYYY-MM-DDTHH:MM:SS.sssZ'. The purge
+    // compares the stored `ts` against an ISO cutoff string LEXICALLY
+    // (`ts < ?`), which is only correct if both sides share that exact
+    // format. These cases prove the comparison at the millisecond boundary.
+    it('keeps a row whose ts is exactly the cutoff (strict <)', () => {
+      const db = getDatabase();
+      const cutoff = '2026-01-01T00:00:00.000Z';
+      insertEvent('2026-01-01T00:00:00.000Z'); // exactly at cutoff → survives
+      insertEvent('2025-12-31T23:59:59.999Z'); // 1ms older → deleted
+
+      const deleted = purgeSessionEventsOlderThan(cutoff);
+
+      expect(deleted).toBe(1);
+      const rows = db.prepare('SELECT ts FROM session_events').all() as { ts: string }[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0].ts).toBe('2026-01-01T00:00:00.000Z');
+    });
+
+    it('orders ISO-Z strings lexically the same as chronologically across day/month/year boundaries', () => {
+      const db = getDatabase();
+      const cutoff = '2026-07-21T00:00:00.000Z';
+      const older = [
+        '2025-12-31T23:59:59.999Z',
+        '2026-06-30T23:59:59.999Z',
+        '2026-07-20T23:59:59.999Z',
+      ];
+      const newer = [
+        '2026-07-21T00:00:00.000Z',
+        '2026-07-21T00:00:00.001Z',
+        '2026-08-01T00:00:00.000Z',
+      ];
+      for (const ts of [...older, ...newer]) insertEvent(ts);
+
+      const deleted = purgeSessionEventsOlderThan(cutoff);
+
+      expect(deleted).toBe(older.length);
+      expect(eventCount(db)).toBe(newer.length);
+    });
+  });
+
+  describe('purgeSessionEventsUnderSizePressure (size valve)', () => {
+    it('no-ops under the size gate even when over the row cap', () => {
+      const db = getDatabase();
+      // 50 rows, tiny cap — but no warnBytes injected, and an in-memory DB has
+      // no measurable file size, so checkDatabaseSize().warning is false and
+      // the gate must hold.
+      for (let i = 0; i < 50; i++) insertEvent(daysAgo(50 - i));
+      const deleted = purgeSessionEventsUnderSizePressure({ maxRows: 10 });
+      expect(deleted).toBe(0);
+      expect(eventCount(db)).toBe(50);
+    });
+
+    it('trims the OLDEST rows down to the cap when over pressure', () => {
+      const db = getDatabase();
+      for (let i = 0; i < 100; i++) insertEvent(daysAgo(100 - i));
+      expect(eventCount(db)).toBe(100);
+
+      const deleted = purgeSessionEventsUnderSizePressure({ warnBytes: 0, maxRows: 40 });
+
+      expect(deleted).toBe(60);
+      expect(eventCount(db)).toBe(40);
+
+      // Oldest-first eviction: every survivor is newer than every deleted row,
+      // i.e. the oldest surviving row is at most 40 days old.
+      const oldest = db
+        .prepare('SELECT ts FROM session_events ORDER BY ts ASC LIMIT 1')
+        .get() as { ts: string };
+      expect(new Date(oldest.ts).getTime()).toBeGreaterThan(
+        Date.now() - 41 * 24 * 60 * 60 * 1000,
+      );
+    });
+
+    it('respects the cap exactly — no purge at or under maxRows', () => {
+      const db = getDatabase();
+      for (let i = 0; i < 40; i++) insertEvent(daysAgo(40 - i));
+      const deleted = purgeSessionEventsUnderSizePressure({ warnBytes: 0, maxRows: 40 });
+      expect(deleted).toBe(0);
+      expect(eventCount(db)).toBe(40);
+    });
+
+    it('exposes a production row cap that bounds worst-case bytes well under the 100MB block', () => {
+      // Edith incident: 29,835 rows ≈ 62.8MB payload + ~6MB indexes → ~2.3KB/row
+      // all-in. The cap must keep session_events' worst case clearly under the
+      // 100MB hard block even alongside the audit valve's own 100k-row cap.
+      expect(SESSION_PRESSURE_ROW_CAP).toBeGreaterThan(0);
+      expect(SESSION_PRESSURE_ROW_CAP * 2.4 * 1024).toBeLessThan(50 * 1024 * 1024);
+    });
+  });
+
+  describe('previewOldSessionEvents (dry-run support)', () => {
+    it('reports matched count + payload bytes without deleting anything', () => {
+      const db = getDatabase();
+      insertEvent(daysAgo(40), 'a'.repeat(1000));
+      insertEvent(daysAgo(35), 'b'.repeat(500));
+      insertEvent(daysAgo(5), 'c'.repeat(2000));
+
+      const preview = previewOldSessionEvents(30);
+
+      expect(preview.matched).toBe(2);
+      expect(preview.payloadBytes).toBe(1500);
+      expect(eventCount(db)).toBe(3); // nothing deleted
+    });
+  });
+
+  describe('resolveSessionRetentionDays (env knob)', () => {
+    it('defaults to DEFAULT_SESSION_RETENTION_DAYS when unset', () => {
+      delete process.env.SHIELDCORTEX_SESSION_RETENTION_DAYS;
+      expect(resolveSessionRetentionDays()).toBe(DEFAULT_SESSION_RETENTION_DAYS);
+    });
+
+    it('honours a valid SHIELDCORTEX_SESSION_RETENTION_DAYS override', () => {
+      process.env.SHIELDCORTEX_SESSION_RETENTION_DAYS = '7';
+      expect(resolveSessionRetentionDays()).toBe(7);
+    });
+
+    it('rejects invalid values (non-numeric, zero, negative, absurd) and falls back', () => {
+      for (const bad of ['banana', '0', '-5', '1.5', '99999', '']) {
+        process.env.SHIELDCORTEX_SESSION_RETENTION_DAYS = bad;
+        expect(resolveSessionRetentionDays()).toBe(DEFAULT_SESSION_RETENTION_DAYS);
+      }
+    });
+
+    it('feeds the env override into purgeOldSessionEvents by default', () => {
+      const db = getDatabase();
+      insertEvent(daysAgo(10));
+      insertEvent(daysAgo(2));
+      process.env.SHIELDCORTEX_SESSION_RETENTION_DAYS = '7';
+      const deleted = purgeOldSessionEvents();
+      expect(deleted).toBe(1);
+      expect(eventCount(db)).toBe(1);
+    });
+  });
+
+  describe('schema support', () => {
+    it('has a bare-ts index so the age purge does not full-scan', () => {
+      const db = getDatabase();
+      const idx = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_session_events_ts'")
+        .get() as { name?: string } | undefined;
+      expect(idx?.name).toBe('idx_session_events_ts');
+    });
+  });
+});

--- a/src/__tests__/session-import-jsonl.test.ts
+++ b/src/__tests__/session-import-jsonl.test.ts
@@ -47,7 +47,9 @@ describe('parseTranscriptLine — pure mapper', () => {
     expect(events).toHaveLength(1);
     expect(events[0].kind).toBe('prompt');
     expect(events[0].session_id).toBe('s1');
-    expect(events[0].ts).toBe('2026-05-10T10:00:00Z');
+    // #110 review: timestamps are normalised to canonical ISO-8601 UTC with
+    // milliseconds ('…T10:00:00.000Z'), no longer passed through verbatim.
+    expect(events[0].ts).toBe('2026-05-10T10:00:00.000Z');
     expect(events[0].payload).toEqual({ text: 'hi' });
   });
 
@@ -235,6 +237,74 @@ describe('importJsonlTranscript — end-to-end against fixture', () => {
       expect(result.eventCount).toBe(2);
       // 1 malformed JSON line counts as skipped; blank lines do not.
       expect(result.skipped).toBe(1);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('timestamp normalisation (#110 review) — importer ENFORCES ISO-Z', () => {
+  // The retention purge compares `ts` LEXICALLY; verbatim passthrough let an
+  // epoch-millis string sort before every '2026-…' row (→ purged as
+  // "infinitely old" immediately) and offset-bearing ISO misorder at
+  // boundaries. Every accepted timestamp must round-trip through
+  // Date.parse → toISOString().
+
+  it('normalises an epoch-millis timestamp to the correct ISO instant — NOT purged as ancient', async () => {
+    // A recent instant (1 day ago) expressed as epoch millis.
+    const recentMs = Date.now() - 24 * 60 * 60 * 1000;
+    const events = parseTranscriptLine({
+      type: 'user',
+      sessionId: 's-epoch',
+      timestamp: String(recentMs),
+      message: { role: 'user', content: [{ type: 'text', text: 'epoch line' }] },
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].ts).toBe(new Date(recentMs).toISOString());
+
+    // End-to-end: insert it and prove the 30-day purge does NOT delete it.
+    const { recordEvent } = await import('../sessions/capture.js');
+    const { purgeOldSessionEvents } = await import('../sessions/retention.js');
+    recordEvent(events[0]);
+    const deleted = purgeOldSessionEvents(30);
+    expect(deleted).toBe(0);
+    const count = (
+      getDatabase().prepare('SELECT COUNT(*) AS c FROM session_events').get() as { c: number }
+    ).c;
+    expect(count).toBe(1);
+  });
+
+  it('normalises offset-bearing ISO to the equivalent Z instant', () => {
+    const events = parseTranscriptLine({
+      type: 'user',
+      sessionId: 's-offset',
+      timestamp: '2026-07-21T01:00:00+09:00',
+      message: { role: 'user', content: [{ type: 'text', text: 'offset line' }] },
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].ts).toBe('2026-07-20T16:00:00.000Z');
+  });
+
+  it('rejects a garbage timestamp: counted malformed, nothing inserted', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'sc-import-badts-'));
+    const path = join(tmp, 'bad-ts.jsonl');
+    writeFileSync(
+      path,
+      [
+        '{"type":"user","sessionId":"s3","timestamp":"soon-ish","message":{"role":"user","content":[{"type":"text","text":"bad ts"}]}}',
+        '{"type":"user","sessionId":"s3","timestamp":"2026-05-10T12:00:00Z","message":{"role":"user","content":[{"type":"text","text":"good ts"}]}}',
+      ].join('\n'),
+    );
+    try {
+      const result = importJsonlTranscript(path);
+      expect(result.eventCount).toBe(1); // only the good line
+      expect(result.malformed).toBe(1); // the garbage-timestamp line
+      const rows = getDatabase()
+        .prepare('SELECT ts, payload FROM session_events')
+        .all() as Array<{ ts: string; payload: string }>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].ts).toBe('2026-05-10T12:00:00.000Z'); // normalised on insert
+      expect(rows[0].payload).toContain('good ts');
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/cli/__tests__/doctor-disk-breakdown.test.ts
+++ b/src/cli/__tests__/doctor-disk-breakdown.test.ts
@@ -80,7 +80,14 @@ describe('doctor checkDiskUsage names the real disk consumer (4.45.1)', () => {
   // When session_events payload dominates the memories table, the remedy must
   // name `shieldcortex sessions prune` (and vacuum AFTER, to reclaim the pages
   // the prune frees).
-  function buildRealDb(opts: { memories: number; memoryBytes: number; events: number; eventBytes: number }): void {
+  function buildRealDb(opts: {
+    memories: number;
+    memoryBytes: number;
+    events: number;
+    eventBytes: number;
+    auditRows?: number;
+    auditBytes?: number;
+  }): void {
     const db = new Database(path.join(tmpDir, 'memories.db'));
     db.exec(`
       CREATE TABLE memories (id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT NOT NULL);
@@ -91,6 +98,14 @@ describe('doctor checkDiskUsage names the real disk consumer (4.45.1)', () => {
         kind TEXT NOT NULL,
         payload TEXT NOT NULL
       );
+      CREATE TABLE defence_audit (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        reason TEXT,
+        threat_indicators TEXT DEFAULT '[]',
+        blocked_patterns TEXT DEFAULT '[]',
+        source_type TEXT NOT NULL DEFAULT 'test',
+        source_identifier TEXT NOT NULL DEFAULT 'test'
+      );
     `);
     const insMem = db.prepare('INSERT INTO memories (content) VALUES (?)');
     for (let i = 0; i < opts.memories; i++) insMem.run('m'.repeat(opts.memoryBytes));
@@ -99,6 +114,10 @@ describe('doctor checkDiskUsage names the real disk consumer (4.45.1)', () => {
     );
     for (let i = 0; i < opts.events; i++) {
       insEvt.run(new Date(Date.now() - i * 60_000).toISOString(), 'p'.repeat(opts.eventBytes));
+    }
+    const insAudit = db.prepare('INSERT INTO defence_audit (reason) VALUES (?)');
+    for (let i = 0; i < (opts.auditRows ?? 0); i++) {
+      insAudit.run('a'.repeat(opts.auditBytes ?? 0));
     }
     db.close();
   }
@@ -116,6 +135,30 @@ describe('doctor checkDiskUsage names the real disk consumer (4.45.1)', () => {
     expect(result.fix).toMatch(/shieldcortex vacuum/);
     // And it must NOT lead with the no-op remedies the incident hit.
     expect(result.fix).not.toMatch(/^Run `shieldcortex memories prune/);
+  });
+
+  it('does NOT recommend sessions prune on an audit-dominated DB (#111 review repro)', async () => {
+    // Reviewer repro: 1 memory + ~600 B of session events + ~200 KB of
+    // defence_audit. The pre-review condition (sessionEventBytes >
+    // memoriesBytes) blamed session capture and recommended `sessions prune`
+    // — a no-op. Session capture may only be named when it genuinely
+    // dominates (> 40% of the live DB AND > audit bytes).
+    buildRealDb({
+      memories: 1,
+      memoryBytes: 100,
+      events: 3,
+      eventBytes: 200,
+      auditRows: 100,
+      auditBytes: 2048,
+    });
+
+    const result = await checkDiskUsage(tmpDir, 128 * KB);
+
+    expect(result.status).toBe('fail');
+    expect(result.fix).not.toMatch(/sessions prune/);
+    expect(result.fix).not.toMatch(/bulk is session-capture/);
+    // Vacuum guidance is retained for the audit-dominated case.
+    expect(result.fix).toMatch(/shieldcortex vacuum/);
   });
 
   it('does not claim session capture is the bulk when the memories table dominates', async () => {

--- a/src/cli/__tests__/doctor-disk-breakdown.test.ts
+++ b/src/cli/__tests__/doctor-disk-breakdown.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
 import { checkDiskUsage } from '../doctor.js';
@@ -70,6 +71,62 @@ describe('doctor checkDiskUsage names the real disk consumer (4.45.1)', () => {
     const result = await checkDiskUsage(tmpDir, 32 * KB);
     expect(result.status).toBe('fail');
     expect(result.fix).toMatch(/audit\/log files/);
+  });
+
+  // ── #110 signature: big DB, tiny memories table ─────────────────────────
+  // Live incident (Edith, 2026-07-21, v4.47.12): 79.6 MB DB with only 117
+  // memories — dbstat put session_events at 62.8 MB. The old remedy pointed at
+  // vacuum (0.0 MB of free pages — no-op) and memories prune (117 rows — no-op).
+  // When session_events payload dominates the memories table, the remedy must
+  // name `shieldcortex sessions prune` (and vacuum AFTER, to reclaim the pages
+  // the prune frees).
+  function buildRealDb(opts: { memories: number; memoryBytes: number; events: number; eventBytes: number }): void {
+    const db = new Database(path.join(tmpDir, 'memories.db'));
+    db.exec(`
+      CREATE TABLE memories (id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT NOT NULL);
+      CREATE TABLE session_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        ts TIMESTAMP NOT NULL,
+        kind TEXT NOT NULL,
+        payload TEXT NOT NULL
+      );
+    `);
+    const insMem = db.prepare('INSERT INTO memories (content) VALUES (?)');
+    for (let i = 0; i < opts.memories; i++) insMem.run('m'.repeat(opts.memoryBytes));
+    const insEvt = db.prepare(
+      "INSERT INTO session_events (session_id, ts, kind, payload) VALUES ('s', ?, 'prompt', ?)",
+    );
+    for (let i = 0; i < opts.events; i++) {
+      insEvt.run(new Date(Date.now() - i * 60_000).toISOString(), 'p'.repeat(opts.eventBytes));
+    }
+    db.close();
+  }
+
+  it('points at `shieldcortex sessions prune` when session_events dominate a big DB (#110)', async () => {
+    // ~200 KB of session payload vs ~1 KB of memories → DB well over 50% of a
+    // 128 KB limit, with the #110 signature (big DB, tiny memories table).
+    buildRealDb({ memories: 5, memoryBytes: 200, events: 100, eventBytes: 2048 });
+
+    const result = await checkDiskUsage(tmpDir, 128 * KB);
+
+    expect(result.status).toBe('fail');
+    expect(result.fix).toMatch(/shieldcortex sessions prune/);
+    // Vacuum must still be named — prune alone leaves free pages in the file.
+    expect(result.fix).toMatch(/shieldcortex vacuum/);
+    // And it must NOT lead with the no-op remedies the incident hit.
+    expect(result.fix).not.toMatch(/^Run `shieldcortex memories prune/);
+  });
+
+  it('does not claim session capture is the bulk when the memories table dominates', async () => {
+    buildRealDb({ memories: 100, memoryBytes: 2048, events: 3, eventBytes: 100 });
+
+    const result = await checkDiskUsage(tmpDir, 128 * KB);
+
+    expect(result.status).toBe('fail');
+    // Generic big-DB remedy — must not assert that session_events is the bulk.
+    expect(result.fix).not.toMatch(/session_events .*is the bulk|bulk is session-capture/);
+    expect(result.fix).toMatch(/shieldcortex vacuum/);
   });
 
   it('honours a custom limit (the plumbing behind the breakdown remedy)', async () => {

--- a/src/cli/__tests__/sessions-prune.test.ts
+++ b/src/cli/__tests__/sessions-prune.test.ts
@@ -1,0 +1,101 @@
+/**
+ * `shieldcortex sessions prune` CLI tests (issue #110).
+ *
+ * Mirrors the memories-prune conventions (src/cli/migrate-legacy.ts runPrune):
+ * dry-run by default, `--execute` to delete, `--days N` to override the
+ * retention window. Dry-run prints matched count + payload MB and must not
+ * delete anything; --execute deletes and reminds about `shieldcortex vacuum`
+ * (deleted rows leave free pages in the file — only VACUUM shrinks it).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { closeDatabase, getDatabase } from '../../database/init.js';
+import { recordEvent } from '../../sessions/capture.js';
+import { runSessionsPrune } from '../sessions.js';
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe('shieldcortex sessions prune (#110)', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let logSpy: jest.SpiedFunction<typeof console.log>;
+  let logged: () => string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-sessions-prune-'));
+    dbPath = path.join(tmpDir, 'memories.db');
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    logged = () => logSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n');
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    closeDatabase();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  async function seed(): Promise<void> {
+    // runSessionsPrune inits the DB itself; seed through a first invocation
+    // is not possible, so init here via the override path used by the CLI.
+    const { initDatabase } = await import('../../database/init.js');
+    initDatabase(dbPath);
+    recordEvent({ session_id: 's1', ts: daysAgo(45), kind: 'prompt', payload: 'x'.repeat(2048) });
+    recordEvent({ session_id: 's1', ts: daysAgo(40), kind: 'response', payload: 'y'.repeat(2048) });
+    recordEvent({ session_id: 's2', ts: daysAgo(3), kind: 'prompt', payload: 'z'.repeat(2048) });
+  }
+
+  it('dry-run by default: prints matched count + payload MB and deletes NOTHING', async () => {
+    await seed();
+
+    await runSessionsPrune([], dbPath);
+
+    const out = logged();
+    expect(out).toMatch(/DRY RUN/);
+    expect(out).toMatch(/Matched: 2/);
+    expect(out).toMatch(/MB/);
+    expect(out).toMatch(/--execute/);
+
+    const db = getDatabase();
+    const count = (db.prepare('SELECT COUNT(*) AS c FROM session_events').get() as { c: number }).c;
+    expect(count).toBe(3); // untouched
+  });
+
+  it('--execute deletes matched rows, prints deleted count, and reminds about vacuum', async () => {
+    await seed();
+
+    await runSessionsPrune(['--execute'], dbPath);
+
+    const out = logged();
+    expect(out).not.toMatch(/DRY RUN/);
+    expect(out).toMatch(/Deleted: 2/);
+    expect(out).toMatch(/shieldcortex vacuum/);
+
+    const db = getDatabase();
+    const count = (db.prepare('SELECT COUNT(*) AS c FROM session_events').get() as { c: number }).c;
+    expect(count).toBe(1);
+  });
+
+  it('honours --days N', async () => {
+    await seed();
+
+    await runSessionsPrune(['--days', '2', '--execute'], dbPath);
+
+    const db = getDatabase();
+    const count = (db.prepare('SELECT COUNT(*) AS c FROM session_events').get() as { c: number }).c;
+    expect(count).toBe(0); // everything is older than 2 days
+    expect(logged()).toMatch(/Deleted: 3/);
+  });
+
+  it('rejects a non-numeric --days value', async () => {
+    await seed();
+    await expect(runSessionsPrune(['--days', 'soon', '--execute'], dbPath)).rejects.toThrow(/--days/);
+    const db = getDatabase();
+    const count = (db.prepare('SELECT COUNT(*) AS c FROM session_events').get() as { c: number }).c;
+    expect(count).toBe(3); // nothing deleted on bad input
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -627,6 +627,8 @@ interface DbRowConsumers {
   memoriesBytes: number;
   sessionEventCount: number;
   sessionEventBytes: number;
+  auditCount: number;
+  auditBytes: number;
 }
 
 function readDbRowConsumers(dbPath: string): DbRowConsumers | null {
@@ -641,11 +643,35 @@ function readDbRowConsumers(dbPath: string): DbRowConsumers | null {
     const se = db.prepare(
       'SELECT COUNT(*) AS c, COALESCE(SUM(LENGTH(payload)), 0) AS b FROM session_events',
     ).get() as { c: number; b: number };
+
+    // defence_audit is the OTHER unbounded-growth table (bounded since Phase
+    // 8a, but pre-valve DBs can still be audit-dominated). Approximate its
+    // stored bytes by summing the text-bearing columns. Guarded separately:
+    // a DB without the table (older install, partial fixture) just reports 0
+    // rather than nulling out the whole peek.
+    let auditCount = 0;
+    let auditBytes = 0;
+    try {
+      const audit = db.prepare(`
+        SELECT COUNT(*) AS c, COALESCE(SUM(
+          LENGTH(COALESCE(reason, '')) +
+          LENGTH(COALESCE(threat_indicators, '')) +
+          LENGTH(COALESCE(blocked_patterns, '')) +
+          LENGTH(COALESCE(source_type, '')) +
+          LENGTH(COALESCE(source_identifier, ''))
+        ), 0) AS b FROM defence_audit
+      `).get() as { c: number; b: number };
+      auditCount = audit.c;
+      auditBytes = audit.b;
+    } catch { /* table absent — keep zeros */ }
+
     return {
       memoriesCount: mem.c,
       memoriesBytes: mem.b,
       sessionEventCount: se.c,
       sessionEventBytes: se.b,
+      auditCount,
+      auditBytes,
     };
   } catch {
     return null;
@@ -738,13 +764,31 @@ export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limit
       if (liveDbSize > limit * 0.5) {
         // #110 signature: a big DB whose memories table is tiny — the bulk is
         // session-capture rows. Live incident (Edith, 2026-07-21): 79.6 MB DB,
-        // 117 memories, session_events 62.8 MB; both previously suggested
-        // fixes (vacuum — 0.0 MB free pages — and memories prune) were no-ops.
-        // Best-effort peek inside the DB to name the actual consumer; falls
-        // through to the generic remedy when the DB can't be read.
+        // 117 memories, session_events 62.8 MB (79% of the file); both
+        // previously suggested fixes (vacuum — 0.0 MB free pages — and
+        // memories prune) were no-ops. Best-effort peek inside the DB to name
+        // the actual consumer; falls through to the generic remedy when the
+        // DB can't be read.
+        //
+        // Review hardening: only blame session capture when its payload
+        // GENUINELY dominates — more than 40% of the live DB file (Edith's
+        // signature was 79%) AND more than the defence_audit bytes. A merely
+        // "bigger than the memories table" comparison misattributed
+        // audit-dominated DBs and recommended a no-op sessions prune.
         const consumers = readDbRowConsumers(path.join(scDir, 'memories.db'));
-        if (consumers && consumers.sessionEventCount > 0 && consumers.sessionEventBytes > consumers.memoriesBytes) {
+        if (
+          consumers &&
+          consumers.sessionEventCount > 0 &&
+          consumers.sessionEventBytes > liveDbSize * 0.4 &&
+          consumers.sessionEventBytes > consumers.auditBytes
+        ) {
           return `The database is ${formatBytes(liveDbSize)} but the memories table holds only ${consumers.memoriesCount} memor${consumers.memoriesCount === 1 ? 'y' : 'ies'} — the bulk is session-capture rows (session_events: ${consumers.sessionEventCount} rows, ${formatBytes(consumers.sessionEventBytes)} of payload), which memories prune/dedupe and vacuum alone can't shrink. Run \`shieldcortex sessions prune --execute\` (deletes events older than 30 days; --days N to adjust), then \`shieldcortex vacuum\` to reclaim the freed pages on disk.`;
+        }
+        if (consumers && consumers.auditBytes > consumers.sessionEventBytes) {
+          // Audit-dominated: the worker's Phase 8a audit retention (90d + row
+          // cap) bounds this over time; don't send the user to a sessions
+          // prune that would be a no-op.
+          return `The database is ${formatBytes(liveDbSize)} — the bulk is defence-audit rows (defence_audit: ${consumers.auditCount} rows, ~${formatBytes(consumers.auditBytes)}), which the background worker's audit retention trims over time (90-day window + row cap). Reclaim free space with \`shieldcortex vacuum\` (compacts the DB in place via the bundled engine — no sqlite3 CLI needed); if it is genuinely the memory table, \`shieldcortex memories prune --execute\`.`;
         }
         return `The database is ${formatBytes(liveDbSize)} — usually session capture + audit rows, which prune/dedupe can't shrink. If it is session capture, \`shieldcortex sessions prune --execute\` deletes events older than 30 days. Reclaim free space with \`shieldcortex vacuum\` (compacts the DB in place via the bundled engine — no sqlite3 CLI needed); if it is genuinely the memory table, \`shieldcortex memories prune --execute\`.`;
       }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -615,6 +615,47 @@ async function checkProcesses(): Promise<CheckResult[]> {
  * under `~/.shieldcortex/`, producing a false `Disk: at limit!` for any
  * user with a local AI model cached.
  */
+/**
+ * Best-effort read-only peek at what actually fills the live DB (#110):
+ * row counts + stored byte totals for the memories and session_events
+ * tables. Returns null on ANY failure (missing file, corrupt/locked DB,
+ * missing tables, unreadable engine) — the caller then falls back to the
+ * generic remedy text, so this can never break the disk check itself.
+ */
+interface DbRowConsumers {
+  memoriesCount: number;
+  memoriesBytes: number;
+  sessionEventCount: number;
+  sessionEventBytes: number;
+}
+
+function readDbRowConsumers(dbPath: string): DbRowConsumers | null {
+  if (!fs.existsSync(dbPath)) return null;
+  let db: any = null;
+  try {
+    const Database = require('better-sqlite3');
+    db = new Database(dbPath, { readonly: true });
+    const mem = db.prepare(
+      'SELECT COUNT(*) AS c, COALESCE(SUM(LENGTH(content)), 0) AS b FROM memories',
+    ).get() as { c: number; b: number };
+    const se = db.prepare(
+      'SELECT COUNT(*) AS c, COALESCE(SUM(LENGTH(payload)), 0) AS b FROM session_events',
+    ).get() as { c: number; b: number };
+    return {
+      memoriesCount: mem.c,
+      memoriesBytes: mem.b,
+      sessionEventCount: se.c,
+      sessionEventBytes: se.b,
+    };
+  } catch {
+    return null;
+  } finally {
+    if (db) {
+      try { db.close(); } catch { /* ignore */ }
+    }
+  }
+}
+
 export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limitBytes: number = 100 * 1024 * 1024): Promise<CheckResult> {
   if (!fs.existsSync(scDir)) {
     return { label: 'Disk', status: 'pass', message: '0 B / 100 MB limit (directory not yet created)' };
@@ -695,7 +736,17 @@ export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limit
         return `${formatBytes(backupsSize)} is stale DB backups (memories.db.* migration snapshots). Clear them — \`rm ~/.shieldcortex/memories.db.{pre-backfill,empty-live,stub,bak}*\` keeps the live DB; v4.45.1+ also auto-prunes them on start.`;
       }
       if (liveDbSize > limit * 0.5) {
-        return `The database is ${formatBytes(liveDbSize)} — usually session capture + audit rows, which prune/dedupe can't shrink. Reclaim free space with \`shieldcortex vacuum\` (compacts the DB in place via the bundled engine — no sqlite3 CLI needed); if it is genuinely the memory table, \`shieldcortex memories prune --execute\`.`;
+        // #110 signature: a big DB whose memories table is tiny — the bulk is
+        // session-capture rows. Live incident (Edith, 2026-07-21): 79.6 MB DB,
+        // 117 memories, session_events 62.8 MB; both previously suggested
+        // fixes (vacuum — 0.0 MB free pages — and memories prune) were no-ops.
+        // Best-effort peek inside the DB to name the actual consumer; falls
+        // through to the generic remedy when the DB can't be read.
+        const consumers = readDbRowConsumers(path.join(scDir, 'memories.db'));
+        if (consumers && consumers.sessionEventCount > 0 && consumers.sessionEventBytes > consumers.memoriesBytes) {
+          return `The database is ${formatBytes(liveDbSize)} but the memories table holds only ${consumers.memoriesCount} memor${consumers.memoriesCount === 1 ? 'y' : 'ies'} — the bulk is session-capture rows (session_events: ${consumers.sessionEventCount} rows, ${formatBytes(consumers.sessionEventBytes)} of payload), which memories prune/dedupe and vacuum alone can't shrink. Run \`shieldcortex sessions prune --execute\` (deletes events older than 30 days; --days N to adjust), then \`shieldcortex vacuum\` to reclaim the freed pages on disk.`;
+        }
+        return `The database is ${formatBytes(liveDbSize)} — usually session capture + audit rows, which prune/dedupe can't shrink. If it is session capture, \`shieldcortex sessions prune --execute\` deletes events older than 30 days. Reclaim free space with \`shieldcortex vacuum\` (compacts the DB in place via the bundled engine — no sqlite3 CLI needed); if it is genuinely the memory table, \`shieldcortex memories prune --execute\`.`;
       }
       if (logsSize > limit * 0.2) {
         return `${formatBytes(logsSize)} is audit/log files — safe to rotate or clear under ~/.shieldcortex/{logs,audit}/.`;

--- a/src/cli/sessions.ts
+++ b/src/cli/sessions.ts
@@ -1,0 +1,100 @@
+/**
+ * `shieldcortex sessions` — session-capture maintenance CLI (issue #110).
+ *
+ * session_events is append-only turn capture (src/sessions/capture.ts) with,
+ * until #110, no deletion path at all — live incident data showed it carrying
+ * a DB to 79.6 MB with only 117 memories. `sessions prune` is the manual
+ * valve alongside the brain worker's automatic retention: dry-run by default
+ * (prints matched count + payload MB), `--execute` to delete. Follows the
+ * `memories prune` conventions (src/cli/migrate-legacy.ts runPrune): same
+ * flag parsing, same [DRY RUN] banner + Matched/Deleted output shape, same
+ * initDatabase() startup (which owns the "[database] Another ShieldCortex
+ * process ..." single-writer behaviour).
+ */
+
+function flagValue(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  if (idx === -1) return undefined;
+  const v = args[idx + 1];
+  if (!v || v.startsWith('--')) return undefined;
+  return v;
+}
+
+/**
+ * Run `sessions prune [--days N] [--execute]`.
+ *
+ * `dbPathOverride` is injectable for tests; production callers omit it and
+ * initDatabase() resolves the standard ~/.shieldcortex/memories.db path.
+ * Throws on invalid input (the command wrapper turns that into exit 1).
+ */
+export async function runSessionsPrune(args: string[], dbPathOverride?: string): Promise<void> {
+  const { initDatabase } = await import('../database/init.js');
+  const {
+    resolveSessionRetentionDays,
+    previewOldSessionEvents,
+    purgeSessionEventsOlderThan,
+  } = await import('../sessions/retention.js');
+
+  initDatabase(dbPathOverride);
+
+  const dryRun = !args.includes('--execute');
+  const rawDays = flagValue(args, '--days');
+  let days: number;
+  if (rawDays === undefined) {
+    days = resolveSessionRetentionDays();
+  } else {
+    days = Number(rawDays);
+    if (!Number.isInteger(days) || days < 0) {
+      throw new Error(`--days expects a non-negative integer, got '${rawDays}'`);
+    }
+  }
+
+  const preview = previewOldSessionEvents(days);
+  const payloadMb = preview.payloadBytes / (1024 * 1024);
+
+  const banner = dryRun ? '[DRY RUN] ' : '';
+  console.log(`${banner}Prune session_events older than ${days}d (ts < ${preview.cutoffIso})`);
+  console.log(`  Matched: ${preview.matched} event${preview.matched === 1 ? '' : 's'} · ~${payloadMb.toFixed(1)} MB payload`);
+
+  if (dryRun) {
+    if (preview.matched > 0) {
+      console.log('  Re-run with --execute to delete.');
+    }
+    return;
+  }
+
+  // Delete against the SAME cutoff the preview reported, so the printed
+  // matched/deleted numbers can only differ by rows written in between.
+  const deleted = purgeSessionEventsOlderThan(preview.cutoffIso);
+  console.log(`  Deleted: ${deleted}`);
+  if (deleted > 0) {
+    console.log('  Freed rows leave free pages inside the DB file — run `shieldcortex vacuum` to shrink it on disk.');
+  }
+}
+
+function printUsage(): void {
+  console.log('Usage: shieldcortex sessions <subcommand> [options]');
+  console.log('');
+  console.log('Subcommands:');
+  console.log('  prune [--days 30] [--execute]');
+  console.log('      Delete session-capture events (session_events) older than N days.');
+  console.log('      DRY-RUN BY DEFAULT — prints matched count + payload MB; pass');
+  console.log('      --execute to actually delete, then run `shieldcortex vacuum` to');
+  console.log('      reclaim the file space. Default window: 30 days, overridable via');
+  console.log('      the SHIELDCORTEX_SESSION_RETENTION_DAYS env var (1-3650).');
+}
+
+export async function handleSessionsCommand(args: string[]): Promise<void> {
+  const sub = args[0];
+  if (sub === 'prune') {
+    try {
+      await runSessionsPrune(args.slice(1));
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+    return;
+  }
+  printUsage();
+  process.exit(1);
+}

--- a/src/database/inline-schema.ts
+++ b/src/database/inline-schema.ts
@@ -344,6 +344,10 @@ export function getInlineSchema(): string {
     CREATE INDEX IF NOT EXISTS idx_session_events_session ON session_events(session_id, ts);
     CREATE INDEX IF NOT EXISTS idx_session_events_project ON session_events(project, ts DESC);
     CREATE INDEX IF NOT EXISTS idx_session_events_sensitivity ON session_events(sensitivity_level);
+    -- #110: bare-ts index for the retention purge (DELETE ... WHERE ts < ?).
+    -- The composite (session_id, ts)/(project, ts) indexes can't serve a bare
+    -- ts range predicate, so without this the age purge would full-scan.
+    CREATE INDEX IF NOT EXISTS idx_session_events_ts ON session_events(ts);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_session_events_dedupe
       ON session_events(session_id, ts, kind, content_hash);
 

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -851,4 +851,23 @@ export function runMigrations(database: Database.Database): void {
   } catch (err) {
     logIfUnexpectedDdlError(err, 'provenance ledger indexes (audit operation, memories content_hash/source)');
   }
+
+  // Migration: issue #110 — bare-ts index on session_events for the retention
+  // purge (src/sessions/retention.ts, DELETE ... WHERE ts < ?). The existing
+  // composite (session_id, ts) / (project, ts) indexes can't serve a bare ts
+  // range predicate, so without this the daily age purge would full-scan a
+  // table that live incidents have shown reaching ~30k rows / ~63 MB. Fresh
+  // installs get the index from schema.sql / inline-schema.ts; this block
+  // upgrades existing DBs. Guarded on table existence like the other
+  // session_events migrations above.
+  try {
+    const sessionEventsTable = database
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session_events'")
+      .get();
+    if (sessionEventsTable) {
+      database.exec('CREATE INDEX IF NOT EXISTS idx_session_events_ts ON session_events(ts)');
+    }
+  } catch (err) {
+    logIfUnexpectedDdlError(err, 'session_events bare-ts retention index');
+  }
 }

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -152,6 +152,10 @@ CREATE TABLE IF NOT EXISTS session_events (
 CREATE INDEX IF NOT EXISTS idx_session_events_session ON session_events(session_id, ts);
 CREATE INDEX IF NOT EXISTS idx_session_events_project ON session_events(project, ts DESC);
 CREATE INDEX IF NOT EXISTS idx_session_events_sensitivity ON session_events(sensitivity_level);
+-- #110: bare-ts index for the retention purge (DELETE ... WHERE ts < ?).
+-- The composite (session_id, ts)/(project, ts) indexes can't serve a bare
+-- ts range predicate, so without this the age purge would full-scan.
+CREATE INDEX IF NOT EXISTS idx_session_events_ts ON session_events(ts);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_session_events_dedupe
   ON session_events(session_id, ts, kind, content_hash);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -639,6 +639,7 @@ ${bold}COMMANDS${reset}
   ${cyan}status${reset}                Show current protection status
   ${cyan}doctor${reset}                Diagnose installation issues
   ${cyan}vacuum${reset}                Compact the memory DB, reclaiming free pages (no sqlite3 CLI needed)
+  ${cyan}sessions${reset} prune        Delete old session-capture events (dry-run; --days N, --execute)
   ${cyan}quickstart${reset} [target]    Detect integrations and guide/install setup
   ${cyan}config${reset} [options]      Configure cloud sync and settings
   ${cyan}cloud${reset} sync --full     Backfill local memories + graph to ShieldCortex Cloud
@@ -817,6 +818,14 @@ ${bold}DOCS${reset}
   if (process.argv[2] === 'import-jsonl') {
     const { handleImportJsonlCommand } = await import('./cli/import-jsonl.js');
     await handleImportJsonlCommand(process.argv.slice(3));
+    return;
+  }
+
+  // Handle "sessions" subcommand (#110) — session-capture maintenance
+  // (currently `sessions prune`, the retention valve for session_events).
+  if (process.argv[2] === 'sessions') {
+    const { handleSessionsCommand } = await import('./cli/sessions.js');
+    await handleSessionsCommand(process.argv.slice(3));
     return;
   }
 
@@ -1194,7 +1203,7 @@ ${bold}DOCS${reset}
     'openclaw', 'clawdbot', 'copilot', 'codex', 'service', 'config', 'status',
     'graph', 'license', 'licence', 'audit', 'mcp', 'iron-dome', 'scan', 'cloud', 'review-copilot',
     'scan-skill', 'scan-skills', 'dashboard', 'api', 'worker', 'stats', 'cortex', 'consolidate', 'xray', 'xray-preinstall',
-    'memories', 'import-jsonl', 'remember', 'vacuum', 'compact',
+    'memories', 'import-jsonl', 'remember', 'vacuum', 'compact', 'sessions',
   ]);
   const arg = process.argv[2];
   if (arg && !arg.startsWith('-') && !knownCommands.has(arg)) {

--- a/src/sessions/import-jsonl.ts
+++ b/src/sessions/import-jsonl.ts
@@ -82,23 +82,70 @@ export function parseTranscriptLine(line: unknown): SessionEventInput[] {
   if (typeof l.sessionId !== 'string' || l.sessionId.length === 0) return [];
   if (typeof l.timestamp !== 'string' || l.timestamp.length === 0) return [];
 
+  // #110 review: NORMALISE the timestamp to canonical ISO-8601 UTC
+  // ('YYYY-MM-DDTHH:MM:SS.sssZ') instead of passing it through verbatim.
+  // The retention purge (src/sessions/retention.ts) compares `ts` strings
+  // LEXICALLY, which is only chronological when every row shares that exact
+  // format. Verbatim passthrough let two proven misorderings in:
+  //   - epoch-millis strings ('1784640743169') sort before any '2026-…' row,
+  //     so the 30-day purge classified them as infinitely old and deleted
+  //     them immediately;
+  //   - offset-bearing ISO ('2026-07-21T01:00:00+09:00') misorders against
+  //     Z-format rows at boundaries.
+  // Plain ISO-Z round-trips unchanged. An unparseable timestamp rejects the
+  // line, which the importer counts in the `malformed` tally.
+  const parsedMs = parseTimestampMs(l.timestamp);
+  if (Number.isNaN(parsedMs)) return [];
+  const ts = new Date(parsedMs).toISOString();
+
   const content = l.message?.content;
   if (!Array.isArray(content) || content.length === 0) return [];
 
   const events: SessionEventInput[] = [];
   for (const block of content) {
-    const event = blockToEvent(block, l);
+    const event = blockToEvent(block, l, ts);
     if (event) events.push(event);
   }
   return events;
 }
 
+/**
+ * Timestamp string → epoch milliseconds (NaN when unparseable).
+ *
+ * Date.parse alone does NOT cover the epoch-numeric vector: in V8,
+ * Date.parse('1784640743169') is NaN (a 13-digit string is not a valid date
+ * literal), so the reviewer's proven-bad input would be dropped as malformed
+ * instead of recovered to its real instant. All-digit strings are therefore
+ * recognised explicitly first — 13 digits as epoch milliseconds, 10 digits
+ * as epoch seconds — and everything else goes through Date.parse (which
+ * handles ISO with or without offsets/milliseconds).
+ */
+function parseTimestampMs(raw: string): number {
+  if (/^\d{13}$/.test(raw)) return Number(raw); // epoch milliseconds
+  if (/^\d{10}$/.test(raw)) return Number(raw) * 1000; // epoch seconds
+  return Date.parse(raw);
+}
+
+/**
+ * True when a conversation line carries a timestamp string that cannot be
+ * parsed at all — the case `parseTranscriptLine` rejects and the importer
+ * must count as `malformed` (not merely `skipped`).
+ */
+function hasUnparseableTimestamp(line: unknown): boolean {
+  if (!line || typeof line !== 'object') return false;
+  const l = line as TranscriptLine;
+  if (l.type !== 'user' && l.type !== 'assistant') return false;
+  if (typeof l.timestamp !== 'string' || l.timestamp.length === 0) return false;
+  return Number.isNaN(parseTimestampMs(l.timestamp));
+}
+
 function blockToEvent(
   block: ContentBlock,
   line: TranscriptLine,
+  /** Normalised ISO-8601 UTC timestamp (see parseTranscriptLine). */
+  ts: string,
 ): SessionEventInput | null {
   const session_id = line.sessionId as string;
-  const ts = line.timestamp as string;
 
   if (block.type === 'thinking') return null;
 
@@ -240,6 +287,10 @@ export function importJsonlTranscript(path: string): ImportResult {
     }
     const events = parseTranscriptLine(parsed);
     if (events.length === 0) {
+      // A conversation line rejected for an unparseable timestamp is bad
+      // DATA, not merely an uninteresting line type — count it malformed
+      // (matching the ImportResult.malformed contract) as well as skipped.
+      if (hasUnparseableTimestamp(parsed)) malformed++;
       skipped++;
       return;
     }

--- a/src/sessions/retention.ts
+++ b/src/sessions/retention.ts
@@ -30,6 +30,16 @@
  * use `datetime(current_timestamp, '-N days')` — SQLite's datetime() renders
  * 'YYYY-MM-DD HH:MM:SS' (space, no ms, no Z), which does NOT collate cleanly
  * against the stored 'T'/'Z' format at the boundary.
+ *
+ * Since the #110 review, the JSONL importer ENFORCES this (it previously
+ * only assumed it): import-jsonl.ts normalises every transcript timestamp
+ * through Date.parse → toISOString(), so epoch-millis strings can no longer
+ * lexically sort as "infinitely old" and offset-bearing ISO can no longer
+ * misorder at the boundary. Dedupe implication: `ts` is part of the
+ * idx_session_events_dedupe UNIQUE key, so rows imported BEFORE the
+ * normalisation under an offset/epoch format keep their old key — re-running
+ * the same transcript now inserts normalised-ts rows alongside them rather
+ * than deduping (a one-time duplication for affected legacy rows only).
  */
 
 import { getDatabase, checkDatabaseSize } from '../database/init.js';

--- a/src/sessions/retention.ts
+++ b/src/sessions/retention.ts
@@ -1,0 +1,186 @@
+/**
+ * Session-events retention + size-pressure valve (issue #110).
+ *
+ * `recordEvent()`/`recordEvents()` insert a session_events row for EVERY
+ * captured turn event (prompts, responses, tool calls/results, hook fires)
+ * and nothing ever deletes them — the table grows forever. The DB has a
+ * 100MB hard limit (init.ts MAX_DB_SIZE) that BLOCKS all writes once
+ * exceeded, and consolidation/vacuum can't shrink rows that are never
+ * deleted. Live incident (Edith box, 2026-07-21, v4.47.12): a 79.6 MB DB
+ * holding only 117 memories — session_events was 62.8 MB (+ ~6 MB indexes)
+ * across 29,835 rows over 65 days; doctor's suggested fixes (vacuum /
+ * memories prune) were both no-ops for that failure mode.
+ *
+ * Mirrors the Phase 8a defence_audit valve (src/defence/audit/retention.ts)
+ * with ONE deliberate difference: NO aggregate rollup. The audit valve needed
+ * one because getLifetimeStats() scans the whole defence_audit table, so
+ * deleting rows would make lifetime totals silently regress. Nothing computes
+ * lifetime stats from session_events — the only reader is the on-demand
+ * per-session replay (timeline.ts getTimeline / the sessions API routes), so
+ * deletion is lossy-but-safe: replays of sessions older than the retention
+ * window simply truncate. No rollup, no coupled table, plain DELETEs.
+ *
+ * Timestamps: rows store a caller-supplied ISO-8601 `ts` string — in practice
+ * always `new Date().toISOString()` ('YYYY-MM-DDTHH:MM:SS.sssZ'; the JSONL
+ * importer passes through Claude Code transcript timestamps, same format).
+ * The purge compares `ts < ?` LEXICALLY against a cutoff produced by the
+ * exact same `toISOString()` formatter, so both sides share the format and
+ * lexical order === chronological order (proven at the millisecond boundary
+ * in src/__tests__/session-events-retention.test.ts). We deliberately do NOT
+ * use `datetime(current_timestamp, '-N days')` — SQLite's datetime() renders
+ * 'YYYY-MM-DD HH:MM:SS' (space, no ms, no Z), which does NOT collate cleanly
+ * against the stored 'T'/'Z' format at the boundary.
+ */
+
+import { getDatabase, checkDatabaseSize } from '../database/init.js';
+
+/** Default age-based retention window. */
+export const DEFAULT_SESSION_RETENTION_DAYS = 30;
+
+/**
+ * Hard ceiling on live session_events rows under size pressure.
+ *
+ * Sizing (from the Edith incident data): 29,835 rows ≈ 62.8 MB payload +
+ * ~6 MB indexes → ~2.3–2.4 KB per row all-in. 10,000 rows therefore bound
+ * session_events at ~24 MB worst case. The audit valve's own cap
+ * (AUDIT_PRESSURE_ROW_CAP = 100,000 rows of small audit entries, tens of MB
+ * worst case) must fit in the same 100 MB file, so ~24 MB here leaves clear
+ * joint headroom under the hard block — a 20k cap (~48 MB) would not.
+ * 10k rows is still ~3 weeks of the incident box's capture rate, so recent
+ * replay fidelity is preserved.
+ */
+export const SESSION_PRESSURE_ROW_CAP = 10_000;
+
+/** Bounds for the env override — anything outside is treated as invalid. */
+const MIN_RETENTION_DAYS = 1;
+const MAX_RETENTION_DAYS = 3650;
+
+/**
+ * Resolve the retention window: the SHIELDCORTEX_SESSION_RETENTION_DAYS env
+ * var when set to a valid positive integer (1–3650), otherwise the 30-day
+ * default. The audit valve's 90d window is a hard-coded default with no knob;
+ * session capture is far bulkier per row and per-fleet capture rates vary
+ * wildly, so this one gets an override — as an env var, matching the
+ * codebase's existing tunable style (SHIELDCORTEX_DISABLE_WORKER,
+ * SHIELDCORTEX_SKIP_EMBEDDINGS, SHIELDCORTEX_CONFIG_DIR) rather than a new
+ * config subsystem. Invalid values warn on stderr and fall back.
+ */
+export function resolveSessionRetentionDays(
+  raw: string | undefined = process.env.SHIELDCORTEX_SESSION_RETENTION_DAYS,
+): number {
+  if (raw === undefined || raw === '') return DEFAULT_SESSION_RETENTION_DAYS;
+  const parsed = Number(raw);
+  if (
+    !Number.isInteger(parsed) ||
+    parsed < MIN_RETENTION_DAYS ||
+    parsed > MAX_RETENTION_DAYS
+  ) {
+    console.error(
+      `[sessions] Ignoring invalid SHIELDCORTEX_SESSION_RETENTION_DAYS=${JSON.stringify(raw)} ` +
+      `(expected an integer ${MIN_RETENTION_DAYS}-${MAX_RETENTION_DAYS}); using ${DEFAULT_SESSION_RETENTION_DAYS}d`,
+    );
+    return DEFAULT_SESSION_RETENTION_DAYS;
+  }
+  return parsed;
+}
+
+/** ISO-8601 cutoff for a retention window — same formatter capture uses. */
+function retentionCutoffIso(retentionDays: number): string {
+  return new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+}
+
+export interface OldSessionEventsPreview {
+  /** Rows strictly older than the cutoff. */
+  matched: number;
+  /** Total stored payload bytes of the matched rows. */
+  payloadBytes: number;
+  /** The ISO cutoff the counts were taken against. */
+  cutoffIso: string;
+}
+
+/**
+ * Dry-run support for the CLI: count the rows an age purge WOULD delete and
+ * their total payload bytes, without deleting anything.
+ */
+export function previewOldSessionEvents(
+  retentionDays: number = resolveSessionRetentionDays(),
+): OldSessionEventsPreview {
+  const db = getDatabase();
+  const cutoffIso = retentionCutoffIso(retentionDays);
+  const row = db.prepare(`
+    SELECT COUNT(*) AS matched, COALESCE(SUM(LENGTH(payload)), 0) AS payloadBytes
+    FROM session_events
+    WHERE ts < ?
+  `).get(cutoffIso) as { matched: number; payloadBytes: number };
+  return { matched: row.matched, payloadBytes: row.payloadBytes, cutoffIso };
+}
+
+/**
+ * Purge primitive: delete every session_events row with ts STRICTLY older
+ * than the given ISO-8601 cutoff. Exposed separately so tests can pin the
+ * lexical-comparison boundary with a deterministic cutoff string. Uses the
+ * bare-ts index (idx_session_events_ts) — the existing (session_id, ts) /
+ * (project, ts) indexes can't serve a bare ts range predicate.
+ */
+export function purgeSessionEventsOlderThan(cutoffIso: string): number {
+  const db = getDatabase();
+  const res = db.prepare('DELETE FROM session_events WHERE ts < ?').run(cutoffIso);
+  return Number(res.changes ?? 0);
+}
+
+/**
+ * Age-based retention: DELETE rows older than the cutoff. No rollup needed
+ * (see file header — nothing aggregates session_events). Returns the number
+ * of rows deleted. Note: like every SQLite DELETE, this frees pages inside
+ * the file but does not shrink it on disk — `shieldcortex vacuum` does that.
+ */
+export function purgeOldSessionEvents(
+  retentionDays: number = resolveSessionRetentionDays(),
+): number {
+  return purgeSessionEventsOlderThan(retentionCutoffIso(retentionDays));
+}
+
+/**
+ * Size-pressure valve. Cheap to call: it first checks the DB file size and
+ * bails unless the file has crossed the warning threshold (reusing the
+ * codebase's existing 50MB WARN_DB_SIZE via checkDatabaseSize(), so we don't
+ * keep a second copy of the threshold). When over pressure, it trims the
+ * OLDEST session_events rows down to the row cap so capture growth can never
+ * carry the DB to the 100MB block. Eviction is plain oldest-first (ts, then
+ * id for stable ordering within a timestamp) — unlike the audit valve there
+ * is no forensic-value tiering, because all session events carry equal
+ * (replay-only) value.
+ *
+ * Thresholds are injectable for tests, mirroring purgeAuditUnderSizePressure:
+ * simulating a real 50MB file (and, on a `:memory:` DB, ANY measurable file
+ * size) is impractical, so passing `warnBytes` BYPASSES the file-size gate
+ * entirely and drives the row-cap trim directly; `maxRows` sets the cap. In
+ * production neither is passed and the gate uses the live file size vs
+ * WARN_DB_SIZE.
+ */
+export function purgeSessionEventsUnderSizePressure(
+  options: { warnBytes?: number; maxRows?: number } = {},
+): number {
+  const db = getDatabase();
+  const maxRows = options.maxRows ?? SESSION_PRESSURE_ROW_CAP;
+
+  if (options.warnBytes === undefined) {
+    if (!checkDatabaseSize().warning) return 0;
+  }
+
+  return db.transaction(() => {
+    const total = (db.prepare('SELECT COUNT(*) AS c FROM session_events').get() as { c: number }).c;
+    if (total <= maxRows) return 0;
+
+    const over = total - maxRows;
+    const res = db.prepare(`
+      DELETE FROM session_events
+      WHERE id IN (
+        SELECT id FROM session_events
+        ORDER BY ts ASC, id ASC
+        LIMIT ?
+      )
+    `).run(over);
+    return Number(res.changes ?? 0);
+  })();
+}

--- a/src/worker/brain-worker.ts
+++ b/src/worker/brain-worker.ts
@@ -38,6 +38,11 @@ import { processRetryQueue, purgeOldEntries } from '../cloud/sync-queue.js';
 import { sendHeartbeat } from '../cloud/sync.js';
 import { refreshCloudIronDome, applyCachedCloudPatterns } from '../cloud/iron-dome-sync.js';
 import { purgeOldAuditEntries, purgeAuditUnderSizePressure } from '../defence/audit/retention.js';
+import {
+  purgeOldSessionEvents,
+  purgeSessionEventsUnderSizePressure,
+  resolveSessionRetentionDays,
+} from '../sessions/retention.js';
 import { isFeatureEnabled } from '../license/gate.js';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
@@ -51,7 +56,17 @@ const WORKER_STATE_FILE = join(WORKER_STATE_DIR, 'worker.json');
 // bounded, and running it every tick would be wasteful.
 const AUDIT_PURGE_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-function persistWorkerState(profile: string, lastLightTick: Date, lastAuditPurge: Date | null): void {
+// Session-capture retention (#110) shares the same daily cadence rationale:
+// the pressure valve is a cheap size check every tick, the age purge is
+// plenty at once per day.
+const SESSION_PURGE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+function persistWorkerState(
+  profile: string,
+  lastLightTick: Date,
+  lastAuditPurge: Date | null,
+  lastSessionPurge: Date | null,
+): void {
   try {
     if (!existsSync(WORKER_STATE_DIR)) mkdirSync(WORKER_STATE_DIR, { recursive: true });
     writeFileSync(
@@ -62,6 +77,7 @@ function persistWorkerState(profile: string, lastLightTick: Date, lastAuditPurge
           profile,
           lastLightTick: lastLightTick.toISOString(),
           lastAuditPurge: lastAuditPurge ? lastAuditPurge.toISOString() : null,
+          lastSessionPurge: lastSessionPurge ? lastSessionPurge.toISOString() : null,
         },
         null,
         2,
@@ -74,15 +90,16 @@ function persistWorkerState(profile: string, lastLightTick: Date, lastAuditPurge
 }
 
 /**
- * Read the persisted lastAuditPurge timestamp so the 24h throttle survives
- * process restarts — MCP servers restart frequently (one per Claude Code
- * window), and without this every restart would trigger a fresh purge.
+ * Read a persisted purge timestamp so the 24h throttles survive process
+ * restarts — MCP servers restart frequently (one per Claude Code window),
+ * and without this every restart would trigger a fresh purge.
  */
-function readPersistedAuditPurge(): Date | null {
+function readPersistedPurgeDate(key: 'lastAuditPurge' | 'lastSessionPurge'): Date | null {
   try {
-    const raw = JSON.parse(readFileSync(WORKER_STATE_FILE, 'utf-8')) as { lastAuditPurge?: string | null };
-    if (raw.lastAuditPurge) {
-      const d = new Date(raw.lastAuditPurge);
+    const raw = JSON.parse(readFileSync(WORKER_STATE_FILE, 'utf-8')) as Record<string, string | null | undefined>;
+    const value = raw[key];
+    if (value) {
+      const d = new Date(value);
       if (!Number.isNaN(d.getTime())) return d;
     }
   } catch {
@@ -115,9 +132,10 @@ export class BrainWorker {
   private lastLightTick: Date | null = null;
   private lastMediumTick: Date | null = null;
   private lastConsolidation: Date | null = null;
-  // Seeded from persisted state so the 24h audit-purge throttle survives
+  // Seeded from persisted state so the 24h purge throttles survive
   // frequent MCP-server restarts.
-  private lastAuditPurge: Date | null = readPersistedAuditPurge();
+  private lastAuditPurge: Date | null = readPersistedPurgeDate('lastAuditPurge');
+  private lastSessionPurge: Date | null = readPersistedPurgeDate('lastSessionPurge');
 
   /**
    * Create a new BrainWorker
@@ -290,6 +308,38 @@ export class BrainWorker {
         console.error('[BrainWorker] Audit retention failed:', auditErr);
       }
 
+      // 3b. Session-capture retention (#110) — same shape as the audit valve
+      // above, for the other unbounded table: session_events grows on every
+      // captured turn with (pre-#110) no DELETE anywhere; a live incident put
+      // it at 62.8 MB of a 79.6 MB DB that held only 117 memories. The
+      // pressure valve is a cheap size check, so it runs every tick; the
+      // age-based purge (30d default, SHIELDCORTEX_SESSION_RETENTION_DAYS to
+      // override) is throttled to ~once per 24h. Unlike audit retention, no
+      // aggregate rollup is needed — nothing computes lifetime stats from
+      // session_events; old rows only feed on-demand replay, so deletion is
+      // lossy-but-safe (see src/sessions/retention.ts).
+      try {
+        const sessionPressurePurged = purgeSessionEventsUnderSizePressure();
+        if (sessionPressurePurged > 0) {
+          console.error(`[BrainWorker] Session-capture size-pressure valve purged ${sessionPressurePurged} rows`);
+        }
+
+        const sessionNow = result.timestamp.getTime();
+        const dueForSessionPurge =
+          this.lastSessionPurge === null ||
+          sessionNow - this.lastSessionPurge.getTime() >= SESSION_PURGE_INTERVAL_MS;
+        if (dueForSessionPurge) {
+          const retentionDays = resolveSessionRetentionDays();
+          const purged = purgeOldSessionEvents(retentionDays);
+          this.lastSessionPurge = result.timestamp;
+          if (purged > 0) {
+            console.error(`[BrainWorker] Session-capture retention purged ${purged} events older than ${retentionDays}d`);
+          }
+        }
+      } catch (sessionErr) {
+        console.error('[BrainWorker] Session-capture retention failed:', sessionErr);
+      }
+
       // 4. Sync retry queue — drains on BOTH profiles. MCP-only installs have
       // no full worker, so if this stayed full-only their queued audits/
       // memories would age out unsent (the same gap we closed for audit
@@ -337,7 +387,7 @@ export class BrainWorker {
       this.stats.lightTicks++;
 
       // Persist worker freshness for `shieldcortex doctor` to detect stalls.
-      persistWorkerState(this.config.profile, result.timestamp, this.lastAuditPurge);
+      persistWorkerState(this.config.profile, result.timestamp, this.lastAuditPurge, this.lastSessionPurge);
 
       // Emit light tick event
       emitWorkerLightTick(result);


### PR DESCRIPTION
## Problem

`session_events` (turn-by-turn session capture, written by `src/sessions/capture.ts`) is append-only with **no deletion path anywhere** — no retention, no cap, no CLI. Every captured prompt/response/tool event accumulates forever, silently carrying the DB toward the 100 MB hard limit (`init.ts MAX_DB_SIZE`) that blocks **all** writes once exceeded.

### Live incident evidence (Edith box, 2026-07-21, v4.47.12)

- DB at **79.6 MB** holding only **117 memories**
- `vacuum` found **0.0 MB** of free pages — no-op
- `dbstat`: `session_events` **62.8 MB** + ~6 MB indexes; **29,835 rows over 65 days**
- Manual 30-day purge + VACUUM took the file to **45.5 MB**
- Both of doctor's suggested fixes (vacuum / memories prune) were **no-ops** for this failure mode

## Design — mirror of the Phase 8a audit valve

`defence_audit` got exactly this valve in Phase 8a (`src/defence/audit/retention.ts` + brain-worker light-tick wiring). This PR mirrors that pattern for `session_events` — same style, same injectable test thresholds (`warnBytes` / `maxRows`), same `checkDatabaseSize()` gate — with **one deliberate difference: no aggregate rollup**. The audit valve needed one because `getLifetimeStats()` scans the whole table; **nothing** computes lifetime stats from `session_events` — the only reader is on-demand per-session replay (`timeline.ts getTimeline` / the sessions API). Deletion is lossy-but-safe: replays of sessions older than the window simply truncate. This rationale is stated in the module header like `retention.ts` does.

### What's included

1. **`src/sessions/retention.ts`** — `purgeOldSessionEvents(retentionDays = 30)` + `purgeSessionEventsUnderSizePressure({warnBytes?, maxRows?})`.
   - **Row cap = 10,000** (not the suggested 20k): incident data gives ~2.3–2.4 KB/row all-in (62.8 MB payload + ~6 MB indexes over 29,835 rows), so 10k rows ≈ **24 MB worst case**. A 20k cap (~48 MB) plus the audit valve's own 100k-row cap would not leave clear joint headroom under the 100 MB block; 10k does, and is still ~3 weeks of the incident box's capture rate.
   - **Timestamp comparison**: rows store caller-supplied ISO-8601 `ts` (`toISOString()`, `'YYYY-MM-DDTHH:MM:SS.sssZ'` — hooks and the JSONL importer both use this). The purge compares `ts < ?` lexically against a cutoff produced by the *same* `toISOString()` formatter. `datetime(current_timestamp, '-N days')` is deliberately **not** used: SQLite renders `'YYYY-MM-DD HH:MM:SS'` (space, no ms, no Z), which does not collate cleanly against the stored T/Z form at the boundary. Boundary correctness is proven at the millisecond in tests (exact-cutoff row survives, 1 ms-older row deleted; cross day/month/year boundaries).
2. **Config knob** — the audit valve's 90d is a hard-coded default with no knob, so per the brief this adds an env-var override: `SHIELDCORTEX_SESSION_RETENTION_DAYS` (validated integer 1–3650; invalid values warn on stderr and fall back to 30). Env vars are the codebase's existing tunable style (`SHIELDCORTEX_DISABLE_WORKER`, `SHIELDCORTEX_SKIP_EMBEDDINGS`, `SHIELDCORTEX_CONFIG_DIR`); no new config subsystem. Documented in `sessions prune` usage text + module docs.
3. **Brain worker wiring** — both functions run in the light tick directly beside the audit retention block: pressure valve every tick (cheap size check), age purge throttled to ~24h with a persisted `lastSessionPurge` in `worker.json` (mirrors `lastAuditPurge`, survives MCP restarts). Own try/catch, `console.error`, never crashes the tick.
4. **CLI** — `shieldcortex sessions prune [--days N] [--execute]`, following the `memories prune` conventions (same flag parsing, `[DRY RUN]` banner, `Matched:`/`Deleted:` shape, `initDatabase()` startup with its "[database] Another ShieldCortex process…" single-writer behaviour). Dry-run by default printing matched count + payload MB; `--execute` deletes and reminds about `shieldcortex vacuum`. Registered in `knownCommands` + `--help`.
5. **Doctor** — the #110 signature (DB > 50% of limit but session_events payload dominates the memories table) now gets a suggested fix naming `shieldcortex sessions prune --execute` then `shieldcortex vacuum`, via a best-effort read-only peek into the DB (falls back to the generic remedy — now also mentioning sessions prune — whenever the DB can't be read, so the disk check can never break).
6. **Index + migration** — `DELETE … WHERE ts < ?` cannot use the existing composite `(session_id, ts)` / `(project, ts)` indexes, so `idx_session_events_ts` is added in `inline-schema.ts` + `schema.sql`, with a guarded `CREATE INDEX IF NOT EXISTS` migration appended at the end of `runMigrations()` (same table-existence guard as the prior `session_events` migrations).

**Hot path untouched**: no changes to the action guard or defence pipeline; the FP/benign path is unaffected.

## Failing-first proof

Regression tests were written first and run against unpatched code (`8596812`):

- `src/__tests__/session-events-retention.test.ts` (15 tests) + `src/cli/__tests__/sessions-prune.test.ts` (4 tests): **suite-level failure** — modules under test don't exist on main (19 tests unrunnable/red)
- `src/cli/__tests__/doctor-disk-breakdown.test.ts`: **1 failed / 6 passed** — the #110 case got the old remedy text: `"…Reclaim free space with \`shieldcortex vacuum\`…"` with no mention of sessions prune
- Unpatched totals: **3/3 suites failed, 20 of 26 new checks red** (the 6 passing were pre-existing doctor cases + one trivially-negative assertion)

After implementation: **3 suites / 26 tests — all green.**

## Suite results

- New + related suites (sessions/capture/timeline/import, worker, doctor, audit retention): **24 suites passed, 163 tests passed**
- Full repo suite on this branch: **Test Suites: 1 failed, 1 skipped, 267 passed / Tests: 1 failed, 8 skipped, 2824 passed**

### Pre-existing-failure comparison vs clean main

Full suite on a clean worktree of `main` (8596812, dist built): **Test Suites: 9 failed, 1 skipped, 257 passed / Tests: 29 failed, 8 skipped, 2775 passed.** Failing suites: capture-prompt, claims-proof, defence-pipeline-bypass, pre-tool-hook, recall-defence-integration, save-auto-extracted-memory, save-memory-near-dup-dedup, scan-only-entry, action-guard-hook-install.

Running those same 9 suites in isolation on **both** checkouts produces the **identical result — 9 suites / 29 failed, 54 passed — on clean main and on this branch**. This is the known environment-dependent memory-recall/hook-environment failure class on this box (scheduling-dependent: the branch's full run happened to hit only 1 of them). None are introduced by this PR.

## Review focus

- **Row cap 10,000 vs the suggested 20,000** — chosen from the incident's ~2.4 KB/row so the session cap (~24 MB) plus the audit cap leave clear joint headroom under the 100 MB block. Trivial to bump if you'd rather keep more replay history.
- **Valve eviction is plain oldest-first** (`ts ASC, id ASC`) — unlike the audit valve's forensic-value tiering, all session events carry equal replay-only value, so no tiering was added.
- **Env-var knob rather than `~/.shieldcortex/config.json`** — the config-file surface (cloud/autoMemory) is read via `cloud/config.ts`, which the worker path doesn't otherwise pull in; the env var matches the existing `SHIELDCORTEX_*` tunables and avoids coupling.
- **`worker.json` gains a `lastSessionPurge` field** — additive, older readers ignore it.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)
