### PR TITLE
fix(openclaw): preserve nested interceptor config through normalisation (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 > **Coverage note**: 49 v4 versions are documented below — typically every minor (`X.Y.0`) plus significant patches. Many small patch releases between 4.0.0 and 4.20.x are not individually documented (~50 versions, mostly behaviour-preserving fixes). For a specific diff between adjacent npm versions, see `git log vX.Y.Z..vX.Y.W` or compare tarballs. Audited and reconciled 2026-05-27 — gap is intentional, not a sign of release-note drift going forward.
 
+## [Unreleased]
+
+**The OpenClaw plugin honours nested `interceptor` config instead of silently dropping it (closes #112).**
+
+### Fixed
+
+- **`normaliseConfig()` dropped the entire nested `interceptor` block (#112).** The config normaliser was an allowlist rebuild that never included `interceptor`, so an explicit `interceptor.enabled: false` (or any nested `actionGuard`/severity/failure/`autoApprove` setting) was silently ignored and `DEFAULT_INTERCEPTOR_CONFIG` re-armed the `before_tool_call` approval gate from defaults. On approval surfaces with no card rendering (observed live: Codex + Telegram on Edith, realtime plugin 4.47.12 + OpenClaw 2026.7.1-2) every tool call waited out the 120 s gate timeout, making the agent unresponsive. The normaliser now validates and preserves the `interceptor` block (deep-partial: explicit values survive, defaults only fill gaps, malformed values are dropped fail-safe so the gate stays armed), config-source merging is per-key instead of wholesale block replacement, and the plugin JSON schema/uiHints advertise the block instead of rejecting it.
+
+### ⚠️ Upgrade note
+
+- **Previously-ignored `interceptor` blocks take effect on upgrade.** If an existing `openclaw.json` plugin entry or shield config ever gained an `interceptor` block that "did nothing" (because it was being dropped), those values — including ones that disable or soften the Action Guard, such as `interceptor.enabled: false`, `actionGuard.enforce: false`, or `autoApprove` lists — will now be honoured. Audit any `interceptor` config you carry **before** upgrading so your enforcement posture changes only if you mean it to.
+
 ## [4.47.12] - 2026-07-21
 
 **The cortex-memory hook's bootstrap self-heal gets the opt-out the 4.47.11 disclosure promised — and stops migrating a hook that can't load (closes #108, #109).**

--- a/plugins/openclaw/__tests__/interceptor-config-112.test.ts
+++ b/plugins/openclaw/__tests__/interceptor-config-112.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import plugin, {
+  __resetConfigStateForTest,
+  __setDefenceModuleForTest,
+  __setRuntimeForTest,
+} from '../index.js';
+import { evaluateToolCall } from '../../../src/defence/iron-dome/tool-action-guard.js';
+
+/**
+ * Issue #112 — live incident (Edith, shieldcortex-realtime 4.47.12 + OpenClaw
+ * 2026.7.1-2): `extractPluginConfig()` routes the plugin config through
+ * `normaliseConfig()`, which is a strict key allowlist that predates the
+ * interceptor and silently DROPS the entire nested `interceptor` object.
+ * `interceptor.enabled: false` was therefore ignored, DEFAULT_INTERCEPTOR_CONFIG
+ * re-armed the before_tool_call approval gate, Codex tool calls waited 120s on a
+ * Telegram approval that could never resolve, and the agent went catatonic
+ * ("visible channel turn dispatched with no queued reply payloads").
+ *
+ * These tests pin the contract at every layer the config crosses:
+ *   1. normaliseConfig (via plugin.configSchema.parse) preserves every nested
+ *      interceptor key — including explicit `false` values — and still validates.
+ *   2. End-to-end: extractPluginConfig → loadConfig → initInterceptor →
+ *      before_tool_call. `interceptor.enabled:false` means the gate never arms;
+ *      `actionGuard.enforce:false` means advisory (warn-and-allow) for dangerous
+ *      ops while catastrophic ops still hard-block.
+ *   3. Merge semantics: defaults only fill gaps, never override explicit values;
+ *      plugin config deep-merges over shield config per-key, not wholesale.
+ */
+
+const okPipeline = () => ({
+  allowed: true,
+  firewall: { result: 'ALLOW' as const, reason: '', threatIndicators: [] as string[], anomalyScore: 0, blockedPatterns: [] as string[] },
+  trust: { score: 0.5 },
+  sensitivity: { level: 'INTERNAL' },
+  fragmentation: null,
+  auditId: 1,
+});
+
+type Hooks = Record<string, (...args: any[]) => any>;
+type Commands = Record<string, { name: string; handler: () => Promise<{ text: string }> }>;
+
+function makeApi(rootConfig: unknown): { api: any; hooks: Hooks; commands: Commands } {
+  const hooks: Hooks = {};
+  const commands: Commands = {};
+  const api = {
+    id: 'shieldcortex-realtime',
+    name: 'ShieldCortex Real-time Scanner',
+    logger: { info: () => {}, warn: () => {} },
+    on: (name: string, handler: (...args: any[]) => any) => { hooks[name] = handler; },
+    registerCommand: (cmd: any) => { commands[cmd.name] = cmd; },
+    runtime: { config: { current: () => rootConfig } },
+  };
+  return { api, hooks, commands };
+}
+
+/** Root OpenClaw config with the plugin entry config exactly as on Edith. */
+function rootConfigWith(config: unknown): unknown {
+  return { plugins: { entries: { 'shieldcortex-realtime': { enabled: true, config } } } };
+}
+
+function stubRuntime(shieldConfig: Record<string, unknown> = {}) {
+  __setRuntimeForTest({
+    callCortex: async () => null,
+    isOpenClawAutoMemoryEnabled: () => false,
+    loadShieldConfig: async () => shieldConfig,
+  });
+}
+
+beforeEach(() => {
+  __resetConfigStateForTest();
+  stubRuntime({});
+  // Real Action Guard evaluator + stub pipeline: the gate logic is genuine,
+  // only the disk/embedding-backed defence pipeline is stubbed.
+  __setDefenceModuleForTest({ runDefencePipeline: okPipeline, evaluateToolCall } as any);
+});
+
+// ==================== 1. normaliseConfig preserves the interceptor block ====================
+
+describe('#112 — normaliseConfig() preserves nested interceptor config', () => {
+  it('keeps interceptor.enabled:false (the exact Edith incident config)', () => {
+    const parsed = plugin.configSchema.parse({ interceptor: { enabled: false } }) as any;
+    expect(parsed.interceptor).toBeDefined();
+    expect(parsed.interceptor.enabled).toBe(false);
+  });
+
+  it('keeps every nested interceptor key intact', () => {
+    const parsed = plugin.configSchema.parse({
+      interceptor: {
+        enabled: true,
+        severityActions: { high: 'require_approval', critical: 'require_approval' },
+        failurePolicy: { high: 'allow', critical: 'deny' },
+        actionGuard: { enabled: true, enforce: false, autoApprove: ['file-delete'], auditAllows: false },
+      },
+    }) as any;
+    expect(parsed.interceptor).toEqual({
+      enabled: true,
+      severityActions: { high: 'require_approval', critical: 'require_approval' },
+      failurePolicy: { high: 'allow', critical: 'deny' },
+      actionGuard: { enabled: true, enforce: false, autoApprove: ['file-delete'], auditAllows: false },
+    });
+  });
+
+  it('explicit false values survive — false is a value, not an absence', () => {
+    const parsed = plugin.configSchema.parse({
+      interceptor: { enabled: false, actionGuard: { enabled: false, enforce: false, auditAllows: false } },
+    }) as any;
+    expect(parsed.interceptor.enabled).toBe(false);
+    expect(parsed.interceptor.actionGuard).toEqual({ enabled: false, enforce: false, auditAllows: false });
+  });
+
+  it('absent interceptor stays absent — defaults fill downstream, never during normalisation', () => {
+    const parsed = plugin.configSchema.parse({ openclawAutoMemory: true }) as any;
+    expect(parsed.interceptor).toBeUndefined();
+    expect(parsed.openclawAutoMemory).toBe(true);
+  });
+
+  it('still validates: invalid interceptor values are dropped, valid siblings kept', () => {
+    const parsed = plugin.configSchema.parse({
+      interceptor: {
+        enabled: 'yes',
+        severityActions: { high: 'explode', critical: 'require_approval' },
+        failurePolicy: { high: 'maybe' },
+        actionGuard: { enforce: false, autoApprove: 'rm', bogus: true },
+      },
+    }) as any;
+    expect(parsed.interceptor?.enabled).toBeUndefined();
+    expect(parsed.interceptor?.severityActions?.high).toBeUndefined();
+    expect(parsed.interceptor?.severityActions?.critical).toBe('require_approval');
+    expect(parsed.interceptor?.failurePolicy?.high).toBeUndefined();
+    expect(parsed.interceptor?.actionGuard?.enforce).toBe(false);
+    expect(parsed.interceptor?.actionGuard?.autoApprove).toBeUndefined();
+    expect(parsed.interceptor?.actionGuard?.bogus).toBeUndefined();
+  });
+
+  it('allowlist behaviour for everything else is unchanged (unknown keys dropped, scalars kept)', () => {
+    const parsed = plugin.configSchema.parse({ evil: true, cloudApiKey: ' sc_x ', openclawAutoMemoryNoveltyThreshold: 0.8 }) as any;
+    expect(parsed.evil).toBeUndefined();
+    expect(parsed.cloudApiKey).toBe('sc_x');
+    expect(parsed.openclawAutoMemoryNoveltyThreshold).toBe(0.8);
+  });
+});
+
+// ==================== 2. End-to-end: config → before_tool_call gate ====================
+
+describe('#112 — end-to-end: plugin config controls the before_tool_call gate', () => {
+  // "Gate armed" observable: the typed-hook bridge currently surfaces an armed
+  // gate either as { requireApproval } or as a failure-policy { block } (the
+  // interceptor catches the TypedApprovalRequest bridge throw as an approval
+  // error). Both mean the tool call was intercepted; neither may appear when
+  // the user disabled the gate.
+  const intercepted = (result: any): boolean => Boolean(result && (result.requireApproval || result.block));
+
+  it('CONTROL (harness validity): default config arms the gate — dangerous op is intercepted', async () => {
+    const { api, hooks } = makeApi(rootConfigWith({}));
+    plugin.register(api);
+    const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } });
+    expect(intercepted(result)).toBe(true);
+  });
+
+  it('interceptor.enabled:false → the gate never arms; dangerous op passes with NO approval request', async () => {
+    const { api, hooks } = makeApi(rootConfigWith({ interceptor: { enabled: false } }));
+    plugin.register(api);
+    const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } });
+    expect(result).toBeUndefined();
+  });
+
+  it('interceptor.enabled:false → fully off, not partially: even catastrophic ops are not intercepted', async () => {
+    const { api, hooks } = makeApi(rootConfigWith({ interceptor: { enabled: false } }));
+    plugin.register(api);
+    const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'rm -rf /' } });
+    expect(result).toBeUndefined();
+  });
+
+  it('actionGuard.enforce:false → advisory mode: dangerous op allowed without approval', async () => {
+    const { api, hooks } = makeApi(rootConfigWith({ interceptor: { actionGuard: { enforce: false } } }));
+    plugin.register(api);
+    const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } });
+    expect(result).toBeUndefined();
+  });
+
+  it('actionGuard.enforce:false still hard-blocks catastrophic ops (safety floor preserved)', async () => {
+    const { api, hooks } = makeApi(rootConfigWith({ interceptor: { actionGuard: { enforce: false } } }));
+    plugin.register(api);
+    const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'rm -rf /' } });
+    expect(result?.block).toBe(true);
+  });
+
+  it('defaults only fill gaps: partial interceptor config keeps the secure defaults for unspecified sections', async () => {
+    const { api, hooks } = makeApi(rootConfigWith({ interceptor: { severityActions: { high: 'require_approval' } } }));
+    plugin.register(api);
+    const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } });
+    expect(intercepted(result)).toBe(true);
+  });
+});
+
+// ==================== 3. Merge semantics across config sources ====================
+
+describe('#112 — deep-merge semantics: shield config + plugin override, per-key', () => {
+  it('plugin config deep-merges over shield config instead of wholesale-replacing the interceptor object', async () => {
+    // Shield config file contributes autoApprove; plugin config contributes
+    // enforce:false. BOTH must survive into the effective config.
+    stubRuntime({ interceptor: { actionGuard: { autoApprove: ['file-delete'] } } });
+    const { api, commands } = makeApi(rootConfigWith({ interceptor: { actionGuard: { enforce: false } } }));
+    plugin.register(api);
+    const status = await commands['shieldcortex-status'].handler();
+    expect(status.text).toContain('Action guard: warn (1 auto-approved)');
+  });
+
+  it('shieldcortex-status reflects interceptor.enabled:false from plugin config', async () => {
+    const { api, commands } = makeApi(rootConfigWith({ interceptor: { enabled: false } }));
+    plugin.register(api);
+    const status = await commands['shieldcortex-status'].handler();
+    expect(status.text).toContain('Action guard: off');
+  });
+
+  it('interceptor config in the shield config file alone is honoured too (both sources route through normaliseConfig)', async () => {
+    stubRuntime({ interceptor: { enabled: false } });
+    const { api, hooks } = makeApi(rootConfigWith({}));
+    plugin.register(api);
+    const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } });
+    expect(result).toBeUndefined();
+  });
+});

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -178,6 +178,12 @@ export function __setRuntimeForTest(runtime: OpenClawRuntime | null): void {
   _runtimeOverride = runtime;
   if (runtime) runtimePromise = null;
 }
+export function __resetConfigStateForTest(): void {
+  _config = null;
+  _configOverride = null;
+  _lastShieldConfigRef = null;
+  _registered = false;
+}
 
 type LlmInputEvent = {
   runId: string; sessionId: string; provider: string; model: string;
@@ -217,6 +223,27 @@ type PluginApi = {
 
 // ==================== CONFIG ====================
 
+// User-facing interceptor config: a deep-partial of InterceptorConfig. Every
+// key is optional — DEFAULT_INTERCEPTOR_CONFIG fills the gaps in
+// initInterceptor(), never here, so explicit values (including `false`) always
+// win over defaults.
+type InterceptSeverity = 'low' | 'medium' | 'high' | 'critical';
+const INTERCEPT_SEVERITIES: readonly InterceptSeverity[] = ['low', 'medium', 'high', 'critical'];
+const INTERCEPT_ACTIONS = ['log', 'warn', 'require_approval'] as const;
+const FAILURE_ACTIONS = ['allow', 'deny'] as const;
+
+interface InterceptorUserConfig {
+  enabled?: boolean;
+  severityActions?: Partial<Record<InterceptSeverity, (typeof INTERCEPT_ACTIONS)[number]>>;
+  failurePolicy?: Partial<Record<InterceptSeverity, (typeof FAILURE_ACTIONS)[number]>>;
+  actionGuard?: {
+    enabled?: boolean;
+    enforce?: boolean;
+    autoApprove?: string[];
+    auditAllows?: boolean;
+  };
+}
+
 interface SCConfig {
   cloudEnabled?: boolean;
   cloudApiKey?: string;
@@ -226,6 +253,7 @@ interface SCConfig {
   openclawAutoMemoryDedupe?: boolean;
   openclawAutoMemoryNoveltyThreshold?: number;
   openclawAutoMemoryMaxRecent?: number;
+  interceptor?: InterceptorUserConfig;
 }
 
 const PLUGIN_ID = "shieldcortex-realtime";
@@ -268,7 +296,65 @@ const PLUGIN_CONFIG_UI_HINTS = {
     help: "How many recent extracted memories to keep in the dedupe cache.",
     advanced: true,
   },
+  "interceptor.enabled": {
+    label: "Enable Tool Call Interceptor",
+    help: "Scan memory-write tool calls and gate suspicious content behind user approval.",
+  },
+  "interceptor.actionGuard.enabled": {
+    label: "Action Guard",
+    help: "Gate dangerous shell/file/network/git tool calls before they execute. Catastrophic operations are always blocked while enabled.",
+  },
+  "interceptor.actionGuard.enforce": {
+    label: "Enforce Action Guard",
+    help: "Enforce dangerous-operation gating (attended: approval prompt; unattended: failurePolicy). Off = warn-and-allow (advisory). Catastrophic operations block regardless.",
+  },
+  "interceptor.actionGuard.autoApprove": {
+    label: "Action Guard Auto-approve List",
+    help: "Family/action/signal names pre-approved for unattended agents that legitimately need specific dangerous operations.",
+    advanced: true,
+  },
+  "interceptor.actionGuard.auditAllows": {
+    label: "Audit Recognised Allows",
+    help: "Write an audit entry when the guard evaluates a recognised operation and allows it.",
+    advanced: true,
+  },
 } as const;
+
+const SEVERITY_ACTION_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: Object.fromEntries(
+    INTERCEPT_SEVERITIES.map((severity) => [severity, { type: "string", enum: [...INTERCEPT_ACTIONS] }]),
+  ),
+};
+
+const FAILURE_POLICY_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: Object.fromEntries(
+    INTERCEPT_SEVERITIES.map((severity) => [severity, { type: "string", enum: [...FAILURE_ACTIONS] }]),
+  ),
+};
+
+const INTERCEPTOR_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    enabled: { type: "boolean" },
+    severityActions: SEVERITY_ACTION_SCHEMA,
+    failurePolicy: FAILURE_POLICY_SCHEMA,
+    actionGuard: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        enabled: { type: "boolean" },
+        enforce: { type: "boolean" },
+        autoApprove: { type: "array", items: { type: "string" } },
+        auditAllows: { type: "boolean" },
+      },
+    },
+  },
+};
 
 const PLUGIN_CONFIG_JSON_SCHEMA = {
   type: "object",
@@ -282,6 +368,9 @@ const PLUGIN_CONFIG_JSON_SCHEMA = {
     openclawAutoMemoryDedupe: { type: "boolean" },
     openclawAutoMemoryNoveltyThreshold: { type: "number", minimum: 0.6, maximum: 0.99 },
     openclawAutoMemoryMaxRecent: { type: "integer", minimum: 50, maximum: 1000 },
+    // #112: without this, `additionalProperties: false` declared the whole
+    // interceptor block invalid — mirror openclaw.plugin.json's configSchema.
+    interceptor: INTERCEPTOR_JSON_SCHEMA,
   },
 };
 
@@ -345,7 +434,90 @@ function normaliseConfig(raw: unknown): SCConfig {
     config.openclawAutoMemoryMaxRecent = Math.floor(clamp(value.openclawAutoMemoryMaxRecent, 50, 1000));
   }
 
+  // #112: the allowlist above predates the interceptor and silently dropped
+  // the entire nested `interceptor` object — `interceptor.enabled: false` was
+  // ignored and DEFAULT_INTERCEPTOR_CONFIG re-armed the before_tool_call gate.
+  // Validate-and-preserve every nested interceptor key the manifest schema
+  // accepts; invalid values are dropped individually, valid siblings survive.
+  const interceptor = normaliseInterceptorConfig(value.interceptor);
+  if (interceptor) config.interceptor = interceptor;
+
   return config;
+}
+
+function normaliseSeverityMap<A extends string>(
+  raw: unknown,
+  allowed: readonly A[],
+): Partial<Record<InterceptSeverity, A>> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const value = raw as Record<string, unknown>;
+  const out: Partial<Record<InterceptSeverity, A>> = {};
+  for (const severity of INTERCEPT_SEVERITIES) {
+    const entry = value[severity];
+    if (typeof entry === "string" && (allowed as readonly string[]).includes(entry)) {
+      out[severity] = entry as A;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function normaliseInterceptorConfig(raw: unknown): InterceptorUserConfig | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const value = raw as Record<string, unknown>;
+  const out: InterceptorUserConfig = {};
+
+  if (typeof value.enabled === "boolean") out.enabled = value.enabled;
+
+  const severityActions = normaliseSeverityMap(value.severityActions, INTERCEPT_ACTIONS);
+  if (severityActions) out.severityActions = severityActions;
+
+  const failurePolicy = normaliseSeverityMap(value.failurePolicy, FAILURE_ACTIONS);
+  if (failurePolicy) out.failurePolicy = failurePolicy;
+
+  if (value.actionGuard && typeof value.actionGuard === "object" && !Array.isArray(value.actionGuard)) {
+    const rawGuard = value.actionGuard as Record<string, unknown>;
+    const guard: NonNullable<InterceptorUserConfig["actionGuard"]> = {};
+    if (typeof rawGuard.enabled === "boolean") guard.enabled = rawGuard.enabled;
+    if (typeof rawGuard.enforce === "boolean") guard.enforce = rawGuard.enforce;
+    if (typeof rawGuard.auditAllows === "boolean") guard.auditAllows = rawGuard.auditAllows;
+    if (Array.isArray(rawGuard.autoApprove) && rawGuard.autoApprove.every((entry) => typeof entry === "string")) {
+      guard.autoApprove = rawGuard.autoApprove as string[];
+    }
+    if (Object.keys(guard).length > 0) out.actionGuard = guard;
+  }
+
+  return out;
+}
+
+/**
+ * Merge two normalised configs (#112). Semantics:
+ *  - Top-level scalar keys: override wins when present.
+ *  - `interceptor` deep-merges PER KEY — per severity entry, per guard flag —
+ *    so an override that sets one nested key does not wholesale-discard the
+ *    base's other interceptor settings.
+ *  - Explicit values, including `false`, always win over base values; absent
+ *    keys fall through to the base.
+ *  - Defaults are NOT applied here: DEFAULT_INTERCEPTOR_CONFIG only fills the
+ *    remaining gaps in initInterceptor(), so it can never override an explicit
+ *    user value.
+ */
+function mergeConfigs(base: SCConfig, override: SCConfig): SCConfig {
+  const merged: SCConfig = { ...base, ...override };
+  if (base.interceptor || override.interceptor) {
+    const b = base.interceptor ?? {};
+    const o = override.interceptor ?? {};
+    merged.interceptor = { ...b, ...o };
+    if (b.severityActions || o.severityActions) {
+      merged.interceptor.severityActions = { ...b.severityActions, ...o.severityActions };
+    }
+    if (b.failurePolicy || o.failurePolicy) {
+      merged.interceptor.failurePolicy = { ...b.failurePolicy, ...o.failurePolicy };
+    }
+    if (b.actionGuard || o.actionGuard) {
+      merged.interceptor.actionGuard = { ...b.actionGuard, ...o.actionGuard };
+    }
+  }
+  return merged;
 }
 
 function extractPluginConfig(rootConfig: unknown): SCConfig {
@@ -372,10 +544,7 @@ function applyPluginConfigOverride(api: PluginApi): void {
       : api.config;
   const pluginConfig = extractPluginConfig(runtimeConfig);
   if (Object.keys(pluginConfig).length === 0) return;
-  _configOverride = {
-    ...(_configOverride ?? {}),
-    ...pluginConfig,
-  };
+  _configOverride = mergeConfigs(_configOverride ?? {}, pluginConfig);
   // Override changed — invalidate so loadConfig() re-merges with new override.
   _config = null;
   _lastShieldConfigRef = null;
@@ -385,10 +554,9 @@ async function loadConfig(): Promise<SCConfig> {
   const shieldConfigRaw = await (await getRuntime()).loadShieldConfig();
   if (_config && shieldConfigRaw === _lastShieldConfigRef) return _config;
   _lastShieldConfigRef = shieldConfigRaw;
-  _config = {
-    ...normaliseConfig(shieldConfigRaw),
-    ...(_configOverride ?? {}),
-  };
+  // Plugin config (openclaw.json) deep-merges over the shield config file —
+  // see mergeConfigs() for the per-key semantics.
+  _config = mergeConfigs(normaliseConfig(shieldConfigRaw), _configOverride ?? {});
   return _config;
 }
 
@@ -873,7 +1041,9 @@ export default {
 
       try {
         const scConfig = await loadConfig();
-        const rawInterceptorConfig = (scConfig as any).interceptor;
+        // Normalised user config (deep-partial); DEFAULT_INTERCEPTOR_CONFIG
+        // fills the gaps below — defaults never override explicit values.
+        const rawInterceptorConfig = scConfig.interceptor;
         const interceptorConfig: InterceptorConfig = {
           ...DEFAULT_INTERCEPTOR_CONFIG,
           ...(rawInterceptorConfig && typeof rawInterceptorConfig === 'object' ? {
@@ -948,7 +1118,7 @@ export default {
         const cloud = cfg.cloudApiKey ? "configured" : "not configured";
         // Resolve the Action Guard state the same way initInterceptor() does,
         // so the status line reflects what before_tool_call will actually do.
-        const rawInterceptor = (cfg as any).interceptor;
+        const rawInterceptor = cfg.interceptor;
         const guardCfg = {
           ...(DEFAULT_INTERCEPTOR_CONFIG.actionGuard ?? { enabled: true, enforce: true, autoApprove: [] }),
           ...(rawInterceptor && typeof rawInterceptor === 'object' ? rawInterceptor.actionGuard ?? {} : {}),


### PR DESCRIPTION
## Root cause (confirmed)
`normaliseConfig()` rebuilds the plugin config from a scalar whitelist and silently dropped the entire nested `interceptor` object — despite `openclaw.plugin.json` advertising the full `interceptor` block. Every deployment setting `interceptor.enabled:false`, severity/failure overrides, or `actionGuard.*` got `DEFAULT_INTERCEPTOR_CONFIG` instead (approval gate armed). On unattended Codex/Telegram turns the gate waits 120s, times out, and surfaces as `visible channel turn dispatched with no queued reply payloads` — the Edith incident (reported by Tars, root-caused on `@drakon-systems/shieldcortex-realtime` 4.47.12 + OpenClaw 2026.7.1-2).

## Fix
- `normaliseInterceptorConfig()`: validating deep-partial pass-through of the `interceptor` block. Invalid entries drop individually; valid siblings and explicit `false` values survive. Defaults only fill gaps downstream in `initInterceptor()` — they can never override an explicit user value.
- `mergeConfigs()`: shield-config file + plugin-config override now deep-merge the interceptor block **per key** (per severity entry, per guard flag) instead of the previous shallow spread that wholesale-replaced it.
- Runtime `configSchema` + config UI hints gain the `interceptor` block (parity with `openclaw.plugin.json`).

## Verification
- **Red-green**: 15 regression tests; 10 fail with the fix line neutered (incl. the exact incident config `interceptor.enabled:false`), 15/15 pass with it. Control case proves the harness arms the gate under defaults.
- Safety floor covered: `actionGuard.enforce:false` stays advisory but catastrophic ops still hard-block; `interceptor.enabled:false` fully disarms (documented, matches manifest semantics).
- Full `plugins/openclaw` suite: 10 suites / 87 tests green. `tsc` both build configs clean.
- **Built-dist verification**: register() + `before_tool_call` exercised against the compiled `dist/` artifact with openclaw.json-shaped root config — 5/5 (control intercept, incident config passes clean, advisory mode, catastrophic floor, status line reads "Action guard: off").

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ⚠️ Upgrade note (added per Fable review)

Previously-ignored nested `interceptor` blocks take effect on upgrade — audit any existing `interceptor` config (including `enabled:false`, `actionGuard.enforce:false`, `autoApprove`) before upgrading, as values that were silently dropped will now be honoured.
