### PR TITLE
fix(openclaw): don't register before_tool_call when interceptor disabled (#112 follow-up)

### DIFF
--- a/plugins/openclaw/__tests__/interceptor-config-112.test.ts
+++ b/plugins/openclaw/__tests__/interceptor-config-112.test.ts
@@ -157,18 +157,20 @@ describe('#112 — end-to-end: plugin config controls the before_tool_call gate'
     expect(intercepted(result)).toBe(true);
   });
 
-  it('interceptor.enabled:false → the gate never arms; dangerous op passes with NO approval request', async () => {
+  it('interceptor.enabled:false → the before_tool_call hook is not registered at all (stronger contract post-#112-follow-up)', () => {
     const { api, hooks } = makeApi(rootConfigWith({ interceptor: { enabled: false } }));
     plugin.register(api);
-    const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } });
-    expect(result).toBeUndefined();
+    // Not a no-op handler — the hook must be ABSENT so the host's approval
+    // pipeline can never route a tool call (or an approval wait) through us.
+    expect(hooks['before_tool_call']).toBeUndefined();
   });
 
-  it('interceptor.enabled:false → fully off, not partially: even catastrophic ops are not intercepted', async () => {
+  it('interceptor.enabled:false → scanning hooks still register; only the tool-call gate is gone', () => {
     const { api, hooks } = makeApi(rootConfigWith({ interceptor: { enabled: false } }));
     plugin.register(api);
-    const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'rm -rf /' } });
-    expect(result).toBeUndefined();
+    expect(hooks['before_tool_call']).toBeUndefined();
+    expect(typeof hooks['llm_input']).toBe('function');
+    expect(typeof hooks['llm_output']).toBe('function');
   });
 
   it('actionGuard.enforce:false → advisory mode: dangerous op allowed without approval', async () => {

--- a/plugins/openclaw/__tests__/unattended-codex-112.test.ts
+++ b/plugins/openclaw/__tests__/unattended-codex-112.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import plugin, {
+  __resetConfigStateForTest,
+  __setDefenceModuleForTest,
+  __setRuntimeForTest,
+} from '../index.js';
+import { evaluateToolCall } from '../../../src/defence/iron-dome/tool-action-guard.js';
+
+/**
+ * Issue #112 follow-up — unattended Codex command execution regression.
+ *
+ * Live incident (Edith, v4.47.13 + OpenClaw 2026.7.1-2, gpt-5.6-sol/terra +
+ * gpt-5.5 over Telegram): a before_tool_call hook that exists in the host
+ * roster — even as a no-op — changes how OpenClaw resolves tool-call
+ * approvals. `shouldAutoApproveCodexAppServerApprovals()` only auto-resolves
+ * when no plugin approval path is in play; otherwise native shell calls wait
+ * on plugin.approval.waitDecision for ~120s, time out, and the Telegram turn
+ * emits no reply.
+ *
+ * Contract pinned here, at the two layers config can disable the interceptor:
+ *  1. Host plugin config `interceptor.enabled:false` (the unattended-agent
+ *     config) → the hook is NOT REGISTERED. No hook, no approval path, the
+ *     host's native auto-approval decides alone. Scanning hooks stay live.
+ *  2. Shield config file `interceptor.enabled:false` (only loadable async,
+ *     after registration) → the hook exists but must resolve IMMEDIATELY with
+ *     no approval request and no block for a native shell call — never a
+ *     waitDecision-shaped result.
+ */
+
+const okPipeline = () => ({
+  allowed: true,
+  firewall: { result: 'ALLOW' as const, reason: '', threatIndicators: [] as string[], anomalyScore: 0, blockedPatterns: [] as string[] },
+  trust: { score: 0.5 },
+  sensitivity: { level: 'INTERNAL' },
+  fragmentation: null,
+  auditId: 1,
+});
+
+type Hooks = Record<string, (...args: any[]) => any>;
+type Commands = Record<string, { name: string; handler: () => Promise<{ text: string }> }>;
+
+function makeApi(rootConfig: unknown): { api: any; hooks: Hooks; commands: Commands; log: string[] } {
+  const hooks: Hooks = {};
+  const commands: Commands = {};
+  const log: string[] = [];
+  const api = {
+    id: 'shieldcortex-realtime',
+    name: 'ShieldCortex Real-time Scanner',
+    logger: { info: (m: string) => { log.push(m); }, warn: (m: string) => { log.push(m); } },
+    on: (name: string, handler: (...args: any[]) => any) => { hooks[name] = handler; },
+    registerCommand: (cmd: any) => { commands[cmd.name] = cmd; },
+    runtime: { config: { current: () => rootConfig } },
+  };
+  return { api, hooks, commands, log };
+}
+
+/** Root OpenClaw config with the plugin entry config exactly as on Edith. */
+function rootConfigWith(config: unknown): unknown {
+  return { plugins: { entries: { 'shieldcortex-realtime': { enabled: true, config } } } };
+}
+
+function stubRuntime(shieldConfig: Record<string, unknown> = {}) {
+  __setRuntimeForTest({
+    callCortex: async () => null,
+    isOpenClawAutoMemoryEnabled: () => false,
+    loadShieldConfig: async () => shieldConfig,
+  });
+}
+
+// The shapes an unattended Codex agent actually dispatches: native shell
+// commands via the exec/bash family. Includes a benign command AND a
+// "dangerous but non-catastrophic" one — with the interceptor disabled,
+// NEITHER may produce an approval request (there is no one to approve it).
+const UNATTENDED_SHELL_CALLS = [
+  { toolName: 'exec', params: { command: 'ls -la /tmp' } },
+  { toolName: 'Bash', params: { command: 'npm test' } },
+  { toolName: 'Bash', params: { command: 'sudo systemctl restart myservice' } },
+];
+
+beforeEach(() => {
+  __resetConfigStateForTest();
+  stubRuntime({});
+  __setDefenceModuleForTest({ runDefencePipeline: okPipeline, evaluateToolCall } as any);
+});
+
+describe('#112 follow-up — unattended Codex: interceptor disabled in host plugin config', () => {
+  it('before_tool_call is not registered — the host approval pipeline has no plugin to wait on', () => {
+    const { api, hooks } = makeApi(rootConfigWith({ interceptor: { enabled: false } }));
+    plugin.register(api);
+    expect(hooks['before_tool_call']).toBeUndefined();
+    expect(hooks['session_end']).toBeUndefined();
+  });
+
+  it('scanning stays live and the skip is logged', () => {
+    const { api, hooks, log } = makeApi(rootConfigWith({ interceptor: { enabled: false } }));
+    plugin.register(api);
+    expect(typeof hooks['llm_input']).toBe('function');
+    expect(typeof hooks['llm_output']).toBe('function');
+    expect(log.some((m) => m.includes('before_tool_call hook not registered'))).toBe(true);
+  });
+
+  it('shieldcortex-status reports the unregistered gate honestly', async () => {
+    const { api, commands } = makeApi(rootConfigWith({ interceptor: { enabled: false } }));
+    plugin.register(api);
+    const status = await commands['shieldcortex-status'].handler();
+    expect(status.text).toContain('before_tool_call not registered');
+    expect(status.text).not.toContain('before_tool_call (action guard)');
+  });
+
+  it('CONTROL (harness validity): without the disable, the hook IS registered and still gates dangerous ops', async () => {
+    const { api, hooks } = makeApi(rootConfigWith({}));
+    plugin.register(api);
+    expect(typeof hooks['before_tool_call']).toBe('function');
+    const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } });
+    expect(Boolean(result && (result.requireApproval || result.block))).toBe(true);
+  });
+});
+
+describe('#112 follow-up — unattended Codex: interceptor disabled via shield config file only', () => {
+  // Registration cannot see the shield file (async load), so the hook exists —
+  // but every unattended shell call must pass through instantly, untouched.
+  it.each(UNATTENDED_SHELL_CALLS)(
+    'native shell call %# resolves with no approval request and no block',
+    async (event) => {
+      stubRuntime({ interceptor: { enabled: false } });
+      const { api, hooks } = makeApi(rootConfigWith({}));
+      plugin.register(api);
+      const result = await hooks['before_tool_call'](event);
+      expect(result).toBeUndefined();
+    },
+  );
+
+  it('resolves immediately — no timer-based wait anywhere in the disabled path', async () => {
+    stubRuntime({ interceptor: { enabled: false } });
+    const { api, hooks } = makeApi(rootConfigWith({}));
+    plugin.register(api);
+    const started = Date.now();
+    await hooks['before_tool_call']({ toolName: 'exec', params: { command: 'echo unattended' } });
+    // The Edith failure mode was a 120s waitDecision timeout. The disabled
+    // path must be pure function calls — bound it well under any approval
+    // timeout while staying CI-safe.
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+});

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -183,6 +183,7 @@ export function __resetConfigStateForTest(): void {
   _configOverride = null;
   _lastShieldConfigRef = null;
   _registered = false;
+  _beforeToolCallRegistered = false;
 }
 
 type LlmInputEvent = {
@@ -402,6 +403,13 @@ try {
 } catch { /* fallback */ }
 
 let _registered = false;
+// Whether register() actually attached the before_tool_call hook this session.
+// False when the host config explicitly disables the interceptor — in that
+// case the hook must not exist at all, so the host's approval pipeline can
+// never route a tool call through this plugin (issue #112 follow-up: on
+// unattended Codex agents even a no-op registered hook changes how OpenClaw
+// resolves approvals).
+let _beforeToolCallRegistered = false;
 
 function normaliseConfig(raw: unknown): SCConfig {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
@@ -1089,19 +1097,41 @@ export default {
       }
     }
 
-    // Typed before_tool_call hook: this is the OpenClaw agent-loop gate that
-    // can block or require approval before the selected tool executes.
-    api.on('before_tool_call', async (event: TypedBeforeToolCallEvent) => {
-      const interceptor = await initInterceptor();
-      if (!interceptor) return;
-      return handleTypedBeforeToolCall(event, interceptor, api.logger);
-    }, { priority: 80, timeoutMs: 30_000 });
+    // #112 follow-up: when the host config (openclaw.json plugin entry)
+    // explicitly disables the interceptor, do NOT register before_tool_call at
+    // all. A registered-but-no-op hook still appears in the host's hook roster
+    // and changes how OpenClaw resolves tool-call approvals for unattended
+    // Codex agents (plugin.approval.waitDecision waits on a decision no one
+    // can give, times out after 120s, and the turn emits no reply). Absent
+    // hook = the host's native approval path is untouched.
+    //
+    // Only the synchronously-available plugin config can gate registration
+    // (the shield config file loads async via the runtime); a shield-file-only
+    // `enabled:false` keeps the lazy no-op behaviour, which returns
+    // immediately and never requests approval — covered by regression tests.
+    // Note: re-enabling the interceptor from openclaw.json requires a gateway
+    // restart, since registration happens once at plugin load.
+    const interceptorDisabledInHostConfig = _configOverride?.interceptor?.enabled === false;
 
-    // Try to register session_end for cache cleanup
-    try {
-      api.on('session_end', () => { interceptorReady?.resetSession(); });
-    } catch {
-      // session_end may not be a supported hook — TTL safety net handles this
+    if (!interceptorDisabledInHostConfig) {
+      // Typed before_tool_call hook: this is the OpenClaw agent-loop gate that
+      // can block or require approval before the selected tool executes.
+      api.on('before_tool_call', async (event: TypedBeforeToolCallEvent) => {
+        const interceptor = await initInterceptor();
+        if (!interceptor) return;
+        return handleTypedBeforeToolCall(event, interceptor, api.logger);
+      }, { priority: 80, timeoutMs: 30_000 });
+      _beforeToolCallRegistered = true;
+
+      // Try to register session_end for cache cleanup (only meaningful while
+      // an interceptor can exist)
+      try {
+        api.on('session_end', () => { interceptorReady?.resetSession(); });
+      } catch {
+        // session_end may not be a supported hook — TTL safety net handles this
+      }
+    } else {
+      api.logger?.info?.('[shieldcortex] interceptor.enabled:false in plugin config — before_tool_call hook not registered');
     }
 
     api.on("llm_input", handleLlmInput, { timeoutMs: 30_000 });
@@ -1125,13 +1155,18 @@ export default {
         };
         const interceptorOn = (rawInterceptor && typeof rawInterceptor === 'object' ? rawInterceptor.enabled : undefined) ?? DEFAULT_INTERCEPTOR_CONFIG.enabled;
         const autoApproved = Array.isArray(guardCfg.autoApprove) ? guardCfg.autoApprove.length : 0;
-        const guardState = !interceptorOn || !guardCfg.enabled
-          ? "off"
-          : `${guardCfg.enforce ? "enforce" : "warn"}${autoApproved > 0 ? ` (${autoApproved} auto-approved)` : ""}${interceptorReady ? "" : " — not yet initialised this session"}`;
+        const guardState = !_beforeToolCallRegistered
+          ? "off (before_tool_call not registered — interceptor disabled in plugin config)"
+          : !interceptorOn || !guardCfg.enabled
+            ? "off"
+            : `${guardCfg.enforce ? "enforce" : "warn"}${autoApproved > 0 ? ` (${autoApproved} auto-approved)` : ""}${interceptorReady ? "" : " — not yet initialised this session"}`;
+        const hooksLine = _beforeToolCallRegistered
+          ? "llm_input (scan), llm_output (memory), before_tool_call (action guard), session_end (cache reset)"
+          : "llm_input (scan), llm_output (memory)";
         return {
           text:
             `ShieldCortex v${_version}\n` +
-            `  Hooks: llm_input (scan), llm_output (memory), before_tool_call (action guard), session_end (cache reset)\n` +
+            `  Hooks: ${hooksLine}\n` +
             `  Action guard: ${guardState}\n` +
             `  Auto memory: ${autoMemory} | Dedupe: ${dedupe}\n` +
             `  Cloud sync: ${cloud}`,
@@ -1139,7 +1174,7 @@ export default {
       },
     });
 
-    api.logger.info(`[shieldcortex] v${_version} registered (llm_input + llm_output + before_tool_call + /shieldcortex-status)`);
+    api.logger.info(`[shieldcortex] v${_version} registered (llm_input + llm_output${_beforeToolCallRegistered ? " + before_tool_call" : ""} + /shieldcortex-status)`);
     } catch (err) {
       // Plugin must never block channel startup — warn and bail gracefully
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/setup/__tests__/trust-local-plugin-preserves-entries.test.ts
+++ b/src/setup/__tests__/trust-local-plugin-preserves-entries.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { trustLocalPlugin } from '../openclaw.js';
+
+/**
+ * Issue #112 follow-up — the Edith re-enable added
+ * `plugins.entries.codex.config.appServer.networkProxy`, which broke
+ * `shouldAutoApproveCodexAppServerApprovals()` (it auto-approves only when
+ * networkProxy is undefined) and left unattended Sol/Terra/5.5 shell calls
+ * waiting 120s on approvals nobody could give.
+ *
+ * ShieldCortex's installer was suspected. It is innocent — trustLocalPlugin()
+ * only writes `plugins.allow` and its own `plugins.entries[shieldcortex-realtime]`
+ * — and these tests pin that innocence: other plugins' entries (codex included)
+ * must pass through byte-for-byte, and no install/re-enable may ever introduce
+ * `networkProxy` or any other appServer setting.
+ */
+
+const PLUGIN_ID = 'shieldcortex-realtime';
+
+let tmpHome: string;
+
+function configPath(): string {
+  return path.join(tmpHome, '.openclaw', 'openclaw.json');
+}
+
+function writeConfig(config: unknown): void {
+  fs.mkdirSync(path.dirname(configPath()), { recursive: true });
+  fs.writeFileSync(configPath(), JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+function readConfig(): any {
+  return JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+}
+
+// The codex entry exactly as found on Edith after the incident install —
+// including the networkProxy block that must never be authored or altered by us.
+const EDITH_CODEX_ENTRY = {
+  enabled: true,
+  config: {
+    appServer: {
+      networkProxy: { enabled: true, host: '127.0.0.1', port: 8899 },
+      approvalPolicy: 'never',
+      sandbox: 'danger-full-access',
+    },
+  },
+};
+
+beforeEach(() => {
+  // Injected via trustLocalPlugin's homeArg seam — jest's process.env is a
+  // plain-object copy that never reaches the native os.homedir() binding, so
+  // a HOME override cannot redirect the config path here.
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-trust-plugin-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('#112 follow-up — trustLocalPlugin leaves other plugins\' entries untouched', () => {
+  it('preserves plugins.entries.codex (networkProxy included) byte-for-byte', () => {
+    writeConfig({ plugins: { entries: { codex: EDITH_CODEX_ENTRY } } });
+
+    expect(trustLocalPlugin('/unused', '0.0.0-test', tmpHome)).toBe(true);
+
+    const after = readConfig();
+    expect(after.plugins.entries.codex).toEqual(EDITH_CODEX_ENTRY);
+    expect(after.plugins.entries[PLUGIN_ID]).toEqual({ enabled: true });
+    expect(after.plugins.allow).toContain(PLUGIN_ID);
+  });
+
+  it('never introduces networkProxy or appServer keys anywhere in the config', () => {
+    writeConfig({ plugins: { entries: {} } });
+
+    expect(trustLocalPlugin('/unused', '0.0.0-test', tmpHome)).toBe(true);
+
+    const raw = fs.readFileSync(configPath(), 'utf-8');
+    expect(raw).not.toContain('networkProxy');
+    expect(raw).not.toContain('appServer');
+  });
+
+  it('re-enable over an existing install is idempotent for everyone else too', () => {
+    writeConfig({
+      plugins: {
+        allow: [PLUGIN_ID],
+        entries: {
+          codex: EDITH_CODEX_ENTRY,
+          [PLUGIN_ID]: { enabled: true, config: { interceptor: { enabled: false } } },
+        },
+      },
+    });
+    const before = readConfig();
+
+    expect(trustLocalPlugin('/unused', '0.0.0-test', tmpHome)).toBe(true);
+
+    // Already-correct config → idempotency gate skips the write entirely.
+    expect(readConfig()).toEqual(before);
+  });
+
+  it('preserves our own user-set interceptor config when (re)enabling', () => {
+    writeConfig({
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: { enabled: false, config: { interceptor: { enabled: false } } },
+        },
+      },
+    });
+
+    expect(trustLocalPlugin('/unused', '0.0.0-test', tmpHome)).toBe(true);
+
+    const after = readConfig();
+    expect(after.plugins.entries[PLUGIN_ID].enabled).toBe(true);
+    expect(after.plugins.entries[PLUGIN_ID].config).toEqual({ interceptor: { enabled: false } });
+  });
+});

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -464,9 +464,19 @@ export function pluginInstallNeedsWrite(
  * Also actively cleans any legacy `plugins.installs[shieldcortex-realtime]`
  * entry left over from older ShieldCortex versions, so customers upgrading
  * through us never trip OpenClaw's migration-block.
+ *
+ * Exported for direct unit testing (see
+ * trust-local-plugin-preserves-entries.test.ts — pins that other plugins'
+ * entries, e.g. `plugins.entries.codex` and its `appServer.networkProxy`
+ * settings, pass through byte-for-byte untouched; issue #112 follow-up).
+ * `homeArg` injects the home dir for those tests — same seam as
+ * repairOpenClawManagedPins(); jest's process.env copy never reaches the
+ * native os.homedir() binding, so a HOME override can't work there.
  */
-function trustLocalPlugin(_installDir: string, _version: string): boolean {
-  const configPath = openClawConfigPath();
+export function trustLocalPlugin(_installDir: string, _version: string, homeArg?: string): boolean {
+  const configPath = homeArg
+    ? path.join(homeArg, '.openclaw', 'openclaw.json')
+    : openClawConfigPath();
   const configDir = path.dirname(configPath);
   const pluginId = PLUGIN_DIR_NAME; // "shieldcortex-realtime"
 


### PR DESCRIPTION
## Summary

Follow-up to #112/#113. Tars reported (Ekho, 21 Jul 2026 17:30 UTC) that on Edith's unattended Codex box, native shell calls for gpt-5.6-sol/terra and gpt-5.5 were deadlocking for ~120s waiting on `plugin.approval.waitDecision`, even though the ShieldCortex interceptor was configured off (`interceptor.enabled: false`).

Root cause: `register()` always attached `before_tool_call` — as a lazy no-op when disabled, but still *present* in the host's hook roster. A hook merely existing there changes how OpenClaw resolves tool-call approvals for unattended Codex agents: `shouldAutoApproveCodexAppServerApprovals()` only auto-resolves when no plugin approval path is in play. A no-op handler isn't invisible enough — the host still waits on it.

Tars also flagged a second suspect: a `plugins.entries.codex.config.appServer.networkProxy` key that appeared on Edith during the 4.47.13 install/re-enable, which itself breaks `shouldAutoApproveCodexAppServerApprovals()`.

## What this fixes

1. **`before_tool_call` is no longer registered at all** when the host plugin config (`openclaw.json` → `plugins.entries[id].config.interceptor.enabled === false`) disables the interceptor. The `session_end` cache-reset hook (only meaningful alongside the gate) is skipped too. Scanning hooks (`llm_input`/`llm_output`) stay live regardless. `shieldcortex-status` and the registration log line now report the gate as genuinely absent rather than claiming it still exists.
   - A shield-config-file-only disable (loaded async, *after* registration happens) keeps the existing lazy no-op behavior, which already resolves every call instantly with no approval request — this path was already correct and is covered by a dedicated test group.
2. **Regression test pinning `trustLocalPlugin()`'s innocence** on the `networkProxy` question: it only ever writes `plugins.allow` and `plugins.entries[shieldcortex-realtime]` — every other key, including other plugins' `entries` subtrees, passes through untouched (spread, never rebuilt). `trustLocalPlugin` is now exported with an optional `homeArg` test seam (same pattern as `repairOpenClawManagedPins()`) since jest's `process.env` copy never reaches the native `os.homedir()` binding.

## Open question (not resolved by this PR)

**The `networkProxy` provenance is not root-caused.** I read every code path in this repo that writes `plugins.entries` (`trustLocalPlugin`, and the uninstall/reinstall config-restore path in the `repair` command) and none of them ever touch a foreign plugin's entry — they only ever read/write our own `shieldcortex-realtime` key, spreading everything else through. Grepping the whole source tree, `networkProxy`/`appServer` appear nowhere outside the new test fixtures. So either the key was introduced by something outside this repo (OpenClaw itself, Codex's own plugin, or a manual edit on Edith), or by a path I haven't found. Fix (1) above is defensive and closes the incident regardless of where `networkProxy` came from, since it removes ShieldCortex from the approval-resolution path entirely when its own interceptor is off.

## Test evidence

New/changed tests, run via the project's `node scripts/run-jest.mjs` (raw `jest` doesn't pick up this repo's sandbox config):

- `plugins/openclaw/__tests__/unattended-codex-112.test.ts` (new, 8 tests) — registration-gating contract + native shell-call contract for the shield-file-only path.
- `src/setup/__tests__/trust-local-plugin-preserves-entries.test.ts` (new, 4 tests) — pins the Edith `codex` entry (networkProxy included) passing through byte-for-byte.
- `plugins/openclaw/__tests__/interceptor-config-112.test.ts` (modified, 2 assertions changed from "resolves as no-op" to "hook is absent").

**Failing-first**, verified against a clean worktree of `733f091` (this branch's base, pre-fix):
- `unattended-codex-112.test.ts`: 3 of 8 failed (`before_tool_call` was present when it should be absent, status text still claimed the gate, skip wasn't logged).
- `interceptor-config-112.test.ts`: 2 of 15 failed (same "hook present, should be absent" shape).
- `trust-local-plugin-preserves-entries.test.ts`: whole suite failed to load — `trustLocalPlugin` wasn't exported pre-fix (no risk of hitting a real config path).

All pass on this branch: **27/27** across the three files.

Related suites (`plugins/openclaw` + `src/setup`): **123/123 passed, 16/16 suites.**

Full suite on this branch: **2847/2872 tests passed, 269/274 suites**, with the same **18 failures across 5 suites** (`save-memory-near-dup-dedup`, `claims-proof`, `defence-pipeline-bypass`, `save-auto-extracted-memory`, `recall-defence-integration`) reproduced identically on a clean worktree of the base commit `733f091` — confirmed pre-existing in this environment, unrelated to this change.

## Test plan

- [x] New tests fail against pre-fix code, pass against this branch
- [x] Related plugin/setup suites green
- [x] Full suite pre-existing-failure comparison matches base commit exactly
- [ ] Manual verification on Edith once deployed (outside scope of this PR)

Not merged, no version/tag changes — per instructions.