### PR TITLE
fix(doctor): #116 probe migrates before write test + loaded-vs-disk plugin version check

### DIFF
--- a/src/cli/__tests__/doctor-running-plugin-version.test.ts
+++ b/src/cli/__tests__/doctor-running-plugin-version.test.ts
@@ -1,0 +1,121 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import {
+  checkOpenClawRunningPluginVersion,
+  parseRunningPluginVersion,
+} from '../doctor.js';
+
+/**
+ * The #94-class false green: doctor's "plugin loaded" surfaces read the version
+ * on DISK and green-tick it, even when the RUNNING gateway registered an older
+ * build hours/days ago (live 21 Jul 2026: box ran v4.47.8 under a "v4.47.13
+ * loaded" green tick). The gateway logs `[shieldcortex] vX.Y.Z registered` every
+ * time it (re)starts, so the most recent such line in its journal is the version
+ * actually running. This check compares running-vs-disk and refuses to claim
+ * "current" when they differ or when the journal can't be read.
+ *
+ * The journal reader is injected so these tests never touch systemd/journald.
+ */
+const PLUGIN_ID = '@drakon-systems/shieldcortex-realtime';
+const PKG_SUBPATH = path.join('node_modules', '@drakon-systems', 'shieldcortex-realtime');
+
+let home: string;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-doctor-running-'));
+});
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+/** Install the realtime plugin on disk at the given version. */
+function installOnDisk(diskVersion: string): void {
+  const oc = path.join(home, '.openclaw');
+  fs.mkdirSync(path.join(oc, 'plugins'), { recursive: true });
+  const pkgDir = path.join(oc, 'npm', 'projects', 'drakon-systems-shieldcortex-realtime-abc', PKG_SUBPATH);
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ version: diskVersion }));
+  fs.writeFileSync(
+    path.join(oc, 'plugins', 'installs.json'),
+    JSON.stringify({ installRecords: { [PLUGIN_ID]: { version: diskVersion, installPath: pkgDir } } }),
+  );
+}
+
+/** A journal transcript ending with the given registered version(s), oldest → newest. */
+function journalWith(...registeredVersions: string[]): string {
+  const lines = [
+    'Jul 21 09:00:01 host openclaw-gateway[123]: starting gateway',
+    ...registeredVersions.map(
+      (v, i) =>
+        `Jul 21 09:0${i}:05 host openclaw-gateway[123]: [shieldcortex] v${v} registered (llm_input + llm_output + before_tool_call + /shieldcortex-status)`,
+    ),
+  ];
+  return lines.join('\n') + '\n';
+}
+
+describe('parseRunningPluginVersion', () => {
+  it('returns the most recent registered version (last wins)', () => {
+    expect(parseRunningPluginVersion(journalWith('4.47.8', '4.47.13'))).toBe('4.47.13');
+  });
+
+  it('returns null when no registration line is present', () => {
+    expect(parseRunningPluginVersion('Jul 21 09:00:01 host openclaw-gateway[123]: starting gateway\n')).toBeNull();
+  });
+
+  it('parses a single registration', () => {
+    expect(parseRunningPluginVersion(journalWith('4.47.8'))).toBe('4.47.8');
+  });
+});
+
+describe('checkOpenClawRunningPluginVersion', () => {
+  it('skips (info) when OpenClaw is not present', async () => {
+    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => journalWith('4.47.13') });
+    expect(r.status).toBe('info');
+    expect(r.message).toMatch(/not detected|skipped/i);
+  });
+
+  it('passes when the running version matches the on-disk version', async () => {
+    installOnDisk('4.47.13');
+    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => journalWith('4.47.8', '4.47.13') });
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/4\.47\.13/);
+  });
+
+  it('warns when the running version is stale (older than on disk) — gateway restart needed', async () => {
+    installOnDisk('4.47.13');
+    // Gateway registered v4.47.8 at last start; disk was upgraded to v4.47.13 but
+    // the gateway was never restarted — the live incident signature.
+    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => journalWith('4.47.8') });
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/stale/i);
+    expect(r.message).toMatch(/4\.47\.8 running/i);
+    expect(r.message).toMatch(/4\.47\.13 on disk/i);
+    expect(r.fix).toMatch(/restart/i);
+  });
+
+  it('reports info (never a green "current") when the gateway journal is unreadable', async () => {
+    installOnDisk('4.47.13');
+    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => null });
+    expect(r.status).toBe('info');
+    expect(r.message).toMatch(/cannot verify running version/i);
+    expect(r.status).not.toBe('pass');
+  });
+
+  it('reports info when the journal is readable but holds no registration line', async () => {
+    installOnDisk('4.47.13');
+    const r = await checkOpenClawRunningPluginVersion(home, {
+      readGatewayJournal: () => 'Jul 21 09:00:01 host openclaw-gateway[123]: starting gateway\n',
+    });
+    expect(r.status).toBe('info');
+    expect(r.message).toMatch(/cannot verify running version/i);
+  });
+
+  it('skips (info) when OpenClaw is present but the realtime plugin is not installed', async () => {
+    fs.mkdirSync(path.join(home, '.openclaw'), { recursive: true });
+    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => journalWith('4.47.13') });
+    expect(r.status).toBe('info');
+    expect(r.message).toMatch(/not installed|skipped/i);
+  });
+});

--- a/src/cli/__tests__/doctor-write-probe.test.ts
+++ b/src/cli/__tests__/doctor-write-probe.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import { runWritePathProbe } from '../doctor.js';
-import { closeDatabase, initDatabase } from '../../database/init.js';
+import { closeDatabase, getCanonicalSchema, initDatabase } from '../../database/init.js';
 
 /**
  * The doctor's write-path probe is the smoking-gun check for stale
@@ -58,28 +58,61 @@ describe('doctor write-path probe', () => {
     }
   });
 
-  it('returns "fail" with the actual sqlite error when the schema is broken', () => {
-    // Create a database with a memories table but missing the uuid column
-    // — the exact failure mode that v4.12.5 had silently in production.
-    const db = new Database(dbPath);
-    try {
-      db.exec(`
-        CREATE TABLE memories (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          type TEXT NOT NULL,
-          category TEXT NOT NULL,
-          title TEXT NOT NULL,
-          content TEXT NOT NULL
-        );
-      `);
-    } finally {
-      db.close();
-    }
+  it('returns "fail" with the actual sqlite error when the database file is corrupt / unopenable', () => {
+    // A genuinely broken DB (not just a stale schema) must still fail loudly.
+    // Migrations can heal a missing column; they cannot open a non-SQLite file.
+    fs.writeFileSync(dbPath, 'this is not a sqlite database at all');
 
     const result = runWritePathProbe(dbPath);
     expect(result.status).toBe('fail');
     expect(result.message).toMatch(/round-trip failed/i);
     // The fix hint should explicitly call out the schema/migration root cause
-    expect(result.fix).toMatch(/schema|migration|install/i);
+    expect(result.fix).toMatch(/schema|migration|install|repair/i);
+  });
+
+  // ── #116 regression: the probe must migrate before it writes ──────────────
+  //
+  // The probe used to open the DB raw and INSERT against whatever schema was on
+  // disk. After a column-adding upgrade (e.g. 4.47.13's defence_verdict) a
+  // perfectly healthy pre-restart DB is simply missing that one column — the
+  // running init/migration path adds it on the next open. Opening raw meant the
+  // probe INSERT hit "no such column: defence_verdict" and doctor screamed
+  // "❌ Write path: round-trip failed — the smoking gun for migration drift" on
+  // an install that was one `shieldcortex` command away from healthy. The fix:
+  // run the same migrations initDatabase() runs before the probe INSERT.
+  it('passes on a healthy DB that is merely missing a recently-added migration column (#116)', () => {
+    // Build the real, current schema, then rewind it to a pre-upgrade state by
+    // removing defence_verdict (and the provenance trigger that references it) —
+    // exactly what a DB looks like after upgrading the package but before the
+    // migration path has re-opened it.
+    const db = new Database(dbPath);
+    try {
+      db.exec(getCanonicalSchema());
+      db.exec('DROP TRIGGER IF EXISTS trg_memories_provenance');
+      db.exec('ALTER TABLE memories DROP COLUMN defence_verdict');
+      const cols = (db.prepare('PRAGMA table_info(memories)').all() as Array<{ name: string }>)
+        .map((c) => c.name);
+      expect(cols).not.toContain('defence_verdict'); // fixture sanity
+    } finally {
+      db.close();
+    }
+
+    const result = runWritePathProbe(dbPath);
+    expect(result.status).toBe('pass');
+    expect(result.message).toMatch(/round-trip/i);
+
+    // And the migration must have actually run (column now present, no leak).
+    const verify = new Database(dbPath, { readonly: true });
+    try {
+      const cols = (verify.prepare('PRAGMA table_info(memories)').all() as Array<{ name: string }>)
+        .map((c) => c.name);
+      expect(cols).toContain('defence_verdict');
+      const orphans = verify.prepare(
+        "SELECT COUNT(*) AS c FROM memories WHERE source = 'cli:doctor'",
+      ).get() as { c: number };
+      expect(orphans.c).toBe(0);
+    } finally {
+      verify.close();
+    }
   });
 });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -19,6 +19,7 @@ import {
 import { gatherReconcileInput, reconcilePluginState } from '../integrations/openclaw-plugin-index.js';
 import { resolveSelfInstallDir } from '../setup/native-binding.js';
 import { getCanonicalSchema } from '../database/init.js';
+import { runMigrations } from '../database/migrations.js';
 import { detectStaleDashboard, realDeps } from '../service/dashboard-staleness.js';
 import { MCP_LIGHT_TICK_INTERVAL_MS } from '../worker/types.js';
 
@@ -291,7 +292,7 @@ async function checkMemoryStats(): Promise<CheckResult> {
  * exercise it against any database path (in-memory or temp file)
  * without going through doctor's homedir-derived getDbPath().
  */
-export function runWritePathProbe(dbPath: string): CheckResult {
+export function runWritePathProbe(dbPath: string, env: Environment = detectEnvironment()): CheckResult {
   if (!fs.existsSync(dbPath)) {
     return { label: 'Write path', status: 'warn', message: 'skipped (no database)' };
   }
@@ -300,9 +301,29 @@ export function runWritePathProbe(dbPath: string): CheckResult {
   const probeUuid = `doctor-probe-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   const probeTitle = '__shieldcortex_doctor_probe__';
 
+  // On an OpenClaw-only / headless box there is no MCP server to "restart" —
+  // telling the user to do so is a dead end. The reliable heal is any command
+  // that opens the DB through the init/migration path; `shieldcortex repair`
+  // does that (and rebuilds a broken engine too). (#116)
+  const isOpenClawOnly = env.hasOpenClaw && !env.hasClaude;
+  const failFix = isOpenClawOnly
+    ? 'Run `shieldcortex repair` — it opens the database through the full init/migration path (and rebuilds the DB engine if that is the fault). This box has no MCP server to restart.'
+    : 'This is the smoking gun for a stale schema or migration drift. Run `shieldcortex repair` (opens the DB through the full init/migration path), restart the MCP server (auto-migrates on next open), or re-install: shieldcortex install';
+
   try {
     const Database = require('better-sqlite3');
     db = new Database(dbPath);
+
+    // Bring the schema current before probing — the same migration path
+    // initDatabase() runs on every open (runMigrations → canonical schema).
+    // Without this the probe opened the DB raw and INSERTed against whatever
+    // was on disk, so a healthy pre-restart DB that is merely missing a
+    // freshly-added column (e.g. 4.47.13's defence_verdict) failed here and
+    // doctor cried "migration drift" on an install one open away from healthy.
+    // Pending migrations apply on the next real init anyway; applying them here
+    // makes the probe test the schema the runtime will actually use. (#116)
+    runMigrations(db);
+    db.exec(getCanonicalSchema());
 
     // INSERT — exercises NOT NULL columns + CHECK constraints. The schema
     // adds these silently across versions; an INSERT against a stale schema
@@ -347,7 +368,7 @@ export function runWritePathProbe(dbPath: string): CheckResult {
       label: 'Write path',
       status: 'fail',
       message: `round-trip failed — ${msg}`,
-      fix: 'This is the smoking gun for a stale schema or migration drift. Try restarting the MCP server (auto-migrates), or re-install: shieldcortex install',
+      fix: failFix,
     };
   } finally {
     if (db) {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import semver from 'semver';
+import { execFileSync } from 'child_process';
 import { createRequire } from 'module';
 import { REQUIRED_HOOK_NAMES } from '../setup/settings-hooks.js';
 import {
@@ -2112,6 +2113,152 @@ export async function checkOpenClawPluginLoadState(
   }
 }
 
+/**
+ * The #94-class false green: every prior "plugin loaded" surface reads the
+ * version on DISK and green-ticks it, so a gateway that registered an older
+ * build hours/days ago hides behind a "current" tick (live 21 Jul 2026: box
+ * ran v4.47.8 under a "v4.47.13 loaded" green tick). The realtime plugin logs
+ * `[shieldcortex] vX.Y.Z registered` on every (re)start, so the most recent
+ * such line in the gateway journal is the version actually running. This check
+ * reads that line and compares it to the on-disk install:
+ *
+ *   - running == disk            → PASS (the loaded build matches disk).
+ *   - running != disk            → WARN "stale plugin loaded (vX running, vY
+ *                                  on disk) — gateway restart needed" (the
+ *                                  upgrade is on disk but not yet live).
+ *   - journal unreadable / no
+ *     registration line found    → INFO "cannot verify running version" — we
+ *                                  never emit a green claiming "current" when
+ *                                  we could not actually read the running one.
+ *
+ * The journal reader is injected (see `realRunningPluginVersionDeps`) so the
+ * check has no hard dependency on systemd being present or readable.
+ */
+export interface RunningPluginVersionDeps {
+  /** Returns the gateway journal/log text, or null when it can't be read. */
+  readGatewayJournal: () => string | null;
+}
+
+/**
+ * Extract the running realtime-plugin version from a gateway journal by taking
+ * the LAST `[shieldcortex] vX.Y.Z registered` line — journald/log output is
+ * chronological (oldest → newest), so the final match is the current start's
+ * registration. Returns null when no registration line is present.
+ */
+export function parseRunningPluginVersion(journal: string): string | null {
+  // Matches "[shieldcortex] v4.47.8 registered (...)" including semver
+  // pre-release/build suffixes. Global so we can walk to the final match.
+  const re = /\[shieldcortex\]\s+v(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\s+registered/g;
+  let match: RegExpExecArray | null;
+  let last: string | null = null;
+  while ((match = re.exec(journal)) !== null) {
+    last = match[1];
+  }
+  return last;
+}
+
+/**
+ * Real journal reader: prefer the user gateway service journal, fall back to
+ * OpenClaw's on-disk gateway log. Returns null on ANY failure (no systemd, no
+ * perms, no log file) so the check downgrades to "cannot verify" rather than a
+ * false green. Follows the execFileSync-with-stderr-swallowed pattern used by
+ * the dashboard-staleness probe.
+ */
+export function realRunningPluginVersionDeps(home: string = os.homedir()): RunningPluginVersionDeps {
+  return {
+    readGatewayJournal: (): string | null => {
+      // 1. systemd user journal for the gateway unit (the supported layout).
+      try {
+        const out = execFileSync(
+          'journalctl',
+          ['--user', '-u', 'openclaw-gateway', '--no-pager', '-n', '2000'],
+          { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+        );
+        if (typeof out === 'string' && out.trim().length > 0) return out;
+      } catch {
+        // no systemd / unit unknown / no perms — fall through to the log file
+      }
+
+      // 2. On-disk gateway log fallback for non-systemd installs.
+      const candidates = [
+        path.join(home, '.openclaw', 'logs', 'gateway.log'),
+        path.join(home, '.openclaw', 'logs', 'openclaw-gateway.log'),
+        path.join(home, '.openclaw', 'gateway.log'),
+      ];
+      for (const file of candidates) {
+        try {
+          if (fs.existsSync(file)) {
+            const text = fs.readFileSync(file, 'utf8');
+            if (text.trim().length > 0) return text;
+          }
+        } catch {
+          // unreadable — try the next candidate
+        }
+      }
+
+      return null;
+    },
+  };
+}
+
+export async function checkOpenClawRunningPluginVersion(
+  home: string = os.homedir(),
+  deps: RunningPluginVersionDeps = realRunningPluginVersionDeps(home),
+): Promise<CheckResult> {
+  const label = 'OpenClaw plugin running version';
+
+  if (!fs.existsSync(path.join(home, '.openclaw'))) {
+    return { label, status: 'info', message: 'skipped (OpenClaw not detected)' };
+  }
+
+  const diskVersion = readInstalledRealtimePluginVersion(home);
+  if (!diskVersion) {
+    return { label, status: 'info', message: 'skipped (realtime plugin not installed)' };
+  }
+
+  const journal = deps.readGatewayJournal();
+  if (journal === null) {
+    return {
+      label,
+      status: 'info',
+      message:
+        `cannot verify running version (gateway journal unreadable — no systemd/journald access, ` +
+        `unknown unit, or no gateway log); on-disk v${diskVersion}`,
+    };
+  }
+
+  const running = parseRunningPluginVersion(journal);
+  if (!running) {
+    return {
+      label,
+      status: 'info',
+      message:
+        `cannot verify running version (no \`[shieldcortex] … registered\` line in the gateway journal — ` +
+        `gateway not started since logs rotated, or plugin never loaded); on-disk v${diskVersion}`,
+    };
+  }
+
+  if (running === diskVersion) {
+    return {
+      label,
+      status: 'pass',
+      message: `running v${running} matches on-disk v${diskVersion} (gateway loaded the current build)`,
+    };
+  }
+
+  return {
+    label,
+    status: 'warn',
+    message:
+      `stale plugin loaded (v${running} running, v${diskVersion} on disk) — the gateway is still ` +
+      `enforcing the older build; a gateway restart is needed to pick up the on-disk upgrade`,
+    fix:
+      'Restart the OpenClaw gateway so it re-registers the on-disk plugin ' +
+      '(`systemctl --user restart openclaw-gateway`, or restart the OpenClaw process). ' +
+      'Until then the live interceptor is the version shown as "running", not the one on disk.',
+  };
+}
+
 // ── Check 8: Model cache ─────────────────────────────────
 async function checkModelCache(): Promise<CheckResult> {
   const cacheDir = path.join(os.homedir(), '.cache', 'shieldcortex', 'models', 'Xenova', 'all-MiniLM-L6-v2');
@@ -2205,6 +2352,7 @@ export async function runDoctor(args: string[] = []): Promise<void> {
     checkOpenClawHookFreshness,
     checkOpenClawPluginVersion,
     checkOpenClawPluginLoadState,
+    checkOpenClawRunningPluginVersion,
     checkOpenClawPluginPackage,
     checkOpenClawDuplicateInstalls,
     checkOpenClawManagedPinDrift,


### PR DESCRIPTION
## What & why

Two doctor/diagnostics-only fixes for 4.47.15. No enforcement/interceptor code paths touched.

### Fix 1 — #116: write-path probe migrates before the round-trip INSERT
The write-path probe opened the DB **raw** and INSERTed against whatever schema was on disk. After any column-adding upgrade (e.g. 4.47.13's `defence_verdict`) a perfectly healthy *pre-restart* DB is simply missing that one column — the running init/migration path adds it on the next open. Opening raw meant the probe INSERT hit `no such column: defence_verdict` and doctor screamed:

> ❌ Write path: round-trip failed — the smoking gun for … migration drift

…on an install that was one `shieldcortex` command away from healthy.

**Fix:** run the same `runMigrations()` + canonical-schema pass `initDatabase()` runs, *before* the probe INSERT — so the probe tests the schema the runtime will actually use. Pending migrations apply on the next real init anyway; applying them in the probe just makes the check honest. The steady-state cost is nil (migrations no-op when columns already exist; schema is all `IF NOT EXISTS`).

Also fixed the **fail hint** for OpenClaw-only / headless boxes: there is no MCP server to "restart" there — the hint now points at `shieldcortex repair`, which opens the DB through the full init/migration path (and rebuilds the engine if that's the fault).

### Fix 2 — loaded-vs-disk false green (#94 class; live 21 Jul 2026)
Every prior "plugin loaded" surface reads the version on **disk** and green-ticks it, so a gateway that registered an **older build hours/days ago** hides behind a "current" tick — our box ran **v4.47.8 live under a "v4.47.13 loaded" green tick**.

**Fix:** new check `checkOpenClawRunningPluginVersion`. The realtime plugin logs `[shieldcortex] vX.Y.Z registered` on every (re)start, so the **most recent** such line in the gateway journal is the version actually running. The check compares running-vs-disk:

| Situation | Verdict |
|---|---|
| running == disk | ✅ pass `running vX matches on-disk vX` |
| running != disk | ⚠️ warn `stale plugin loaded (vX running, vY on disk) — gateway restart needed` |
| journal unreadable / no registration line | ℹ️ info `cannot verify running version` (never a green claiming current) |

Journal reader is **injected** (`realRunningPluginVersionDeps`): tries `journalctl --user -u openclaw-gateway`, falls back to an on-disk `gateway.log`, returns `null` (→ info, never a false green) when neither is readable — so the check has no hard systemd dependency and is fully unit-testable.

## Failing-first evidence (TDD)

**Fix 1** — new test `passes on a healthy DB that is merely missing a recently-added migration column (#116)` (fixture = full canonical schema with `defence_verdict` + its provenance trigger dropped, simulating a pre-restart DB):

_Before the fix:_
```
✕ passes on a healthy DB that is merely missing a recently-added migration column (#116)
  expect(received).toBe(expected)
  Expected: "pass"
  Received: "fail"
```
_After the fix:_
```
✓ returns "warn / skipped" when the database file does not exist
✓ passes the round-trip on a freshly initialised database and leaves no probe rows behind
✓ returns "fail" with the actual sqlite error when the database file is corrupt / unopenable
✓ passes on a healthy DB that is merely missing a recently-added migration column (#116)
Tests: 4 passed, 4 total
```
(The old "missing uuid → fail" test asserted the *buggy* contract — a missing column is now auto-migrated, not a failure — so it was repurposed to a genuinely-unmigratable case: a corrupt/non-SQLite file, which must still fail loudly.)

**Fix 2** — new suite `doctor-running-plugin-version.test.ts` with fabricated journal fixtures for match / mismatch / unreadable / no-registration-line:

_Before the fix:_
```
SyntaxError: The requested module '../doctor.js' does not provide an export named 'checkOpenClawRunningPluginVersion'
Tests: 0 total
```
_After the fix:_
```
✓ parseRunningPluginVersion: most recent registered version (last wins)
✓ parseRunningPluginVersion: null when no registration line is present
✓ passes when the running version matches the on-disk version
✓ warns when the running version is stale (older than on disk) — gateway restart needed
✓ reports info (never a green "current") when the gateway journal is unreadable
✓ reports info when the journal is readable but holds no registration line
✓ skips (info) when OpenClaw not present / plugin not installed
Tests: 9 passed, 9 total
```

## Test suite numbers

- **Doctor suites (scope of this change):** `10 passed, 10 total` suites / `56 passed, 56 total` tests.
- **Changed/new tests:** `doctor-write-probe` 4/4, `doctor-running-plugin-version` 9/9.
- **Full suite** (`--workerIdleMemoryLimit=500MB`): `2752 passed, 6 skipped`; **2 tests failed**, 9 suites reported "failed to run".

### About the full-suite failures — environmental, not this change
This ARM box cannot run the full suite without **native `onnxruntime` (embeddings) `SIGABRT` crashes** (`OrtValueToNapiValue` under memory pressure). When a worker aborts mid-suite, jest marks that suite "failed to run" and its in-flight test "failed". Verified:

- The **same crash cascade reproduces at clean `origin/main`** (worktree, shared `node_modules`) — clean HEAD full run was actually *worse*: `10 suites failed / 29 tests failed`. So the instability predates and is independent of this change.
- Every flagged suite **passes in isolation** on this branch: `save-auto-extracted-memory` 11/11, `claim 1a (provenance invariant)` ✓, all 10 doctor suites 56/56.
- The **only genuine assertion failure is the pre-existing `recall-defence-integration › drops the injection row`**, which fails identically at clean HEAD (`access_count` expected ≥1, received 0). The second "failed" test in any given run is whichever test a crashing worker was executing.
- None of the crashing suites import the changed file (`src/cli/doctor.ts`); the changes are diagnostics-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
