### PR TITLE
fix(#103): prove plugin load against the live gateway roster, not the install index

### DIFF
--- a/src/__tests__/openclaw-gateway-roster.test.ts
+++ b/src/__tests__/openclaw-gateway-roster.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  parseBootRosterLine,
+  parseLatestBootRoster,
+  readLatestBootRoster,
+  rosterContains,
+} from '../integrations/openclaw-gateway-roster.js';
+import { reconcilePluginState, type ReconcileInput } from '../integrations/openclaw-plugin-index.js';
+
+/**
+ * Regression suite for field incident #103 (veronica, 19–26 Jul 2026).
+ *
+ * `shieldcortex repair` printed "enabled, loaded in roster, versions agree"
+ * for six days while the running gateway had booted WITHOUT the plugin. The
+ * reconciler was reading the SQLite install index and calling it the roster.
+ * These tests pin the distinction: install state ≠ load state.
+ */
+
+// Real lines, copied from clawdbot1 and veronica gateway logs.
+const JARVIS_LINE =
+  '2026-07-26T10:28:52.378+00:00 [gateway] http server listening (14 plugins: acpx, anthropic, browser, codex, ekho-adapter, elevenlabs, google, memory-core, microsoft, multi-clawd, openai, shieldcortex-realtime, telegram, xai; 4.0s)';
+const VERONICA_LINE =
+  '2026-07-20T00:16:51.758+01:00 [gateway] http server listening (11 plugins: anthropic, browser, canvas, device-pair, ekho-adapter, file-transfer, memory-core, ollama, phone-control, talk-voice, telegram; 1.1s)';
+
+describe('parseBootRosterLine', () => {
+  it('parses a roster line into ids, declared count and timestamp', () => {
+    const r = parseBootRosterLine(JARVIS_LINE);
+    expect(r).not.toBeNull();
+    expect(r!.declaredCount).toBe(14);
+    expect(r!.plugins).toHaveLength(14);
+    expect(r!.plugins).toContain('shieldcortex-realtime');
+    expect(r!.atMs).toBe(Date.parse('2026-07-26T10:28:52.378+00:00'));
+  });
+
+  it('parses the veronica line and does NOT find the plugin', () => {
+    const r = parseBootRosterLine(VERONICA_LINE);
+    expect(r!.declaredCount).toBe(11);
+    expect(r!.plugins).toHaveLength(11);
+    expect(rosterContains(r!, 'shieldcortex-realtime')).toBe(false);
+  });
+
+  it('handles the zero-plugin shape with no id list', () => {
+    const r = parseBootRosterLine('2026-07-20T00:00:00.000Z [gateway] http server listening (0 plugins; 1.2s)');
+    expect(r).not.toBeNull();
+    expect(r!.declaredCount).toBe(0);
+    expect(r!.plugins).toEqual([]);
+  });
+
+  it('parses the JSON-per-line file format the gateway also writes', () => {
+    const json = JSON.stringify({
+      message: 'http server listening (2 plugins: telegram, shieldcortex-realtime; 0.9s)',
+      time: '2026-07-26T10:28:52.378+00:00',
+    });
+    const r = parseBootRosterLine(json);
+    expect(r!.plugins).toEqual(['telegram', 'shieldcortex-realtime']);
+  });
+
+  it('returns null for unrelated lines', () => {
+    expect(parseBootRosterLine('[gateway] ready')).toBeNull();
+    expect(parseBootRosterLine('')).toBeNull();
+  });
+
+  it('declaredCount and parsed ids agree on real lines (guards list truncation)', () => {
+    for (const line of [JARVIS_LINE, VERONICA_LINE]) {
+      const r = parseBootRosterLine(line)!;
+      expect(r.plugins).toHaveLength(r.declaredCount);
+    }
+  });
+});
+
+describe('parseLatestBootRoster', () => {
+  it('takes the LAST roster line — a log spans many boots, only the newest is live', () => {
+    const text = [VERONICA_LINE, '[gateway] ready', JARVIS_LINE, 'noise'].join('\n');
+    const r = parseLatestBootRoster(text)!;
+    expect(r.declaredCount).toBe(14);
+    expect(rosterContains(r, 'shieldcortex-realtime')).toBe(true);
+  });
+
+  it('returns null when no roster line is present', () => {
+    expect(parseLatestBootRoster('nothing\nto\nsee')).toBeNull();
+  });
+});
+
+describe('readLatestBootRoster', () => {
+  const files: Record<string, string> = {
+    'openclaw-2026-07-25.log': VERONICA_LINE,
+    'openclaw-2026-07-26.log': JARVIS_LINE,
+    'not-a-log.txt': JARVIS_LINE,
+  };
+  const mtimes: Record<string, number> = {
+    'openclaw-2026-07-25.log': 1000,
+    'openclaw-2026-07-26.log': 2000,
+  };
+  const io = {
+    logDir: '/tmp/openclaw',
+    readDir: () => Object.keys(files),
+    readFile: (f: string) => files[f.split('/').pop()!],
+    statMtimeMs: (f: string) => mtimes[f.split('/').pop()!] ?? 0,
+  };
+
+  it('reads the newest log file and reports its source', () => {
+    const r = readLatestBootRoster(io)!;
+    expect(r.declaredCount).toBe(14);
+    expect(r.source).toBe('/tmp/openclaw/openclaw-2026-07-26.log');
+  });
+
+  it('returns null when the log dir cannot be read', () => {
+    expect(
+      readLatestBootRoster({
+        readDir: () => {
+          throw new Error('ENOENT');
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when no openclaw-*.log files exist', () => {
+    expect(readLatestBootRoster({ ...io, readDir: () => ['other.txt'] })).toBeNull();
+  });
+
+  it('SAFETY: rejects a roster line older than the running process', () => {
+    // A line from a previous boot proves nothing about the process running now.
+    const stale = readLatestBootRoster({
+      ...io,
+      processStartedAtMs: Date.parse('2026-07-26T10:28:52.378+00:00') + 1,
+    });
+    expect(stale).toBeNull();
+  });
+
+  it('accepts a roster line at or after the process start', () => {
+    const live = readLatestBootRoster({
+      ...io,
+      processStartedAtMs: Date.parse('2026-07-26T10:28:52.378+00:00'),
+    });
+    expect(live).not.toBeNull();
+  });
+});
+
+describe('reconcilePluginState — #103 live roster overrides the install index', () => {
+  /** Veronica's exact state on 26 Jul: installed, enabled, allow-listed, index
+   * says enabled — and the running gateway booted without it. */
+  const veronica: ReconcileInput = {
+    pluginId: 'shieldcortex-realtime',
+    expectedVersion: '4.47.10',
+    config: { enabled: true, inAllow: true },
+    installsJson: { version: '4.47.10', installPath: '/home/mike/.openclaw/npm/projects/x' },
+    index: {
+      installRecords: {
+        'shieldcortex-realtime': {
+          source: 'npm',
+          version: '4.47.10',
+          installPath: '/home/mike/.openclaw/npm/projects/x',
+        },
+      },
+      plugins: [{ pluginId: 'shieldcortex-realtime', enabled: true }],
+    },
+    onDiskVersion: '4.47.10',
+    projectDirs: ['drakon-systems-shieldcortex-realtime-6e7e2e7717'],
+    liveRoster: parseBootRosterLine(VERONICA_LINE)!.plugins,
+  };
+
+  it('SECURITY: the #103 false positive is now a hard fail, not healthy', () => {
+    const v = reconcilePluginState(veronica);
+    expect(v.state).toBe('enabled-not-loaded');
+    expect(v.severity).toBe('fail');
+    expect(v.loadedInIndex).toBe(true); // install index still says enabled…
+    expect(v.loadedInLiveRoster).toBe(false); // …but the gateway never loaded it.
+    expect(v.reasons.join(' ')).toMatch(/ABSENT from the RUNNING gateway boot roster/);
+  });
+
+  it('says out loud that the index disagrees, so the operator can see why', () => {
+    const v = reconcilePluginState(veronica);
+    expect(v.reasons.join(' ')).toMatch(/install state, not load state/);
+  });
+
+  it('is healthy when the live roster DOES name the plugin', () => {
+    const v = reconcilePluginState({
+      ...veronica,
+      expectedVersion: '4.47.16',
+      onDiskVersion: '4.47.16',
+      liveRoster: parseBootRosterLine(JARVIS_LINE)!.plugins,
+    });
+    expect(v.state).toBe('healthy');
+    expect(v.loadedInLiveRoster).toBe(true);
+    expect(v.reasons.join(' ')).toMatch(/present on the running gateway boot roster/);
+  });
+
+  it('HONESTY: an unreadable live roster must not be reported as "loaded"', () => {
+    const v = reconcilePluginState({ ...veronica, liveRoster: null });
+    expect(v.loadedInLiveRoster).toBeNull();
+    expect(v.reasons.join(' ')).toMatch(/could NOT be read/);
+    expect(v.reasons.join(' ')).not.toMatch(/present on the running gateway boot roster/);
+  });
+
+  it('a live roster proving load survives an unreadable SQLite index', () => {
+    const v = reconcilePluginState({
+      ...veronica,
+      expectedVersion: '4.47.16',
+      onDiskVersion: '4.47.16',
+      index: null,
+      liveRoster: parseBootRosterLine(JARVIS_LINE)!.plugins,
+    });
+    expect(v.state).not.toBe('index-unreadable');
+    expect(v.loadedInLiveRoster).toBe(true);
+  });
+});

--- a/src/integrations/openclaw-gateway-roster.ts
+++ b/src/integrations/openclaw-gateway-roster.ts
@@ -1,0 +1,179 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Reading the LIVE gateway plugin roster.
+ *
+ * Field incident #103 (veronica, 2026-07-19 → 26): `shieldcortex repair`
+ * reported `✓ realtime plugin healthy: enabled, loaded in roster, versions
+ * agree` on a host whose gateway had booted WITHOUT the plugin six days
+ * earlier. The plugin was installed and enabled, so it was present in the
+ * SQLite `installed_plugin_index.plugins_json` — and that is what the
+ * reconciler was reading and calling "the loaded roster".
+ *
+ * It is not. `plugins_json` records what OpenClaw has INSTALLED and enabled;
+ * it says nothing about what the running gateway process actually loaded. The
+ * only ground truth for that is the gateway's own boot line:
+ *
+ *   [gateway] http server listening (14 plugins: acpx, anthropic, …; 4.0s)
+ *
+ * A plugin can be installed, enabled, allow-listed and index-present, and
+ * still be absent from that line — which is precisely the fail-open the roster
+ * proof exists to catch, and precisely what it missed.
+ *
+ * This module reads that line. When it cannot (log rotated, wiped from /tmp,
+ * gateway logging elsewhere) it returns null, and callers MUST degrade to
+ * "could not prove" rather than inheriting the index's optimism.
+ */
+
+/** A parsed `http server listening` boot roster line. */
+export interface BootRoster {
+  /** Plugin ids named on the line, in order. */
+  plugins: string[];
+  /** The count the gateway itself declared, for cross-checking. */
+  declaredCount: number;
+  /** Epoch ms parsed from the line's ISO timestamp, when present. */
+  atMs: number | null;
+  /** File the line came from, for operator-facing evidence. */
+  source?: string;
+}
+
+/**
+ * The gateway prints one line per boot. Two shapes are in the wild:
+ *   "http server listening (14 plugins: a, b, c; 4.0s)"
+ *   "http server listening (0 plugins; 1.2s)"
+ * The trailing duration is optional, and the id list is absent when the count
+ * is zero.
+ */
+const ROSTER_RE = /http server listening \((\d+) plugins?(?::\s*([^;)]+))?[;)]/;
+
+/** ISO-8601 timestamp at the head of a gateway log line or JSON `time` field. */
+const ISO_RE = /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))/;
+
+function parseTimestamp(line: string): number | null {
+  const m = ISO_RE.exec(line);
+  if (!m) return null;
+  const ms = Date.parse(m[1]);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Parse a single log line into a boot roster. PURE. Returns null when the line
+ * is not a roster line.
+ *
+ * Accepts both the plain console format and the JSON-per-line file format,
+ * since the gateway writes the same message through both.
+ */
+export function parseBootRosterLine(line: string): BootRoster | null {
+  const m = ROSTER_RE.exec(line);
+  if (!m) return null;
+  const declaredCount = Number.parseInt(m[1], 10);
+  const list = (m[2] ?? '').trim();
+  const plugins = list
+    ? list
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+  return { plugins, declaredCount, atMs: parseTimestamp(line) };
+}
+
+/**
+ * Scan text for the LAST roster line it contains. PURE.
+ *
+ * Last, not first: a log file spans many boots and only the most recent one
+ * describes the process that is running now.
+ */
+export function parseLatestBootRoster(text: string): BootRoster | null {
+  let latest: BootRoster | null = null;
+  for (const line of text.split('\n')) {
+    const parsed = parseBootRosterLine(line);
+    if (parsed) latest = parsed;
+  }
+  return latest;
+}
+
+/** Does the roster name this plugin? */
+export function rosterContains(roster: BootRoster, pluginId: string): boolean {
+  return roster.plugins.includes(pluginId);
+}
+
+export interface ReadBootRosterOptions {
+  /**
+   * Directory the gateway writes its log files to. OpenClaw uses
+   * `/tmp/openclaw` by default and announces it at boot ("log file: …").
+   */
+  logDir?: string;
+  /**
+   * Epoch ms the current gateway process started. When supplied, a roster line
+   * older than this is from a PREVIOUS process and is rejected — a stale line
+   * must never be read as proof about the process running now.
+   */
+  processStartedAtMs?: number;
+  /** Injected for tests. */
+  readDir?: (dir: string) => string[];
+  readFile?: (file: string) => string;
+  statMtimeMs?: (file: string) => number;
+}
+
+const DEFAULT_LOG_DIR = '/tmp/openclaw';
+
+/**
+ * Read the newest boot roster the gateway has written.
+ *
+ * Returns null — meaning "cannot prove" — when the log dir is missing, holds
+ * no roster line, or the only line found predates the running process. Callers
+ * must treat null as absence of evidence, NEVER as evidence of health.
+ */
+export function readLatestBootRoster(options: ReadBootRosterOptions = {}): BootRoster | null {
+  const logDir = options.logDir ?? DEFAULT_LOG_DIR;
+  const readDir = options.readDir ?? ((d: string) => fs.readdirSync(d));
+  const readFile = options.readFile ?? ((f: string) => fs.readFileSync(f, 'utf-8'));
+  const statMtimeMs = options.statMtimeMs ?? ((f: string) => fs.statSync(f).mtimeMs);
+
+  let names: string[];
+  try {
+    names = readDir(logDir);
+  } catch {
+    return null;
+  }
+
+  const logs = names
+    .filter((n) => n.startsWith('openclaw-') && n.endsWith('.log'))
+    .map((n) => path.join(logDir, n));
+  if (logs.length === 0) return null;
+
+  // Newest file first: the current boot is in the most recently written log.
+  const ordered = logs
+    .map((file) => {
+      let mtimeMs = 0;
+      try {
+        mtimeMs = statMtimeMs(file);
+      } catch {
+        mtimeMs = 0;
+      }
+      return { file, mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const { file } of ordered) {
+    let text: string;
+    try {
+      text = readFile(file);
+    } catch {
+      continue;
+    }
+    const roster = parseLatestBootRoster(text);
+    if (!roster) continue;
+    // A line from a previous process proves nothing about this one.
+    if (
+      options.processStartedAtMs != null &&
+      roster.atMs != null &&
+      roster.atMs < options.processStartedAtMs
+    ) {
+      return null;
+    }
+    return { ...roster, source: file };
+  }
+  return null;
+}

--- a/src/integrations/openclaw-plugin-index.ts
+++ b/src/integrations/openclaw-plugin-index.ts
@@ -6,6 +6,7 @@ import {
   resolveRealtimePluginInstallPath,
   readInstalledRealtimePluginVersion,
 } from './openclaw-plugin-state.js';
+import { readLatestBootRoster } from './openclaw-gateway-roster.js';
 
 /**
  * Reconciling OpenClaw plugin-install state across its three authoritative
@@ -74,6 +75,13 @@ export interface ReconcileInput {
   onDiskVersion: string | null;
   /** `~/.openclaw/npm/projects/*` dir names matching the plugin. */
   projectDirs?: string[];
+  /**
+   * Plugin ids named on the RUNNING gateway's boot roster line, or null when
+   * that line could not be read (#103). This is the only ground truth for what
+   * the gateway actually loaded; `index.plugins` merely records what is
+   * installed and enabled. Null means "cannot prove", never "healthy".
+   */
+  liveRoster?: string[] | null;
 }
 
 export type PluginLoadState =
@@ -99,8 +107,17 @@ export interface ReconcileVerdict {
   severity: ReconcileSeverity;
   recommendedAction: RecommendedAction;
   enabledInConfig: boolean;
-  /** plugins_json roster carries an enabled entry for the plugin. */
+  /**
+   * plugins_json carries an enabled entry for the plugin. NOTE: this is the
+   * INSTALL index, not the live gateway roster — it says the plugin is
+   * installed and enabled, not that the running gateway loaded it (#103).
+   */
   loadedInIndex: boolean;
+  /**
+   * The running gateway's boot roster names the plugin. `null` when that line
+   * could not be read — absence of evidence, not evidence of absence.
+   */
+  loadedInLiveRoster: boolean | null;
   /** The SQLite install index was actually readable (false ⇒ we CANNOT know
    * whether the plugin is loaded — never claim UNPROTECTED off an unreadable index). */
   indexReadable: boolean;
@@ -144,6 +161,10 @@ export function reconcilePluginState(input: ReconcileInput): ReconcileVerdict {
     index?.plugins?.some((p) => p.pluginId === pluginId && p.enabled === true),
   );
 
+  // #103: the live gateway roster overrides the install index. Null = unread.
+  const liveRoster = input.liveRoster ?? null;
+  const loadedInLiveRoster = liveRoster == null ? null : liveRoster.includes(pluginId);
+
   const installsJsonVersion = input.installsJson?.version ?? null;
   const indexVersion = indexRecord?.version ?? indexRecord?.resolvedVersion ?? null;
   const onDiskVersion = input.onDiskVersion ?? null;
@@ -179,6 +200,7 @@ export function reconcilePluginState(input: ReconcileInput): ReconcileVerdict {
   const base = {
     enabledInConfig,
     loadedInIndex,
+    loadedInLiveRoster,
     indexReadable,
     openClawTracked,
     indexWarnsConflict,
@@ -197,7 +219,24 @@ export function reconcilePluginState(input: ReconcileInput): ReconcileVerdict {
     return { ...base, state: 'not-installed', severity: 'ok', recommendedAction: 'install', reasons };
   }
 
-  // 2. Cannot read the loaded roster (SQLite index unreadable): a broken
+  // 2. THE #103 silent drop: the RUNNING gateway's boot roster does not name
+  //    the plugin. This outranks every index-derived signal — on veronica the
+  //    plugin was installed, enabled, allow-listed and present in plugins_json
+  //    (so the checks below all read "healthy") while the gateway had booted
+  //    without it six days earlier. Install state is not load state.
+  if (enabledInConfig && loadedInLiveRoster === false) {
+    reasons.push('enabled:true in config but ABSENT from the RUNNING gateway boot roster — interceptor not loaded, host unprotected while status reports ON');
+    if (loadedInIndex) reasons.push('the SQLite install index lists it as enabled — install state, not load state; the live roster is authoritative');
+    return {
+      ...base,
+      state: 'enabled-not-loaded',
+      severity: 'fail',
+      recommendedAction: openClawTracked ? 'update-openclaw-tracked' : 'reinstall-pinned',
+      reasons,
+    };
+  }
+
+  // 3. Cannot read the loaded roster (SQLite index unreadable): a broken
   //    better-sqlite3 binding, a locked DB, or a pre-2026.6.1 OpenClaw with no
   //    `installed_plugin_index` table all return a null index. We literally
   //    cannot know whether the plugin is loaded — reporting the #74 fail-open
@@ -205,12 +244,12 @@ export function reconcilePluginState(input: ReconcileInput): ReconcileVerdict {
   //    fault repair pass-1 exists to fix). Classify as a diagnostic gap (warn),
   //    NEVER as a security fail-open. Only reached when enabled + installed but
   //    the index is unreadable; a genuinely uninstalled plugin fell out at (1).
-  if (enabledInConfig && !loadedInIndex && index == null) {
+  if (enabledInConfig && !loadedInIndex && index == null && loadedInLiveRoster !== true) {
     reasons.push('cannot read the loaded roster — the SQLite plugin install index is unreadable (broken better-sqlite3 binding, locked DB, or pre-2026.6.1 OpenClaw with no installed_plugin_index table); cannot confirm whether the interceptor is loaded');
     return { ...base, state: 'index-unreadable', severity: 'warn', recommendedAction: 'none', reasons };
   }
 
-  // 3. THE #74 silent drop: enabled in config but missing from a READABLE roster.
+  // 4. THE #74 silent drop: enabled in config but missing from a READABLE index.
   if (enabledInConfig && !loadedInIndex) {
     reasons.push('enabled:true in config but ABSENT from the loaded roster (plugins_json) — interceptor not loaded, host unprotected while status reports ON');
     if (indexWarnsConflict) reasons.push('index reports conflicting install metadata for this plugin');
@@ -248,7 +287,13 @@ export function reconcilePluginState(input: ReconcileInput): ReconcileVerdict {
     return { ...base, state: 'duplicate-install', severity: 'warn', recommendedAction: 'dedupe-and-reload', reasons };
   }
 
-  reasons.push('enabled, loaded in roster, versions agree at the expected build');
+  // Say exactly which evidence we have. Claiming "loaded in roster" off the
+  // install index alone is what made #103 a false positive.
+  reasons.push(
+    loadedInLiveRoster === true
+      ? 'enabled, present on the running gateway boot roster, versions agree at the expected build'
+      : 'enabled and installed, versions agree at the expected build — but the running gateway boot roster could NOT be read, so the plugin is not proven loaded',
+  );
   return { ...base, state: 'healthy', severity: 'ok', recommendedAction: 'none', reasons };
 }
 
@@ -434,6 +479,11 @@ export interface GatherOptions {
   expectedVersion: string;
   /** Injectable index reader (defaults to the live SQLite read). */
   readIndex?: (home: string) => PluginIndexRow | null;
+  /**
+   * Injectable live-roster reader (defaults to reading the gateway's newest
+   * `http server listening` boot line). Returns null when it cannot be proven.
+   */
+  readLiveRoster?: () => string[] | null;
 }
 
 function readConfigEnable(home: string, pluginId: string): { enabled: boolean | null; inAllow: boolean } {
@@ -488,6 +538,12 @@ function scanProjectDirs(home: string, pluginId: string): string[] {
 export function gatherReconcileInput(home: string, options: GatherOptions): ReconcileInput {
   const pluginId = options.pluginId ?? REALTIME_PLUGIN_ID;
   const readIndex = options.readIndex ?? ((h: string) => readPluginInstallIndex(h));
+  // The default roster read touches the host's real gateway log dir (/tmp/openclaw),
+  // which no `home` override can redirect — so it must never fire under Jest, or a
+  // test would silently inherit THIS box's roster. Tests inject readLiveRoster.
+  const readRoster =
+    options.readLiveRoster ??
+    (() => (process.env.JEST_WORKER_ID !== undefined ? null : (readLatestBootRoster()?.plugins ?? null)));
   return {
     pluginId,
     expectedVersion: options.expectedVersion,
@@ -496,6 +552,7 @@ export function gatherReconcileInput(home: string, options: GatherOptions): Reco
     index: readIndex(home),
     onDiskVersion: readInstalledRealtimePluginVersion(home),
     projectDirs: scanProjectDirs(home, pluginId),
+    liveRoster: readRoster(),
   };
 }
 

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -221,7 +221,12 @@ export function formatReconcileReport(result: ReconcileExecResult): string[] {
 
   if (!result.applied) {
     if (verdict.state === 'healthy') {
-      lines.push('✓ realtime plugin healthy: enabled, loaded in roster, versions agree.');
+      // #103: only claim "loaded" when the RUNNING gateway roster proves it.
+      lines.push(
+        verdict.loadedInLiveRoster === true
+          ? '✓ realtime plugin healthy: enabled, loaded on the running gateway roster, versions agree.'
+          : '⚠ realtime plugin installed and enabled, versions agree — NOT proven loaded: the running gateway boot roster could not be read. Restart the gateway, then re-run, or check `journalctl --user -u openclaw-gateway | grep "http server listening"` yourself.',
+      );
       return lines;
     }
     lines.push('');


### PR DESCRIPTION
Closes the second half of #103 — the one I consider the more serious of the two.

## The defect

On veronica, `shieldcortex repair` printed:

> `✓ realtime plugin healthy: enabled, loaded in roster, versions agree`

for six days, on a box whose gateway had booted **without** the plugin. The host was unprotected the whole time while our own health check said otherwise.

Root cause is a wrong assumption baked into the reconciler: `loadedInIndex` reads `installed_plugin_index.plugins_json` and the code called that "the LOADED roster". It isn't. `plugins_json` records what OpenClaw has **installed and enabled**; it says nothing about what the running gateway process actually loaded. A plugin can be installed, enabled, allow-listed and index-present and still be absent from the gateway's boot roster — which is precisely the state veronica was in, and precisely the fail-open the roster proof exists to catch.

## The fix

New `src/integrations/openclaw-gateway-roster.ts` reads the gateway's own boot line, which is the only ground truth for what loaded:

```
[gateway] http server listening (14 plugins: acpx, anthropic, …, shieldcortex-realtime, …; 4.0s)
```

- `reconcilePluginState` now takes `liveRoster`. When it names the plugin **absent**, the verdict is a hard `enabled-not-loaded` fail regardless of what the index says, and the reasons spell out that the index disagrees so the operator can see why.
- When the roster **cannot be read**, the verdict says "not proven loaded" rather than inheriting the index's optimism. Absence of evidence is no longer reported as health — `formatReconcileReport` degrades that line from `✓ healthy` to a `⚠ NOT proven loaded` with the journal command to check by hand.
- A roster line older than the running process is rejected: a stale boot proves nothing about the process running now.
- A live roster proving load now also survives an unreadable SQLite index, which the old ordering classified as a diagnostic gap.

## Testing

18 new tests in `openclaw-gateway-roster.test.ts`, driven by the **real** boot lines from both boxes — including a fixture replaying veronica's exact state (installed + enabled + allow-listed + index-enabled + absent from the live roster) which must now classify as `fail`. Full suite: 2933 passed.

⚠️ One **pre-existing, unrelated** failure on `main`: `recall-defence-integration.test.ts` › "drops the injection row (access_count stays 0)". I verified it fails identically on a clean stash of this branch, so it is not introduced here — but it is a genuinely failing test on main and needs its own issue.

## Not in scope

The other half of #103 — why the plugin was dropped at boot at all — is still open pending one experiment on veronica (`plugins.bundledDiscovery` unset + non-empty `plugins.allow`; evidence table in the issue). This PR does not attempt that fix; it makes sure we stop *lying* about the result either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)