### PR TITLE
fix(#125): isolate recall-defence integration test from inherited SHIELDCORTEX_* env

### DIFF
--- a/src/__tests__/recall-defence-integration.test.ts
+++ b/src/__tests__/recall-defence-integration.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
 import { execFileSync, execSync } from 'node:child_process';
 import Database from 'better-sqlite3';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -24,8 +24,21 @@ describe('recall-defence integration — prompt-recall withholds a poisoned row'
   let dbPath: string;
 
   beforeAll(() => {
-    // The hook dynamic-imports built dist modules; make sure they're current.
-    execSync('npm run build:ts', { cwd: repoRoot, stdio: 'ignore' });
+    // The hook dynamic-imports built dist modules, so dist has to exist. Build
+    // ONLY when it doesn't: `npm run build:ts` starts by rm -rf'ing dist, and
+    // Jest runs suites in parallel — wiping dist mid-run races every other
+    // suite that asserts on a dist artefact (action-guard-hook-install's
+    // `existsSync(dist/index.js)` lost that race in CI on 27 Jul). CI builds
+    // before it runs tests, so this is a local-convenience path only.
+    const distProbes = [
+      join(repoRoot, 'dist', 'index.js'),
+      join(repoRoot, 'dist', 'defence', 'trust', 'recall-filter.js'),
+      join(repoRoot, 'dist', 'defence', 'audit', 'logger.js'),
+      join(repoRoot, 'dist', 'database', 'init.js'),
+    ];
+    if (!distProbes.every((p) => existsSync(p))) {
+      execSync('npm run build:ts', { cwd: repoRoot, stdio: 'ignore' });
+    }
 
     home = mkdtempSync(join(tmpdir(), 'recall-defence-it-'));
     mkdirSync(join(home, '.shieldcortex'), { recursive: true });

--- a/src/__tests__/recall-defence-integration.test.ts
+++ b/src/__tests__/recall-defence-integration.test.ts
@@ -52,10 +52,18 @@ describe('recall-defence integration — prompt-recall withholds a poisoned row'
 
   it('drops the injection row (access_count stays 0) and keeps the benign one', () => {
     const input = JSON.stringify({ prompt: 'how do I deploy this project', cwd: '/tmp/recall-it', session_id: null });
-    // Redirect homedir() (DB + config) at the temp dir; drop the per-worker
-    // config sandbox so the spawned hook reads our config.json.
+    // Redirect homedir() (DB + config) at the temp dir, then strip EVERY
+    // inherited SHIELDCORTEX_* var so the spawned hook runs against this
+    // fixture alone. Dropping only SHIELDCORTEX_CONFIG_DIR was not enough:
+    // on any box that actually runs the hooks, SHIELDCORTEX_PROJECT_KEY is
+    // exported in the shell, and deriveProjectKey() honours it ahead of the
+    // cwd basename — so the hook queried project "clawd" instead of
+    // "recall-it", matched nothing, injected nothing, and the benign row's
+    // access_count stayed 0 (issue #125).
     const env = { ...process.env, HOME: home, USERPROFILE: home };
-    delete (env as Record<string, string | undefined>).SHIELDCORTEX_CONFIG_DIR;
+    for (const key of Object.keys(env)) {
+      if (key.startsWith('SHIELDCORTEX_')) delete (env as Record<string, string | undefined>)[key];
+    }
 
     try {
       execFileSync('node', [HOOK], { input, env, timeout: 30_000, stdio: ['pipe', 'pipe', 'pipe'] });


### PR DESCRIPTION
Closes #125.

## Triage result: test-only, not a recall regression

Issue #125 offered two readings. It is reading 1 — with a specific cause: **environment leakage into the spawned hook**.

The test spawns `scripts/prompt-recall-hook.mjs` with `{...process.env}` and deleted only `SHIELDCORTEX_CONFIG_DIR`. On any box that actually runs the ShieldCortex hooks, **`SHIELDCORTEX_PROJECT_KEY` is exported in the shell**, and `deriveProjectKey()` honours that env var ahead of the cwd basename (resolution order step 1). So the hook queried project `clawd` while the fixture rows are project `recall-it` → FTS matched nothing → nothing injected → `benign.access_count` stayed 0, and no `defence_audit` row was written either.

## Evidence the product is fine

Same fixture, same hook, `SHIELDCORTEX_PROJECT_KEY` unset:

```
STDOUT: {"hookSpecificOutput":{"hookEventName":"UserPromptSubmit",
  "additionalContext":"🧠 Recalled from memory:\n- **Deploy runbook**: ... _[mem #1]_"}}
rows:  uuid-benign access_count=1   uuid-evil access_count=0
audit: reason='recall-withheld: instruction:hidden_instruction'
       threat_indicators=["recall:instruction"] firewall_result=BLOCK
```

Benign row injected and reinforced, injection row withheld and never reinforced, withhold audited. Recall-boundary defence behaves exactly as documented — no under-serving of legitimate memories.

## Fix

Strip every inherited `SHIELDCORTEX_*` var from the child env so the spawned hook runs against the fixture config alone.

`npm test -- src/__tests__/recall-defence-integration.test.ts` → 1/1 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)