### PR TITLE
fix(#129): first-run polish — doctor is honest on a fresh box, internal logs stay internal

### DIFF
--- a/src/__tests__/doctor-db-init-hint.test.ts
+++ b/src/__tests__/doctor-db-init-hint.test.ts
@@ -1,7 +1,9 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
-import { fileURLToPath } from 'url';
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+import { runDatabaseCheck } from '../cli/doctor.js';
 
 /**
  * Lock in the corrected DB-init hint. v4.12.1 doctor pointed users at
@@ -11,27 +13,37 @@ import { describe, expect, it } from '@jest/globals';
  *
  * The reliable one-shot init paths are `shieldcortex scan "..."` (any
  * install shape) or starting an MCP-bound session (Claude Code).
+ *
+ * Asserted against the check's actual output rather than doctor's source, so
+ * the guard survives refactors of how the check is wired up.
  */
-describe('doctor — database-not-found hint', () => {
-  const thisFile = fileURLToPath(import.meta.url);
-  const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
-  const doctorSource = fs.readFileSync(path.join(repoRoot, 'src', 'cli', 'doctor.ts'), 'utf-8');
+describe('doctor — database-not-initialised hint', () => {
+  const claudeEnv = { hasClaude: true, hasOpenClaw: false, hasVSCode: false, hasCodex: false, isHeadless: false };
+  let tmpDir: string;
+  let missingDb: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-db-hint-'));
+    missingDb = path.join(tmpDir, 'memories.db');
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
 
   it('does not suggest `shieldcortex quickstart` as a way to initialise the database', () => {
-    const checkDatabaseFn = doctorSource.match(/async function checkDatabase\(\)[\s\S]*?\n\}/);
-    expect(checkDatabaseFn).not.toBeNull();
-    expect(checkDatabaseFn![0]).not.toMatch(/quickstart.*?initialise the database/i);
-    expect(checkDatabaseFn![0]).not.toMatch(/run `shieldcortex quickstart`/);
+    const { fix } = runDatabaseCheck(missingDb, claudeEnv);
+    expect(fix).not.toMatch(/quickstart/i);
   });
 
   it('suggests `shieldcortex scan` as the explicit init command', () => {
-    const checkDatabaseFn = doctorSource.match(/async function checkDatabase\(\)[\s\S]*?\n\}/);
-    expect(checkDatabaseFn![0]).toMatch(/shieldcortex scan ["']init["']/);
+    const { fix } = runDatabaseCheck(missingDb, claudeEnv);
+    expect(fix).toMatch(/shieldcortex scan ["']init["']/);
   });
 
   it('still mentions the Claude Code MCP-server lazy-init path on Claude+OpenClaw hosts', () => {
-    const checkDatabaseFn = doctorSource.match(/async function checkDatabase\(\)[\s\S]*?\n\}/);
-    expect(checkDatabaseFn![0]).toMatch(/Claude Code session/i);
-    expect(checkDatabaseFn![0]).toMatch(/lazy-init|MCP server/i);
+    const { fix } = runDatabaseCheck(missingDb, claudeEnv);
+    expect(fix).toMatch(/Claude Code session/i);
+    expect(fix).toMatch(/lazy-init|MCP server/i);
   });
 });

--- a/src/__tests__/firstrun-output-hygiene.test.ts
+++ b/src/__tests__/firstrun-output-hygiene.test.ts
@@ -1,0 +1,136 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { debugLog, isDebugLoggingEnabled } from '../debug-log.js';
+import { closeDatabase, initDatabase } from '../database/init.js';
+
+/**
+ * First-run output hygiene (#129).
+ *
+ * A clean-box `remember` / `scan` printed three lines that belong to us, not
+ * to the user:
+ *
+ *   [database] Startup runtime=installed db=/root/.shieldcortex/memories.db …
+ *   [shieldcortex] pre-backfill snapshot saved: …/memories.db.pre-backfill-…
+ *   dtype not specified for "model". Using the default dtype (fp32) …
+ *
+ * Internal startup state, an internal restore-point path, and a dependency
+ * warning. All three now stay out of user output on a healthy install;
+ * `--verbose` / `SHIELDCORTEX_DEBUG` restores the first two.
+ */
+describe('debug gate', () => {
+  it('is off by default', () => {
+    expect(isDebugLoggingEnabled({}, ['node', 'shieldcortex', 'remember', 'hello'])).toBe(false);
+  });
+
+  it.each(['1', 'true', 'yes', 'on', 'anything-truthy'])('is on for SHIELDCORTEX_DEBUG=%s', (value) => {
+    expect(isDebugLoggingEnabled({ SHIELDCORTEX_DEBUG: value }, ['node', 'shieldcortex'])).toBe(true);
+  });
+
+  it.each(['0', 'false', 'no', 'off', ''])('stays off for SHIELDCORTEX_DEBUG=%s', (value) => {
+    expect(isDebugLoggingEnabled({ SHIELDCORTEX_DEBUG: value }, ['node', 'shieldcortex'])).toBe(false);
+  });
+
+  it.each(['--verbose', '--debug'])('is on for %s on the command line', (flag) => {
+    expect(isDebugLoggingEnabled({}, ['node', 'shieldcortex', 'scan', 'x', flag])).toBe(true);
+  });
+
+  it('lets --verbose win over an inherited SHIELDCORTEX_DEBUG=0', () => {
+    expect(isDebugLoggingEnabled({ SHIELDCORTEX_DEBUG: '0' }, ['node', 'shieldcortex', '--verbose'])).toBe(true);
+  });
+
+  it('writes to stderr only when enabled', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const previous = process.env.SHIELDCORTEX_DEBUG;
+    try {
+      delete process.env.SHIELDCORTEX_DEBUG;
+      debugLog('internal detail');
+      expect(spy).not.toHaveBeenCalled();
+
+      process.env.SHIELDCORTEX_DEBUG = '1';
+      debugLog('internal detail');
+      expect(spy).toHaveBeenCalledWith('internal detail');
+    } finally {
+      if (previous === undefined) delete process.env.SHIELDCORTEX_DEBUG;
+      else process.env.SHIELDCORTEX_DEBUG = previous;
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('database startup diagnostics stay out of user output', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let previousDebug: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-quiet-startup-'));
+    dbPath = path.join(tmpDir, 'memories.db');
+    previousDebug = process.env.SHIELDCORTEX_DEBUG;
+    delete process.env.SHIELDCORTEX_DEBUG;
+    closeDatabase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    if (previousDebug === undefined) delete process.env.SHIELDCORTEX_DEBUG;
+    else process.env.SHIELDCORTEX_DEBUG = previousDebug;
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  function captureStderrDuringInit(): string {
+    const lines: string[] = [];
+    const spy = jest.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      lines.push(args.map(String).join(' '));
+    });
+    try {
+      initDatabase(dbPath);
+    } finally {
+      spy.mockRestore();
+      closeDatabase();
+    }
+    return lines.join('\n');
+  }
+
+  it('does not print the [database] Startup line by default', () => {
+    expect(captureStderrDuringInit()).not.toMatch(/\[database\] Startup/);
+  });
+
+  it('prints it again under SHIELDCORTEX_DEBUG', () => {
+    process.env.SHIELDCORTEX_DEBUG = '1';
+    expect(captureStderrDuringInit()).toMatch(/\[database\] Startup runtime=/);
+  });
+
+  it('never leaks an internal restore-point path by default', () => {
+    // First init creates the file; a second init is what can take the
+    // pre-backfill snapshot of an existing database.
+    captureStderrDuringInit();
+    const output = captureStderrDuringInit();
+    expect(output).not.toMatch(/pre-backfill snapshot saved/);
+    expect(output).not.toMatch(/\.pre-backfill-/);
+  });
+});
+
+describe('embedding model load does not warn about dtype', () => {
+  const thisFile = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
+
+  it.each([
+    ['src/embeddings/worker.ts'],
+    ['src/defence/judge/worker.ts'],
+  ])('%s pins an explicit dtype on its transformers pipeline', (relPath) => {
+    const source = fs.readFileSync(path.join(repoRoot, relPath), 'utf-8');
+    // transformers.js prints `dtype not specified for "model" …` to the
+    // console whenever a pipeline is constructed without one. Inspect the
+    // options block of every pipeline construction in the file.
+    const callSites = [...source.matchAll(/\bpipeline(?:Fn)?\(/g)];
+    expect(callSites.length).toBeGreaterThan(0);
+    for (const site of callSites) {
+      const optionsBlock = source.slice(site.index!, site.index! + 400);
+      expect(optionsBlock).toMatch(/dtype:\s*'[a-z0-9]+'/);
+    }
+  });
+});

--- a/src/cli/__tests__/doctor-fresh-install.test.ts
+++ b/src/cli/__tests__/doctor-fresh-install.test.ts
@@ -1,0 +1,168 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createRequire } from 'module';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+import {
+  partitionUninitialisedSkips,
+  runDatabaseCheck,
+  runHooksCheck,
+  runMemoryStatsCheck,
+  runSchemaDriftCheck,
+  runWritePathProbe,
+  type CheckResult,
+} from '../doctor.js';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * First-run health contract (#129).
+ *
+ * On a virgin box — global install, nothing written yet — `doctor` used to
+ * print a red `❌ Database: not found` plus four dependent ⚠️ lines. Nothing
+ * was wrong: the database is created lazily on the first memory operation and
+ * `~/.claude/settings.json` only exists once Claude Code has run. But doctor
+ * is precisely the command a new user runs to confirm the install worked, and
+ * a red cross there reads as "this product is broken".
+ *
+ * The contract these tests lock in:
+ *   - normal-for-a-fresh-install states are ℹ️ with an actionable next step
+ *   - the dependent "no database" checks collapse to one note, not four ⚠️
+ *   - a genuinely broken database is still ❌
+ */
+describe('doctor — fresh-install states are informational, not failures', () => {
+  const claudeEnv = { hasClaude: true, hasOpenClaw: false, hasVSCode: false, hasCodex: false, isHeadless: false };
+  const openClawEnv = { hasClaude: false, hasOpenClaw: true, hasVSCode: false, hasCodex: false, isHeadless: true };
+
+  let tmpDir: string;
+  let missingDb: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-firstrun-'));
+    missingDb = path.join(tmpDir, 'memories.db');
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  describe('Database check', () => {
+    it('reports "not initialised yet" as info, never a failure', () => {
+      const result = runDatabaseCheck(missingDb, claudeEnv);
+      expect(result.status).toBe('info');
+      expect(result.message).toMatch(/not initialised yet/i);
+      expect(result.message).not.toMatch(/not found/i);
+    });
+
+    it('gives an actionable next step on a Claude Code host', () => {
+      const result = runDatabaseCheck(missingDb, claudeEnv);
+      expect(result.fix).toMatch(/shieldcortex scan ["']init["']/);
+      expect(result.fix).toMatch(/Claude Code session/i);
+      expect(result.fix).toMatch(/lazy-init|MCP server/i);
+    });
+
+    it('gives an OpenClaw-only host a next step that does not depend on an MCP server', () => {
+      const result = runDatabaseCheck(missingDb, openClawEnv);
+      expect(result.fix).toMatch(/shieldcortex scan ["']init["']/);
+      expect(result.fix).not.toMatch(/Claude Code session/i);
+    });
+
+    it('still reports a healthy database as pass', () => {
+      const Database = require('better-sqlite3');
+      const db = new Database(missingDb);
+      db.exec('CREATE TABLE memories (id INTEGER PRIMARY KEY)');
+      db.close();
+
+      const result = runDatabaseCheck(missingDb, claudeEnv);
+      expect(result.status).toBe('pass');
+      expect(result.message).toMatch(/healthy/);
+    });
+
+    it('STILL reports ❌ for a genuinely broken database file', () => {
+      // A file that exists but is not a database — the case the info status
+      // must never swallow.
+      fs.writeFileSync(missingDb, Buffer.from('this is not a sqlite file, at all'));
+
+      const result = runDatabaseCheck(missingDb, claudeEnv);
+      expect(result.status).toBe('fail');
+      expect(result.fix).toBeDefined();
+    });
+  });
+
+  describe('dependent checks', () => {
+    it.each([
+      ['Schema', () => runSchemaDriftCheck(missingDb)],
+      ['Write path', () => runWritePathProbe(missingDb)],
+      ['Memories', () => runMemoryStatsCheck(missingDb)],
+    ])('%s is info + marked skipped when there is no database yet', (label, run) => {
+      const result = run();
+      expect(result.label).toBe(label);
+      expect(result.status).toBe('info');
+      expect(result.skipped).toBe('db-uninitialised');
+    });
+
+    it('collapses the dependent skips out of the printed report', () => {
+      const results: CheckResult[] = [
+        runDatabaseCheck(missingDb, claudeEnv),
+        runSchemaDriftCheck(missingDb),
+        runWritePathProbe(missingDb),
+        runMemoryStatsCheck(missingDb),
+        { label: 'Processes', status: 'pass', message: 'fine' },
+      ];
+
+      const { visible, suppressed } = partitionUninitialisedSkips(results);
+      expect(suppressed.map(r => r.label)).toEqual(['Schema', 'Write path', 'Memories']);
+      expect(visible.map(r => r.label)).toEqual(['Database', 'Processes']);
+    });
+
+    it('keeps real findings visible — suppression is scoped to the uninitialised case', () => {
+      const results: CheckResult[] = [
+        { label: 'Schema', status: 'warn', message: 'drift: missing defence_verdict' },
+        { label: 'Write path', status: 'fail', message: 'round-trip failed' },
+      ];
+      const { visible, suppressed } = partitionUninitialisedSkips(results);
+      expect(suppressed).toHaveLength(0);
+      expect(visible).toHaveLength(2);
+    });
+  });
+
+  describe('Hooks check', () => {
+    it('treats a missing settings.json on a Claude host as info with a next step', () => {
+      const result = runHooksCheck(path.join(tmpDir, 'settings.json'), claudeEnv);
+      expect(result.status).toBe('info');
+      expect(result.fix).toMatch(/shieldcortex install/);
+    });
+
+    it('treats a host without Claude Code as info, with nothing to fix', () => {
+      const result = runHooksCheck(path.join(tmpDir, 'settings.json'), openClawEnv);
+      expect(result.status).toBe('info');
+      expect(result.message).toMatch(/not applicable/i);
+      expect(result.fix).toBeUndefined();
+    });
+
+    it('STILL warns when settings.json exists but the hooks are not wired', () => {
+      const settingsPath = path.join(tmpDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify({ hooks: {} }));
+
+      const result = runHooksCheck(settingsPath, claudeEnv);
+      expect(result.status).toBe('warn');
+      expect(result.message).toMatch(/missing:/);
+    });
+  });
+
+  it('produces a clean-box report with no ❌ and no ⚠️', () => {
+    // The acceptance criterion from #129, assembled from the checks that were
+    // red/yellow on the observed clean-box run.
+    const results: CheckResult[] = [
+      runDatabaseCheck(missingDb, openClawEnv),
+      runSchemaDriftCheck(missingDb),
+      runWritePathProbe(missingDb),
+      runMemoryStatsCheck(missingDb),
+      runHooksCheck(path.join(tmpDir, 'settings.json'), openClawEnv),
+    ];
+
+    expect(results.filter(r => r.status === 'fail')).toEqual([]);
+    expect(results.filter(r => r.status === 'warn')).toEqual([]);
+  });
+});

--- a/src/cli/__tests__/doctor-fresh-install.test.ts
+++ b/src/cli/__tests__/doctor-fresh-install.test.ts
@@ -5,6 +5,7 @@ import { createRequire } from 'module';
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
 import {
+  missingWorkerStateResult,
   partitionUninitialisedSkips,
   runDatabaseCheck,
   runHooksCheck,
@@ -151,6 +152,20 @@ describe('doctor — fresh-install states are informational, not failures', () =
     });
   });
 
+  describe('Brain worker check', () => {
+    it('is info when nothing has run on this box yet', () => {
+      const result = missingWorkerStateResult(false);
+      expect(result.status).toBe('info');
+      expect(result.message).toMatch(/not started yet/i);
+    });
+
+    it('STILL warns when a database exists but the worker never recorded a tick', () => {
+      const result = missingWorkerStateResult(true);
+      expect(result.status).toBe('warn');
+      expect(result.fix).toBeDefined();
+    });
+  });
+
   it('produces a clean-box report with no ❌ and no ⚠️', () => {
     // The acceptance criterion from #129, assembled from the checks that were
     // red/yellow on the observed clean-box run.
@@ -160,6 +175,7 @@ describe('doctor — fresh-install states are informational, not failures', () =
       runWritePathProbe(missingDb),
       runMemoryStatsCheck(missingDb),
       runHooksCheck(path.join(tmpDir, 'settings.json'), openClawEnv),
+      missingWorkerStateResult(false),
     ];
 
     expect(results.filter(r => r.status === 'fail')).toEqual([]);

--- a/src/cli/__tests__/doctor-schema-drift.test.ts
+++ b/src/cli/__tests__/doctor-schema-drift.test.ts
@@ -31,10 +31,14 @@ describe('doctor schema drift check', () => {
     try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
-  it('returns "warn / skipped" when the database file does not exist', () => {
+  // Skipped, not warned: "no database yet" is the normal state of a fresh
+  // install (the DB is created lazily on first use), so this is reported as
+  // info and collapsed out of doctor's printed report (#129).
+  it('skips cleanly, without crashing or warning, when the database file does not exist', () => {
     const result = runSchemaDriftCheck(dbPath);
-    expect(result.status).toBe('warn');
-    expect(result.message).toMatch(/no database/i);
+    expect(result.status).toBe('info');
+    expect(result.skipped).toBe('db-uninitialised');
+    expect(result.message).toMatch(/database not created yet/i);
   });
 
   it('passes on a freshly initialised (fully migrated) database', () => {

--- a/src/cli/__tests__/doctor-write-probe.test.ts
+++ b/src/cli/__tests__/doctor-write-probe.test.ts
@@ -10,7 +10,7 @@ import { closeDatabase, getCanonicalSchema, initDatabase } from '../../database/
  * The doctor's write-path probe is the smoking-gun check for stale
  * schema or migration drift. It has to:
  *   - Pass on a healthy database (round-trip succeeds, leaves no rows).
- *   - Warn cleanly when the database file doesn't exist (don't crash).
+ *   - Skip cleanly when the database file doesn't exist (don't crash).
  *   - Fail with the actual error when the schema is broken.
  *
  * v4.12.4 (path encoding) and v4.12.5 (NOT NULL UUID) both shipped
@@ -32,10 +32,14 @@ describe('doctor write-path probe', () => {
     try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
   });
 
-  it('returns "warn / skipped" when the database file does not exist', () => {
+  // Skipped, not warned: "no database yet" is the normal state of a fresh
+  // install (the DB is created lazily on first use), so this is reported as
+  // info and collapsed out of doctor's printed report (#129).
+  it('skips cleanly, without crashing or warning, when the database file does not exist', () => {
     const result = runWritePathProbe(dbPath);
-    expect(result.status).toBe('warn');
-    expect(result.message).toMatch(/no database/i);
+    expect(result.status).toBe('info');
+    expect(result.skipped).toBe('db-uninitialised');
+    expect(result.message).toMatch(/database not created yet/i);
   });
 
   it('passes the round-trip on a freshly initialised database and leaves no probe rows behind', () => {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -43,6 +43,24 @@ export interface CheckResult {
   status: CheckStatus;
   message: string;
   fix?: string;
+  /**
+   * Set when the check did not run because a prerequisite simply does not
+   * exist yet on a fresh install. runDoctor() collapses these into a single
+   * dim note instead of printing a line per dependent check — the cascade of
+   * "skipped (no database)" warnings read as four separate faults on a
+   * perfectly healthy first run (#129).
+   */
+  skipped?: 'db-uninitialised';
+}
+
+/**
+ * Uniform "the database hasn't been created yet" result for the checks that
+ * need a database to say anything at all. Informational, never a warning:
+ * the DB is created lazily on first use, so its absence on a fresh install
+ * is the expected state, not a fault.
+ */
+function skippedNoDatabase(label: string): CheckResult {
+  return { label, status: 'info', message: 'skipped — database not created yet', skipped: 'db-uninitialised' };
 }
 
 function icon(status: CheckStatus): string {
@@ -103,23 +121,29 @@ function getDbPath(): string {
 }
 
 // ── Check 1: Database health ──────────────────────────────
-async function checkDatabase(): Promise<CheckResult> {
-  const dbPath = getDbPath();
-
+/**
+ * Pure helper for the database health check. Exported so tests can drive it
+ * against any path/environment without going through doctor's homedir-derived
+ * getDbPath().
+ */
+export function runDatabaseCheck(dbPath: string, env: Environment = detectEnvironment()): CheckResult {
   if (!fs.existsSync(dbPath)) {
-    // The database is created lazily on the first memory operation.
+    // Not a failure. The database is created lazily on the first memory
+    // operation, so "no database yet" is the normal state of a fresh install —
+    // and doctor is exactly the command a new user runs to check the install
+    // worked. Reporting ❌ there told healthy installs they were broken (#129).
+    //
     // `quickstart` only configures hooks/MCP — it does NOT touch the DB.
     // The reliable one-shot init paths are: `shieldcortex scan "..."`
     // (works on every install shape) or starting an MCP-bound session
     // (Claude Code) which lazy-inits via the MCP server.
-    const env = detectEnvironment();
     const fix = env.hasClaude
       ? 'Run `shieldcortex scan "init"` to create the database now, or start a Claude Code session — the MCP server will lazy-init on first memory call'
       : 'Run `shieldcortex scan "init"` to create the database now (OpenClaw-only / headless install)';
     return {
       label: 'Database',
-      status: 'fail',
-      message: 'not found',
+      status: 'info',
+      message: 'not initialised yet — created automatically on first use',
       fix,
     };
   }
@@ -167,6 +191,10 @@ async function checkDatabase(): Promise<CheckResult> {
   }
 }
 
+async function checkDatabase(): Promise<CheckResult> {
+  return runDatabaseCheck(getDbPath());
+}
+
 // ── Check 2: Schema version ──────────────────────────────
 /**
  * Diff the live memories table against the canonical schema instead of a
@@ -183,7 +211,7 @@ async function checkDatabase(): Promise<CheckResult> {
  */
 export function runSchemaDriftCheck(dbPath: string): CheckResult {
   if (!fs.existsSync(dbPath)) {
-    return { label: 'Schema', status: 'warn', message: 'skipped (no database)' };
+    return skippedNoDatabase('Schema');
   }
 
   try {
@@ -230,10 +258,13 @@ async function checkSchema(): Promise<CheckResult> {
 }
 
 // ── Check 3: Memory stats ─────────────────────────────────
-async function checkMemoryStats(): Promise<CheckResult> {
-  const dbPath = getDbPath();
+/**
+ * Pure helper for the memory-count check. Exported so tests can drive it
+ * against a temp database instead of the homedir install.
+ */
+export function runMemoryStatsCheck(dbPath: string): CheckResult {
   if (!fs.existsSync(dbPath)) {
-    return { label: 'Memories', status: 'warn', message: 'skipped (no database)' };
+    return skippedNoDatabase('Memories');
   }
 
   try {
@@ -273,6 +304,10 @@ async function checkMemoryStats(): Promise<CheckResult> {
   }
 }
 
+async function checkMemoryStats(): Promise<CheckResult> {
+  return runMemoryStatsCheck(getDbPath());
+}
+
 // ── Check 3b: Write-path smoke test ───────────────────────
 /**
  * The honest "is it working?" check.
@@ -295,7 +330,7 @@ async function checkMemoryStats(): Promise<CheckResult> {
  */
 export function runWritePathProbe(dbPath: string, env: Environment = detectEnvironment()): CheckResult {
   if (!fs.existsSync(dbPath)) {
-    return { label: 'Write path', status: 'warn', message: 'skipped (no database)' };
+    return skippedNoDatabase('Write path');
   }
 
   let db: any = null;
@@ -383,16 +418,29 @@ async function checkWritePath(): Promise<CheckResult> {
 }
 
 // ── Check 4: Hook installation ────────────────────────────
-async function checkHooks(): Promise<CheckResult> {
-  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
-
+/**
+ * Pure helper for the hook-installation check. Exported so tests can point it
+ * at a temp settings.json (or a deliberately absent one) without touching the
+ * real homedir.
+ */
+export function runHooksCheck(settingsPath: string, env: Environment = detectEnvironment()): CheckResult {
   if (!fs.existsSync(settingsPath)) {
-    return {
-      label: 'Hooks',
-      status: 'warn',
-      message: 'settings.json not found',
-      fix: 'Run `shieldcortex install` to configure hooks',
-    };
+    // No settings.json is not a fault. Either Claude Code isn't on this box at
+    // all (OpenClaw-only / headless installs never grow one), or it is and the
+    // user hasn't run `shieldcortex install` yet — the exact state of every
+    // fresh install. A ⚠️ here told healthy boxes something was wrong (#129).
+    return env.hasClaude
+      ? {
+          label: 'Hooks',
+          status: 'info',
+          message: 'not configured yet — no ~/.claude/settings.json',
+          fix: 'Run `shieldcortex install` to configure hooks',
+        }
+      : {
+          label: 'Hooks',
+          status: 'info',
+          message: 'not applicable — Claude Code not detected on this host',
+        };
   }
 
   try {
@@ -441,6 +489,10 @@ async function checkHooks(): Promise<CheckResult> {
     const msg = err instanceof Error ? err.message : String(err);
     return { label: 'Hooks', status: 'warn', message: `check failed — ${msg}` };
   }
+}
+
+async function checkHooks(): Promise<CheckResult> {
+  return runHooksCheck(path.join(os.homedir(), '.claude', 'settings.json'));
 }
 
 // ── Check 4b: Auto-memory hook gates ──────────────────────
@@ -2327,6 +2379,22 @@ export async function checkDashboardFreshness(): Promise<CheckResult> {
   }
 }
 
+/**
+ * Split the report into lines worth printing and the dependent checks that
+ * were skipped only because the database has not been created yet.
+ *
+ * Exported for tests: the first-run contract is that a clean box shows no ❌
+ * and no ⚠️, and that the cascade of dependent skips collapses to one note.
+ */
+export function partitionUninitialisedSkips(
+  results: CheckResult[],
+): { visible: CheckResult[]; suppressed: CheckResult[] } {
+  return {
+    visible: results.filter(r => r.skipped !== 'db-uninitialised'),
+    suppressed: results.filter(r => r.skipped === 'db-uninitialised'),
+  };
+}
+
 export async function runDoctor(args: string[] = []): Promise<void> {
   console.log(`\n${bold}ShieldCortex Doctor${reset} v${pkg.version}\n`);
 
@@ -2398,17 +2466,25 @@ export async function runDoctor(args: string[] = []): Promise<void> {
     }
   }
 
+  // Collapse the dependent "no database yet" checks into one dim note. On a
+  // fresh install they added Schema/Write path/Memories lines that all restate
+  // the same single fact already reported by the Database line (#129).
+  const { visible, suppressed } = partitionUninitialisedSkips(results);
+
   // Print results
-  for (const r of results) {
+  for (const r of visible) {
     console.log(`  ${icon(r.status)} ${bold}${r.label}:${reset} ${r.message}`);
+  }
+  if (suppressed.length > 0) {
+    console.log(`  ${dim}(${suppressed.map(r => r.label).join(', ')} checked once the database exists)${reset}`);
   }
 
   // Summary
-  const passed = results.filter(r => r.status === 'pass').length;
-  const warnings = results.filter(r => r.status === 'warn').length;
-  const failures = results.filter(r => r.status === 'fail').length;
-  const infos = results.filter(r => r.status === 'info').length;
-  const total = results.length;
+  const passed = visible.filter(r => r.status === 'pass').length;
+  const warnings = visible.filter(r => r.status === 'warn').length;
+  const failures = visible.filter(r => r.status === 'fail').length;
+  const infos = visible.filter(r => r.status === 'info').length;
+  const total = visible.length;
 
   console.log('');
   const parts: string[] = [];
@@ -2419,7 +2495,7 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   console.log(`  ${parts.join(', ')}`);
 
   // Suggested fixes
-  const fixes = results.filter(r => r.fix);
+  const fixes = visible.filter(r => r.fix);
   if (fixes.length > 0) {
     console.log(`\n  ${bold}Suggested fixes:${reset}`);
     for (const f of fixes) {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1675,6 +1675,34 @@ function workerRecoveryFix(): string {
 // not a failure.
 const WORKER_TAKEOVER_GRACE_MS = MCP_LIGHT_TICK_INTERVAL_MS + 5 * 60 * 1000;
 
+/**
+ * "No worker.json" means two different things depending on whether the product
+ * has ever run on this box.
+ *
+ * With no database either, nothing has run yet — the worker starts with the
+ * first ShieldCortex session, so its absence is the normal state of a fresh
+ * install and a ⚠️ there is the same false alarm as ❌ Database (#129).
+ *
+ * With a database present, something HAS run and the worker still never
+ * recorded a tick — that is a real gap, and still warns.
+ */
+export function missingWorkerStateResult(databaseExists: boolean): CheckResult {
+  if (!databaseExists) {
+    return {
+      label: 'Brain worker',
+      status: 'info',
+      message: 'not started yet — starts with your first ShieldCortex session',
+      fix: workerRecoveryFix(),
+    };
+  }
+  return {
+    label: 'Brain worker',
+    status: 'warn',
+    message: 'no worker.json — worker has not run yet',
+    fix: workerRecoveryFix(),
+  };
+}
+
 export async function checkBrainWorker(): Promise<CheckResult> {
   if (process.env.SHIELDCORTEX_DISABLE_WORKER === '1') {
     return {
@@ -1685,12 +1713,7 @@ export async function checkBrainWorker(): Promise<CheckResult> {
   }
   const statePath = path.join(getShieldCortexDir(), 'state', 'worker.json');
   if (!fs.existsSync(statePath)) {
-    return {
-      label: 'Brain worker',
-      status: 'warn',
-      message: 'no worker.json — worker has not run yet',
-      fix: workerRecoveryFix(),
-    };
+    return missingWorkerStateResult(fs.existsSync(getDbPath()));
   }
   try {
     const raw = JSON.parse(fs.readFileSync(statePath, 'utf-8')) as {

--- a/src/database/init.ts
+++ b/src/database/init.ts
@@ -12,6 +12,7 @@ import { execSync } from 'child_process';
 import { runMigrations } from './migrations.js';
 import { getInlineSchema } from './inline-schema.js';
 import { seedDefaultFirewallRules } from './seed-firewall-rules.js';
+import { debugLog } from '../debug-log.js';
 
 const _currentFile = fileURLToPath(import.meta.url);
 const _currentDir = dirname(_currentFile);
@@ -519,7 +520,9 @@ export function initDatabase(dbPath?: string): Database.Database {
   currentDbPath = expandedPath;
   acquireStartupLock(expandedPath);
 
-  console.error(`[database] Startup runtime=${resolveRuntimeInfo().kind} db=${expandedPath} wal=${existsSync(expandedPath + '-wal')} shm=${existsSync(expandedPath + '-shm')}`);
+  // Internal startup state — support-thread material, not user output. Silent
+  // unless SHIELDCORTEX_DEBUG / --verbose asks for it (#129).
+  debugLog(`[database] Startup runtime=${resolveRuntimeInfo().kind} db=${expandedPath} wal=${existsSync(expandedPath + '-wal')} shm=${existsSync(expandedPath + '-shm')}`);
 
   // Lazily inspect `.corrupt.*` backups (Phase 17 B4). Each backup inspection
   // opens the file read-only and runs a FULL integrity check, so doing it
@@ -703,7 +706,9 @@ export function initDatabase(dbPath?: string): Database.Database {
       db.pragma('wal_checkpoint(TRUNCATE)');
       const snapshotPath = `${expandedPath}.pre-backfill-${Date.now()}`;
       copyFileSync(expandedPath, snapshotPath);
-      console.error(`[shieldcortex] pre-backfill snapshot saved: ${snapshotPath}`);
+      // Debug-gated: the snapshot is an internal restore point and the line
+      // leaks its on-disk path into user output otherwise (#129).
+      debugLog(`[shieldcortex] pre-backfill snapshot saved: ${snapshotPath}`);
     }
   } catch {
     // Best-effort restore point; never block startup.

--- a/src/debug-log.ts
+++ b/src/debug-log.ts
@@ -1,0 +1,42 @@
+/**
+ * Debug gate for internal diagnostic logging.
+ *
+ * Startup diagnostics (database runtime state, restore-point paths, …) are
+ * invaluable when a support thread is open and pure noise the rest of the time.
+ * Before v4.47.17 they were printed unconditionally, so the very first thing a
+ * new user saw from `remember`/`scan` was a `[database] Startup runtime=…` line
+ * and an internal `.pre-backfill-…` path — internal state leaking into user
+ * output on a healthy install (#129).
+ *
+ * Everything routed through `debugLog()` is silent by default and restored by
+ * either `SHIELDCORTEX_DEBUG` or a `--verbose` / `--debug` flag on the command
+ * line. Output always goes to stderr, never stdout: the MCP stdio transport
+ * owns stdout and a stray byte there closes the connection.
+ */
+
+const FALSY = /^(0|false|no|off)$/i;
+
+/**
+ * True when internal diagnostics should be printed.
+ *
+ * `--verbose` / `--debug` on the command line always wins — the documented
+ * "show me everything" escape hatch must not be defeated by an inherited
+ * `SHIELDCORTEX_DEBUG=0` in the environment.
+ */
+export function isDebugLoggingEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+  argv: readonly string[] = process.argv,
+): boolean {
+  if (argv.includes('--verbose') || argv.includes('--debug')) return true;
+  const raw = (env.SHIELDCORTEX_DEBUG ?? '').trim();
+  if (raw === '') return false;
+  return !FALSY.test(raw);
+}
+
+/**
+ * Print an internal diagnostic line — stderr, and only when debug/verbose is on.
+ */
+export function debugLog(...args: unknown[]): void {
+  if (!isDebugLoggingEnabled()) return;
+  console.error(...args);
+}

--- a/src/embeddings/worker.ts
+++ b/src/embeddings/worker.ts
@@ -39,9 +39,16 @@ let extractor: any = null;
 async function loadModel(): Promise<void> {
   if (extractor) return;
   await initTransformers();
+  // dtype is pinned explicitly. Omitting it makes transformers.js print
+  //   dtype not specified for "model". Using the default dtype (fp32) ...
+  // to the console on every model load — a dependency warning that surfaced in
+  // user-facing `remember`/`scan` output on a healthy install (#129). fp32 is
+  // exactly what it was defaulting to on CPU, so behaviour is unchanged; the
+  // defence judge worker pins its dtype the same way.
   extractor = await pipelineFn(
     'feature-extraction',
     'Xenova/all-MiniLM-L6-v2',
+    { dtype: 'fp32' },
   );
 }
 


### PR DESCRIPTION
Closes #129.

Two first-run polish defects, both landing on the exact user deciding whether to keep us.

## 1. `doctor` reported a red ❌ on a healthy fresh install

On a virgin box `doctor` printed `❌ Database: not found` plus a cascade of dependent ⚠️ lines. Nothing was wrong — the database is created lazily on the first memory operation, `~/.claude/settings.json` only exists once Claude Code has run, and the brain worker starts with the first session — but `doctor` is exactly the command a new user runs to confirm the install worked.

- **Database** and **Hooks** are now ℹ️, with the actionable next step preserved in the fix line.
- The dependent **Schema / Write path / Memories** checks are marked skipped and **collapse into a single dim note** instead of three warnings restating one fact.
- **Brain worker** is informational *when there is no database either* — nothing has run at all, so the worker not having started is the normal state.

Genuine faults are untouched, and each has a test:

| state | still reports |
|---|---|
| corrupt / unreadable DB file | ❌ |
| `settings.json` present, hooks not wired | ⚠️ |
| DB present but worker never ticked | ⚠️ |
| real schema drift / write-path failure | ⚠️ / ❌ |

## 2. Internal logging leaked into user output

`remember` and `scan` printed three lines that belong to us, not the user. The `[database] Startup …` state dump and the `[shieldcortex] pre-backfill snapshot saved: <path>` line (which also leaked an internal on-disk path) now route through a shared debug gate in `src/debug-log.ts` — silent by default, restored by `SHIELDCORTEX_DEBUG` or `--verbose` / `--debug` (the flag wins over an inherited `SHIELDCORTEX_DEBUG=0`, so the documented escape hatch can't be defeated by the environment). Output still goes to stderr, never stdout, so the MCP stdio transport is unaffected.

The `dtype not specified for "model"` warning is fixed at source by pinning `dtype: 'fp32'` on the embedding pipeline — the same thing `src/defence/judge/worker.ts` already does. fp32 is exactly what transformers.js was defaulting to on CPU, and the only cached ONNX file is the fp32 `model.onnx`, so nothing new is downloaded. Verified byte-identical: embedding the same string through the built worker with and without the pin gives `dims=384 sum=0.082104042 first3=0.035496801,0.061286218,0.052692048` either way — only the warning differs.

---

## Clean-box proof — node:22-slim, throwaway container, global install

BEFORE is `scripts/sc-firstrun-testbed.sh` against the published `shieldcortex@latest` (v4.47.16). AFTER is the same script adapted to `npm install -g` a local `npm pack` tarball of this branch, plus two extra steps (`--verbose`, and a second `doctor` once the DB exists). All nine steps PASS, no user-visible errors.

### `doctor` — BEFORE

```
ShieldCortex Doctor v4.47.16

  ❌ Database: not found
  ⚠️  Schema: skipped (no database)
  ⚠️  Write path: skipped (no database)
  ⚠️  Memories: skipped (no database)
  ⚠️  Hooks: settings.json not found
  ℹ️  Hook timeouts: skipped (settings.json not found)
  ℹ️  Auto-memory: Stop hook: opt-in (not installed)
  ℹ️  Auto-memory: SessionEnd hook: opt-in (not installed)
  ✅ Auto-memory sampling: every 5 turn(s), salience-bypass on
  ⚠️  Brain worker: no worker.json — worker has not run yet
  ℹ️  Project keys: skipped (no DB yet)
  ...
  5/27 checks passed, 5 warnings, 1 failure, 16 info

  Suggested fixes:
  → Run `shieldcortex scan "init"` to create the database now (OpenClaw-only / headless install)
  → Run `shieldcortex install` to configure hooks
  → For persistence, run `shieldcortex service install --headless` (recommended on headless hosts) or restart Claude Code
```

### `doctor` — AFTER

```
ShieldCortex Doctor v4.47.16

  ℹ️  Database: not initialised yet — created automatically on first use
  ℹ️  Hooks: not applicable — Claude Code not detected on this host
  ℹ️  Hook timeouts: skipped (settings.json not found)
  ℹ️  Auto-memory: Stop hook: opt-in (not installed)
  ℹ️  Auto-memory: SessionEnd hook: opt-in (not installed)
  ✅ Auto-memory sampling: every 5 turn(s), salience-bypass on
  ℹ️  Brain worker: not started yet — starts with your first ShieldCortex session
  ℹ️  Project keys: skipped (no DB yet)
  ℹ️  API server: not running (optional on headless/OpenClaw-only setups)
  ℹ️  Dashboard: not running (optional on headless/OpenClaw-only setups)
  ℹ️  Dashboard freshness: no managed dashboard service running
  ✅ Disk: 188 B / 100 MB limit
  ✅ Lock: clean
  ℹ️  OpenClaw residue: skipped (OpenClaw not detected)
  ℹ️  OpenClaw hook: skipped (cortex-memory hook not installed)
  ℹ️  OpenClaw plugin version: skipped (OpenClaw plugin registry not present)
  ℹ️  OpenClaw plugin loaded: skipped (OpenClaw not detected)
  ℹ️  OpenClaw plugin running version: skipped (OpenClaw not detected)
  ℹ️  OpenClaw plugin pkg: skipped (OpenClaw plugin dir not present)
  ℹ️  OpenClaw dup installs: skipped (OpenClaw not detected)
  ℹ️  OpenClaw plugin pins: skipped (OpenClaw not detected)
  ✅ Defence canary: caught (4ms, pattern: defence_canary)
  ✅ Action guard: verdict probes 3/3 (catastrophic→block, dangerous→approval, benign→allow) in 11ms — ...
  ℹ️  Embeddings: model not cached — will download on first recall
  (Schema, Write path, Memories checked once the database exists)

  5/24 checks passed, 19 info

  Suggested fixes:
  → Run `shieldcortex scan "init"` to create the database now (OpenClaw-only / headless install)
  → For persistence, run `shieldcortex service install --headless` (recommended on headless hosts) or restart Claude Code
```

**Zero ❌, zero ⚠️** — the acceptance criterion from the issue.

### `remember` / `scan` — BEFORE

```
===STEP remember===
[database] Startup runtime=installed db=/root/.shieldcortex/memories.db wal=false shm=false
[shieldcortex] pre-backfill snapshot saved: /root/.shieldcortex/memories.db.pre-backfill-1785267251624
dtype not specified for "model". Using the default dtype (fp32) for this device (cpu).
Remembered "first run smoke" (id 1, note, salience 25%).

===STEP scan===
[database] Startup runtime=installed db=/root/.shieldcortex/memories.db wal=false shm=false
[shieldcortex] pre-backfill snapshot saved: /root/.shieldcortex/memories.db.pre-backfill-1785267255937

ShieldCortex Scan Result
──────────────────────────────────────────────────
  Result:      QUARANTINE
  Trust:       0.90
  Sensitivity: PUBLIC
  Anomaly:     0.00
  Reason:      Quarantined: Instruction injection detected (confidence: 0.8)
  Threats:     instruction_injection
  Patterns:    hidden_instruction
```

### `remember` / `scan` — AFTER

```
===STEP remember===
Remembered "first run smoke" (id 1, note, salience 25%).

===STEP scan===

ShieldCortex Scan Result
──────────────────────────────────────────────────
  Result:      QUARANTINE
  Trust:       0.90
  Sensitivity: PUBLIC
  Anomaly:     0.00
  Reason:      Quarantined: Instruction injection detected (confidence: 0.8)
  Threats:     instruction_injection
  Patterns:    hidden_instruction
```

Result blocks only — and `scan` still correctly returns QUARANTINE at confidence 0.8 with no configuration.

### `--verbose` still shows everything

```
===STEP remember-verbose===
[database] Startup runtime=installed db=/root/.shieldcortex/memories.db wal=true shm=true
Remembered "verbose smoke" (id 3, preference, salience 50%).
```

### `doctor` once the database exists — the collapsed checks come back

```
  ✅ Database: healthy (364.0 KB, WAL 0 B)
  ✅ Schema: up to date
  ✅ Write path: INSERT/SELECT/DELETE round-trip OK
  ✅ Memories: 1 total (1 STM, 0 LTM)
  ℹ️  Hooks: not applicable — Claude Code not detected on this host
  ...
  ⚠️  Brain worker: no worker.json — worker has not run yet
```

That last ⚠️ is the preserved negative case: the database exists, so something HAS run, and the worker still never recorded a tick — a real gap, still surfaced.

---

## Tests

`npm test` — **284/284 suites, 2970 passed, 7 skipped, 0 failed.**

New coverage:

- `src/cli/__tests__/doctor-fresh-install.test.ts` — the fresh-install contract (info states, actionable fixes, collapsed cascade, an assembled clean-box report with no fail/warn) plus every negative case in the table above.
- `src/__tests__/firstrun-output-hygiene.test.ts` — the debug-gate matrix (env truthy/falsy/unset, `--verbose` beating `SHIELDCORTEX_DEBUG=0`), `initDatabase()` asserted silent by default and loud under `SHIELDCORTEX_DEBUG`, no `.pre-backfill-` path leak, and an explicit dtype on every transformers pipeline in the tree.
- `src/__tests__/doctor-db-init-hint.test.ts` rewritten from a source-text regex guard to a behavioural one against the check's real output, so it survives refactors of how the check is wired.

The checks that needed a homedir-derived path are now pure exported helpers (`runDatabaseCheck` / `runMemoryStatsCheck` / `runHooksCheck` / `missingWorkerStateResult` / `partitionUninitialisedSkips`), which is what makes all of the above assertable against real output rather than source text.

## Notes

- The regression guard the issue asks for — `sc-firstrun-testbed.sh` across Node 20/22/24 before each release — is **not** in this PR: that script lives in the ops workspace, not this repo. Worth a follow-up issue to bring it in-repo and wire it to the release checklist.
- Not published, not merged, per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
