### PR TITLE
fix(#132): doctor must not read "permission denied" as "fresh install" — and now exits non-zero on ❌

### DIFF
--- a/src/cli/__tests__/doctor-permission-denied.test.ts
+++ b/src/cli/__tests__/doctor-permission-denied.test.ts
@@ -1,0 +1,273 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+import {
+  doctorExitCode,
+  probePath,
+  runDatabaseCheck,
+  runHooksCheck,
+  runMemoryStatsCheck,
+  runSchemaDriftCheck,
+  runWritePathProbe,
+  checkDiskUsage,
+  checkLockFile,
+  type CheckResult,
+} from '../doctor.js';
+
+const require = createRequire(import.meta.url);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Permission-denied is not a fresh install (#132).
+ *
+ * #131 made a missing database an informational "not initialised yet" — right
+ * for a genuine first run. It asked `fs.existsSync`, which returns false for
+ * "not there" AND for "there but unreadable", so a root-owned `~/.shieldcortex`
+ * (the classic artefact of one `sudo shieldcortex …`) started reporting a clean
+ * bill of health on a genuinely broken install. Doctor exists for exactly that
+ * user; going green on them is its worst possible failure mode.
+ *
+ * The contract locked in here:
+ *   - ENOENT  → ℹ️ "not initialised yet", exit 0 (the #129/#131 behaviour)
+ *   - EACCES/EPERM → ❌ naming ownership as the likely cause, exit 1
+ *   - any other errno → ❌ with the real error surfaced, never swallowed
+ *   - a healthy install is unchanged
+ */
+
+const errno = (code: string): NodeJS.ErrnoException => {
+  const err = new Error(`${code}: simulated`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+};
+
+const throwing = (code: string) => (): fs.Stats => { throw errno(code); };
+
+// chmod cannot deny root anything, so the filesystem-level tests are
+// meaningless when the suite runs as root (containers, some CI images). The
+// injected-statSync tests below cover every branch deterministically either
+// way; these add the proof that a real EACCES lands in the right branch.
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+const describeUnprivileged = isRoot ? describe.skip : describe;
+
+describe('doctor — probePath keeps absent, denied and broken apart', () => {
+  it('classifies ENOENT as absent — the only "fresh install" code', () => {
+    expect(probePath('/nope', throwing('ENOENT'))).toEqual({ kind: 'absent' });
+  });
+
+  it.each(['EACCES', 'EPERM'])('classifies %s as denied, not absent', (code) => {
+    const probe = probePath('/root-owned', throwing(code));
+    expect(probe.kind).toBe('denied');
+    expect(probe).toMatchObject({ code });
+  });
+
+  it('classifies any other errno as an error, keeping the code and message', () => {
+    const probe = probePath('/flaky', throwing('EIO'));
+    expect(probe.kind).toBe('error');
+    expect(probe).toMatchObject({ code: 'EIO' });
+    if (probe.kind === 'error') expect(probe.message).toMatch(/simulated/);
+  });
+
+  it('reports a readable path as present', () => {
+    const probe = probePath(__filename);
+    expect(probe.kind).toBe('present');
+  });
+});
+
+describe('doctor — exit code', () => {
+  const result = (status: CheckResult['status']): CheckResult =>
+    ({ label: 'X', status, message: 'm' });
+
+  it('exits 1 when any check failed', () => {
+    expect(doctorExitCode([result('pass'), result('fail')])).toBe(1);
+  });
+
+  it('exits 0 for a clean run', () => {
+    expect(doctorExitCode([result('pass'), result('pass')])).toBe(0);
+  });
+
+  it('exits 0 on a fresh install — info states are not failures', () => {
+    expect(doctorExitCode([result('info'), result('info'), result('pass')])).toBe(0);
+  });
+
+  it('exits 0 on warnings by default', () => {
+    expect(doctorExitCode([result('warn'), result('pass')])).toBe(0);
+  });
+
+  it('exits 1 on warnings under --strict', () => {
+    expect(doctorExitCode([result('warn')], { strict: true })).toBe(1);
+  });
+
+  it('--strict still passes a run with nothing but info/pass', () => {
+    expect(doctorExitCode([result('info'), result('pass')], { strict: true })).toBe(0);
+  });
+});
+
+describeUnprivileged('doctor — an unreadable install is ❌, never "fresh"', () => {
+  const claudeEnv = { hasClaude: true, hasOpenClaw: false, hasVSCode: false, hasCodex: false, isHeadless: false };
+
+  let tmpDir: string;
+  let scDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-denied-'));
+    scDir = path.join(tmpDir, '.shieldcortex');
+    dbPath = path.join(scDir, 'memories.db');
+    fs.mkdirSync(scDir);
+    const Database = require('better-sqlite3');
+    const db = new Database(dbPath);
+    db.exec('CREATE TABLE memories (id INTEGER PRIMARY KEY)');
+    db.close();
+  });
+
+  afterEach(() => {
+    try { fs.chmodSync(scDir, 0o755); } catch { /* already gone */ }
+    try { fs.chmodSync(path.join(tmpDir, '.claude'), 0o755); } catch { /* may not exist */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  /** Deny traversal the way a root-owned directory does to a normal user. */
+  const deny = (): void => { fs.chmodSync(scDir, 0o000); };
+
+  it('Database reports ❌ with an ownership remedy, not "not initialised yet"', () => {
+    deny();
+    const result = runDatabaseCheck(dbPath, claudeEnv);
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/permission denied/i);
+    expect(result.message).toMatch(/EACCES/);
+    expect(result.message).not.toMatch(/not initialised yet/i);
+    expect(result.fix).toMatch(/chown -R/);
+    expect(result.fix).toMatch(/sudo/i);
+  });
+
+  it.each([
+    ['Schema', () => runSchemaDriftCheck(dbPath)],
+    ['Write path', () => runWritePathProbe(dbPath)],
+    ['Memories', () => runMemoryStatsCheck(dbPath)],
+  ])('%s reports ❌ and is never collapsed into the fresh-install note', (label, run) => {
+    deny();
+    const result = run();
+
+    expect(result.label).toBe(label);
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/permission denied/i);
+    // The suppression that hides dependent checks on a fresh box must not
+    // hide a permission fault — that is the regression being closed.
+    expect(result.skipped).toBeUndefined();
+  });
+
+  it('Disk does not report a green 0 B for an unreadable directory', async () => {
+    deny();
+    const result = await checkDiskUsage(scDir);
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/permission denied/i);
+    expect(result.message).not.toMatch(/not yet created/i);
+  });
+
+  it('Lock does not report "clean" for an unreadable directory', async () => {
+    deny();
+    const result = await checkLockFile(scDir);
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/permission denied/i);
+    expect(result.message).not.toMatch(/clean/i);
+  });
+
+  it('Hooks reports ❌ for an unreadable settings.json, not "not configured yet"', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    fs.mkdirSync(claudeDir);
+    fs.writeFileSync(settingsPath, JSON.stringify({ hooks: {} }));
+    fs.chmodSync(claudeDir, 0o000);
+
+    const result = runHooksCheck(settingsPath, claudeEnv);
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/permission denied/i);
+    expect(result.message).not.toMatch(/not configured yet/i);
+    expect(result.fix).toMatch(/ownership and permissions/i);
+  });
+
+  it('a readable database is still healthy — the check only fires on real denial', () => {
+    const result = runDatabaseCheck(dbPath, claudeEnv);
+    expect(result.status).toBe('pass');
+    expect(result.message).toMatch(/healthy/);
+  });
+
+  it('an absent database is still the friendly informational state', () => {
+    const result = runDatabaseCheck(path.join(tmpDir, 'nothing-here.db'), claudeEnv);
+    expect(result.status).toBe('info');
+    expect(result.message).toMatch(/not initialised yet/i);
+  });
+});
+
+/**
+ * End-to-end through the real CLI: the exit code is the part CI consumes, and
+ * it can only be proven by running the binary.
+ */
+describeUnprivileged('doctor — CLI exit status', () => {
+  const cliPath = path.resolve(__dirname, '..', '..', '..', 'dist', 'index.js');
+
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-doctor-home-'));
+  });
+
+  afterEach(() => {
+    try { fs.chmodSync(path.join(home, '.shieldcortex'), 0o755); } catch { /* may not exist */ }
+    try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  /**
+   * A scrubbed environment: HOME points at the sandbox so doctor reads and
+   * writes nothing of the host's, and inherited SHIELDCORTEX_* would otherwise
+   * change what the checks resolve to (#125).
+   */
+  const runDoctorCli = (args: string[] = []): Promise<{ stdout: string; code: number }> =>
+    new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [cliPath, 'doctor', ...args], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { PATH: process.env.PATH ?? '/usr/bin:/bin', HOME: home },
+      });
+      let stdout = '';
+      child.stdout.on('data', (c) => { stdout += c.toString(); });
+      child.stderr.on('data', (c) => { stdout += c.toString(); });
+      child.on('error', reject);
+      child.on('close', (code) => resolve({ stdout, code: code ?? 0 }));
+    });
+
+  it('exits 0 on a fresh box — a first run must not fail a pipeline', async () => {
+    // dist is built before tests in CI; assert the invariant so a missing
+    // build fails loudly rather than green-skipping the exit-code proof.
+    expect(fs.existsSync(cliPath)).toBe(true);
+
+    const { stdout, code } = await runDoctorCli();
+    expect(stdout).toMatch(/not initialised yet/);
+    expect(stdout).not.toMatch(/failure/);
+    expect(code).toBe(0);
+  }, 60_000);
+
+  it('exits 1 with a ❌ when ~/.shieldcortex cannot be read', async () => {
+    expect(fs.existsSync(cliPath)).toBe(true);
+
+    const scDir = path.join(home, '.shieldcortex');
+    fs.mkdirSync(scDir);
+    fs.writeFileSync(path.join(scDir, 'memories.db'), '');
+    fs.chmodSync(scDir, 0o000);
+
+    const { stdout, code } = await runDoctorCli();
+    expect(stdout).toMatch(/permission denied/i);
+    expect(stdout).toMatch(/chown -R/);
+    expect(stdout).not.toMatch(/not initialised yet/);
+    expect(code).toBe(1);
+  }, 60_000);
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -63,6 +63,132 @@ function skippedNoDatabase(label: string): CheckResult {
   return { label, status: 'info', message: 'skipped — database not created yet', skipped: 'db-uninitialised' };
 }
 
+/**
+ * How a path actually failed to be readable.
+ *
+ * `fs.existsSync()` collapses three very different states into one `false`:
+ * "not created yet", "there but I'm not allowed to look at it", and "the
+ * filesystem returned something else entirely". #131 made doctor treat that
+ * `false` as the friendly fresh-install state, so a root-owned
+ * `~/.shieldcortex` — the classic artefact of a single `sudo shieldcortex …`
+ * run — reported a clean bill of health on a genuinely broken install. A
+ * diagnostic going green on the box it exists to diagnose is its worst
+ * possible failure mode (#132).
+ *
+ * probePath() keeps the cases apart. `statSync` is injectable so tests can
+ * drive every branch deterministically, including on hosts where the test
+ * runner is root and chmod cannot deny it anything.
+ */
+export type PathProbe =
+  | { kind: 'present'; stat: fs.Stats }
+  | { kind: 'absent' }
+  | { kind: 'denied'; code: string; message: string }
+  | { kind: 'error'; code: string; message: string };
+
+export function probePath(
+  target: string,
+  statSync: (p: string) => fs.Stats = fs.statSync,
+): PathProbe {
+  try {
+    return { kind: 'present', stat: statSync(target) };
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException)?.code ?? 'UNKNOWN';
+    const message = err instanceof Error ? err.message : String(err);
+    // ENOENT is the only code that means "genuinely not there yet".
+    if (code === 'ENOENT') return { kind: 'absent' };
+    if (code === 'EACCES' || code === 'EPERM') return { kind: 'denied', code, message };
+    return { kind: 'error', code, message };
+  }
+}
+
+/** True only for "this path is genuinely not there yet" — never for unreadable. */
+function isAbsent(target: string): boolean {
+  return probePath(target).kind === 'absent';
+}
+
+function tildify(target: string): string {
+  const home = os.homedir();
+  return target.startsWith(home) ? target.replace(home, '~') : target;
+}
+
+/**
+ * The remedy for the only cause worth naming: ShieldCortex state owned by a
+ * different user. Practically always one `sudo shieldcortex …` (or an install
+ * script run under sudo) leaving root-owned files behind.
+ */
+function ownershipFix(): string {
+  return (
+    'Those paths exist but this user cannot read them — almost always ShieldCortex state owned by ' +
+    'another user, typically root, left behind by one `sudo shieldcortex …` run. Restore ownership: ' +
+    '`sudo chown -R "$USER" ~/.shieldcortex` (also `~/.claude-memory` on a legacy install), then ' +
+    're-run `shieldcortex doctor`.'
+  );
+}
+
+/**
+ * Turn a non-present, non-absent probe into an honest ❌. Never swallows the
+ * underlying errno — a code we have no advice for still gets surfaced verbatim
+ * rather than being reported as a healthy or fresh install.
+ *
+ * `opts.fix` overrides the remedy: a string for a path the ownership hint does
+ * not fit, `false` for a dependent check whose root cause is already reported
+ * (repeating one remedy per affected check reads as several problems).
+ */
+function unreadableResult(
+  label: string,
+  target: string,
+  probe: Extract<PathProbe, { kind: 'denied' | 'error' }>,
+  opts: { fix?: string | false } = {},
+): CheckResult {
+  const defaultFix = probe.kind === 'denied'
+    ? ownershipFix()
+    : `Resolve the filesystem error above on ${tildify(target)}, then re-run \`shieldcortex doctor\`.`;
+  const fix = opts.fix === undefined ? defaultFix : opts.fix;
+  return {
+    label,
+    status: 'fail',
+    message: probe.kind === 'denied'
+      ? `permission denied reading ${tildify(target)} (${probe.code})`
+      : `cannot read ${tildify(target)} — ${probe.code}: ${probe.message}`,
+    ...(fix === false ? {} : { fix }),
+  };
+}
+
+/**
+ * Upgrade a caught filesystem error to a permission ❌ when that is what it is.
+ * Returns null for anything else so the caller keeps its own handling.
+ */
+function permissionFailure(
+  label: string,
+  target: string,
+  err: unknown,
+  opts: { fix?: string | false } = {},
+): CheckResult | null {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  if (code === 'EACCES' || code === 'EPERM') {
+    const fix = opts.fix === undefined ? ownershipFix() : opts.fix;
+    return {
+      label,
+      status: 'fail',
+      message: `permission denied reading ${tildify(target)} (${code})`,
+      ...(fix === false ? {} : { fix }),
+    };
+  }
+  return null;
+}
+
+/** better-sqlite3 surfaces a denied open as SQLITE_CANTOPEN, not EACCES. */
+function looksLikePermissionError(err: unknown, msg: string): boolean {
+  const code = (err as NodeJS.ErrnoException)?.code ?? '';
+  return (
+    code === 'EACCES' ||
+    code === 'EPERM' ||
+    code === 'SQLITE_CANTOPEN' ||
+    code === 'SQLITE_READONLY' ||
+    /EACCES|EPERM|permission denied|unable to open database file/i.test(msg)
+  );
+}
+
 function icon(status: CheckStatus): string {
   switch (status) {
     case 'pass': return `${green}\u2705${reset}`;
@@ -115,8 +241,12 @@ function detectEnvironment(): Environment {
 function getDbPath(): string {
   const newPath = path.join(getShieldCortexDir(), 'memories.db');
   const legacyPath = path.join(os.homedir(), '.claude-memory', 'memories.db');
-  if (fs.existsSync(newPath)) return newPath;
-  if (fs.existsSync(legacyPath)) return legacyPath;
+  // Probe rather than existsSync: an unreadable DB at the canonical path must
+  // still resolve to that path, so the checks report the permission fault
+  // against the real install instead of silently falling back to the legacy
+  // location (or to "fresh install") (#132).
+  if (!isAbsent(newPath)) return newPath;
+  if (!isAbsent(legacyPath)) return legacyPath;
   return newPath; // default expected path
 }
 
@@ -127,7 +257,15 @@ function getDbPath(): string {
  * getDbPath().
  */
 export function runDatabaseCheck(dbPath: string, env: Environment = detectEnvironment()): CheckResult {
-  if (!fs.existsSync(dbPath)) {
+  const probe = probePath(dbPath);
+
+  if (probe.kind === 'denied' || probe.kind === 'error') {
+    // There IS something at this path, we just cannot read it. Never the
+    // friendly fresh-install line — that is the #131 regression this closes.
+    return unreadableResult('Database', dbPath, probe);
+  }
+
+  if (probe.kind === 'absent') {
     // Not a failure. The database is created lazily on the first memory
     // operation, so "no database yet" is the normal state of a fresh install —
     // and doctor is exactly the command a new user runs to check the install
@@ -180,19 +318,44 @@ export function runDatabaseCheck(dbPath: string, env: Environment = detectEnviro
     }
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
+    const isNativeBindingFault = /bindings file|napi|abi|MODULE_VERSION|was compiled against/i.test(msg);
+    // A stat'able DB can still be unopenable because the file itself is owned
+    // by another user (mode 600 root:root — the other half of the sudo
+    // artefact). Telling that user to delete their database is bad advice.
+    const fix = isNativeBindingFault
+      ? `Native DB engine failed to load. Run \`shieldcortex repair\` (compiles better-sqlite3 from source + re-verifies), or manually: cd "${path.join(resolveSelfInstallDir(), 'node_modules', 'better-sqlite3')}" && npm run build-release`
+      : looksLikePermissionError(err, msg)
+        ? ownershipFix()
+        : 'Back up and delete `~/.shieldcortex/memories.db`, then restart the MCP server';
     return {
       label: 'Database',
       status: 'fail',
       message: `cannot open — ${msg}`,
-      fix: /bindings file|napi|abi|MODULE_VERSION|was compiled against/i.test(msg)
-        ? `Native DB engine failed to load. Run \`shieldcortex repair\` (compiles better-sqlite3 from source + re-verifies), or manually: cd "${path.join(resolveSelfInstallDir(), 'node_modules', 'better-sqlite3')}" && npm run build-release`
-        : 'Back up and delete `~/.shieldcortex/memories.db`, then restart the MCP server',
+      fix,
     };
   }
 }
 
 async function checkDatabase(): Promise<CheckResult> {
   return runDatabaseCheck(getDbPath());
+}
+
+/**
+ * Gate for the checks that can say nothing without a readable database.
+ * Returns the result to return early with, or null to carry on.
+ *
+ * The three states are deliberately distinct: absent is the friendly
+ * fresh-install skip, unreadable is a ❌ that must never be collapsed into it
+ * (#132), readable proceeds to the real check.
+ */
+function databasePrerequisite(label: string, dbPath: string): CheckResult | null {
+  const probe = probePath(dbPath);
+  if (probe.kind === 'absent') return skippedNoDatabase(label);
+  if (probe.kind === 'present') return null;
+  // No fix line here on purpose: the Database check already carries the
+  // ownership remedy, and repeating it per dependent check turns "Suggested
+  // fixes" into four copies of one sentence.
+  return unreadableResult(label, dbPath, probe, { fix: false });
 }
 
 // ── Check 2: Schema version ──────────────────────────────
@@ -210,9 +373,8 @@ async function checkDatabase(): Promise<CheckResult> {
  * long-lived DBs) are harmless and stay silent.
  */
 export function runSchemaDriftCheck(dbPath: string): CheckResult {
-  if (!fs.existsSync(dbPath)) {
-    return skippedNoDatabase('Schema');
-  }
+  const prerequisite = databasePrerequisite('Schema', dbPath);
+  if (prerequisite) return prerequisite;
 
   try {
     const Database = require('better-sqlite3');
@@ -263,9 +425,8 @@ async function checkSchema(): Promise<CheckResult> {
  * against a temp database instead of the homedir install.
  */
 export function runMemoryStatsCheck(dbPath: string): CheckResult {
-  if (!fs.existsSync(dbPath)) {
-    return skippedNoDatabase('Memories');
-  }
+  const prerequisite = databasePrerequisite('Memories', dbPath);
+  if (prerequisite) return prerequisite;
 
   try {
     const Database = require('better-sqlite3');
@@ -329,9 +490,8 @@ async function checkMemoryStats(): Promise<CheckResult> {
  * without going through doctor's homedir-derived getDbPath().
  */
 export function runWritePathProbe(dbPath: string, env: Environment = detectEnvironment()): CheckResult {
-  if (!fs.existsSync(dbPath)) {
-    return skippedNoDatabase('Write path');
-  }
+  const prerequisite = databasePrerequisite('Write path', dbPath);
+  if (prerequisite) return prerequisite;
 
   let db: any = null;
   const probeUuid = `doctor-probe-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
@@ -424,7 +584,18 @@ async function checkWritePath(): Promise<CheckResult> {
  * real homedir.
  */
 export function runHooksCheck(settingsPath: string, env: Environment = detectEnvironment()): CheckResult {
-  if (!fs.existsSync(settingsPath)) {
+  const probe = probePath(settingsPath);
+
+  if (probe.kind === 'denied' || probe.kind === 'error') {
+    // A settings.json we cannot read is not "not configured yet" — doctor
+    // simply cannot tell whether the hooks are wired, and saying so is the
+    // only honest answer (#132).
+    return unreadableResult('Hooks', settingsPath, probe, {
+      fix: `Check ownership and permissions of ${tildify(settingsPath)} — while it is unreadable, doctor cannot tell whether the hooks are wired.`,
+    });
+  }
+
+  if (probe.kind === 'absent') {
     // No settings.json is not a fault. Either Claude Code isn't on this box at
     // all (OpenClaw-only / headless installs never grow one), or it is and the
     // user hasn't run `shieldcortex install` yet — the exact state of every
@@ -486,6 +657,12 @@ export function runHooksCheck(settingsPath: string, env: Environment = detectEnv
       };
     }
   } catch (err: unknown) {
+    // A settings.json that stats but will not open (mode 000) is a permission
+    // fault, not an inconclusive check.
+    const denied = permissionFailure('Hooks', settingsPath, err, {
+      fix: `Check ownership and permissions of ${tildify(settingsPath)} — while it is unreadable, doctor cannot tell whether the hooks are wired.`,
+    });
+    if (denied) return denied;
     const msg = err instanceof Error ? err.message : String(err);
     return { label: 'Hooks', status: 'warn', message: `check failed — ${msg}` };
   }
@@ -784,7 +961,14 @@ function readDbRowConsumers(dbPath: string): DbRowConsumers | null {
 }
 
 export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limitBytes: number = 100 * 1024 * 1024): Promise<CheckResult> {
-  if (!fs.existsSync(scDir)) {
+  const dirProbe = probePath(scDir);
+  if (dirProbe.kind === 'denied' || dirProbe.kind === 'error') {
+    // "Directory not yet created" is a ✅. An unreadable one is not — this is
+    // the same false-clean shape as the Database check, on the same directory
+    // (#132).
+    return unreadableResult('Disk', scDir, dirProbe);
+  }
+  if (dirProbe.kind === 'absent') {
     return { label: 'Disk', status: 'pass', message: '0 B / 100 MB limit (directory not yet created)' };
   }
 
@@ -917,6 +1101,10 @@ export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limit
       return { label: 'Disk', status: 'pass', message: `${dataStr}${modelsStr}` };
     }
   } catch (err: unknown) {
+    // A directory that stats but cannot be listed (mode 700, another owner) is
+    // a permission fault, not an inconclusive check.
+    const denied = permissionFailure('Disk', scDir, err);
+    if (denied) return denied;
     const msg = err instanceof Error ? err.message : String(err);
     return { label: 'Disk', status: 'warn', message: `check failed — ${msg}` };
   }
@@ -930,7 +1118,11 @@ export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limit
 // to delete a file that is still in active use.
 export async function checkLockFile(scDir: string = getShieldCortexDir()): Promise<CheckResult> {
 
-  if (!fs.existsSync(scDir)) {
+  const dirProbe = probePath(scDir);
+  if (dirProbe.kind === 'denied' || dirProbe.kind === 'error') {
+    return unreadableResult('Lock', scDir, dirProbe, { fix: false });
+  }
+  if (dirProbe.kind === 'absent') {
     return { label: 'Lock', status: 'pass', message: 'clean' };
   }
 
@@ -999,6 +1191,8 @@ export async function checkLockFile(scDir: string = getShieldCortexDir()): Promi
 
     return { label: 'Lock', status: 'pass', message: `clean (${active.length} active lock${active.length !== 1 ? 's' : ''})` };
   } catch (err: unknown) {
+    const denied = permissionFailure('Lock', scDir, err, { fix: false });
+    if (denied) return denied;
     const msg = err instanceof Error ? err.message : String(err);
     return { label: 'Lock', status: 'warn', message: `check failed — ${msg}` };
   }
@@ -1712,8 +1906,16 @@ export async function checkBrainWorker(): Promise<CheckResult> {
     };
   }
   const statePath = path.join(getShieldCortexDir(), 'state', 'worker.json');
-  if (!fs.existsSync(statePath)) {
-    return missingWorkerStateResult(fs.existsSync(getDbPath()));
+  const stateProbe = probePath(statePath);
+  if (stateProbe.kind === 'denied' || stateProbe.kind === 'error') {
+    // Unreadable state is not "the worker has not run yet" (#132).
+    return unreadableResult('Brain worker', statePath, stateProbe);
+  }
+  if (stateProbe.kind === 'absent') {
+    // isAbsent, not existsSync: an unreadable database means something HAS
+    // been installed here, so a missing worker.json is a real gap, not the
+    // fresh-install state.
+    return missingWorkerStateResult(!isAbsent(getDbPath()));
   }
   try {
     const raw = JSON.parse(fs.readFileSync(statePath, 'utf-8')) as {
@@ -2418,7 +2620,36 @@ export function partitionUninitialisedSkips(
   };
 }
 
-export async function runDoctor(args: string[] = []): Promise<void> {
+/**
+ * What `shieldcortex doctor` reports back to its caller — and to the shell.
+ */
+export interface DoctorSummary {
+  passed: number;
+  warnings: number;
+  failures: number;
+  infos: number;
+  total: number;
+  exitCode: number;
+}
+
+/**
+ * Exit-code policy.
+ *
+ * doctor used to always exit 0, so `shieldcortex doctor && …` succeeded on a
+ * broken install and CI could not gate on it (#132). A ❌ now means exit 1.
+ *
+ * Warnings and info stay 0 deliberately: fresh-install states are ℹ️ (#129),
+ * and a first run must not fail anyone's pipeline for being a first run.
+ * `--strict` opts into escalating ⚠️ as well, for callers that want a
+ * zero-tolerance gate.
+ */
+export function doctorExitCode(results: CheckResult[], opts: { strict?: boolean } = {}): number {
+  if (results.some(r => r.status === 'fail')) return 1;
+  if (opts.strict && results.some(r => r.status === 'warn')) return 1;
+  return 0;
+}
+
+export async function runDoctor(args: string[] = []): Promise<DoctorSummary> {
   console.log(`\n${bold}ShieldCortex Doctor${reset} v${pkg.version}\n`);
 
   const results: CheckResult[] = [];
@@ -2517,12 +2748,14 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   if (infos > 0) parts.push(`${infos} info`);
   console.log(`  ${parts.join(', ')}`);
 
-  // Suggested fixes
-  const fixes = visible.filter(r => r.fix);
+  // Suggested fixes. Deduplicated: one root cause can fail several checks at
+  // once (a root-owned ~/.shieldcortex fails Database, Disk and Lock), and
+  // printing the same remedy three times reads as three separate problems.
+  const fixes = [...new Set(visible.filter(r => r.fix).map(r => r.fix as string))];
   if (fixes.length > 0) {
     console.log(`\n  ${bold}Suggested fixes:${reset}`);
     for (const f of fixes) {
-      console.log(`  ${dim}\u2192${reset} ${f.fix}`);
+      console.log(`  ${dim}\u2192${reset} ${f}`);
     }
   }
 
@@ -2530,5 +2763,20 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   // Free + Enterprise repricing \u2014 there is no self-serve tier to nudge
   // towards. `config --upsell-mute/--upsell-unmute` remain accepted no-ops.)
 
+  // Exit code. Set rather than process.exit() so buffered stdout is flushed
+  // in full (doctor's report is long and often piped), and only ever set to
+  // a failure \u2014 never reset to 0 over an exit code someone else set.
+  const strict = args.includes('--strict');
+  const exitCode = doctorExitCode(visible, { strict });
+  if (exitCode !== 0) {
+    process.exitCode = exitCode;
+    const reason = failures > 0
+      ? `${failures} failed check${failures !== 1 ? 's' : ''}`
+      : `${warnings} warning${warnings !== 1 ? 's' : ''} (--strict)`;
+    console.log(`  ${dim}exit ${exitCode} \u2014 ${reason}${reset}`);
+  }
+
   console.log('');
+
+  return { passed, warnings, failures, infos, total, exitCode };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -638,7 +638,7 @@ ${bold}COMMANDS${reset}
   ${cyan}dashboard${reset}             Open the local security dashboard
   ${cyan}worker${reset}                Run headless background sync + heartbeat worker
   ${cyan}status${reset}                Show current protection status
-  ${cyan}doctor${reset}                Diagnose installation issues
+  ${cyan}doctor${reset}                Diagnose installation issues (exits 1 on a ❌; --strict also fails on ⚠️)
   ${cyan}vacuum${reset}                Compact the memory DB, reclaiming free pages (no sqlite3 CLI needed)
   ${cyan}sessions${reset} prune        Delete old session-capture events (dry-run; --days N, --execute)
   ${cyan}quickstart${reset} [target]    Detect integrations and guide/install setup


### PR DESCRIPTION
Closes #132.

Two fast-follows from the review of #131.

## 1. Permission-denied read as "pristine fresh install" (regression from #131)

`fs.existsSync()` returns `false` for **both** "not there" and "there but unreadable". #131 made that `false` mean the friendly ℹ️ `Database: not initialised yet — created automatically on first use`, so a root-owned `~/.shieldcortex` — the classic artefact of one `sudo shieldcortex …` run — started reporting a clean bill of health, with zero ❌ and zero ⚠️, on a genuinely broken install.

Every health inference now goes through one classifier that splits on the errno:

```ts
export type PathProbe =
  | { kind: 'present'; stat: fs.Stats }
  | { kind: 'absent' }                              // ENOENT only
  | { kind: 'denied'; code: string; message: string }   // EACCES / EPERM
  | { kind: 'error';  code: string; message: string };  // anything else, verbatim
```

- **ENOENT** → unchanged. The #129/#131 fresh-install wording and its next-step fix line stay exactly as they are.
- **EACCES / EPERM** → ❌ naming the path and the likely cause, with the ownership remedy (`sudo chown -R "$USER" ~/.shieldcortex`).
- **anything else** → ❌ carrying the real code and message. Never swallowed, never reported as healthy or fresh.

`statSync` is injectable so every branch is testable on a host where the runner is root and `chmod` cannot deny it anything.

### Audit of the whole #131 diff

The Database line was not the only place a `false` was read as health. Everything the diff touched:

| site | was, on an unreadable install | now |
|---|---|---|
| `runDatabaseCheck` | ℹ️ "not initialised yet" | ❌ + ownership remedy |
| `runSchemaDriftCheck` / `runWritePathProbe` / `runMemoryStatsCheck` | ℹ️ "skipped — database not created yet", *and collapsed out of the printed report* | ❌, never suppressed |
| `runHooksCheck` | ℹ️ "not configured yet" | ❌ — doctor cannot tell whether hooks are wired while settings.json is unreadable |
| `checkBrainWorker` → `missingWorkerStateResult(fs.existsSync(getDbPath()))` | ℹ️ "not started yet" | ❌ for unreadable `state/worker.json`; the DB-exists inference no longer treats unreadable as absent |

Three pre-existing checks in the same family go with them, because they went green on the very directory this issue is about:

| site | was | now |
|---|---|---|
| `getDbPath()` | silently fell back to the legacy `~/.claude-memory` path | resolves to the canonical path so the fault is reported against the real install |
| `checkDiskUsage` | ✅ `0 B / 100 MB limit (directory not yet created)` when the directory cannot even be stat'd; ⚠️ `check failed — EACCES` when it can | ❌ + ownership remedy, either way |
| `checkLockFile` | ✅ `clean`, or ⚠️ `check failed — EACCES`, likewise | ❌ |

`runDatabaseCheck`'s open path also grew a permission branch: a DB that stats fine but is mode 600 root:root (the other half of the sudo artefact) surfaces as `SQLITE_CANTOPEN`, and the old advice there was "back up and delete your database" — bad advice for a permission problem.

Suggested fixes are now deduplicated. One root cause failing four checks printed the same sentence four times, which reads as four separate problems.

## 2. `doctor` never set a non-zero exit code — ⚠️ USER-VISIBLE CHANGE

`shieldcortex doctor && …` used to succeed on a broken install, so it could not gate anything.

- **any ❌ → exit 1.**
- ⚠️ and ℹ️ → exit 0, unchanged. A fresh install is all-ℹ️ after #129 and must not fail anyone's pipeline for being a first run.
- `--strict` escalates ⚠️ to exit 1 for callers that want a zero-tolerance gate (the option #132 floated; opt-in, nothing changes without it).

`process.exitCode` is set rather than calling `process.exit()`, so the (long, frequently piped) report is flushed in full, and an exit code set elsewhere is never reset to 0. When it is non-zero doctor prints one dim line saying why. `runDoctor()` now returns a `DoctorSummary` (counts + exitCode) instead of `void`; the only caller is the CLI dispatch in `src/index.ts`, and the help line now documents the exit behaviour.

Anything that scripted `shieldcortex doctor` and ignored the exit code is unaffected; anything using `&&` or `set -e` will now stop on a genuinely failing install — which is the point.

## Tests

`src/cli/__tests__/doctor-permission-denied.test.ts` — 22 tests:

- **Classifier**, with an injected `statSync`, so these run deterministically everywhere: ENOENT → absent, EACCES/EPERM → denied, any other errno → error with the code and message preserved.
- **Real filesystem denial** (`chmod 000` on a tmp `~/.shieldcortex`), skipped when the runner is root because root bypasses the permission bits being tested: Database, Schema, Write path, Memories, Disk, Lock and Hooks each report ❌ with a permission message; the dependent checks are not marked `skipped` so they cannot be collapsed out of the report; a readable DB is still ✅ healthy and an absent one is still the friendly ℹ️.
- **Exit-code policy**: 1 on any ❌; 0 on a clean run, on warnings, and on an all-ℹ️ fresh install; 1 on warnings only under `--strict`.
- **End-to-end through the built CLI** with a sandbox `HOME`: fresh box → `not initialised yet`, exit **0**; unreadable `~/.shieldcortex` → `permission denied` + `chown -R`, exit **1**.

### Suite status

Full suite green — `npm test`:

```
Test Suites: 285 passed, 285 total
Tests:       7 skipped, 2992 passed, 2999 total
```

All 19 doctor suites pass (142 tests), 22 of them new.

---

## Clean-box proof — node:22-slim, throwaway container, global install of a local `npm pack` of this branch

Steps 2 and 3 run as the unprivileged `node` user; root bypasses file permissions, so a root-run `chmod 000` would prove nothing. State 2 is built the way a real user builds it: run the product once as root (`sudo`), then look at it as yourself.

### 1. FRESH — no `~/.shieldcortex` at all

```
ShieldCortex Doctor v4.47.16

  ℹ️  Database: not initialised yet — created automatically on first use
  ℹ️  Hooks: not applicable — Claude Code not detected on this host
  ℹ️  Hook timeouts: skipped (settings.json not found)
  ℹ️  Auto-memory: Stop hook: opt-in (not installed)
  ℹ️  Auto-memory: SessionEnd hook: opt-in (not installed)
  ✅ Auto-memory sampling: every 5 turn(s), salience-bypass on
  ℹ️  Brain worker: not started yet — starts with your first ShieldCortex session
  ℹ️  Project keys: skipped (no DB yet)
  ℹ️  API server: not running (optional on headless/OpenClaw-only setups)
  ℹ️  Dashboard: not running (optional on headless/OpenClaw-only setups)
  ℹ️  Dashboard freshness: no managed dashboard service running
  ✅ Disk: 0 B / 100 MB limit (directory not yet created)
  ✅ Lock: clean
  ℹ️  OpenClaw residue: skipped (OpenClaw not detected)
  ...
  ✅ Defence canary: caught (4ms, pattern: defence_canary)
  ✅ Action guard: verdict probes 3/3 (catastrophic→block, dangerous→approval, benign→allow) in 11ms
  ℹ️  Embeddings: model not cached — will download on first recall
  (Schema, Write path, Memories checked once the database exists)

  5/24 checks passed, 19 info

  Suggested fixes:
  → Run `shieldcortex scan "init"` to create the database now (OpenClaw-only / headless install)
  → For persistence, run `shieldcortex service install --headless` (recommended on headless hosts) or restart Claude Code

EXIT=0
```

Unchanged from #131 — that behaviour is preserved exactly.

### 2. PERMISSION DENIED — root-owned `~/.shieldcortex` (the sudo artefact)

`shieldcortex scan "init"` run as root in the user's home, then `chmod 700`, then `doctor` as `node`.

**On `main` this same broken box reports** — `ℹ️ Database: not initialised yet`, no ❌ anywhere, and **exit 0**. Only Disk and Lock notice anything at all, as an inconclusive ⚠️ (run on this branch's parent commit, same scenario, paths elided):

```
  ℹ️  Database: not initialised yet — created automatically on first use
  ℹ️  Brain worker: not started yet — starts with your first ShieldCortex session
  ⚠️  Disk: check failed — EACCES: permission denied, scandir '~/.shieldcortex'
  ⚠️  Lock: check failed — EACCES: permission denied, scandir '~/.shieldcortex'
  (Schema, Write path, Memories checked once the database exists)

  3/24 checks passed, 2 warnings, 19 info

  Suggested fixes:
  → Run `shieldcortex scan "init"` to create the database now (OpenClaw-only / headless install)

EXIT=0
```

With this branch:

```
ShieldCortex Doctor v4.47.16

  ❌ Database: permission denied reading ~/.shieldcortex/memories.db (EACCES)
  ❌ Schema: permission denied reading ~/.shieldcortex/memories.db (EACCES)
  ❌ Write path: permission denied reading ~/.shieldcortex/memories.db (EACCES)
  ❌ Memories: permission denied reading ~/.shieldcortex/memories.db (EACCES)
  ℹ️  Hooks: not applicable — Claude Code not detected on this host
  ℹ️  Hook timeouts: skipped (settings.json not found)
  ℹ️  Auto-memory: Stop hook: opt-in (not installed)
  ℹ️  Auto-memory: SessionEnd hook: opt-in (not installed)
  ✅ Auto-memory sampling: every 5 turn(s), salience-bypass on
  ❌ Brain worker: permission denied reading ~/.shieldcortex/state/worker.json (EACCES)
  ℹ️  Project keys: skipped (no DB yet)
  ℹ️  API server: not running (optional on headless/OpenClaw-only setups)
  ℹ️  Dashboard: not running (optional on headless/OpenClaw-only setups)
  ℹ️  Dashboard freshness: no managed dashboard service running
  ❌ Disk: permission denied reading ~/.shieldcortex (EACCES)
  ❌ Lock: permission denied reading ~/.shieldcortex (EACCES)
  ℹ️  OpenClaw residue: skipped (OpenClaw not detected)
  ...
  ✅ Defence canary: caught (3ms, pattern: defence_canary)
  ✅ Action guard: verdict probes 3/3 (catastrophic→block, dangerous→approval, benign→allow) in 12ms
  ℹ️  Embeddings: model not cached — will download on first recall

  3/27 checks passed, 7 failures, 17 info

  Suggested fixes:
  → Those paths exist but this user cannot read them — almost always ShieldCortex state owned by another user, typically root, left behind by one `sudo shieldcortex …` run. Restore ownership: `sudo chown -R "$USER" ~/.shieldcortex` (also `~/.claude-memory` on a legacy install), then re-run `shieldcortex doctor`.
  exit 1 — 7 failed checks

EXIT=1
```

### 3. HEALTHY — database created, owned by the user running doctor

```
ShieldCortex Doctor v4.47.16

  ✅ Database: healthy (348.0 KB, WAL 0 B)
  ✅ Schema: up to date
  ✅ Write path: INSERT/SELECT/DELETE round-trip OK
  ✅ Memories: 0 total (0 STM, 0 LTM)
  ℹ️  Hooks: not applicable — Claude Code not detected on this host
  ℹ️  Hook timeouts: skipped (settings.json not found)
  ℹ️  Auto-memory: Stop hook: opt-in (not installed)
  ℹ️  Auto-memory: SessionEnd hook: opt-in (not installed)
  ✅ Auto-memory sampling: every 5 turn(s), salience-bypass on
  ⚠️  Brain worker: no worker.json — worker has not run yet
  ✅ Project keys: 0 distinct, no legacy/canonical collisions
  ℹ️  API server: not running (optional on headless/OpenClaw-only setups)
  ℹ️  Dashboard: not running (optional on headless/OpenClaw-only setups)
  ℹ️  Dashboard freshness: no managed dashboard service running
  ✅ Disk: 400.0 KB / 100 MB limit
  ✅ Lock: clean
  ℹ️  OpenClaw residue: skipped (OpenClaw not detected)
  ...
  ✅ Defence canary: caught (3ms, pattern: defence_canary)
  ✅ Action guard: verdict probes 3/3 (catastrophic→block, dangerous→approval, benign→allow) in 11ms
  ℹ️  Embeddings: model not cached — will download on first recall

  10/27 checks passed, 1 warning, 16 info

  Suggested fixes:
  → For persistence, run `shieldcortex service install --headless` (recommended on headless hosts) or restart Claude Code

EXIT=0
```

The ⚠️ there is the real, pre-existing brain-worker warning (a DB exists but the worker has not ticked yet) — and it exits 0, which is exactly the warnings-do-not-gate policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
