### PR TITLE
fix(#89): modify-scheduler must not fire on a variable named `at`

### DIFF
--- a/src/defence/iron-dome/__tests__/fp-precision-88-89.test.ts
+++ b/src/defence/iron-dome/__tests__/fp-precision-88-89.test.ts
@@ -124,6 +124,37 @@ describe('#89 — modify-scheduler must not fire on read-only crontab -l', () =>
   });
 });
 
+describe('#89 (follow-up) — modify-scheduler must not fire on a variable named `at`', () => {
+  // Live FP on the Jarvis box, 2026-07-29: a read-only Xero P&L pull was
+  // blocked because the heredoc body assigned `at = <token>` at the start of a
+  // line. The command-position anchor treats a newline as a command boundary,
+  // so `\nat` matched the scheduler verb — but `at` immediately followed by
+  // `=` is an assignment in every shell and in the embedded-script bodies the
+  // guard also scans. The real `at` command is `at [options] TIME`; its
+  // grammar has no `=` in that position, so excluding it costs no detection.
+  const allow: Array<[string, string]> = [
+    ['bare assignment', 'at=$(cat token.txt)'],
+    ['assignment after newline', "tok=load('creds.json')\nat=tok.get('access_token')"],
+    ['spaced assignment in a heredoc body', "python3 - <<'EOF'\nat = tk.get('access_token')\nEOF"],
+    ['assignment then use', 'at=abc; curl -H "Authorization: Bearer $at" https://api.example.com/v1/ping'],
+  ];
+  it.each(allow)('allows: %s', (_l, command) => {
+    expect(decision({ command })).toBe('allow');
+  });
+
+  // Must-STILL-FIRE siblings: the assignment carve-out must not rescue the verb.
+  const approve: Array<[string, string]> = [
+    ['at after newline', 'echo job > /tmp/j\nat now + 1 minute < /tmp/j'],
+    ['at with time argument', 'at 23:30 -f /tmp/job.sh'],
+    ['at after a semicolon', 'ls; at midnight -f /tmp/job.sh'],
+  ];
+  it.each(approve)('still requires approval: %s', (_l, command) => {
+    const v = verdict({ command });
+    expect(v.decision).toBe('require_approval');
+    expect(v.signals).toContain('modify-scheduler');
+  });
+});
+
 describe('#90 — install-package-global must gate npm install-verb abbreviations', () => {
   // Review follow-up on #88/#89: the narrowed regex only rescued the exact `i`
   // shorthand, so npm's own alias resolver (which accepts the whole

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -247,7 +247,12 @@ const DANGEROUS: Pattern[] = [
   // non-matching tail exits without re-partitioning (same ReDoS discipline as
   // issue #92 must-fix 1). The read-only `-l` exemption applies unchanged
   // through wrappers (`time crontab -l` stays allowed).
-  { re: /(?:^|[;&|(\n]|\$\()\s*(?:\w+=\S*\s+)*(?:sudo\s+)?(?:(?:env|nohup|time|stdbuf|nice)\b(?:\s+(?:-{1,2}\S+|\w+=\S*|\d+))*\s+)*(?:sudo\s+)?(?:crontab\b(?!\s+-l\b)|at\b(?!\s+-l\b)(?!\s*$))|\/etc\/cron|\bsystemd-run\b[^|;&\n]*--on-(?:calendar|active|boot|startup|unit-active|unit-inactive)\b/i, signal: 'modify-scheduler' },
+  // `at` additionally excludes a following `=`: the newline in the
+  // command-position anchor makes every line start a command, so a variable
+  // named `at` (common in embedded script bodies the guard also scans) matched
+  // the scheduler verb. `at(1)` takes `at [options] TIME` — its grammar has no
+  // `=` in that slot, so the carve-out removes the FP without losing a verb.
+  { re: /(?:^|[;&|(\n]|\$\()\s*(?:\w+=\S*\s+)*(?:sudo\s+)?(?:(?:env|nohup|time|stdbuf|nice)\b(?:\s+(?:-{1,2}\S+|\w+=\S*|\d+))*\s+)*(?:sudo\s+)?(?:crontab\b(?!\s+-l\b)|at\b(?!\s+-l\b)(?!\s*=)(?!\s*$))|\/etc\/cron|\bsystemd-run\b[^|;&\n]*--on-(?:calendar|active|boot|startup|unit-active|unit-inactive)\b/i, signal: 'modify-scheduler' },
   // Zero out a file's contents (issue #4475.7a): the pre-existing rule below
   // only caught a `.log` target; `-s 0` / `--size 0` is data-destructive
   // regardless of the target file, so it is gated on its own.


### PR DESCRIPTION
## The false positive

The `modify-scheduler` rule anchors to command position, and its anchor class includes `\n` — so **every line start is a command boundary**. The guard also scans embedded script bodies as command text. Together that means any line beginning `at=...` matches the scheduler verb.

Hit live on the Jarvis box on 2026-07-29: a **read-only Xero P&L pull** was blocked because its heredoc body assigned `at = <access token>`. Second FP from this rule family in one day.

```
ShieldCortex Action Guard: recognised dangerous operation requires approval
[rule: modify-scheduler; matched: "...xero_lumina_tokens.json')) at"]
```

## The fix

One negative lookahead: `at\b(?!\s+-l\b)(?!\s*=)(?!\s*$)`.

`at(1)` takes `at [options] TIME`. There is no `=` in that slot in any invocation, so excluding a following `=` cannot mask a real scheduler call — it only rules out what is unambiguously an assignment, in shell and in the script bodies the guard scans.

`crontab` is untouched: it has no plausible variable-name collision.

## Tests

Per the #88/#89 precision discipline, every allow-case ships a must-STILL-FIRE sibling:

**Allow (was blocked, now passes):** bare `at=$(cat token.txt)`, assignment after a newline, spaced assignment inside a heredoc body, assignment-then-use with `curl`.

**Still requires approval:** `at` after a newline, `at 23:30 -f`, `at midnight` after a semicolon.

Verified failing before the change (4 allow-cases red), passing after. `src/defence`: **45 suites / 973 tests green**.

## Note on a stale local build (correction)

An earlier revision of this description claimed `main` was red with 17 failures. **That was wrong and has been retracted** — the failures were my working checkout carrying a `dist/` built on 11 Jul, which made `loadDefenceModules()` return `null` and every memory save return before its INSERT. CI here proves the point: **284/284 suites, 2977 passed** on Node 20 and 22. After `npm run build:ts` my box matches CI exactly. Details in #136 (closed as invalid).

This PR's own change is unaffected: the `src/defence` suites were green before and after, and CI is green on both Node versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
