### PR TITLE
fix: Action Guard scans the script a command invokes, not just the command string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 > **Coverage note**: 49 v4 versions are documented below — typically every minor (`X.Y.0`) plus significant patches. Many small patch releases between 4.0.0 and 4.20.x are not individually documented (~50 versions, mostly behaviour-preserving fixes). For a specific diff between adjacent npm versions, see `git log vX.Y.Z..vX.Y.W` or compare tarballs. Audited and reconciled 2026-05-27 — gap is intentional, not a sign of release-note drift going forward.
 
+## [4.47.17] - 2026-07-30
+
+**Security: the Action Guard now scans the script a command invokes, not just the command string. Every rule was previously bypassable by moving the command into a file.**
+
+### Fixed
+
+- **Guard rules no longer stop at the command string (security).** Found by dogfooding on 29 Jul 2026: an operation was correctly gated when run inline, then ran with no gate at all when the identical command was moved into a shell script and invoked as `bash script.sh`. Root cause was structural rather than a gap in any one rule — the guard built its match surface from the command, path and url arguments only and never read the file a command pointed at, so **all** tiers were affected: the catastrophic patterns, the dangerous table, `find -delete`, the secret-exfil hard block and the egress predicate alike. Since writing a script and running it is how agents normally work, this was likely being hit routinely in the field, producing audit logs that looked clean because the guard had never looked. The guard now resolves invoked scripts and folds their contents into the scan: interpreter-plus-file (`bash`/`sh`/`zsh`/`python`/`node`/`ruby`/`perl`/`php`), bare `./script`, `source`/`.`, and all of those behind `env`/`sudo`/`nohup`-style wrappers and env assignments. `bash -c '<inline>'` is deliberately not treated as a file invocation — that program is already scanned — though a file invocation nested inside it is followed.
+  - **No new friction.** Resolved content is appended to the existing surface, never substituted, so a verdict can only become more accurate and never flips direction; a clean script returns exactly the pre-fix verdict.
+  - **Bounded on every axis (zeroth law).** Depth 3, 12 files, 256KB per file and in total, a visited-set cycle guard, and binary or oversized content refused rather than truncated past a danger signal. Worst case measured at ~22ms; a real-world script is sub-millisecond.
+  - **`evaluateToolCall` stays pure and synchronous.** The file is read through a caller-injected `resolveScriptSource` seam, so `doctor` and `openclaw-selfcheck` keep driving it with synthetic commands whose paths do not exist. The fs-backed resolver is wired at the interceptor: `statSync` first so a FIFO can never be opened, `/proc`, `/sys` and `/dev` refused, size-capped, every error swallowed to `null`.
+  - **Fails visible, not silent.** When an invocation is recognised but its contents cannot be folded (no resolver, unreadable, oversized, binary, too deep), the verdict carries `opaque-script-invocation` at the lowest surfaced tier — recorded and auditable, never a gate on its own. The previous behaviour was to pass such calls as though they were clean.
+
 ## [4.47.16] - 2026-07-25
 
 **Memory recall stops surfacing housekeeping noise above load-bearing facts (#120), and the skill scanner stops crying wolf on legitimate skills while gaining an operator accept mechanism (#121).**

--- a/plugins/openclaw/__tests__/script-source-resolver-4.test.ts
+++ b/plugins/openclaw/__tests__/script-source-resolver-4.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createInterceptor, DEFAULT_CONFIG, createScriptSourceResolver } from '../interceptor.js';
+import { evaluateToolCall } from '../../../src/defence/iron-dome/tool-action-guard.js';
+
+/**
+ * Issue #4 — the fs-backed half of the script-file fix.
+ *
+ * The guard core stays pure and asks the caller for an invoked script's source;
+ * this is the resolver the interceptor injects, plus the end-to-end proof that
+ * a dangerous command inside a real `.sh` on disk is now gated exactly as the
+ * same command typed inline.
+ *
+ * Zeroth law: the resolver must never throw, never block and never let a
+ * gateway call fail because of it.
+ */
+
+const okPipeline = () => ({
+  allowed: true,
+  firewall: { result: 'ALLOW' as const, reason: '', threatIndicators: [] as string[], anomalyScore: 0, blockedPatterns: [] as string[] },
+  trust: { score: 0.5 },
+  sensitivity: { level: 'INTERNAL' },
+  fragmentation: null,
+  auditId: 1,
+});
+
+function makeInterceptor(overrides: Record<string, unknown> = {}) {
+  const config = { ...DEFAULT_CONFIG, ...overrides } as any;
+  return createInterceptor(config, okPipeline as any, { evaluateToolCall: evaluateToolCall as any });
+}
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sc-guard-4-'));
+  writeFileSync(join(dir, 'danger.sh'), '#!/bin/bash\nsudo systemctl stop ssh\n');
+  writeFileSync(join(dir, 'clean.sh'), '#!/bin/bash\necho hello\nnpm test\n');
+  writeFileSync(join(dir, 'binary.bin'), Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x00, 0x01]));
+  mkdirSync(join(dir, 'sub'));
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('#4 — createScriptSourceResolver', () => {
+  it('reads an absolute path', () => {
+    expect(createScriptSourceResolver()(join(dir, 'clean.sh'))).toContain('echo hello');
+  });
+
+  it('resolves a relative path against the supplied cwd', () => {
+    expect(createScriptSourceResolver(dir)('./clean.sh')).toContain('echo hello');
+    expect(createScriptSourceResolver(dir)('clean.sh')).toContain('echo hello');
+  });
+
+  it('returns null for a missing file, a directory and a device', () => {
+    const r = createScriptSourceResolver(dir);
+    expect(r(join(dir, 'nope.sh'))).toBeNull();
+    expect(r(join(dir, 'sub'))).toBeNull();
+    expect(r('/dev/zero')).toBeNull();
+    expect(r('/proc/self/cmdline')).toBeNull();
+  });
+
+  it('never throws on hostile input', () => {
+    const r = createScriptSourceResolver(dir);
+    for (const p of ['', '\0bad', '/', '~/', 'x'.repeat(5000)]) {
+      expect(() => r(p)).not.toThrow();
+    }
+  });
+
+  it('refuses a FIFO rather than blocking on it (zeroth law)', () => {
+    // A `read` on a FIFO with no writer blocks forever — statSync-first means
+    // it is never opened. Skipped where mkfifo is unavailable.
+    const fifo = join(dir, 'pipe.fifo');
+    try {
+      execFileSync('mkfifo', [fifo]);
+    } catch {
+      return;
+    }
+    const t = Date.now();
+    expect(createScriptSourceResolver(dir)(fifo)).toBeNull();
+    expect(Date.now() - t).toBeLessThan(2000);
+  });
+});
+
+describe('#4 — end-to-end: a dangerous script on disk is gated like the inline command', () => {
+  it('denies an unattended `bash danger.sh` exactly as the inline sudo command', async () => {
+    const i = makeInterceptor();
+    await expect(
+      i.handleToolCall({ toolName: 'Bash', arguments: { command: 'sudo systemctl stop ssh' } }),
+    ).rejects.toThrow(/blocked|deny/i);
+    await expect(
+      i.handleToolCall({ toolName: 'Bash', arguments: { command: `bash ${join(dir, 'danger.sh')}` } }),
+    ).rejects.toThrow(/blocked|deny/i);
+  });
+
+  it('resolves a relative script against the call cwd', async () => {
+    const i = makeInterceptor();
+    await expect(
+      i.handleToolCall({ toolName: 'Bash', arguments: { command: 'bash ./danger.sh', cwd: dir } }),
+    ).rejects.toThrow(/blocked|deny/i);
+  });
+
+  it('a clean script still passes with no prompt and no friction', async () => {
+    const i = makeInterceptor();
+    await expect(
+      i.handleToolCall({ toolName: 'Bash', arguments: { command: `bash ${join(dir, 'clean.sh')}` }, cwd: dir }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('an unreadable script is allowed, not denied — the gap is recorded, not enforced', async () => {
+    const entries: Array<Record<string, unknown>> = [];
+    const i = createInterceptor(DEFAULT_CONFIG as any, okPipeline as any, {
+      evaluateToolCall: evaluateToolCall as any,
+      onAuditEntry: (e) => entries.push(e as unknown as Record<string, unknown>),
+    });
+    await expect(
+      i.handleToolCall({ toolName: 'Bash', arguments: { command: `bash ${join(dir, 'ghost.sh')}` } }),
+    ).resolves.toBeUndefined();
+    const allow = entries.find((e) => e.action === 'allow');
+    expect(allow).toBeDefined();
+    expect(allow!.threats).toContain('opaque-script-invocation');
+  });
+});

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
-import { mkdirSync, appendFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, appendFileSync, readFileSync, statSync } from 'node:fs';
+import { join, isAbsolute, resolve as resolvePath } from 'node:path';
 import { homedir } from 'node:os';
 
 export type Severity = 'low' | 'medium' | 'high' | 'critical';
@@ -42,7 +42,19 @@ export interface ToolGuardVerdictLike {
   reason: string;
   signals: string[];
 }
-export type ToolGuardEvaluator = (toolName: string, args: Record<string, unknown>) => ToolGuardVerdictLike;
+/** Optional 4th-parameter seam on the real evaluator (issue #4): the guard core
+ *  stays pure/synchronous and asks the CALLER to resolve an invoked script's
+ *  source, so `bash deploy.sh` is scanned by the same rules as the inline
+ *  command. Structurally typed, like ToolGuardVerdictLike above. */
+export interface ToolGuardEvaluatorOptions {
+  resolveScriptSource?: (scriptPath: string) => string | null;
+}
+export type ToolGuardEvaluator = (
+  toolName: string,
+  args: Record<string, unknown>,
+  config?: unknown,
+  options?: ToolGuardEvaluatorOptions,
+) => ToolGuardVerdictLike;
 
 export interface InterceptorConfig {
   enabled: boolean;
@@ -56,6 +68,10 @@ export interface ToolCallContext {
   toolName: string;
   arguments: Record<string, unknown>;
   requireApproval?: (message: string) => Promise<boolean>;
+  /** Working directory the tool call runs in, when the gateway supplies one —
+   *  used to resolve a relative script path (issue #4). Falls back to the
+   *  call's own `cwd` argument, then `process.cwd()`. */
+  cwd?: string;
 }
 
 export interface InterceptAuditEntry {
@@ -487,6 +503,49 @@ type PipelineRunner = (content: string, title: string, source: { type: string; i
   auditId: number;
 };
 
+// ── Script source resolution (issue #4) ─────────────────────────────────────
+// `bash deploy.sh` used to bypass EVERY Action Guard rule, because the guard
+// only ever scanned the command string and never opened the file it pointed at.
+// The guard core stays pure (doctor/self-check drive it with synthetic commands
+// whose paths do not exist); this is the fs-backed half, wired in here.
+//
+// Zeroth law — this must never hang, block or crash the host gateway:
+//   * `statSync` first: only a REGULAR file is read, so a FIFO/socket/device
+//     (a `read` on which could block forever) is skipped, not opened;
+//   * `/proc`, `/sys`, `/dev` are never touched;
+//   * anything over the size cap is refused (the guard then records it as
+//     `opaque-script-invocation` rather than pretending it was scanned);
+//   * every error returns `null`. Nothing escapes.
+const MAX_SCRIPT_SOURCE_BYTES = 262_144;   // 256KB — matches the guard core's cap
+const UNREADABLE_PATH_PREFIX = /^\/(?:proc|sys|dev)\//;
+
+export function createScriptSourceResolver(cwd?: string): (scriptPath: string) => string | null {
+  const base = cwd && typeof cwd === 'string' ? cwd : process.cwd();
+  return (scriptPath: string): string | null => {
+    try {
+      if (!scriptPath || typeof scriptPath !== 'string') return null;
+      const expanded = scriptPath.startsWith('~/') ? join(homedir(), scriptPath.slice(2)) : scriptPath;
+      const full = isAbsolute(expanded) ? expanded : resolvePath(base, expanded);
+      if (UNREADABLE_PATH_PREFIX.test(full)) return null;
+      const st = statSync(full);
+      if (!st.isFile() || st.size > MAX_SCRIPT_SOURCE_BYTES) return null;
+      return readFileSync(full, 'utf8');
+    } catch {
+      return null;                          // missing, unreadable, anything — stay silent, stay alive
+    }
+  };
+}
+
+/** The cwd a tool call runs in, if the gateway or the call itself names one. */
+function toolCallCwd(context: ToolCallContext): string | undefined {
+  if (typeof context.cwd === 'string' && context.cwd) return context.cwd;
+  for (const k of ['cwd', 'workdir', 'working_directory', 'workingDirectory', 'directory']) {
+    const v = context.arguments?.[k];
+    if (typeof v === 'string' && v) return v;
+  }
+  return undefined;
+}
+
 interface InterceptorOptions {
   maxPromptsPerMinute?: number;
   onAuditEntry?: (entry: InterceptAuditEntry) => void;
@@ -591,7 +650,12 @@ export function createInterceptor(
 
     let v: ToolGuardVerdictLike;
     try {
-      v = evaluateToolCall(context.toolName, context.arguments || {});
+      // 4th arg (issue #4): lets the pure guard core scan the CONTENTS of a
+      // script the command invokes (`bash deploy.sh`) through this fs-backed
+      // resolver. An evaluator that predates the seam simply ignores it.
+      v = evaluateToolCall(context.toolName, context.arguments || {}, undefined, {
+        resolveScriptSource: createScriptSourceResolver(toolCallCwd(context)),
+      });
     } catch (err) {
       handleGuardUnavailable(context, `action-guard error: ${err instanceof Error ? err.message : err}`);
       return;

--- a/src/defence/index.ts
+++ b/src/defence/index.ts
@@ -78,8 +78,8 @@ export {
   DEFAULT_IRON_DOME_CONFIG,
 } from './iron-dome/index.js';
 // Tool Action Guard — gates what the agent DOES at runtime (shell/file/network/git).
-export { evaluateToolCall, classifyFamily, isCriticalPath, normaliseToolName } from './iron-dome/tool-action-guard.js';
-export type { ToolGuardVerdict, ToolGuardDecision, ToolGuardSeverity, ToolFamily } from './iron-dome/tool-action-guard.js';
+export { evaluateToolCall, classifyFamily, isCriticalPath, normaliseToolName, detectScriptInvocation } from './iron-dome/tool-action-guard.js';
+export type { ToolGuardVerdict, ToolGuardDecision, ToolGuardSeverity, ToolFamily, ToolGuardOptions } from './iron-dome/tool-action-guard.js';
 export type {
   IronDomeConfig,
   IronDomeProfile,

--- a/src/defence/iron-dome/__tests__/script-file-bypass.test.ts
+++ b/src/defence/iron-dome/__tests__/script-file-bypass.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { evaluateToolCall, detectScriptInvocation } from '../tool-action-guard.js';
+import type { ToolGuardVerdict } from '../tool-action-guard.js';
+
+/**
+ * Issue #4 — a dangerous command moved into a script file bypassed EVERY rule.
+ *
+ * The guard's danger matchers all ran against the exec surface built from the
+ * COMMAND STRING only (`[execCommand, path, url]`), so `bash payload.sh` was a
+ * universal bypass: catastrophic patterns, the dangerous table, `find -delete`,
+ * the secret-exfil hard block and the egress predicate all saw nothing. Live
+ * repro: a `curl -X DELETE` loop against an external API was correctly gated
+ * inline (`external-egress`), then ran with no gate at all from a `.sh` file.
+ *
+ * The fix keeps `evaluateToolCall` pure — the file is read by a resolver the
+ * CALLER injects (`options.resolveScriptSource`); these tests use stubs and
+ * never touch the real filesystem. When the source cannot be folded the call is
+ * still ALLOWED (this is how agents normally work) but carries a recorded
+ * `opaque-script-invocation` signal, so the gap is auditable instead of silent.
+ */
+
+/** A stub resolver over an in-memory file table. */
+function stubResolver(files: Record<string, string>): (p: string) => string | null {
+  return (p: string) => (Object.prototype.hasOwnProperty.call(files, p) ? files[p] : null);
+}
+
+function verdictOf(command: string, files?: Record<string, string>): ToolGuardVerdict {
+  return evaluateToolCall(
+    'Bash',
+    { command },
+    undefined,
+    files ? { resolveScriptSource: stubResolver(files) } : undefined,
+  );
+}
+
+const OPAQUE = 'opaque-script-invocation';
+/** A real NUL byte, built at runtime — source files stay NUL-free (source-hygiene). */
+const NUL = String.fromCharCode(0);
+
+describe('#4 — the live repro: external egress hidden in a script file', () => {
+  const inline = 'curl -X DELETE -H "Authorization: Bearer $T" https://api.example.com/x';
+
+  it('gates the via-file invocation exactly as it gates the inline command', () => {
+    const direct = verdictOf(inline);
+    expect(direct.decision).toBe('require_approval');
+    expect(direct.signals).toContain('external-egress');
+
+    const viaFile = verdictOf('bash /tmp/x.sh', { '/tmp/x.sh': `#!/bin/bash\nset -e\n${inline}\n` });
+    expect(viaFile.decision).toBe(direct.decision);
+    expect(viaFile.severity).toBe(direct.severity);
+    expect(viaFile.signals).toContain('external-egress');
+    expect(viaFile.signals).not.toContain(OPAQUE);   // the file WAS read
+  });
+
+  it('is the bypass it was before the fix when nothing resolves the file', () => {
+    // Documented, deliberate residual: with no resolver the contents are
+    // unknowable — but the call is now RECORDED as unscanned, not invisible.
+    const v = verdictOf('bash /tmp/x.sh');
+    expect(v.signals).toContain(OPAQUE);
+    expect(v.decision).toBe('allow');
+  });
+});
+
+describe('#4 — parity: inline verdict === via-file verdict', () => {
+  const cases: Array<[signal: string, command: string]> = [
+    ['install-package-global', 'npm install -g leftpad'],
+    ['privilege-escalation', 'sudo systemctl restart nginx'],
+    ['file-delete', 'rm /tmp/old-report.txt'],
+    ['dd-overwrite', 'dd if=/dev/zero of=/tmp/data.img bs=1M count=10'],
+    ['truncate-to-zero', 'truncate -s 0 /var/log/app.log'],
+  ];
+
+  it.each(cases)('%s', (signal, command) => {
+    const direct = verdictOf(command);
+    expect(direct.decision).toBe('require_approval');
+    expect(direct.signals).toContain(signal);
+
+    const viaFile = verdictOf('bash ./run.sh', { './run.sh': `#!/usr/bin/env bash\n${command}\n` });
+    expect(viaFile.decision).toBe(direct.decision);
+    expect(viaFile.severity).toBe(direct.severity);
+    expect(viaFile.action).toBe(direct.action);
+    expect(viaFile.signals).toEqual(expect.arrayContaining(direct.signals));
+  });
+
+  it('a catastrophic payload in a file still hard-blocks', () => {
+    const v = verdictOf('sh /tmp/wipe.sh', { '/tmp/wipe.sh': 'rm -rf /\n' });
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('catastrophic');
+    expect(v.signals).toContain('recursive-force-delete');
+  });
+
+  it('covers every invocation shape, not just `bash f.sh`', () => {
+    const payload = 'sudo rm -r /var/lib/thing\n';
+    const shapes: Array<[string, Record<string, string>]> = [
+      ['bash -e /tmp/a.sh', { '/tmp/a.sh': payload }],
+      ['sh /tmp/a.sh', { '/tmp/a.sh': payload }],
+      ['zsh /tmp/a.sh', { '/tmp/a.sh': payload }],
+      ['dash /tmp/a.sh', { '/tmp/a.sh': payload }],
+      ['ksh /tmp/a.sh', { '/tmp/a.sh': payload }],
+      ['python3 /tmp/a.py', { '/tmp/a.py': payload }],
+      ['node /tmp/a.js', { '/tmp/a.js': payload }],
+      ['ruby /tmp/a.rb', { '/tmp/a.rb': payload }],
+      ['perl /tmp/a.pl', { '/tmp/a.pl': payload }],
+      ['./a.sh', { './a.sh': payload }],
+      ['/opt/tools/a.sh', { '/opt/tools/a.sh': payload }],
+      ['source /tmp/a.sh', { '/tmp/a.sh': payload }],
+      ['. /tmp/a.sh', { '/tmp/a.sh': payload }],
+      ['env FOO=1 bash /tmp/a.sh', { '/tmp/a.sh': payload }],
+      ['sudo -u deploy bash /tmp/a.sh', { '/tmp/a.sh': payload }],
+      ['cd /tmp && ./a.sh', { './a.sh': payload }],
+    ];
+    for (const [command, files] of shapes) {
+      const v = verdictOf(command, files);
+      expect([command, v.decision]).toEqual([command, 'require_approval']);
+      expect([command, v.signals.includes('privilege-escalation')]).toEqual([command, true]);
+    }
+  });
+});
+
+describe('#4 — bounded following of nested scripts', () => {
+  it('follows a script that invokes a script (within the depth limit)', () => {
+    const v = verdictOf('bash /tmp/a.sh', {
+      '/tmp/a.sh': 'echo step 1\nbash /tmp/b.sh\n',
+      '/tmp/b.sh': 'echo step 2\nsh /tmp/c.sh\n',
+      '/tmp/c.sh': 'rm -rf /\n',
+    });
+    expect(v.decision).toBe('block');
+    expect(v.signals).toContain('recursive-force-delete');
+  });
+
+  it('stops at depth 3 and says so instead of pretending it scanned', () => {
+    const v = verdictOf('bash /tmp/a.sh', {
+      '/tmp/a.sh': 'bash /tmp/b.sh\n',
+      '/tmp/b.sh': 'bash /tmp/c.sh\n',
+      '/tmp/c.sh': 'bash /tmp/d.sh\n',
+      '/tmp/d.sh': 'rm -rf /\n',
+    });
+    expect(v.signals).toContain(OPAQUE);
+    expect(v.decision).not.toBe('block');
+  });
+
+  it('terminates on a source cycle (a → b → a) without hanging', () => {
+    const started = Date.now();
+    const v = verdictOf('bash /tmp/a.sh', {
+      '/tmp/a.sh': 'source /tmp/b.sh\n',
+      '/tmp/b.sh': 'source /tmp/a.sh\nsudo rm -r /srv/data\n',
+    });
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(v.decision).toBe('require_approval');
+    expect(v.signals).toContain('privilege-escalation');
+  });
+
+  it('bounds how many files one call may fold', () => {
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 40; i++) files[`/tmp/s${i}.sh`] = `echo ${i}\n`;
+    const command = Object.keys(files).map(p => `bash ${p}`).join('; ');
+    const calls: string[] = [];
+    const v = evaluateToolCall('Bash', { command }, undefined, {
+      resolveScriptSource: (p) => { calls.push(p); return files[p] ?? null; },
+    });
+    expect(calls.length).toBeLessThanOrEqual(12);
+    expect(v.decision).toBe('allow');
+  });
+});
+
+describe('#4 — could-not-scan is visible, never silent, never a gate', () => {
+  it('no resolver at all → opaque signal, decision NOT escalated', () => {
+    const v = verdictOf('bash /tmp/deploy.sh');
+    expect(v.signals).toContain(OPAQUE);
+    expect(v.decision).toBe('allow');
+    expect(v.severity).toBe('sensitive');       // recorded + surfaced, not benign
+    expect(v.reason).toMatch(/could not read the invoked script/);
+  });
+
+  it('resolver returns null (missing / unreadable file) → opaque', () => {
+    const v = verdictOf('bash /tmp/gone.sh', { '/tmp/other.sh': 'echo hi\n' });
+    expect(v.signals).toContain(OPAQUE);
+    expect(v.decision).toBe('allow');
+  });
+
+  it('oversized content → opaque, not a silent pass', () => {
+    const huge = `echo padding\n`.repeat(30_000);        // > 256KB
+    expect(huge.length).toBeGreaterThan(262_144);
+    const v = verdictOf('bash /tmp/big.sh', { '/tmp/big.sh': huge });
+    expect(v.signals).toContain(OPAQUE);
+    expect(v.decision).toBe('allow');
+  });
+
+  it('binary content (NUL bytes) → opaque', () => {
+    const binary = 'ELF' + NUL + NUL + 'payload'.repeat(20);
+    const v = verdictOf('./tool', { './tool': binary });
+    expect(v.signals).toContain(OPAQUE);
+    expect(v.decision).toBe('allow');
+  });
+
+  it('a throwing resolver cannot break the call (zeroth law)', () => {
+    const v = evaluateToolCall('Bash', { command: 'bash /tmp/a.sh' }, undefined, {
+      resolveScriptSource: () => { throw new Error('EACCES'); },
+    });
+    expect(v.decision).toBe('allow');
+    expect(v.signals).toContain(OPAQUE);
+  });
+
+  it('an opaque script alongside a real danger neither hides nor upgrades it', () => {
+    const v = verdictOf('sudo systemctl stop nginx; bash /tmp/unknown.sh');
+    expect(v.decision).toBe('require_approval');
+    expect(v.signals).toContain('privilege-escalation');
+    expect(v.signals).toContain(OPAQUE);
+  });
+});
+
+describe('#4 — no new friction on the way agents actually work', () => {
+  it('a clean script reads clean: allow, benign, zero signals', () => {
+    const v = verdictOf('bash /tmp/hello.sh', { '/tmp/hello.sh': 'echo hello\n' });
+    expect(v.decision).toBe('allow');
+    expect(v.severity).toBe('benign');
+    expect(v.signals).toEqual([]);
+  });
+
+  it('a clean script verdict is identical to the pre-fix verdict', () => {
+    const clean = 'npm test\nnode build.js\necho done\n';
+    const before = evaluateToolCall('Bash', { command: 'echo done' });
+    const after = verdictOf('bash /tmp/ci.sh', { '/tmp/ci.sh': clean, 'build.js': 'console.log(1)\n' });
+    expect(after.decision).toBe(before.decision);
+    expect(after.severity).toBe(before.severity);
+    expect(after.signals).toEqual([]);
+  });
+
+  it('a comment mentioning a dangerous command is not an action', () => {
+    const v = verdictOf('bash /tmp/doc.sh', { '/tmp/doc.sh': '# never run rm -rf / here\necho safe\n' });
+    expect(v.decision).toBe('allow');
+    expect(v.severity).toBe('benign');
+  });
+
+  it('does not resolve anything for commands that invoke no script', () => {
+    const calls: string[] = [];
+    const resolveScriptSource = (p: string) => { calls.push(p); return null; };
+    for (const command of ['ls -la', 'npm test', 'git status', 'grep -rn foo src/', 'echo hi']) {
+      const v = evaluateToolCall('Bash', { command }, undefined, { resolveScriptSource });
+      expect([command, v.decision]).toEqual([command, 'allow']);
+      expect([command, v.signals.includes(OPAQUE)]).toEqual([command, false]);
+    }
+    expect(calls).toEqual([]);
+  });
+
+  it('never reads a file just because a path/url ARGUMENT names one', () => {
+    // Field discipline: detection runs on the command, never on path/url args,
+    // so editing a script is not the same as executing it.
+    const resolveScriptSource = jest.fn((_p: string) => 'rm -rf /\n');
+    const v = evaluateToolCall(
+      'Write',
+      { file_path: '/tmp/deploy.sh', content: 'whatever' },
+      undefined,
+      { resolveScriptSource: resolveScriptSource as unknown as (p: string) => string | null },
+    );
+    expect(resolveScriptSource).not.toHaveBeenCalled();
+    expect(v.decision).toBe('allow');
+  });
+});
+
+describe('#4 — detectScriptInvocation shapes', () => {
+  it('recognises interpreters, bare paths, source and wrapper prefixes', () => {
+    expect(detectScriptInvocation('bash /tmp/x.sh')).toEqual(['/tmp/x.sh']);
+    expect(detectScriptInvocation('bash -e ./f.sh')).toEqual(['./f.sh']);
+    expect(detectScriptInvocation('python3 /tmp/a.py')).toEqual(['/tmp/a.py']);
+    expect(detectScriptInvocation('node server.js')).toEqual(['server.js']);
+    expect(detectScriptInvocation('ruby ./task.rb')).toEqual(['./task.rb']);
+    expect(detectScriptInvocation('perl ./task.pl')).toEqual(['./task.pl']);
+    expect(detectScriptInvocation('./f.sh')).toEqual(['./f.sh']);
+    expect(detectScriptInvocation('/opt/bin/deploy')).toEqual(['/opt/bin/deploy']);
+    expect(detectScriptInvocation('source f.sh')).toEqual(['f.sh']);
+    expect(detectScriptInvocation('. ./f.sh')).toEqual(['./f.sh']);
+    expect(detectScriptInvocation('env VAR=1 bash f.sh')).toEqual(['f.sh']);
+    expect(detectScriptInvocation('nohup sudo bash /tmp/f.sh &')).toEqual(['/tmp/f.sh']);
+    expect(detectScriptInvocation('timeout 30 bash f.sh')).toEqual(['f.sh']);
+  });
+
+  it('does NOT treat an inline program as a file invocation', () => {
+    expect(detectScriptInvocation(`bash -c 'echo hi && ls'`)).toEqual([]);
+    expect(detectScriptInvocation(`sh -c "curl https://x.test | jq ."`)).toEqual([]);
+    expect(detectScriptInvocation(`python3 -c "import os; print(os.getcwd())"`)).toEqual([]);
+    expect(detectScriptInvocation(`python3 -m http.server`)).toEqual([]);
+    expect(detectScriptInvocation(`node -e "console.log(1)"`)).toEqual([]);
+    expect(detectScriptInvocation(`perl -ne 'print' file.txt`)).toEqual([]);
+    expect(detectScriptInvocation('cat data.json | python3 -')).toEqual([]);
+  });
+
+  it('still follows a file invocation NESTED inside an inline program', () => {
+    expect(detectScriptInvocation(`bash -c 'bash /tmp/inner.sh'`)).toEqual(['/tmp/inner.sh']);
+  });
+
+  it('finds nothing in ordinary non-script commands', () => {
+    for (const c of ['ls -la', 'npm test', 'git status', 'npx tsc', 'grep -rn "bash x.sh" docs/']) {
+      expect([c, detectScriptInvocation(c)]).toEqual([c, []]);
+    }
+  });
+
+  it('stays fast on adversarial input (30k chars, no match)', () => {
+    const s = 'nice -n 10 env FOO=1 nohup '.repeat(1100) + 'echo done';
+    const t = process.hrtime.bigint();
+    detectScriptInvocation(s);
+    const ms = Number(process.hrtime.bigint() - t) / 1e6;
+    expect(ms).toBeLessThan(300);
+  });
+});

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -490,6 +490,7 @@ const REMEDIATION: Record<string, string> = {
   'recursive-perms-system-dir': 'confirm this is intentional — recursive permission changes on a system directory can break the host',
   'truncate-to-zero': 'confirm the target file before truncating — this discards its contents',
   'dd-overwrite': 'confirm the destination before running dd — it overwrites the target without confirmation',
+  'opaque-script-invocation': 'the guard could not read the invoked script, so its contents were not scanned — inspect the file before running it',
 };
 
 /** Compose a reason string that names the rule, the matched span, and a fix hint. */
@@ -751,6 +752,279 @@ export function commandScanText(cmd: string): string {
   return stripComments(stripQuotedHeredocs(cmd));
 }
 
+// ── Script-file invocation (issue #4) ────────────────────────────────────────
+//
+// Every rule above scans the EXEC SURFACE — the command string. So moving a
+// dangerous command into a file and running `bash script.sh` bypassed all of
+// them: the guard never read the file. (Confirmed live: a `curl -X DELETE`
+// loop was blocked inline as `external-egress`, then ran ungated from a `.sh`.)
+//
+// The fix is a recognition helper (below) plus an INJECTED source resolver
+// (`ToolGuardOptions.resolveScriptSource`) that the caller supplies. This file
+// stays pure and synchronous — see the evaluateToolCall docblock for why that
+// is load-bearing — and the fs-backed resolver lives at the interceptor / hook
+// boundary. When no resolver is available, the invocation is still RECORDED
+// (`opaque-script-invocation`, lowest surfaced tier) rather than silently
+// unscanned: the gap becomes legible in the audit log instead of invisible.
+
+/** Interpreters that take a SCRIPT FILE argument and execute its contents. */
+const SCRIPT_INTERPRETER = /^(?:bash|sh|zsh|ksh|dash|ash|python\d?(?:\.\d+)?|node|nodejs|ruby|perl|php)$/;
+/** Transparent process wrappers — they don't change WHAT is executed. Same set
+ *  (plus `timeout`/`setsid`) as the modify-scheduler command-position rule. */
+const EXEC_WRAPPER = /^(?:sudo|doas|env|nohup|time|stdbuf|nice|command|exec|setsid|ionice|timeout)$/;
+/** Shell keywords that may sit in front of the real command word. */
+const SHELL_KEYWORD = /^(?:then|else|elif|do|done|fi|in|\{|\}|!)$/;
+/** Flags that consume the FOLLOWING token as their value (so it is not a path). */
+const FLAG_TAKES_VALUE = /^(?:-o|-O|-X|-W|-r|--require|--rcfile|--init-file|--loader|--experimental-loader)$/;
+/** Per-wrapper flags that take a separate value token — without these,
+ *  `sudo -u bob bash run.sh` reads `bob` as the command word and the real
+ *  interpreter is never seen. */
+const WRAPPER_FLAG_TAKES_VALUE: Record<string, RegExp> = {
+  sudo: /^-(?:u|g|p|C|D|R|T|h)$/,
+  doas: /^-(?:u|C)$/,
+  env: /^-(?:u|C|S)$/,
+  timeout: /^-(?:s|k)$/,
+  nice: /^-n$/,
+  ionice: /^-(?:c|n|p)$/,
+  stdbuf: /^-(?:i|o|e)$/,
+};
+
+/** A path token worth resolving: explicitly relative/absolute/home-anchored. */
+function looksLikePathToken(tok: string): boolean {
+  return /^(?:\.{1,2}\/|\/|~\/)/.test(tok) && !/^\/dev\//.test(tok);
+}
+
+/** Does an interpreter flag mean "the program is inline / on stdin", not a file? */
+function isInlineProgramFlag(interp: string, flag: string): boolean {
+  const cluster = /^-[A-Za-z]+$/.test(flag) ? flag.slice(1) : '';
+  if (/^(?:bash|sh|zsh|ksh|dash|ash)$/.test(interp)) {
+    // Lowercase `c` in a short cluster is always -c (the uppercase -C is
+    // noclobber); `s` is "read the program from stdin".
+    return cluster.includes('c') || cluster.includes('s');
+  }
+  if (/^python/.test(interp)) return cluster.includes('c') || cluster.includes('m');
+  if (/^node/.test(interp)) return /^(?:-e|-p|--eval|--print)$/.test(flag);
+  if (/^(?:perl|ruby)$/.test(interp)) return cluster.toLowerCase().includes('e');
+  if (interp === 'php') return cluster.includes('r');
+  return false;
+}
+
+/** Split shell text into candidate statements. Command substitution, subshells
+ *  and backticks open a new statement, exactly like `;`. */
+function splitCommandStatements(text: string): string[] {
+  return text.replace(/\$\(|[`()]/g, '\n').split(/[;&|\n\r]+/);
+}
+
+/**
+ * Whitespace-split a statement into argv-ish tokens, keeping quoted spans
+ * together. Hand-rolled (not a regex) so it is linear and cannot backtrack —
+ * this runs on every tool call, on strings up to OVERSIZED_COMMAND_LENGTH.
+ */
+function tokeniseStatement(stmt: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let quote: string | null = null;
+  for (let i = 0; i < stmt.length; i++) {
+    const c = stmt[i];
+    if (c === '\\' && quote !== "'" && i + 1 < stmt.length) { cur += stmt[++i]; continue; }
+    if (quote) {
+      if (c === quote) quote = null;
+      else cur += c;
+      continue;
+    }
+    if (c === '"' || c === "'") { quote = c; continue; }
+    if (c === ' ' || c === '\t') { if (cur) { out.push(cur); cur = ''; } continue; }
+    cur += c;
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+/** `/usr/bin/python3` → `python3`; quotes already stripped by the tokeniser. */
+function commandBaseName(tok: string): string {
+  const slash = tok.lastIndexOf('/');
+  return slash >= 0 ? tok.slice(slash + 1) : tok;
+}
+
+const MAX_DETECTED_SCRIPTS = 8;
+/** How deep to look inside `sh -c '…'` strings for a nested file invocation. */
+const MAX_INLINE_RECURSION = 2;
+
+/**
+ * Paths of script FILES this command executes — the targets whose contents the
+ * danger rules never saw before.
+ *
+ * Recognised shapes: `bash f.sh` (with intervening short flags, `bash -e f.sh`),
+ * `python3 f.py` / `node f.js` / `ruby f.rb` / `perl f.pl`, `./f.sh` and other
+ * explicit relative/absolute paths in command position, `source f.sh` / `. f.sh`,
+ * and all of the above behind env-assignment / `env` / `sudo` / `nohup`-style
+ * wrapper prefixes.
+ *
+ * Deliberately NOT recognised: `bash -c '<inline>'`. That inline program is
+ * already part of the exec surface and already scanned — treating it as a file
+ * would be both wrong and a resolver dead-end. (A file invocation *nested*
+ * inside the inline string is still recognised, by recursing into it.)
+ */
+export function detectScriptInvocation(execSurface: string, depth = 0): string[] {
+  const found: string[] = [];
+  if (!execSurface || depth > MAX_INLINE_RECURSION) return found;
+
+  const add = (p: string): void => {
+    const clean = p.trim();
+    if (!clean || clean === '-' || /^https?:\/\//i.test(clean)) return;
+    if (!found.includes(clean) && found.length < MAX_DETECTED_SCRIPTS) found.push(clean);
+  };
+
+  for (const stmt of splitCommandStatements(execSurface)) {
+    if (found.length >= MAX_DETECTED_SCRIPTS) break;
+    if (!stmt.trim()) continue;
+    const tokens = tokeniseStatement(stmt);
+
+    // Step over env assignments, transparent wrappers (and their own flags /
+    // assignments / duration args) and shell keywords to reach the command word.
+    let i = 0;
+    while (i < tokens.length) {
+      const t = tokens[i];
+      if (/^\w+=/.test(t) || SHELL_KEYWORD.test(t)) { i++; continue; }
+      const wrapper = commandBaseName(t);
+      if (EXEC_WRAPPER.test(wrapper)) {
+        const takesValue = WRAPPER_FLAG_TAKES_VALUE[wrapper];
+        i++;
+        while (i < tokens.length) {
+          const a = tokens[i];
+          if (/^\w+=/.test(a) || /^\d+[smhd]?$/.test(a)) { i++; continue; }
+          if (a.startsWith('-')) { i++; if (takesValue?.test(a)) i++; continue; }
+          break;
+        }
+        continue;
+      }
+      break;
+    }
+    if (i >= tokens.length) continue;
+
+    const cmd = tokens[i];
+    const base = commandBaseName(cmd);
+
+    // `source f.sh` / `. f.sh`
+    if (base === 'source' || cmd === '.') {
+      const target = tokens[i + 1];
+      if (target && !target.startsWith('-')) add(target);
+      continue;
+    }
+
+    if (SCRIPT_INTERPRETER.test(base)) {
+      for (let j = i + 1; j < tokens.length; j++) {
+        const a = tokens[j];
+        if (a === '-') break;                                   // program on stdin
+        if (a === '<') continue;                                // `bash < f.sh`
+        if (a.startsWith('<')) { add(a.slice(1)); break; }
+        if (a.startsWith('>')) break;                           // redirect target, not a program
+        if (a.startsWith('-')) {
+          if (isInlineProgramFlag(base, a)) {
+            // The inline program itself is already in the exec surface (and
+            // already scanned); only follow a file invocation NESTED in it.
+            if (/^(?:bash|sh|zsh|ksh|dash|ash)$/.test(base)) {
+              for (const nested of detectScriptInvocation(tokens[j + 1] ?? '', depth + 1)) add(nested);
+            }
+            break;
+          }
+          if (FLAG_TAKES_VALUE.test(a)) j++;
+          continue;
+        }
+        add(a);
+        break;
+      }
+      continue;
+    }
+
+    // `./f.sh`, `/opt/deploy/run`, `~/bin/task`
+    if (looksLikePathToken(cmd)) add(cmd);
+  }
+  return found;
+}
+
+/** Per-file read cap. Larger than any hand-written script; a file over it is
+ *  treated as opaque rather than truncated — truncating could cut past a danger
+ *  signal, the same reasoning as OVERSIZED_COMMAND_LENGTH below. */
+const MAX_SCRIPT_BYTES = 262_144;
+/** Total folded content per tool call — the global bound on worst-case scan
+ *  work, so the guard can never stall the host gateway (zeroth law). Measured
+ *  on the ARM box: a full 256KB fold costs ~22ms of synchronous scanning; a
+ *  real-world script (a few KB) is sub-millisecond. */
+const MAX_FOLDED_BYTES = 262_144;
+/** A script that invokes a script is followed, bounded. */
+const MAX_SCRIPT_DEPTH = 3;
+/** Backstop on how many files one tool call may fold. */
+const MAX_SCRIPTS_PER_CALL = 12;
+
+export interface ToolGuardOptions {
+  /**
+   * Resolve an invoked script path to its source text, or `null` when it cannot
+   * be read. Supplied by the CALLER (interceptor / hook), never by this module —
+   * that is what keeps `evaluateToolCall` pure and synchronous. Must never throw
+   * and must never block (see the interceptor's fs-backed implementation).
+   */
+  resolveScriptSource?: (scriptPath: string) => string | null;
+}
+
+interface ScriptFold {
+  /** Scan-ready text of every script whose source was resolved. */
+  content: string;
+  /** A script invocation was recognised but its contents could NOT be folded. */
+  opaque: boolean;
+}
+
+/**
+ * Resolve the scripts a command invokes and return their (comment-stripped)
+ * contents for scanning. Bounded on every axis: depth, file count, per-file
+ * size, total size, and a visited set that makes a source-cycle terminate.
+ */
+function foldScriptSources(
+  execCommand: string,
+  resolveScriptSource?: (scriptPath: string) => string | null,
+): ScriptFold {
+  const roots = detectScriptInvocation(execCommand);
+  if (roots.length === 0) return { content: '', opaque: false };
+  if (typeof resolveScriptSource !== 'function') return { content: '', opaque: true };
+
+  const visited = new Set<string>();
+  const queue: Array<{ path: string; depth: number }> = roots.map(path => ({ path, depth: 1 }));
+  const parts: string[] = [];
+  let total = 0;
+  let opaque = false;
+
+  while (queue.length > 0) {
+    const next = queue.shift();
+    if (!next) break;
+    if (visited.has(next.path)) continue;              // cycle guard
+    visited.add(next.path);
+    if (visited.size > MAX_SCRIPTS_PER_CALL) { opaque = true; break; }
+
+    let src: string | null = null;
+    try {
+      src = resolveScriptSource(next.path);
+    } catch {
+      src = null;                                       // a resolver must never break the call
+    }
+    if (typeof src !== 'string') { opaque = true; continue; }   // missing / unreadable
+    if (src.length === 0) continue;                     // empty file — nothing to scan, not a gap
+    if (src.includes('\0')) { opaque = true; continue; }        // binary
+    if (src.length > MAX_SCRIPT_BYTES || total + src.length > MAX_FOLDED_BYTES) { opaque = true; continue; }
+
+    const scan = commandScanText(deobfuscateIfs(src));
+    total += src.length;
+    parts.push(scan);
+
+    const nested = detectScriptInvocation(scan);
+    if (nested.length > 0) {
+      if (next.depth >= MAX_SCRIPT_DEPTH) opaque = true;         // depth exceeded — say so
+      else for (const p of nested) if (!visited.has(p)) queue.push({ path: p, depth: next.depth + 1 });
+    }
+  }
+
+  return { content: parts.join('\n'), opaque };
+}
+
 // ── Main entry point ─────────────────────────────────────────────────────────
 
 // A command this long is already anomalous for an interactive tool call — cap
@@ -779,11 +1053,18 @@ const ACTION_BY_FAMILY: Record<ToolFamily, string> = {
  * Pure and synchronous — no I/O. The interceptor decides how to ENFORCE the
  * verdict (block / prompt / warn) based on its own posture; this function only
  * RECOGNISES and recommends.
+ *
+ * Purity is load-bearing and must stay: this runs on EVERY tool call, and
+ * `src/cli/doctor.ts` + `src/setup/openclaw-selfcheck.ts` drive it with
+ * synthetic commands whose paths deliberately do not exist. Reading the script
+ * a command points at (issue #4) therefore comes in through the caller-supplied
+ * `options.resolveScriptSource` seam — no `fs` here, ever.
  */
 export function evaluateToolCall(
   toolName: string,
   args: Record<string, unknown> = {},
   config?: IronDomeConfig,
+  options?: ToolGuardOptions,
 ): ToolGuardVerdict {
   const family = classifyFamily(toolName);
   const command = deobfuscateIfs(extractCommand(args));
@@ -807,16 +1088,33 @@ export function evaluateToolCall(
   const execCommand = commandScanText(command);
   const execSurface = [execCommand, path, url].filter(Boolean).join('   ');
 
+  // Script-file invocation (issue #4): `bash deploy.sh` used to hide EVERY rule
+  // below behind a file the guard never opened. Detection runs on the COMMAND
+  // only — never on a path/url argument — so an `Edit`/`Write` whose target
+  // merely *is* a script is untouched, preserving the field discipline above.
+  // An oversized command is already flagged (and already anomalous); skip the
+  // work rather than tokenise 50k+ chars of it.
+  const fold = command.length > OVERSIZED_COMMAND_LENGTH
+    ? { content: '', opaque: false }
+    : foldScriptSources(execCommand, options?.resolveScriptSource);
+  // Folded script source is appended, never substituted: the command surface is
+  // scanned exactly as before, so no existing verdict can change direction.
+  const scanSurface = fold.content ? `${execSurface}\n${fold.content}` : execSurface;
+  // Recorded at the lowest surfaced tier when a script's contents could not be
+  // read (no resolver, unreadable, oversized, binary, too deep). Never a gate on
+  // its own — the doctor/selfcheck probes and plenty of legitimate calls hit it.
+  const opaqueSignals = fold.opaque ? ['opaque-script-invocation'] : [];
+
   // 1) Catastrophic — hard block, cannot fail open, ignores config.
   // Span-classified (#84): a catastrophic token inside a URL or a quoted DATA
   // argument is a mention, not intent (`grep "rm -rf /" log`, a fetched URL
   // whose path contains "rm-rf") — but any executed occurrence still hard-blocks.
-  const catastrophicMatches = matchSpansClassified(CATASTROPHIC, execSurface);
+  const catastrophicMatches = matchSpansClassified(CATASTROPHIC, scanSurface);
   if (catastrophicMatches.length > 0) {
     const catastrophicSignals = catastrophicMatches.map(m => m.signal);
     return verdict('block', 'catastrophic', family, ACTION_BY_FAMILY[family],
       buildReason('catastrophic operation blocked', catastrophicSignals, catastrophicMatches[0].span),
-      catastrophicSignals);
+      [...catastrophicSignals, ...opaqueSignals]);
   }
 
   // 1a) A structured delete tool carries its target as a path, not a command —
@@ -830,18 +1128,19 @@ export function evaluateToolCall(
   // catastrophic when <path> is root/home/a system dir/a wildcard — same rule
   // as 1a. A non-critical path still recursively deletes everything under it,
   // so it is folded into the DANGEROUS signals below (dangerSignals) instead.
-  const findDeleteMatch = matchFindDelete(execSurface);
+  const findDeleteMatch = matchFindDelete(scanSurface);
   if (findDeleteMatch && isCriticalPath(findDeleteMatch[1])) {
     return verdict('block', 'catastrophic', family, ACTION_BY_FAMILY[family],
       buildReason('catastrophic operation blocked', ['recursive-find-delete'], findDeleteMatch[0].trim().replace(/\s+/g, ' ').slice(0, 80)),
-      ['recursive-find-delete']);
+      ['recursive-find-delete', ...opaqueSignals]);
   }
 
   // 1c) Secret exfiltration: external egress carrying a credential/secret.
-  const egress = family === 'network' || EXTERNAL_EGRESS.test(execCommand) || EXTERNAL_EGRESS.test(url);
-  if (egress && SECRET_HINT.test(`${execSurface}   ${rawStringArgs(args)}`) && looksExternal(url, execSurface)) {
+  const egressCommand = fold.content ? `${execCommand}\n${fold.content}` : execCommand;
+  const egress = family === 'network' || EXTERNAL_EGRESS.test(egressCommand) || EXTERNAL_EGRESS.test(url);
+  if (egress && SECRET_HINT.test(`${scanSurface}   ${rawStringArgs(args)}`) && looksExternal(url, scanSurface)) {
     return verdict('block', 'catastrophic', family, 'data_exfiltration',
-      'blocked likely secret exfiltration (credential bound for an external host)', ['secret-egress']);
+      'blocked likely secret exfiltration (credential bound for an external host)', ['secret-egress', ...opaqueSignals]);
   }
 
   // Config can auto-approve specific actions the operator has whitelisted.
@@ -852,14 +1151,14 @@ export function evaluateToolCall(
 
   // 2) Dangerous — recognised, effectful, worth a human nod → require approval.
   // Span-classified (#84): same mention-vs-intent filter as catastrophic above.
-  const dangerMatches = matchSpansClassified(DANGEROUS, execSurface);
+  const dangerMatches = matchSpansClassified(DANGEROUS, scanSurface);
   const dangerSignals = dangerMatches.map(m => m.signal);
   let dangerSpan = dangerMatches[0]?.span;
   // External egress is a potential exfil vector — but only when the call carries
   // a payload OFF-host. A read-only GET (docs / releases fetch) leaves nothing
   // behind and is not egress (issue #73.2). Secret-bearing egress already hard
   // blocked at step 1b above regardless of method.
-  if (egress && looksExternal(url, execSurface) && hasOutboundData(args, execSurface)) {
+  if (egress && looksExternal(url, scanSurface) && hasOutboundData(args, scanSurface)) {
     dangerSignals.push('external-egress');
     dangerSpan = dangerSpan ?? (url || 'external host');
   }
@@ -875,9 +1174,9 @@ export function evaluateToolCall(
   // shape counts as registry-code-exec — see isGatedNpxBunx for the boundary.
   // uvx / pnpm-yarn dlx are unconditional matches already captured by the
   // DANGEROUS patterns above.
-  if (isGatedNpxBunx(execSurface) && !dangerSignals.includes('registry-code-exec')) {
+  if (isGatedNpxBunx(scanSurface) && !dangerSignals.includes('registry-code-exec')) {
     dangerSignals.push('registry-code-exec');
-    dangerSpan = dangerSpan ?? (execSurface.match(NPX_BUNX_COMMAND_RE)?.[0]?.trim() ?? 'npx/bunx');
+    dangerSpan = dangerSpan ?? (scanSurface.match(NPX_BUNX_COMMAND_RE)?.[0]?.trim() ?? 'npx/bunx');
   }
   // An anomalously long command is worth a human nod on its own (issue
   // #86-redos) — flagged here, after every catastrophic check above has
@@ -891,13 +1190,24 @@ export function evaluateToolCall(
     const action = dangerActionFor(dangerSignals, family);
     return verdict('require_approval', 'dangerous', family, action,
       buildReason('recognised dangerous operation requires approval', dangerSignals, dangerSpan),
-      dangerSignals);
+      [...dangerSignals, ...opaqueSignals]);
   }
 
   // 3) Sensitive-but-routine — allow, but tag so the interceptor can announce.
-  const sensitiveSignal = firstMatch(SENSITIVE, execSurface);
+  const sensitiveSignal = firstMatch(SENSITIVE, scanSurface);
   if (sensitiveSignal) {
-    return verdict('allow', 'sensitive', family, canonical, `sensitive operation (${sensitiveSignal})`, [sensitiveSignal]);
+    return verdict('allow', 'sensitive', family, canonical, `sensitive operation (${sensitiveSignal})`,
+      [sensitiveSignal, ...opaqueSignals]);
+  }
+
+  // 3a) A script invocation whose contents could NOT be read (issue #4). Allowed
+  // — this is the normal shape of agent work and must not become a gate — but
+  // recorded at the sensitive tier so the unscanned gap is auditable instead of
+  // invisible. When the source IS resolvable and clean, nothing is added here
+  // and the verdict is bit-for-bit what it was before this change.
+  if (opaqueSignals.length > 0) {
+    return verdict('allow', 'sensitive', family, canonical,
+      buildReason('script contents were not scanned', opaqueSignals), opaqueSignals);
   }
 
   // 4) A bare exec/network/write/git call with no dangerous signal is treated as


### PR DESCRIPTION
## The bug

The Action Guard built its match surface from the command / path / url arguments only, and never read the file a command pointed at. Moving any command into a script and running `bash script.sh` therefore bypassed **every** rule — the catastrophic patterns, the dangerous table, `find -delete`, the secret-exfil hard block and the egress predicate all scanned a surface that contained none of the relevant text.

Found by dogfooding on 29 Jul 2026: a bulk `curl -X DELETE` against an external API was correctly gated inline as `external-egress`, then ran with no gate at all from a `.sh` file. Same destination, same payload, same credential.

Because writing a script and running it is how agents normally work, this was likely being hit routinely — producing audit logs that read as clean runs when the guard had simply never looked. Tracked privately as ShieldCortex-internal#4 rather than here, since this repo is public and there was no fix at filing time.

## The fix

`detectScriptInvocation()` recognises the invocation shapes and `foldScriptSources()` appends the resolved contents to the scan surface.

Recognised: interpreter + file (`bash`/`sh`/`zsh`/`ksh`/`dash`/`ash`/`python`/`node`/`ruby`/`perl`/`php`), bare `./script` and absolute/home-anchored paths in command position, `source` / `.`, and all of those behind env-assignment, `env`, `sudo`, `nohup`, `timeout`-style wrappers. Wrapper flags that take a separate value are consumed, so `sudo -u bob bash run.sh` still finds `run.sh`.

Deliberately **not** recognised: `bash -c '<inline>'`. That program is already in the exec surface and already scanned. A file invocation *nested* inside the inline string is still followed.

### Design constraints held

- **`evaluateToolCall` stays pure and synchronous.** No `fs` in the guard. The file is read through a caller-injected `options.resolveScriptSource`, because `src/cli/doctor.ts` and `src/setup/openclaw-selfcheck.ts` drive the evaluator with synthetic commands whose paths deliberately do not exist. The fs-backed resolver lives at the interceptor boundary: `statSync` first so a FIFO can never be opened, `/proc` + `/sys` + `/dev` refused, size-capped, every error swallowed to `null`. It can neither hang nor break the host gateway.
- **Append, never substitute.** The command surface is scanned exactly as before and folded content is added to it, so an existing verdict cannot change direction — only become more accurate.
- **No new friction.** A resolvable, clean script produces exactly the pre-fix verdict. `bash build.sh` does not start prompting.
- **Bounded on every axis (zeroth law).** Depth 3, 12 files, 256KB per file and in total, visited-set cycle guard, binary and oversized content refused rather than truncated past a danger signal — the same reasoning already documented for `OVERSIZED_COMMAND_LENGTH`. Worst case measured at ~22ms for a full 256KB fold; a real script is sub-millisecond.
- **Fails visible.** When an invocation is recognised but cannot be folded, the verdict carries `opaque-script-invocation` at the lowest surfaced tier — recorded and auditable, never a gate on its own (the doctor/selfcheck probes and plenty of legitimate calls hit it). The old behaviour was to pass silently as clean.

## Verification

Full suite: **286 suites, 3008 passed, 7 skipped, 0 failed.** No existing expectation was modified — in particular the false-positive tuning suites (`fp-precision-88-89`, `guard-tune-91-89`, `rm-flag-fp`, `span-classifier-84`) pass untouched, which is the check that the fix is not over-aggressive.

38 new tests: 29 guard-core (stub resolvers, no filesystem) covering the live repro, an inline-vs-via-file parity table, nesting, cycles, opacity paths and the no-friction guarantees; 9 over the real resolver and the interceptor end-to-end.

Replayed the original bypass against the built output with a real fs-backed resolver:

| case | before | after |
|---|---|---|
| `curl -X DELETE` loop, inline | `require_approval` | `require_approval` |
| same loop via `bash cleanup.sh` | **allow** | `require_approval` |
| `rm -rf /` via file | **allow** | `block` / catastrophic |
| secret exfil via file | **allow** | `require_approval` |
| `sudo systemctl stop` via file | **allow** | `require_approval` |
| `dd of=/dev/sda` via file | **allow** | `block` / catastrophic |
| nested a.sh → b.sh (`rm -rf /`) | **allow** | `block` / catastrophic |
| clean `build.sh` | allow | allow (unchanged) |
| source cycle a ⇄ b | — | terminates, no hang |
| no resolver supplied | silently clean | `opaque-script-invocation` |

Closes ShieldCortex-internal#4.
