### PR TITLE
feat: doctor reports the Claude Code version the guard depends on

### DIFF
--- a/src/__tests__/claude-code-version-floor.test.ts
+++ b/src/__tests__/claude-code-version-floor.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Claude Code enforcement floor — doctor reports the harness version it depends on.
+ *
+ * Motivating incident (2026-07-30, aiquant): Claude Code 2.1.76 discarded the
+ * Action Guard's `"ask"` verdict under `bypassPermissions` and ran a global npm
+ * install. The guard was correct, the audit row recorded it, and nothing was
+ * stopped — because the harness that honours our verdicts is versioned
+ * independently of us and nobody was tracking it across two install channels.
+ *
+ * These tests pin the reporting: below the floor is a FAIL (the dangerous tier
+ * is decorative on that box), an unreadable version is a WARN (unproven, not
+ * assumed fine), and no Claude Code at all is INFO (the floor does not apply).
+ */
+import path from 'path';
+import { describe, expect, it } from '@jest/globals';
+import {
+  CLAUDE_CODE_ENFORCEMENT_FLOOR,
+  classifyClaudeCodeChannel,
+  detectClaudeCode,
+  parseClaudeCodeVersion,
+  upgradeCommandFor,
+  type DetectClaudeCodeDeps,
+} from '../integrations/claude-code-version.js';
+import { checkClaudeCodeVersion } from '../cli/doctor.js';
+
+const HOME = '/home/tester';
+
+/** A detector wired to fixture values instead of the host's real install. */
+function deps(overrides: {
+  bin?: string | null;
+  real?: string | null;
+  versionOutput?: string;
+  versionThrows?: string;
+}): DetectClaudeCodeDeps {
+  return {
+    which: () => (overrides.bin === undefined ? '/home/tester/.local/bin/claude' : overrides.bin),
+    realpath: () => (overrides.real === undefined ? '/home/tester/.local/share/claude/versions/2.1.220' : overrides.real),
+    runVersion: () => {
+      if (overrides.versionThrows) throw new Error(overrides.versionThrows);
+      return overrides.versionOutput ?? '2.1.220 (Claude Code)';
+    },
+    homedir: () => HOME,
+  };
+}
+
+describe('parseClaudeCodeVersion', () => {
+  it('reads the version out of the real output shape', () => {
+    expect(parseClaudeCodeVersion('2.1.220 (Claude Code)')).toBe('2.1.220');
+  });
+
+  it('tolerates surrounding noise', () => {
+    expect(parseClaudeCodeVersion('  claude version 2.1.76 \n')).toBe('2.1.76');
+  });
+
+  it('returns null when there is no version to read', () => {
+    expect(parseClaudeCodeVersion('command not found')).toBeNull();
+    expect(parseClaudeCodeVersion('')).toBeNull();
+  });
+});
+
+describe('classifyClaudeCodeChannel', () => {
+  it('names the native installer layout', () => {
+    expect(classifyClaudeCodeChannel(path.join(HOME, '.local/share/claude/versions/2.1.220'), HOME)).toBe('native');
+  });
+
+  it('names an npm global', () => {
+    expect(
+      classifyClaudeCodeChannel('/usr/lib/node_modules/@anthropic-ai/claude-code/cli.js', HOME),
+    ).toBe('npm');
+  });
+
+  it('refuses to guess an unrecognised layout', () => {
+    expect(classifyClaudeCodeChannel('/opt/weird/claude', HOME)).toBe('unknown');
+    expect(classifyClaudeCodeChannel(null, HOME)).toBe('unknown');
+  });
+
+  it('does not mistake another user home for this one', () => {
+    expect(classifyClaudeCodeChannel('/home/someone-else/.local/share/claude/versions/2.1.220', HOME)).toBe(
+      'unknown',
+    );
+  });
+});
+
+describe('detectClaudeCode', () => {
+  it('returns null when claude is not on PATH', () => {
+    expect(detectClaudeCode(deps({ bin: null }))).toBeNull();
+  });
+
+  it('reports version, channel and paths for a healthy install', () => {
+    const install = detectClaudeCode(deps({}));
+    expect(install).toMatchObject({
+      version: '2.1.220',
+      rawVersion: '2.1.220 (Claude Code)',
+      channel: 'native',
+      binPath: '/home/tester/.local/bin/claude',
+    });
+    expect(install?.error).toBeUndefined();
+  });
+
+  it('records the failure instead of throwing when --version cannot run', () => {
+    const install = detectClaudeCode(deps({ versionThrows: 'ETIMEDOUT' }));
+    expect(install?.version).toBeNull();
+    expect(install?.error).toContain('ETIMEDOUT');
+  });
+});
+
+describe('upgradeCommandFor', () => {
+  it('gives the channel-correct instruction', () => {
+    expect(upgradeCommandFor('npm')).toContain('npm i -g @anthropic-ai/claude-code@latest');
+    expect(upgradeCommandFor('native')).toContain('claude update');
+  });
+
+  it('offers both when the channel is unknown, rather than guessing one', () => {
+    const fix = upgradeCommandFor('unknown');
+    expect(fix).toContain('claude update');
+    expect(fix).toContain('npm i -g @anthropic-ai/claude-code@latest');
+  });
+});
+
+describe('doctor check — Claude Code version', () => {
+  it('FAILS below the floor and names the actual exposure', async () => {
+    const result = await checkClaudeCodeVersion(
+      deps({ versionOutput: '2.1.76 (Claude Code)', real: '/usr/lib/node_modules/@anthropic-ai/claude-code/cli.js' }),
+    );
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('2.1.76');
+    expect(result.message).toContain(CLAUDE_CODE_ENFORCEMENT_FLOOR);
+    expect(result.message).toContain('npm channel');
+    // The operator must learn that the audit log is misleading on this box —
+    // that is the whole reason the incident went unnoticed for 144 versions.
+    expect(result.message).toContain('audit log');
+    expect(result.fix).toContain('npm i -g @anthropic-ai/claude-code@latest');
+  });
+
+  it('PASSES at the floor exactly — the floor is the lowest build proven good', async () => {
+    const result = await checkClaudeCodeVersion(deps({ versionOutput: `${CLAUDE_CODE_ENFORCEMENT_FLOOR} (Claude Code)` }));
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain(CLAUDE_CODE_ENFORCEMENT_FLOOR);
+  });
+
+  it('PASSES above the floor and states the channel', async () => {
+    const result = await checkClaudeCodeVersion(deps({}));
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('2.1.220');
+    expect(result.message).toContain('native channel');
+  });
+
+  it('WARNS rather than passing when the version cannot be read', async () => {
+    const result = await checkClaudeCodeVersion(deps({ versionThrows: 'spawn ETIMEDOUT' }));
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('cannot confirm');
+    expect(result.fix).toBeDefined();
+  });
+
+  it('WARNS when --version prints something unparseable', async () => {
+    const result = await checkClaudeCodeVersion(deps({ versionOutput: 'not a version' }));
+    expect(result.status).toBe('warn');
+  });
+
+  it('is INFO, not a fault, on a box with no Claude Code', async () => {
+    const result = await checkClaudeCodeVersion(deps({ bin: null }));
+    expect(result.status).toBe('info');
+    expect(result.message).toContain('not detected');
+  });
+
+  it('still reports the version when the channel cannot be named', async () => {
+    const result = await checkClaudeCodeVersion(deps({ real: '/opt/somewhere/claude' }));
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('unknown channel');
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -23,6 +23,12 @@ import { getCanonicalSchema } from '../database/init.js';
 import { runMigrations } from '../database/migrations.js';
 import { detectStaleDashboard, realDeps } from '../service/dashboard-staleness.js';
 import { MCP_LIGHT_TICK_INTERVAL_MS } from '../worker/types.js';
+import {
+  CLAUDE_CODE_ENFORCEMENT_FLOOR,
+  detectClaudeCode,
+  upgradeCommandFor,
+  type DetectClaudeCodeDeps,
+} from '../integrations/claude-code-version.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../../package.json');
@@ -1561,6 +1567,65 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
   return results;
 }
 
+// ── Check 8b: Claude Code enforcement floor ───────────────
+/**
+ * The Action Guard's Claude Code surface is only as strong as the harness that
+ * honours its verdicts, and that harness is versioned independently of us.
+ *
+ * On 2026-07-30 a box running Claude Code 2.1.76 was found discarding hook
+ * `"ask"` decisions under `bypassPermissions` and executing the command — the
+ * audit log recorded the guard firing, the command ran anyway, and this went
+ * unnoticed because nobody tracked the harness version. See
+ * `claude-code-version.ts` for the mechanism and how the floor was set.
+ *
+ * A below-floor build is a `fail`, not a warning: on that box the guard's
+ * dangerous tier is decorative, and the operator has no other signal that it is.
+ */
+export async function checkClaudeCodeVersion(
+  deps: DetectClaudeCodeDeps = {},
+): Promise<CheckResult> {
+  const label = 'Claude Code version';
+
+  const install = detectClaudeCode(deps);
+  if (!install) {
+    return { label, status: 'info', message: 'skipped (Claude Code not detected on PATH)' };
+  }
+
+  const where = `${install.channel} channel`;
+
+  if (!install.version) {
+    return {
+      label,
+      status: 'warn',
+      message:
+        `could not read a version from \`${install.binPath} --version\` ` +
+        `(${install.error ?? `output: ${install.rawVersion ?? 'empty'}`}) — ` +
+        `cannot confirm this build honours the guard's approval verdicts ` +
+        `(floor ${CLAUDE_CODE_ENFORCEMENT_FLOOR})`,
+      fix: `Run \`claude --version\` by hand; if it is below ${CLAUDE_CODE_ENFORCEMENT_FLOOR}, upgrade with \`${upgradeCommandFor(install.channel)}\`.`,
+    };
+  }
+
+  if (semver.lt(install.version, CLAUDE_CODE_ENFORCEMENT_FLOOR)) {
+    return {
+      label,
+      status: 'fail',
+      message:
+        `${install.version} (${where}) is below the enforcement floor ${CLAUDE_CODE_ENFORCEMENT_FLOOR} — ` +
+        `builds this old discard the Action Guard's approval verdicts in promptless modes ` +
+        `(e.g. \`--permission-mode bypassPermissions\`) and run the command anyway. ` +
+        `The audit log will show the guard firing while nothing was actually stopped.`,
+      fix: `Upgrade Claude Code: \`${upgradeCommandFor(install.channel)}\`. Sessions already running keep the old build in memory until they cycle.`,
+    };
+  }
+
+  return {
+    label,
+    status: 'pass',
+    message: `${install.version} (${where}) — at or above the ${CLAUDE_CODE_ENFORCEMENT_FLOOR} enforcement floor`,
+  };
+}
+
 /** Read a package's `version` field; returns null on any failure. */
 function readPkgVersion(pkgJson: string): string | null {
   try {
@@ -2450,6 +2515,7 @@ export async function runDoctor(args: string[] = []): Promise<void> {
     checkOpenClawApprovalButtons,
     checkDefenceCanary,
     checkActionGuard,
+    checkClaudeCodeVersion,
     checkModelCache,
   ];
 

--- a/src/integrations/claude-code-version.ts
+++ b/src/integrations/claude-code-version.ts
@@ -1,0 +1,174 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Detecting the installed Claude Code build, and whether it is new enough to
+ * enforce the Action Guard's verdicts.
+ *
+ * Incident, 2026-07-30 (aiquant): under `--permission-mode bypassPermissions`,
+ * Claude Code 2.1.76 converts a PreToolUse hook's `"ask"` decision into
+ * `allow` and runs the command. The permission resolver preserves `"ask"` only
+ * for `decisionReason.type === "rule"` or tools that require user interaction;
+ * a hook-ask is type `"hook"`, so in a promptless mode it falls through to
+ * mode-allow. `deny` is honoured unconditionally in every build we have
+ * examined. A global `npm i -g` earned `require_approval` at 06:53:23Z, was
+ * written to the audit log as gated, and installed anyway.
+ *
+ * The guard-side fix is to deny rather than ask when no prompt surface can be
+ * confirmed. But the deeper condition is that the harness ShieldCortex depends
+ * on for enforcement was 144 versions stale on one box and nobody knew: it is
+ * distributed through two channels (npm global and the native installer),
+ * neither of which anyone was tracking. A guard that silently depends on an
+ * untracked version of something else is not a guard. So doctor reads the
+ * version and says so.
+ *
+ * The floor is behavioural, not theoretical: 2.1.215 (native) and 2.1.220
+ * (npm) were both observed honouring a hook-ask under `bypassPermissions` on
+ * separate hosts; 2.1.76 was observed discarding it. We have not bisected the
+ * range between, so the floor is the lowest build actually proven good.
+ */
+
+/**
+ * Lowest Claude Code version observed to honour a hook `"ask"` in a promptless
+ * mode. Below this, hook verdicts requiring approval may be silently discarded.
+ */
+export const CLAUDE_CODE_ENFORCEMENT_FLOOR = '2.1.215';
+
+/** Where a Claude Code build came from — the two channels differ in upgrade path. */
+export type ClaudeCodeChannel = 'native' | 'npm' | 'unknown';
+
+export interface ClaudeCodeInstall {
+  /** Parsed `major.minor.patch`, or null when the output could not be parsed. */
+  version: string | null;
+  /** Exactly what `claude --version` printed, for operator-facing evidence. */
+  rawVersion: string | null;
+  /** The `claude` that PATH resolves to. */
+  binPath: string;
+  /** `binPath` with symlinks followed, when resolvable — this is what names the channel. */
+  realPath: string | null;
+  channel: ClaudeCodeChannel;
+  /** Set when the binary exists but `--version` could not be run or read. */
+  error?: string;
+}
+
+export interface DetectClaudeCodeDeps {
+  /** Resolve `claude` on PATH; return null when it is not installed. */
+  which?: (cmd: string) => string | null;
+  /** Follow symlinks; return null when the path cannot be resolved. */
+  realpath?: (p: string) => string | null;
+  /** Run `claude --version` and return stdout; throw when it cannot be run. */
+  runVersion?: (bin: string) => string;
+  homedir?: () => string;
+}
+
+/** Resolve a command through PATH without a shell. */
+function defaultWhich(cmd: string): string | null {
+  const pathEnv = process.env.PATH;
+  if (!pathEnv) return null;
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, cmd);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      /* not here — keep walking PATH */
+    }
+  }
+  return null;
+}
+
+function defaultRealpath(p: string): string | null {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `claude --version` is a fast local print, but doctor must never hang on a
+ * wedged binary — hence the timeout and the empty-stdin redirect, which stops
+ * a build that decides to read stdin from blocking forever.
+ */
+function defaultRunVersion(bin: string): string {
+  return execFileSync(bin, ['--version'], {
+    encoding: 'utf-8',
+    timeout: 10_000,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+/** First `x.y.z` in the output — builds print `2.1.220 (Claude Code)`. */
+export function parseClaudeCodeVersion(output: string): string | null {
+  const match = /(\d+\.\d+\.\d+)/.exec(output);
+  return match ? match[1] : null;
+}
+
+/**
+ * Name the distribution channel from the resolved binary path.
+ *
+ * Native installs live under `~/.local/share/claude/versions/<version>` with a
+ * shim in `~/.local/bin`; npm globals resolve into a
+ * `node_modules/@anthropic-ai/claude-code` directory. Anything else is
+ * `unknown` — a channel we cannot name is reported as such rather than guessed,
+ * because the upgrade instruction differs per channel and a wrong one wastes
+ * an operator's time.
+ */
+export function classifyClaudeCodeChannel(realPath: string | null, homedir: string): ClaudeCodeChannel {
+  if (!realPath) return 'unknown';
+  const normalised = realPath.split(path.sep).join('/');
+  if (normalised.includes('/node_modules/@anthropic-ai/claude-code')) return 'npm';
+  const nativeRoot = path.join(homedir, '.local', 'share', 'claude').split(path.sep).join('/');
+  if (normalised.startsWith(nativeRoot)) return 'native';
+  return 'unknown';
+}
+
+/**
+ * Locate Claude Code and read its version. Returns null when no `claude` is on
+ * PATH at all — that is not a fault, it just means this box does not run the
+ * Claude Code surface and the version floor does not apply to it.
+ */
+export function detectClaudeCode(deps: DetectClaudeCodeDeps = {}): ClaudeCodeInstall | null {
+  const which = deps.which ?? defaultWhich;
+  const realpath = deps.realpath ?? defaultRealpath;
+  const runVersion = deps.runVersion ?? defaultRunVersion;
+  const homedir = deps.homedir ?? os.homedir;
+
+  const binPath = which('claude');
+  if (!binPath) return null;
+
+  const realPath = realpath(binPath);
+  const channel = classifyClaudeCodeChannel(realPath, homedir());
+
+  let rawVersion: string | null = null;
+  let error: string | undefined;
+  try {
+    rawVersion = runVersion(binPath).trim();
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  return {
+    version: rawVersion ? parseClaudeCodeVersion(rawVersion) : null,
+    rawVersion,
+    binPath,
+    realPath,
+    channel,
+    ...(error ? { error } : {}),
+  };
+}
+
+/** Per-channel upgrade instruction, so the fix text is actionable as printed. */
+export function upgradeCommandFor(channel: ClaudeCodeChannel): string {
+  switch (channel) {
+    case 'npm':
+      return `npm i -g @anthropic-ai/claude-code@latest`;
+    case 'native':
+      return `claude update`;
+    default:
+      return `re-run the Claude Code installer for whichever channel this box uses (\`claude update\` for the native installer, \`npm i -g @anthropic-ai/claude-code@latest\` for the npm global)`;
+  }
+}


### PR DESCRIPTION
Second half of the 2026-07-30 enforcement-hole work. [#139](https://github.com/Drakon-Systems-Ltd/ShieldCortex/pull/139) fixes the guard's own behaviour; this makes the dependency visible.

## Why

The Action Guard's Claude Code surface is only as strong as the harness that honours its verdicts, and that harness is versioned independently of ShieldCortex. On 2026-07-30 a box running Claude Code **2.1.76** was found discarding hook `"ask"` decisions under `bypassPermissions` and executing the command. The audit log recorded the guard firing. Nothing was stopped.

It went unnoticed for 144 versions because Claude Code ships through two channels — the npm global and the native installer — and nobody was tracking either. A guard that silently depends on an untracked version of something else is not a guard.

## What doctor now says

| state | status | why |
|---|---|---|
| version ≥ floor | `pass` | reports version + channel |
| version < floor | `fail` | the dangerous tier is decorative on this box |
| `--version` unreadable / unparseable | `warn` | unproven, not assumed fine |
| no `claude` on PATH | `info` | the floor does not apply here |

Below-floor is a **fail** rather than a warn deliberately: on that box an operator's only other signal is an audit log that says the opposite of what happened.

## The floor: 2.1.215

Behavioural, not theoretical. 2.1.215 (native) and 2.1.220 (npm) were each observed honouring a hook-ask in a promptless mode, on separate hosts, with the same inert probe. 2.1.76 was observed discarding it. The range between is unbisected, so the floor is the lowest build actually proven good — not the lowest we suspect is fine.

## Details worth a look in review

- **Channel-correct fix text.** `claude update` and `npm i -g @anthropic-ai/claude-code@latest` are not interchangeable; a wrong upgrade instruction costs an operator real time. When the install layout is unrecognised the check says `unknown` and offers both rather than guessing.
- **Home-scoped native detection.** `/home/someone-else/.local/share/claude/...` does not classify as this box's native install (pinned by test).
- **No hang.** `claude --version` runs with a 10s timeout and stdin ignored, so a wedged binary can't stall doctor.
- **All injectable.** `detectClaudeCode()` takes `which` / `realpath` / `runVersion` / `homedir`, so the tests never touch the host's real install.

## Tests

New `src/__tests__/claude-code-version-floor.test.ts` — 19 tests covering parse, channel classification, detection failure modes, and all five doctor outcomes including the floor boundary exactly.

Full suite: **288 suites, 3045 passed, 7 skipped, 0 failed**.

Live-verified on this box: `2.1.220 (native channel) — at or above the 2.1.215 enforcement floor`.

## Follow-up, not in this PR

The fleet recommendation that goes with it — standardise on one distribution channel — is an operator decision, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
