### PR TITLE
fix(#146): hook commands must resolve, not merely exist — install writes absolute, doctor verifies by running, upgrade repairs

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -10,6 +10,7 @@ import semver from 'semver';
 import { execFileSync } from 'child_process';
 import { createRequire } from 'module';
 import { REQUIRED_HOOK_NAMES } from '../setup/settings-hooks.js';
+import { hookCommandResolves } from '../setup/hook-command-resolution.js';
 import {
   resolveRealtimePluginInstallPath,
   readInstalledRealtimePluginVersion,
@@ -454,19 +455,29 @@ export function runHooksCheck(settingsPath: string, env: Environment = detectEnv
     let installed = 0;
     const missing: string[] = [];
 
+    // Commands that are configured but do NOT resolve. This is the #146 check:
+    // a hook entry existing in settings.json says nothing about whether it runs.
+    // Three of four fleet boxes on 31 Jul 2026 had every hook configured and
+    // every hook dead, because a bare command name does not resolve in the
+    // non-interactive shell a harness spawns hooks in — and this check used to
+    // report that state as a clean pass.
+    const unresolvable: string[] = [];
+
     for (const name of hookNames) {
       const hookConfig = hooks[name];
       if (hookConfig) {
         // Check if any hook command references shieldcortex.
         // Settings format: [{ hooks: [{ type, command, timeout }] }]
-        const hasShieldCortex = Array.isArray(hookConfig) && hookConfig.some(
-          (entry: { hooks?: Array<{ command?: string }> }) =>
-            Array.isArray(entry?.hooks) && entry.hooks.some(
-              (h) => typeof h?.command === 'string' && h.command.includes('shieldcortex'),
-            ),
-        );
-        if (hasShieldCortex) {
+        const commands: string[] = Array.isArray(hookConfig)
+          ? hookConfig.flatMap((entry: { hooks?: Array<{ command?: string }> }) =>
+              (Array.isArray(entry?.hooks) ? entry.hooks : [])
+                .map(h => h?.command)
+                .filter((c): c is string => typeof c === 'string' && c.includes('shieldcortex')),
+            )
+          : [];
+        if (commands.length > 0) {
           installed++;
+          if (!commands.every(hookCommandResolves)) unresolvable.push(name);
         } else {
           missing.push(name);
         }
@@ -475,8 +486,21 @@ export function runHooksCheck(settingsPath: string, env: Environment = detectEnv
       }
     }
 
+    // A configured-but-dead hook is worse than a missing one: the operator
+    // believes they are protected. FAIL, not warn.
+    if (unresolvable.length > 0) {
+      return {
+        label: 'Hooks',
+        status: 'fail',
+        message:
+          `${installed}/${hookNames.length} installed but ${unresolvable.length} DO NOT RESOLVE ` +
+          `(${unresolvable.join(', ')}) — these hooks never run, so the guard is not enforcing here`,
+        fix: 'Run `shieldcortex install` to rewrite them to an absolute path (#146)',
+      };
+    }
+
     if (installed === hookNames.length) {
-      return { label: 'Hooks', status: 'pass', message: `${installed}/${hookNames.length} installed` };
+      return { label: 'Hooks', status: 'pass', message: `${installed}/${hookNames.length} installed and resolving` };
     } else {
       return {
         label: 'Hooks',

--- a/src/setup/__tests__/action-guard-hook-install.test.ts
+++ b/src/setup/__tests__/action-guard-hook-install.test.ts
@@ -59,7 +59,20 @@ describe('action-guard hook install (PreToolUse)', () => {
     expect(Array.isArray(entries)).toBe(true);
     const entry = entries[0];
     expect(entry.matcher).toBe('*');
-    expect(entry.hooks?.[0]?.command).toBe('shieldcortex hook pre-tool');
+    // #146: the command must target pre-tool AND be runnable. It used to be
+    // asserted as the bare name — which is precisely the bug that left three of
+    // four fleet boxes with a configured-but-dead Action Guard. Where a binary
+    // resolves we now require an absolute path; where none does, degrading to
+    // the bare name is the accepted fallback.
+    const command: string = entry.hooks?.[0]?.command;
+    expect(command.endsWith('hook pre-tool')).toBe(true);
+    const { resolveHookBinary, hookCommandResolves } = await import('../hook-command-resolution.js');
+    if (resolveHookBinary()) {
+      expect(command.startsWith('/')).toBe(true);
+      expect(hookCommandResolves(command)).toBe(true);
+    } else {
+      expect(command).toBe('shieldcortex hook pre-tool');
+    }
     expect(entry.hooks?.[0]?.timeout).toBe(10);
   });
 

--- a/src/setup/__tests__/hook-command-resolution.test.ts
+++ b/src/setup/__tests__/hook-command-resolution.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Failing-first spec for #146 — hook commands must RESOLVE, not merely exist.
+ *
+ * Fleet evidence, 31 Jul 2026: three of four boxes could not resolve a bare
+ * `shieldcortex` from the non-interactive shell a harness spawns hooks in. Two
+ * of them were running zero Claude Code enforcement — installed, configured,
+ * and reported healthy by our own doctor the entire time.
+ *
+ * The root cause is that we wrote a bare command name, making enforcement
+ * depend on the operator's shell config: something we neither control nor
+ * inspect. These tests pin the three halves of the fix.
+ */
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  resolveHookBinary,
+  buildHookCommand,
+  hookCommandResolves,
+  needsAbsolutePathRepair,
+  repairHookCommand,
+} from '../hook-command-resolution.js';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'sc-hookres-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+function fakeBin(name = 'shieldcortex'): string {
+  const binDir = join(dir, 'bin');
+  mkdirSync(binDir, { recursive: true });
+  const p = join(binDir, name);
+  writeFileSync(p, '#!/bin/sh\nexit 0\n');
+  chmodSync(p, 0o755);
+  return p;
+}
+
+// ── 1. The installer must write an absolute path ───────────────────────────
+
+describe('#146 — the installer writes a resolvable absolute command', () => {
+  it('builds a command with an absolute path, not a bare name', () => {
+    const bin = fakeBin();
+    const cmd = buildHookCommand(bin, 'pre-tool');
+    expect(cmd.startsWith('/')).toBe(true);
+    expect(cmd).toBe(`${bin} hook pre-tool`);
+    expect(cmd).not.toMatch(/^shieldcortex\b/);
+  });
+
+  it('quotes a path containing spaces so the command survives sh -c', () => {
+    const spaced = join(dir, 'my tools', 'shieldcortex');
+    mkdirSync(join(dir, 'my tools'), { recursive: true });
+    writeFileSync(spaced, '#!/bin/sh\nexit 0\n');
+    chmodSync(spaced, 0o755);
+    const cmd = buildHookCommand(spaced, 'pre-tool');
+    expect(cmd).toContain('"');
+    expect(cmd).toMatch(/hook pre-tool$/);
+  });
+
+  it('falls back to the bare name only when no binary can be located', () => {
+    // Degrading to today's behaviour is acceptable; silently writing a path
+    // that does not exist is not.
+    expect(buildHookCommand(null, 'pre-tool')).toBe('shieldcortex hook pre-tool');
+  });
+
+  it('resolveHookBinary prefers an explicit npm prefix bin over PATH guesswork', () => {
+    const bin = fakeBin();
+    expect(resolveHookBinary({ npmPrefixBin: join(dir, 'bin') })).toBe(bin);
+  });
+
+  it('resolveHookBinary rejects a candidate that is not executable', () => {
+    const binDir = join(dir, 'bin');
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(binDir, 'shieldcortex'), 'not executable');
+    chmodSync(join(binDir, 'shieldcortex'), 0o644);
+    expect(resolveHookBinary({ npmPrefixBin: binDir })).toBeNull();
+  });
+
+  it('returns null rather than a guess when nothing resolves', () => {
+    expect(resolveHookBinary({ npmPrefixBin: join(dir, 'nope') })).toBeNull();
+  });
+});
+
+// ── 2. The doctor check must be behavioural ────────────────────────────────
+
+describe('#146 — a hook command is verified by RUNNING it', () => {
+  it('reports an absolute, executable command as resolving', () => {
+    const bin = fakeBin();
+    expect(hookCommandResolves(`${bin} hook pre-tool`)).toBe(true);
+  });
+
+  it('reports a bare name that is not on the subprocess PATH as NOT resolving', () => {
+    // The exact live failure: present to an interactive shell, absent to `sh -c`.
+    expect(hookCommandResolves('definitely-not-a-real-binary-xyz hook pre-tool')).toBe(false);
+  });
+
+  it('reports an absolute path that does not exist as NOT resolving', () => {
+    expect(hookCommandResolves(`${join(dir, 'ghost')} hook pre-tool`)).toBe(false);
+  });
+
+  it('sees through an env-var prefix — the form our first fixer missed', () => {
+    const bin = fakeBin();
+    expect(hookCommandResolves(`SHIELDCORTEX_RECALL_ENFORCE=1 ${bin} hook prompt-recall`)).toBe(true);
+    expect(hookCommandResolves('SHIELDCORTEX_RECALL_ENFORCE=1 not-a-real-binary-xyz hook prompt-recall')).toBe(false);
+  });
+
+  it('treats an empty or malformed command as not resolving', () => {
+    expect(hookCommandResolves('')).toBe(false);
+    expect(hookCommandResolves('   ')).toBe(false);
+  });
+});
+
+// ── 3. Upgrade must repair installs that are already wrong ─────────────────
+
+describe('#146 — upgrade repairs existing broken installs', () => {
+  it('flags a bare command as needing repair', () => {
+    expect(needsAbsolutePathRepair('shieldcortex hook pre-tool')).toBe(true);
+  });
+
+  it('flags the env-prefixed bare form as needing repair', () => {
+    expect(needsAbsolutePathRepair('SHIELDCORTEX_RECALL_ENFORCE=1 shieldcortex hook prompt-recall')).toBe(true);
+  });
+
+  it('leaves an already-absolute command alone', () => {
+    expect(needsAbsolutePathRepair('/usr/local/bin/shieldcortex hook pre-tool')).toBe(false);
+    expect(needsAbsolutePathRepair('VAR=1 /usr/local/bin/shieldcortex hook prompt-recall')).toBe(false);
+  });
+
+  it('ignores commands that are nothing to do with us', () => {
+    expect(needsAbsolutePathRepair('some-other-tool hook pre-tool')).toBe(false);
+  });
+
+  it('repairs a bare command in place', () => {
+    const bin = fakeBin();
+    expect(repairHookCommand('shieldcortex hook pre-tool', bin)).toBe(`${bin} hook pre-tool`);
+  });
+
+  it('repairs the env-prefixed form while preserving the prefix', () => {
+    const bin = fakeBin();
+    expect(repairHookCommand('SHIELDCORTEX_RECALL_ENFORCE=1 shieldcortex hook prompt-recall', bin))
+      .toBe(`SHIELDCORTEX_RECALL_ENFORCE=1 ${bin} hook prompt-recall`);
+  });
+
+  it('preserves trailing arguments', () => {
+    const bin = fakeBin();
+    expect(repairHookCommand('shieldcortex hook pre-tool --verbose', bin))
+      .toBe(`${bin} hook pre-tool --verbose`);
+  });
+
+  it('is idempotent — repairing an already-repaired command changes nothing', () => {
+    const bin = fakeBin();
+    const once = repairHookCommand('shieldcortex hook pre-tool', bin);
+    expect(repairHookCommand(once, bin)).toBe(once);
+  });
+
+  it('refuses to repair when it has no binary to point at', () => {
+    expect(repairHookCommand('shieldcortex hook pre-tool', null)).toBe('shieldcortex hook pre-tool');
+  });
+});

--- a/src/setup/hook-command-resolution.ts
+++ b/src/setup/hook-command-resolution.ts
@@ -1,0 +1,161 @@
+/**
+ * ShieldCortex — resolvable hook commands (#146).
+ *
+ * Fleet evidence, 31 Jul 2026: three of four boxes could not resolve a bare
+ * `shieldcortex` from the non-interactive shell a harness spawns hooks in. Two
+ * were running zero Claude Code enforcement — installed, configured, and
+ * reported healthy by `doctor` the whole time.
+ *
+ * The cause was writing a bare command name. That makes enforcement depend on
+ * the operator's shell configuration, which we neither control nor inspect: a
+ * user-level npm prefix (the standard sudo-free setup) plus a distro `.bashrc`
+ * that extends PATH *below* its own non-interactive early-return is enough for
+ * every hook to die silently. The operator's own terminal resolves it fine, so
+ * nothing looks wrong.
+ *
+ * Three halves to the fix, all here so they cannot drift apart:
+ *
+ *   1. `buildHookCommand` — the installer writes an ABSOLUTE path.
+ *   2. `hookCommandResolves` — doctor verifies by RUNNING, not by reading.
+ *   3. `needsAbsolutePathRepair` / `repairHookCommand` — upgrade fixes installs
+ *      that are already wrong. Fixing the installer alone would leave every
+ *      existing broken box broken forever, which is the quiet half of this bug.
+ */
+import { accessSync, constants } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+/** The bare name we historically wrote, and still fall back to. */
+const BARE = 'shieldcortex';
+
+/**
+ * A leading run of `VAR=value` assignments, which sh treats as environment for
+ * the command that follows. Our own installer emits this form
+ * (`SHIELDCORTEX_RECALL_ENFORCE=1 shieldcortex hook prompt-recall`), and a
+ * fixer that only matches commands *starting with* `shieldcortex` silently
+ * skips them — which is exactly what happened during the live fleet repair.
+ */
+const ENV_PREFIX = /^((?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*)/;
+
+function isExecutable(p: string): boolean {
+  try {
+    accessSync(p, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface ResolveHookBinaryOptions {
+  /** `<npm prefix>/bin`, when the caller already knows it. */
+  npmPrefixBin?: string;
+  /** Extra directories to try, in order. */
+  candidates?: string[];
+}
+
+/**
+ * Locate the shieldcortex binary as an absolute path, or null.
+ *
+ * Null is a legitimate answer and callers must handle it: writing a path that
+ * does not exist would be worse than the bare name we already write, because
+ * it would fail on every host rather than merely on most.
+ */
+export function resolveHookBinary(opts: ResolveHookBinaryOptions = {}): string | null {
+  const tried: string[] = [];
+  if (opts.npmPrefixBin) tried.push(join(opts.npmPrefixBin, BARE));
+  for (const c of opts.candidates ?? []) tried.push(c.endsWith(BARE) ? c : join(c, BARE));
+
+  // `npm prefix -g` is the authoritative answer for a global install and is
+  // where every affected fleet box had it. Consulted only if the caller did
+  // not already supply one, since spawning npm is slow.
+  if (!opts.npmPrefixBin) {
+    try {
+      const prefix = execFileSync('npm', ['config', 'get', 'prefix'], {
+        encoding: 'utf-8',
+        timeout: 5_000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      if (prefix && prefix !== 'undefined') tried.push(join(prefix, 'bin', BARE));
+    } catch {
+      // npm absent or slow — fall through to the remaining candidates.
+    }
+  }
+
+  for (const p of tried) if (isExecutable(p)) return p;
+  return null;
+}
+
+/** Quote a path for `sh -c` only when it needs it. */
+function shellQuote(p: string): string {
+  return /[\s"'\\$`]/.test(p) ? `"${p.replace(/(["\\$`])/g, '\\$1')}"` : p;
+}
+
+/**
+ * The command string the installer writes.
+ *
+ * With no binary this returns the historical bare form — degrading to today's
+ * behaviour, which is at least correct on hosts where PATH happens to work.
+ */
+export function buildHookCommand(binary: string | null, subcommand: string): string {
+  if (!binary) return `${BARE} hook ${subcommand}`;
+  return `${shellQuote(binary)} hook ${subcommand}`;
+}
+
+/** Strip a leading env-assignment run and return the executable token. */
+function executableToken(command: string): string | null {
+  const trimmed = String(command ?? '').trim();
+  if (!trimmed) return null;
+  const withoutEnv = trimmed.replace(ENV_PREFIX, '');
+  const m = withoutEnv.match(/^("([^"]+)"|'([^']+)'|\S+)/);
+  if (!m) return null;
+  return m[2] ?? m[3] ?? m[1];
+}
+
+/**
+ * Does this command actually resolve to something runnable?
+ *
+ * This is the check that would have caught the live fleet breakage. It asks the
+ * question a harness asks — resolve this token the way a non-interactive shell
+ * would — rather than the question we used to ask, which was merely "is a hook
+ * entry present in settings.json".
+ */
+export function hookCommandResolves(command: string): boolean {
+  const exe = executableToken(command);
+  if (!exe) return false;
+
+  // Absolute or relative path: check it directly.
+  if (exe.includes('/')) return isExecutable(exe);
+
+  // Bare name: resolve it the way the hook's own subprocess will. `command -v`
+  // inside `sh -c` is precisely the lookup that failed on three fleet boxes.
+  try {
+    execFileSync('sh', ['-c', `command -v ${exe}`], {
+      timeout: 5_000,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Is this one of OUR commands, written in the fragile bare form? */
+export function needsAbsolutePathRepair(command: string): boolean {
+  const exe = executableToken(command);
+  if (!exe) return false;
+  return exe === BARE;
+}
+
+/**
+ * Rewrite a bare command to an absolute one, preserving any env-var prefix and
+ * every trailing argument. Idempotent: an already-absolute command is returned
+ * unchanged, so upgrade can run this on every box every time.
+ */
+export function repairHookCommand(command: string, binary: string | null): string {
+  if (!binary || !needsAbsolutePathRepair(command)) return command;
+  const trimmed = command.trim();
+  const envMatch = trimmed.match(ENV_PREFIX);
+  const prefix = envMatch ? envMatch[1] : '';
+  const rest = trimmed.slice(prefix.length);
+  return prefix + rest.replace(BARE, shellQuote(binary));
+}

--- a/src/setup/settings-hooks.ts
+++ b/src/setup/settings-hooks.ts
@@ -6,6 +6,11 @@ import path from 'path';
 import os from 'os';
 import { getAutoMemoryEnableConfig, setAutoMemoryEnableConfig } from '../cloud/config.js';
 import { readJsonConfigOrAbort, writeJsonConfigWithBackup } from './json-config.js';
+import {
+  resolveHookBinary,
+  needsAbsolutePathRepair,
+  repairHookCommand,
+} from './hook-command-resolution.js';
 
 // Resolved per call, not at import: an import-time constant freezes whichever
 // home os.homedir() saw when the module FIRST loaded, so any later redirection
@@ -81,6 +86,50 @@ const STOP_HOOK: HookEntry = {
 const SESSION_END_HOOK: HookEntry = {
   hooks: [{ type: 'command', command: 'shieldcortex hook session-end', timeout: 10 }],
 };
+
+/**
+ * Rewrite every ShieldCortex hook command to an absolute path (#146).
+ *
+ * Runs on EVERY install and upgrade, not just fresh installs. That is the whole
+ * point: fixing the template alone would leave every already-broken box broken
+ * forever, and those boxes cannot tell — a bare command that does not resolve
+ * fails silently and `doctor` used to report it green.
+ *
+ * Idempotent and conservative: an already-absolute command is untouched, a
+ * command that is not ours is untouched, and if no binary can be located
+ * nothing changes at all rather than writing a path that does not exist.
+ */
+function absolutiseHookCommands(settings: Record<string, any>): number {
+  const binary = resolveHookBinary();
+  if (!binary) return 0;
+  let repaired = 0;
+  for (const entries of Object.values(settings.hooks ?? {})) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      for (const hook of entry?.hooks ?? []) {
+        const cmd = hook?.command;
+        if (typeof cmd === 'string' && needsAbsolutePathRepair(cmd)) {
+          hook.command = repairHookCommand(cmd, binary);
+          repaired++;
+        }
+      }
+    }
+  }
+  return repaired;
+}
+
+/** A copy of a hook template with its command bound to an absolute path. */
+function withAbsoluteCommand(entry: HookEntry, binary: string | null): HookEntry {
+  if (!binary) return entry;
+  return {
+    ...entry,
+    hooks: entry.hooks.map(h =>
+      typeof h.command === 'string' && needsAbsolutePathRepair(h.command)
+        ? { ...h, command: repairHookCommand(h.command, binary) }
+        : { ...h },
+    ),
+  };
+}
 
 function hasCortexHook(entries: HookEntry[]): boolean {
   return entries.some((e) =>
@@ -235,13 +284,25 @@ export function setupHooks(options?: HookOptInOptions): void {
 
   let added = 0;
 
+  // Absolute path, resolved now (#146). A bare command name makes enforcement
+  // depend on the operator's shell config; three of four fleet boxes could not
+  // resolve one from the subprocess a harness spawns hooks in.
+  const hookBinary = resolveHookBinary();
+
+  // Repair hooks written by an EARLIER version before doing anything else —
+  // upgrade has to fix installs that are already wrong, or they stay wrong.
+  const repairedExisting = absolutiseHookCommands(settings);
+  if (repairedExisting > 0) {
+    console.log(`  ~ Hooks: repaired ${repairedExisting} bare command(s) to an absolute path (#146)`);
+  }
+
   // Install command hooks (PreCompact, SessionStart, UserPromptSubmit)
   for (const [name, entry] of Object.entries(CORTEX_HOOKS)) {
     if (!Array.isArray(settings.hooks[name])) {
       settings.hooks[name] = [];
     }
     if (!hasCortexHook(settings.hooks[name])) {
-      settings.hooks[name].push(entry);
+      settings.hooks[name].push(withAbsoluteCommand(entry, hookBinary));
       added++;
       console.log(`  + Hook: ${name}`);
     } else {
@@ -255,7 +316,7 @@ export function setupHooks(options?: HookOptInOptions): void {
       settings.hooks.SessionEnd = [];
     }
     if (!hasCortexHook(settings.hooks.SessionEnd)) {
-      settings.hooks.SessionEnd.push(SESSION_END_HOOK);
+      settings.hooks.SessionEnd.push(withAbsoluteCommand(SESSION_END_HOOK, hookBinary));
       added++;
       console.log(`  + Hook: SessionEnd (opt-in — flipping autoMemory.enableSessionEnd=true)`);
     } else {
@@ -269,7 +330,7 @@ export function setupHooks(options?: HookOptInOptions): void {
       settings.hooks.Stop = [];
     }
     if (!hasCortexHook(settings.hooks.Stop)) {
-      settings.hooks.Stop.push(STOP_HOOK);
+      settings.hooks.Stop.push(withAbsoluteCommand(STOP_HOOK, hookBinary));
       added++;
       console.log(`  + Hook: Stop (opt-in — flipping autoMemory.enableStop=true)`);
     } else {


### PR DESCRIPTION
Closes #146. See the commit message and the fleet-sweep comment on the issue for the evidence: three of four boxes could not resolve a bare `shieldcortex` from a hook subprocess, and two were running zero Claude Code enforcement while doctor reported green.

Install writes an absolute path; doctor verifies by running the command and FAILS on a configured-but-dead hook; upgrade repairs existing broken installs idempotently, including the env-var-prefixed form.

Full suite 298 suites / 3372 pass / 0 fail. Live-verified both directions on this box.