### PR TITLE
fix(#148): budget-aware maintenance backups — plan against the limit, prune superseded copies, refuse rather than overfill

### DIFF
--- a/src/cli/__tests__/backup-budget.test.ts
+++ b/src/cli/__tests__/backup-budget.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Failing-first spec for #148 — a maintenance backup must not consume the
+ * operator's entire disk budget.
+ *
+ * Live on a fleet box, 31 Jul 2026: `doctor` warned about a project-key
+ * collision and recommended `--fix-project-keys`. That repair copied the whole
+ * 48 MB database as a backup with no headroom check, taking the host from
+ * 51.7 MB to 98.8 MB against its own 100 MB limit — so the very next `doctor`
+ * reported a disk FAILURE caused by the fix it had just told the operator to
+ * run. Clearing it did not help: the next repair recreated it. Not winnable
+ * by hand.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  planBackup,
+  pruneOldBackups,
+  BACKUP_SUFFIX_RE,
+} from '../backup-budget.js';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'sc-backup-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+/** Create a file of an exact size. */
+function file(name: string, bytes: number): string {
+  const p = join(dir, name);
+  writeFileSync(p, Buffer.alloc(bytes));
+  return p;
+}
+
+const MB = 1024 * 1024;
+
+describe('#148 — the backup is planned against the disk budget', () => {
+  it('proceeds when there is comfortable headroom', () => {
+    const db = file('memories.db', 10 * MB);
+    const plan = planBackup({ dbPath: db, dir, limitBytes: 100 * MB });
+    expect(plan.action).toBe('backup');
+  });
+
+  it('prunes an older backup rather than refusing, when pruning creates room', () => {
+    const db = file('memories.db', 48 * MB);
+    file('memories.db.bak.2026-07-31T15-27-33-553Z', 48 * MB); // the live incident
+    const plan = planBackup({ dbPath: db, dir, limitBytes: 100 * MB });
+    expect(plan.action).toBe('backup');
+    expect(plan.prune.length).toBe(1);
+    expect(plan.prune[0]).toContain('.bak.');
+  });
+
+  it('REFUSES rather than filling the budget when even pruning cannot make room', () => {
+    // A 60 MB DB cannot be backed up inside a 100 MB budget: 60 live + 60 copy.
+    const db = file('memories.db', 60 * MB);
+    const plan = planBackup({ dbPath: db, dir, limitBytes: 100 * MB });
+    expect(plan.action).toBe('refuse');
+    expect(plan.reason).toMatch(/headroom|budget|limit/i);
+  });
+
+  it('the refusal names a way forward rather than just saying no', () => {
+    const db = file('memories.db', 60 * MB);
+    const plan = planBackup({ dbPath: db, dir, limitBytes: 100 * MB });
+    expect(plan.action).toBe('refuse');
+    expect(plan.reason.length).toBeGreaterThan(20);
+  });
+
+  it('the exact live case: 48MB DB in a 100MB budget with one old backup — proceeds after pruning', () => {
+    const db = file('memories.db', 48 * MB);
+    file('memories.db.bak.2026-07-31T15-27-33-553Z', 48 * MB);
+    const plan = planBackup({ dbPath: db, dir, limitBytes: 100 * MB });
+    expect(plan.action).toBe('backup');
+    // 48 live + 48 new copy = 96 < 100, but ONLY once the old one goes.
+    expect(plan.prune.length).toBeGreaterThan(0);
+  });
+
+  it('counts every file in the directory toward the budget, not just the DB', () => {
+    const db = file('memories.db', 30 * MB);
+    file('audit.log', 45 * MB);
+    const plan = planBackup({ dbPath: db, dir, limitBytes: 100 * MB });
+    // 30 live + 45 other + 30 copy = 105 > 100, and there is no backup to prune.
+    expect(plan.action).toBe('refuse');
+  });
+});
+
+describe('#148 — old backups are pruned, which doctor already claimed happened', () => {
+  it('keeps the newest and removes the rest', () => {
+    file('memories.db', 1 * MB);
+    file('memories.db.bak.2026-07-29T10-00-00-000Z', MB);
+    file('memories.db.bak.2026-07-30T10-00-00-000Z', MB);
+    file('memories.db.bak.2026-07-31T10-00-00-000Z', MB);
+    const removed = pruneOldBackups(dir, 'memories.db', 1);
+    expect(removed.length).toBe(2);
+    const left = readdirSync(dir).filter(f => BACKUP_SUFFIX_RE.test(f));
+    expect(left).toEqual(['memories.db.bak.2026-07-31T10-00-00-000Z']);
+  });
+
+  it('keep=0 removes them all', () => {
+    file('memories.db', 1 * MB);
+    file('memories.db.bak.2026-07-30T10-00-00-000Z', MB);
+    expect(pruneOldBackups(dir, 'memories.db', 0).length).toBe(1);
+  });
+
+  it('never touches the live database', () => {
+    const db = file('memories.db', 1 * MB);
+    file('memories.db.bak.2026-07-30T10-00-00-000Z', MB);
+    pruneOldBackups(dir, 'memories.db', 0);
+    expect(statSync(db).size).toBe(1 * MB);
+  });
+
+  it('never touches WAL, shm or lock siblings', () => {
+    file('memories.db', MB);
+    file('memories.db-wal', MB);
+    file('memories.db-shm', MB);
+    file('memories.db.lock', 100);
+    pruneOldBackups(dir, 'memories.db', 0);
+    const left = readdirSync(dir).sort();
+    expect(left).toEqual(['memories.db', 'memories.db-shm', 'memories.db-wal', 'memories.db.lock']);
+  });
+
+  it('is safe on a directory with no backups at all', () => {
+    file('memories.db', MB);
+    expect(pruneOldBackups(dir, 'memories.db', 1)).toEqual([]);
+  });
+
+  it('only matches OUR backup shape', () => {
+    expect(BACKUP_SUFFIX_RE.test('memories.db.bak.2026-07-31T10-00-00-000Z')).toBe(true);
+    expect(BACKUP_SUFFIX_RE.test('memories.db')).toBe(false);
+    expect(BACKUP_SUFFIX_RE.test('memories.db-wal')).toBe(false);
+    expect(BACKUP_SUFFIX_RE.test('somebody-elses.backup')).toBe(false);
+  });
+});

--- a/src/cli/__tests__/doctor-disk-breakdown.test.ts
+++ b/src/cli/__tests__/doctor-disk-breakdown.test.ts
@@ -33,16 +33,23 @@ describe('doctor checkDiskUsage names the real disk consumer (4.45.1)', () => {
     fs.writeFileSync(fullPath, Buffer.alloc(bytes, 0));
   }
 
-  it('points at clearing backups when stale migration snapshots dominate', async () => {
+  it('points at the backup copies when they dominate the budget', async () => {
     writeBytes('memories.db', 4 * KB);
     writeBytes('memories.db.pre-backfill-1700000000000', 40 * KB);
     writeBytes('memories.db.empty-live.1700000000001', 20 * KB);
     const result = await checkDiskUsage(tmpDir, 32 * KB);
     expect(result.status).toBe('fail');
-    expect(result.fix).toMatch(/stale DB backups/);
-    expect(result.fix).toMatch(/rm ~\/\.shieldcortex\/memories\.db/);
-    // The whole point: NOT the old blanket "Run memories prune/dedupe" advice.
+    // Names the backup copies and the files to act on.
+    expect(result.fix).toMatch(/backup copies/i);
+    expect(result.fix).toMatch(/memories\.db/);
+    // Still NOT the old blanket "Run memories prune/dedupe" advice.
     expect(result.fix).not.toMatch(/^Run `shieldcortex memories prune/);
+    // #148: it must no longer call these "stale migration snapshots" — on a
+    // large-DB host the dominant file is usually a safety copy written minutes
+    // earlier by a repair doctor itself recommended — nor promise an
+    // auto-prune that was never implemented.
+    expect(result.fix).not.toMatch(/stale DB backups/i);
+    expect(result.fix).not.toMatch(/auto-prune/i);
   });
 
   it('includes a DB / backups / logs breakdown in the message', async () => {

--- a/src/cli/backup-budget.ts
+++ b/src/cli/backup-budget.ts
@@ -1,0 +1,147 @@
+/**
+ * ShieldCortex — budget-aware maintenance backups (#148).
+ *
+ * A maintenance command must not be the thing that breaks the host.
+ *
+ * Live on a fleet box, 31 Jul 2026: `doctor` warned about a project-key
+ * collision and recommended `--fix-project-keys`. That repair copied the whole
+ * 48 MB database as a safety backup with no headroom check, taking the host
+ * from 51.7 MB to 98.8 MB against its own 100 MB limit. The next `doctor` then
+ * reported a disk FAILURE — caused by the fix it had itself recommended — and
+ * blamed "stale migration snapshots" it claimed were auto-pruned. They were not
+ * stale, and nothing was pruned. Clearing the file by hand did not help: the
+ * next repair recreated it. An unwinnable loop, ending with a host one write
+ * away from a failing memory system.
+ *
+ * The safety backup is worth keeping — it is the rollback point for a
+ * destructive rewrite. What it must not do is spend the operator's entire
+ * remaining budget without looking, or leave its predecessor lying around.
+ */
+import { readdirSync, statSync, unlinkSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+
+/**
+ * The accounted disk limit.
+ *
+ * Duplicated today in `database/init.ts` (MAX_DB_SIZE) and `cli/doctor.ts`
+ * (checkDiskUsage's default). Exported here so at least the backup path and
+ * the check that reports on it agree; folding the other two onto this constant
+ * is worth doing, because three copies of a limit is three chances to drift.
+ */
+export const DISK_LIMIT_BYTES = 100 * 1024 * 1024;
+
+/** Our own backup shape: `<db>.bak.<ISO-with-dashes>`. Deliberately narrow. */
+export const BACKUP_SUFFIX_RE = /\.bak\.\d{4}-\d{2}-\d{2}T[\d-]+Z$/;
+
+/** Total bytes of every regular file in a directory (non-recursive). */
+function directoryBytes(dir: string): number {
+  let total = 0;
+  for (const name of readdirSync(dir)) {
+    try {
+      const s = statSync(join(dir, name));
+      if (s.isFile()) total += s.size;
+    } catch {
+      // Vanished mid-scan — not our problem, and counting it as 0 is safe
+      // because it is no longer occupying space.
+    }
+  }
+  return total;
+}
+
+/** Backups of THIS database, newest last. */
+function backupsFor(dir: string, dbName: string): string[] {
+  return readdirSync(dir)
+    .filter(f => f.startsWith(`${dbName}.bak.`) && BACKUP_SUFFIX_RE.test(f))
+    .sort();
+}
+
+/**
+ * Remove all but the newest `keep` backups of `dbName`. Returns what it removed.
+ *
+ * This is the behaviour doctor's own suggested-fix text has been claiming
+ * ("v4.45.1+ also auto-prunes them on start") while nothing implemented it.
+ * Never touches the live DB, its WAL/shm siblings, the lock, or anything that
+ * does not match our own backup shape.
+ */
+export function pruneOldBackups(dir: string, dbName: string, keep: number): string[] {
+  const all = backupsFor(dir, dbName);
+  const doomed = keep <= 0 ? all : all.slice(0, Math.max(0, all.length - keep));
+  const removed: string[] = [];
+  for (const name of doomed) {
+    try {
+      unlinkSync(join(dir, name));
+      removed.push(name);
+    } catch {
+      // A backup we cannot remove is not fatal — planBackup will simply find
+      // less headroom than it hoped and refuse rather than overfill.
+    }
+  }
+  return removed;
+}
+
+export interface BackupPlanInput {
+  dbPath: string;
+  /** Directory the budget applies to. Defaults to the database's own directory. */
+  dir?: string;
+  /** The accounted limit — the same 100 MB doctor measures against. */
+  limitBytes: number;
+}
+
+export type BackupPlan =
+  | { action: 'backup'; prune: string[]; reason: string }
+  | { action: 'refuse'; prune: string[]; reason: string };
+
+/**
+ * Decide whether a full-copy backup fits inside the budget, and what to prune
+ * to make it fit.
+ *
+ * Deliberately conservative: it refuses rather than overfilling, because the
+ * caller is about to do something destructive and an operator who is told "I
+ * can't take a safety copy" can act, whereas one whose disk silently filled
+ * cannot.
+ */
+export function planBackup(input: BackupPlanInput): BackupPlan {
+  const dir = input.dir ?? dirname(input.dbPath);
+  const dbName = basename(input.dbPath);
+  const dbSize = statSync(input.dbPath).size;
+
+  const used = directoryBytes(dir);
+  const headroom = input.limitBytes - used;
+  if (headroom >= dbSize) {
+    return { action: 'backup', prune: [], reason: 'sufficient headroom for a full backup' };
+  }
+
+  // Not enough room as-is. Reclaim from our own previous backups — they are
+  // exactly what the new one supersedes.
+  const candidates = backupsFor(dir, dbName);
+  let reclaimable = 0;
+  const prune: string[] = [];
+  for (const name of candidates) {
+    try {
+      reclaimable += statSync(join(dir, name)).size;
+      prune.push(name);
+      if (headroom + reclaimable >= dbSize) break;
+    } catch {
+      // ignore
+    }
+  }
+
+  if (headroom + reclaimable >= dbSize) {
+    return {
+      action: 'backup',
+      prune,
+      reason: `pruning ${prune.length} superseded backup(s) to make room for a fresh one`,
+    };
+  }
+
+  const mb = (n: number) => `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return {
+    action: 'refuse',
+    prune: [],
+    reason:
+      `refusing to write a ${mb(dbSize)} safety backup: it would exceed the ${mb(input.limitBytes)} ` +
+      `disk budget (${mb(used)} already used, ${mb(Math.max(0, headroom))} free, ` +
+      `${mb(reclaimable)} reclaimable from old backups). ` +
+      `Free space under the limit, or take your own copy outside it and re-run with --no-backup.`,
+  };
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -884,7 +884,12 @@ export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limit
 
     const remedy = (): string => {
       if (backupsSize >= liveDbSize || backupsSize > limit * 0.15) {
-        return `${formatBytes(backupsSize)} is stale DB backups (memories.db.* migration snapshots). Clear them — \`rm ~/.shieldcortex/memories.db.{pre-backfill,empty-live,stub,bak}*\` keeps the live DB; v4.45.1+ also auto-prunes them on start.`;
+        // Do not call these "stale migration snapshots" or promise an auto-prune
+        // (#148). On a large-DB host the file filling the budget is typically a
+        // safety copy written minutes earlier by a repair THIS doctor
+        // recommended, and no auto-prune was happening. Describe what they
+        // actually are and let the operator choose.
+        return `${formatBytes(backupsSize)} is DB backup copies (memories.db.*) — safety copies taken before destructive repairs, the newest being your rollback point. Delete the older ones (the \`memories.db.{pre-backfill,empty-live,stub,bak}*\` files; the live DB is just \`memories.db\`), or move them outside ~/.shieldcortex to keep them without spending the budget. From 4.47.21 a repair prunes superseded copies and refuses rather than overfilling the limit.`;
       }
       if (liveDbSize > limit * 0.5) {
         // #110 signature: a big DB whose memories table is tiny — the bulk is

--- a/src/cli/migrate-legacy.ts
+++ b/src/cli/migrate-legacy.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import readline from 'readline';
 import Database from 'better-sqlite3';
 import { deriveProjectKey } from '../context/derive-project-key.js';
+import { planBackup, pruneOldBackups, DISK_LIMIT_BYTES } from './backup-budget.js';
 
 interface LegacyMemoryRow {
   id: number;
@@ -749,6 +750,9 @@ interface RepairReport {
   applied: number;
   logPath?: string;
   backupPath?: string;
+  /** Set when the repair declined to run — currently only when a safety
+   *  backup would not fit inside the disk budget (#148). */
+  aborted?: string;
 }
 
 function parseMapFlags(args: string[]): Record<string, string> {
@@ -907,6 +911,23 @@ export async function repairProjectKeys(opts: RepairOptions = {}): Promise<Repai
           return report;
         }
       }
+    }
+
+    // Budget-aware safety backup (#148). This copy is a full duplicate of the
+    // database, and on a host whose DB is a large fraction of the disk limit it
+    // used to consume the entire remaining budget without looking — turning a
+    // maintenance command doctor had just RECOMMENDED into the thing that put
+    // the host over its own limit, with no way to win by hand because the next
+    // repair simply recreated it.
+    const plan = planBackup({ dbPath, limitBytes: DISK_LIMIT_BYTES });
+    if (plan.action === 'refuse') {
+      console.error(`Aborted — ${plan.reason}`);
+      report.aborted = plan.reason;
+      return report;
+    }
+    if (plan.prune.length > 0) {
+      const removed = pruneOldBackups(path.dirname(dbPath), path.basename(dbPath), 0);
+      if (removed.length > 0) console.log(`Pruned ${removed.length} superseded backup(s) to stay inside the disk budget.`);
     }
 
     const backupPath = `${dbPath}.bak.${new Date().toISOString().replace(/[:.]/g, '-')}`;


### PR DESCRIPTION
Closes #148. A repair doctor recommended was filling the operator's disk budget and then being misdiagnosed by doctor as stale snapshots it falsely claimed to auto-prune.

planBackup() sizes the copy against the accounted limit and reclaims from superseded backups; refuses with actionable numbers when even pruning cannot make room. pruneOldBackups() implements the auto-prune the doctor text already promised, matching only our own backup shape. Doctor's remedy text corrected.

12 new tests including the exact live case (48MB DB, 100MB budget, one stale copy). Full suite 299 suites / 3384 pass / 0 fail.