### PR TITLE
fix(#148 follow-up): fold the disk limits (carefully), and test the wiring rather than the helper

### DIFF
--- a/src/__tests__/repair-project-keys-budget.test.ts
+++ b/src/__tests__/repair-project-keys-budget.test.ts
@@ -1,0 +1,152 @@
+/**
+ * WIRING test for #148 — proves `repair-project-keys` actually consults the
+ * backup budget, not merely that a budget helper exists.
+ *
+ * Written after auditing my own fix for the pattern this week kept producing:
+ * a helper with good unit tests, a confident claim in user-facing text, and
+ * nothing anywhere proving the caller uses it. `backup-budget.test.ts` covers
+ * planBackup/pruneOldBackups in isolation; delete the call site in
+ * migrate-legacy.ts and every one of those tests still passes while the bug is
+ * fully restored. These tests fail in that case, which is the point.
+ *
+ * Same shape as the two defects fixed today (#146, #148): the mechanism was
+ * guarded and the wiring was not.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import Database from 'better-sqlite3';
+
+import { repairProjectKeys } from '../cli/migrate-legacy.js';
+import { DIRECTORY_BUDGET_BYTES } from '../limits.js';
+
+describe('#148 wiring — repair-project-keys respects the disk budget', () => {
+  let tempHome: string;
+  let scDir: string;
+  let dbPath: string;
+  const originalHome = process.env.HOME;
+
+  function seed(): void {
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE memories (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        uuid TEXT, type TEXT, category TEXT, title TEXT,
+        content TEXT, project TEXT, salience REAL
+      );
+    `);
+    const insert = db.prepare(
+      `INSERT INTO memories (uuid, type, category, title, content, project, salience)
+       VALUES (?, 'long_term', 'note', ?, ?, ?, 0.5)`,
+    );
+    insert.run(crypto.randomUUID(), 'a', 'a', 'myrepo');
+    insert.run(crypto.randomUUID(), 'b', 'b', 'acme-myrepo');
+    db.close();
+  }
+
+  /** Occupy the budget with an inert file, the way a real host's data does. */
+  function fill(name: string, bytes: number): string {
+    const p = path.join(scDir, name);
+    fs.writeFileSync(p, Buffer.alloc(bytes));
+    return p;
+  }
+
+  function backupsOnDisk(): string[] {
+    return fs.readdirSync(scDir).filter(f => f.includes('memories.db.bak.'));
+  }
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-repair-budget-'));
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    scDir = path.join(tempHome, '.shieldcortex');
+    fs.mkdirSync(scDir, { recursive: true });
+    dbPath = path.join(scDir, 'memories.db');
+    seed();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+    process.env.HOME = originalHome;
+    jest.restoreAllMocks();
+  });
+
+  it('REFUSES the repair rather than overfilling the budget, and leaves the data untouched', async () => {
+    // Leave less headroom than the database needs for its own copy.
+    fill('bulk.dat', DIRECTORY_BUDGET_BYTES - 1024);
+
+    const report = await repairProjectKeys({
+      dbPath,
+      map: { myrepo: 'acme-myrepo' },
+      noConfirm: true,
+      execute: true,
+    } as Parameters<typeof repairProjectKeys>[0]);
+
+    expect(report.aborted).toBeTruthy();
+    expect(report.applied).toBe(0);
+    expect(backupsOnDisk()).toHaveLength(0);
+
+    // The rewrite must NOT have happened — refusing to back up must refuse the
+    // destructive half too, or we would have traded a disk problem for data
+    // written with no rollback point.
+    const db = new Database(dbPath, { readonly: true });
+    const n = (db.prepare("SELECT COUNT(*) AS n FROM memories WHERE project = 'myrepo'").get() as { n: number }).n;
+    db.close();
+    expect(n).toBe(1);
+  });
+
+  it('the refusal explains itself in terms the operator can act on', async () => {
+    fill('bulk.dat', DIRECTORY_BUDGET_BYTES - 1024);
+    const report = await repairProjectKeys({
+      dbPath,
+      map: { myrepo: 'acme-myrepo' },
+      noConfirm: true,
+      execute: true,
+    } as Parameters<typeof repairProjectKeys>[0]);
+
+    expect(report.aborted).toMatch(/budget|limit|headroom/i);
+    expect(report.aborted!.length).toBeGreaterThan(20);
+  });
+
+  it('proceeds normally when there is headroom, and writes exactly one backup', async () => {
+    const report = await repairProjectKeys({
+      dbPath,
+      map: { myrepo: 'acme-myrepo' },
+      noConfirm: true,
+      execute: true,
+    } as Parameters<typeof repairProjectKeys>[0]);
+
+    expect(report.aborted).toBeFalsy();
+    expect(report.applied).toBe(1);
+    expect(backupsOnDisk()).toHaveLength(1);
+  });
+
+  it('does not accumulate backups across repeated repairs, even with plenty of headroom', async () => {
+    // The first version of this test was vacuous: after the first run there was
+    // nothing left to rewrite, so later runs returned before ever taking a
+    // backup — and it passed with the wiring removed entirely. It now forces a
+    // real rewrite each time by alternating the project key back and forth.
+    //
+    // This is the case that matters most, and the one the first cut of the fix
+    // got wrong: pruning ONLY when short of room still lets copies pile up on a
+    // healthy host until it fills — the live failure, merely deferred.
+    const rounds: Array<Record<string, string>> = [
+      { myrepo: 'acme-myrepo' },
+      { 'acme-myrepo': 'myrepo' },
+      { myrepo: 'acme-myrepo' },
+      { 'acme-myrepo': 'myrepo' },
+    ];
+    for (const map of rounds) {
+      const r = await repairProjectKeys({
+        dbPath, map, noConfirm: true, execute: true,
+      } as Parameters<typeof repairProjectKeys>[0]);
+      expect(r.applied).toBeGreaterThan(0); // prove a real backup was taken
+      expect(backupsOnDisk().length).toBeLessThanOrEqual(1);
+    }
+    expect(backupsOnDisk()).toHaveLength(1);
+  });
+});

--- a/src/cli/backup-budget.ts
+++ b/src/cli/backup-budget.ts
@@ -21,14 +21,10 @@ import { readdirSync, statSync, unlinkSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 
 /**
- * The accounted disk limit.
- *
- * Duplicated today in `database/init.ts` (MAX_DB_SIZE) and `cli/doctor.ts`
- * (checkDiskUsage's default). Exported here so at least the backup path and
- * the check that reports on it agree; folding the other two onto this constant
- * is worth doing, because three copies of a limit is three chances to drift.
+ * The accounted disk budget, from the single definition in ../limits.ts.
+ * Re-exported so existing callers keep working; do not redefine it here.
  */
-export const DISK_LIMIT_BYTES = 100 * 1024 * 1024;
+export { DIRECTORY_BUDGET_BYTES as DISK_LIMIT_BYTES } from '../limits.js';
 
 /** Our own backup shape: `<db>.bak.<ISO-with-dashes>`. Deliberately narrow. */
 export const BACKUP_SUFFIX_RE = /\.bak\.\d{4}-\d{2}-\d{2}T[\d-]+Z$/;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -24,6 +24,7 @@ import { getCanonicalSchema } from '../database/init.js';
 import { runMigrations } from '../database/migrations.js';
 import { detectStaleDashboard, realDeps } from '../service/dashboard-staleness.js';
 import { MCP_LIGHT_TICK_INTERVAL_MS } from '../worker/types.js';
+import { DIRECTORY_BUDGET_BYTES } from '../limits.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../../package.json');
@@ -807,7 +808,7 @@ function readDbRowConsumers(dbPath: string): DbRowConsumers | null {
   }
 }
 
-export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limitBytes: number = 100 * 1024 * 1024): Promise<CheckResult> {
+export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limitBytes: number = DIRECTORY_BUDGET_BYTES): Promise<CheckResult> {
   if (!fs.existsSync(scDir)) {
     return { label: 'Disk', status: 'pass', message: '0 B / 100 MB limit (directory not yet created)' };
   }

--- a/src/cli/migrate-legacy.ts
+++ b/src/cli/migrate-legacy.ts
@@ -925,15 +925,27 @@ export async function repairProjectKeys(opts: RepairOptions = {}): Promise<Repai
       report.aborted = plan.reason;
       return report;
     }
+    // Reclaim first when we are tight, so the new copy has somewhere to go.
     if (plan.prune.length > 0) {
       const removed = pruneOldBackups(path.dirname(dbPath), path.basename(dbPath), 0);
-      if (removed.length > 0) console.log(`Pruned ${removed.length} superseded backup(s) to stay inside the disk budget.`);
+      if (removed.length > 0) console.log(`Pruned ${removed.length} superseded backup(s) to make room.`);
     }
 
     const backupPath = `${dbPath}.bak.${new Date().toISOString().replace(/[:.]/g, '-')}`;
     fs.copyFileSync(dbPath, backupPath);
     report.backupPath = backupPath;
     console.log(`Backup: ${backupPath}`);
+
+    // ...then prune UNCONDITIONALLY, keeping only the copy just written.
+    //
+    // Pruning only when short of room would still let backups accumulate on a
+    // healthy host until it filled — the same failure that took a fleet box to
+    // its limit, merely deferred. It also would not match what doctor now tells
+    // the operator happens. One repair, one rollback point.
+    const superseded = pruneOldBackups(path.dirname(dbPath), path.basename(dbPath), 1);
+    if (superseded.length > 0) {
+      console.log(`Pruned ${superseded.length} superseded backup(s); the newest is your rollback point.`);
+    }
 
     const update = db.prepare(
       `UPDATE memories SET project = ? WHERE project = ? ${typeFilter}`

--- a/src/database/init.ts
+++ b/src/database/init.ts
@@ -13,6 +13,7 @@ import { runMigrations } from './migrations.js';
 import { getInlineSchema } from './inline-schema.js';
 import { seedDefaultFirewallRules } from './seed-firewall-rules.js';
 import { debugLog } from '../debug-log.js';
+import { MAX_DB_FILE_BYTES, WARN_DB_FILE_BYTES } from '../limits.js';
 
 const _currentFile = fileURLToPath(import.meta.url);
 const _currentDir = dirname(_currentFile);
@@ -24,8 +25,10 @@ let lockFileFd: number | null = null;
 let dbInode: bigint | null = null; // Track file identity for staleness detection
 
 // Anti-bloat: Database size limits
-const MAX_DB_SIZE = 100 * 1024 * 1024; // 100MB hard limit
-const WARN_DB_SIZE = 50 * 1024 * 1024; // 50MB warning threshold
+// Re-exported from the single definition in ../limits.ts (#148 follow-up).
+// This bounds the LIVE DB FILE only — not the whole directory. See limits.ts.
+const MAX_DB_SIZE = MAX_DB_FILE_BYTES;
+const WARN_DB_SIZE = WARN_DB_FILE_BYTES;
 
 /**
  * Expand ~ to home directory

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -1,0 +1,38 @@
+/**
+ * ShieldCortex — storage limits, defined once.
+ *
+ * These were previously three separate literals — `database/init.ts`,
+ * `cli/doctor.ts` and the backup planner — all spelling `100 * 1024 * 1024`.
+ * Three copies of a limit is three chances to drift, and drift between "what
+ * fills the disk" and "what reports on the disk" is exactly the class of defect
+ * that produced #148.
+ *
+ * ⚠️ THE TWO LIMITS BELOW ARE NOT THE SAME POLICY, despite currently sharing a
+ * number. Folding them into one constant would be a bug, not a tidy-up:
+ *
+ *   - `DIRECTORY_BUDGET_BYTES` bounds EVERYTHING under ~/.shieldcortex — the
+ *     live DB plus its WAL, backups, audit logs and so on. It is what `doctor`
+ *     reports on and what the backup planner must respect.
+ *   - `MAX_DB_FILE_BYTES` bounds the LIVE DATABASE FILE alone, and exceeding it
+ *     blocks the database outright.
+ *
+ * They are named apart here so a future change to one cannot silently move the
+ * other.
+ *
+ * 📌 Known incoherence, deliberately surfaced rather than papered over: with
+ * both at 100 MB, a database at 99 MB is "allowed" by the file cap while
+ * already exceeding the whole directory budget on its own — before a single
+ * byte of WAL, audit log or backup. The two numbers want separating (a smaller
+ * file cap, or a larger directory budget), but that is a policy decision with
+ * migration consequences for existing hosts, so it is flagged rather than
+ * quietly changed here.
+ */
+
+/** Total bytes permitted under ~/.shieldcortex (excluding cached models). */
+export const DIRECTORY_BUDGET_BYTES = 100 * 1024 * 1024;
+
+/** Bytes permitted for the live database file alone. Exceeding this blocks it. */
+export const MAX_DB_FILE_BYTES = 100 * 1024 * 1024;
+
+/** Live database size at which we warn but keep going. */
+export const WARN_DB_FILE_BYTES = 50 * 1024 * 1024;


### PR DESCRIPTION
Follow-up to #149, from auditing what protects these bugs.

**Limits folded into `src/limits.ts` — but deliberately NOT into one constant.** `DIRECTORY_BUDGET_BYTES` (whole-directory, what doctor reports) and `MAX_DB_FILE_BYTES` (live file only, blocks the DB) are different policies sharing a number. Merging them would have been a bug dressed as a tidy-up. Named apart, with the latent incoherence documented: a 99 MB DB passes the file cap while already blowing the directory budget alone.

**The wiring was untested in my own fix from an hour earlier.** Removing the call site in migrate-legacy.ts left all twelve helper tests passing with the bug fully restored — the same mechanism-guarded/wiring-not shape as #146 and #148. New wiring tests drive the real repair and were verified to fail without the call site.

Those tests then caught a second defect: pruning fired only when short of room, so backups still accumulated on a healthy host until it filled, and doctor's text promised a prune the code did not perform. Now unconditional after a successful backup. My first accumulation test was also vacuous and has been rewritten to force real rewrites.

Full suite 300 suites / 3388 pass / 0 fail.