### PR TITLE
The honesty cluster: live-roster proof (#152), one working canary command (#154), platform-aware restart advice, backups off the disk budget (#153)

### DIFF
--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -10,7 +10,7 @@
   },
   "enabledByDefault": false,
   "activation": {
-    "onStartup": false,
+    "onStartup": true,
     "hooks": [
       "llm_input",
       "llm_output",
@@ -19,6 +19,9 @@
     ],
     "commands": [
       "shieldcortex-status"
+    ],
+    "onCapabilities": [
+      "hook"
     ]
   },
   "contracts": {},

--- a/src/__tests__/openclaw-canary-probe.test.ts
+++ b/src/__tests__/openclaw-canary-probe.test.ts
@@ -140,7 +140,7 @@ describe('runCanaryProbe — active synthetic op + fresh nonce gate', () => {
 });
 
 describe('evaluateSelfCheck — version proof (onDiskVersion >= expectedVersion)', () => {
-  const loadedRoster: PluginIndexRow = {
+  const indexEnabled: PluginIndexRow = {
     installRecords: { [PLUGIN]: { source: 'npm', version: '4.47.2' } },
     plugins: [{ pluginId: PLUGIN, enabled: true, origin: 'npm' }],
     warning: null,
@@ -149,7 +149,7 @@ describe('evaluateSelfCheck — version proof (onDiskVersion >= expectedVersion)
 
   it('HARD FAILS when the on-disk version regressed below expected (silent-downgrade guard)', () => {
     const v = evaluateSelfCheck({
-      pluginId: PLUGIN, index: loadedRoster, canary: passingCanary,
+      pluginId: PLUGIN, index: indexEnabled, liveRoster: [PLUGIN], canary: passingCanary,
       expectedVersion: '4.47.2', onDiskVersion: '4.25.4',
     });
     expect(v.ok).toBe(false);
@@ -159,7 +159,7 @@ describe('evaluateSelfCheck — version proof (onDiskVersion >= expectedVersion)
 
   it('passes the version proof when on-disk == expected', () => {
     const v = evaluateSelfCheck({
-      pluginId: PLUGIN, index: loadedRoster, canary: passingCanary,
+      pluginId: PLUGIN, index: indexEnabled, liveRoster: [PLUGIN], canary: passingCanary,
       expectedVersion: '4.47.2', onDiskVersion: '4.47.2',
     });
     expect(v.versionProof).toBe(true);
@@ -168,7 +168,7 @@ describe('evaluateSelfCheck — version proof (onDiskVersion >= expectedVersion)
 
   it('passes the version proof when on-disk is newer than expected', () => {
     const v = evaluateSelfCheck({
-      pluginId: PLUGIN, index: loadedRoster, canary: passingCanary,
+      pluginId: PLUGIN, index: indexEnabled, liveRoster: [PLUGIN], canary: passingCanary,
       expectedVersion: '4.47.2', onDiskVersion: '4.47.3',
     });
     expect(v.versionProof).toBe(true);
@@ -176,7 +176,7 @@ describe('evaluateSelfCheck — version proof (onDiskVersion >= expectedVersion)
   });
 
   it('version proof is inert (true) when no expectedVersion is supplied', () => {
-    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: loadedRoster, canary: passingCanary });
+    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: indexEnabled, liveRoster: [PLUGIN], canary: passingCanary });
     expect(v.versionProof).toBe(true);
     expect(v.ok).toBe(true);
   });
@@ -200,7 +200,7 @@ describe('runPluginSelfCheck — reads the on-disk version and enforces the vers
     );
   }
 
-  const loadedRoster: PluginIndexRow = {
+  const indexEnabled: PluginIndexRow = {
     installRecords: { [PLUGIN]: { source: 'npm', version: '4.47.2' } },
     plugins: [{ pluginId: PLUGIN, enabled: true, origin: 'npm' }],
     warning: null,
@@ -212,7 +212,8 @@ describe('runPluginSelfCheck — reads the on-disk version and enforces the vers
     const v = await runPluginSelfCheck(home, {
       pluginId: PLUGIN,
       expectedVersion: '4.47.2',
-      readIndex: () => loadedRoster,
+      readIndex: () => indexEnabled,
+      readLiveRoster: () => [PLUGIN],
       canaryProbe: async () => passingCanary,
     });
     expect(v.ok).toBe(false);
@@ -224,7 +225,8 @@ describe('runPluginSelfCheck — reads the on-disk version and enforces the vers
     const v = await runPluginSelfCheck(home, {
       pluginId: PLUGIN,
       expectedVersion: '4.47.2',
-      readIndex: () => loadedRoster,
+      readIndex: () => indexEnabled,
+      readLiveRoster: () => [PLUGIN],
       canaryProbe: async () => passingCanary,
     });
     expect(v.ok).toBe(true);

--- a/src/__tests__/openclaw-install-gateway-restart.test.ts
+++ b/src/__tests__/openclaw-install-gateway-restart.test.ts
@@ -64,11 +64,37 @@ describe('openclaw install — auto gateway restart (v4.12.6)', () => {
     expect(openclawSource).toMatch(/restartOpenClawGateway/);
   });
 
-  it('on restart failure, prints platform-specific manual restart instructions', () => {
-    // Linux hosts get systemctl, macOS gets launchctl. Edith would have
-    // benefited from this clear next-step.
-    expect(openclawSource).toMatch(/systemctl --user restart openclaw-gateway/);
-    expect(openclawSource).toMatch(/launchctl kickstart -k gui\/\$UID\/ai\.openclaw\.gateway/);
+  it('on restart failure, prints platform-specific manual restart instructions', async () => {
+    // Asserted against the shared resolver rather than by grepping this file
+    // for literals: the literals moved once already, and a test that only knows
+    // where the string USED to live proves nothing about what an operator sees.
+    const { gatewayRestartCommand } = await import('../setup/gateway-restart-command.js');
+
+    expect(gatewayRestartCommand('linux').command).toBe('systemctl --user restart openclaw-gateway');
+    expect(gatewayRestartCommand('darwin', 501).command)
+      .toBe('launchctl kickstart -k gui/501/ai.openclaw.gateway');
+    // A Mac must never be handed the Linux command — the live #154 failure.
+    expect(gatewayRestartCommand('darwin', 501).advice).not.toMatch(/systemctl/);
+    expect(gatewayRestartCommand('linux').advice).not.toMatch(/launchctl/);
+
+    // And the install path must route through it rather than reintroducing a
+    // hardcoded branch of its own.
+    expect(openclawSource).toMatch(/gatewayRestartAdvice\(\)/);
+    expect(openclawSource).not.toMatch(/'\s*systemctl --user restart openclaw-gateway\s*'/);
+  });
+
+  it('refuses to invent a command for a platform it has not verified', async () => {
+    // Guessing is how a Mac got told to run systemctl. Unknown means unknown.
+    const { gatewayRestartCommand } = await import('../setup/gateway-restart-command.js');
+    const win = gatewayRestartCommand('win32');
+    expect(win.command).toBeNull();
+    expect(win.advice).not.toMatch(/systemctl|launchctl/);
+  });
+
+  it('prints a copy-pasteable darwin command even when the uid is unreadable', async () => {
+    const { gatewayRestartCommand } = await import('../setup/gateway-restart-command.js');
+    expect(gatewayRestartCommand('darwin', null).command)
+      .toBe('launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway');
   });
 });
 

--- a/src/__tests__/openclaw-plugin-selfcheck.test.ts
+++ b/src/__tests__/openclaw-plugin-selfcheck.test.ts
@@ -13,34 +13,44 @@ import type { PluginIndexRow } from '../integrations/openclaw-plugin-index.js';
 /**
  * Honest-state self-check (#74 deliverable 2). A security plugin must NEVER
  * report success unless BOTH proofs hold:
- *   (a) the loaded roster (plugins_json) shows the plugin actually loaded, AND
+ *   (a) the RUNNING gateway's boot roster names the plugin, AND
  *   (b) a live enforcement canary confirms the interceptor is denying + audited.
  * Absence of either proof is a hard fail — silence is never success.
+ *
+ * These fixtures were once named `loadedRoster` / `droppedRoster` while holding
+ * INSTALL-index rows, which is the misconception #152 was made of: the index
+ * records what is installed and enabled, never what the gateway loaded. They
+ * are named for what they actually are now, and every case supplies the live
+ * roster separately — because that is the only thing that can grant the proof.
  */
 const PLUGIN = 'shieldcortex-realtime';
 
-const loadedRoster: PluginIndexRow = {
+const indexEnabled: PluginIndexRow = {
   installRecords: { [PLUGIN]: { source: 'npm', version: '4.47.2' } },
   plugins: [{ pluginId: PLUGIN, enabled: true, origin: 'npm' }],
   warning: null,
 };
-const droppedRoster: PluginIndexRow = {
+const indexMissing: PluginIndexRow = {
   installRecords: { [PLUGIN]: { source: 'npm', version: '4.47.2' } },
   plugins: [{ pluginId: 'brave', enabled: true, origin: 'npm' }],
   warning: 'conflicting plugin install metadata for: shieldcortex-realtime',
 };
 const passingCanary: CanaryResult = { ran: true, denied: true, auditEntryFound: true };
 
+/** The gateway's own boot line — the authoritative roster (#152). */
+const liveLoaded = [PLUGIN, 'anthropic'];
+const liveAbsent = ['anthropic', 'brave'];
+
 describe('evaluateSelfCheck — both-proofs-or-fail', () => {
   it('passes only when roster shows loaded AND canary denied + audited', () => {
-    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: loadedRoster, canary: passingCanary });
+    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: indexEnabled, liveRoster: liveLoaded, canary: passingCanary });
     expect(v.ok).toBe(true);
     expect(v.rosterProof).toBe(true);
     expect(v.canaryProof).toBe(true);
   });
 
   it('FAILS when the plugin is loaded but the canary never ran (headless/no-consent)', () => {
-    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: loadedRoster, canary: { ran: false, denied: false, auditEntryFound: false } });
+    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: indexEnabled, liveRoster: liveLoaded, canary: { ran: false, denied: false, auditEntryFound: false } });
     expect(v.ok).toBe(false);
     expect(v.rosterProof).toBe(true);
     expect(v.canaryProof).toBe(false);
@@ -48,20 +58,20 @@ describe('evaluateSelfCheck — both-proofs-or-fail', () => {
   });
 
   it('FAILS (the #74 drop) when the canary passes but the roster omits the plugin', () => {
-    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: droppedRoster, canary: passingCanary });
+    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: indexMissing, liveRoster: liveAbsent, canary: passingCanary });
     expect(v.ok).toBe(false);
     expect(v.rosterProof).toBe(false);
     expect(v.reasons.join(' ')).toMatch(/roster|loaded/i);
   });
 
   it('FAILS when the canary ran but the op was NOT denied (interceptor lenient)', () => {
-    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: loadedRoster, canary: { ran: true, denied: false, auditEntryFound: false } });
+    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: indexEnabled, liveRoster: liveLoaded, canary: { ran: true, denied: false, auditEntryFound: false } });
     expect(v.ok).toBe(false);
     expect(v.canaryProof).toBe(false);
   });
 
   it('FAILS when denied but no audit entry appeared (cannot prove the interceptor fired)', () => {
-    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: loadedRoster, canary: { ran: true, denied: true, auditEntryFound: false } });
+    const v = evaluateSelfCheck({ pluginId: PLUGIN, index: indexEnabled, liveRoster: liveLoaded, canary: { ran: true, denied: true, auditEntryFound: false } });
     expect(v.ok).toBe(false);
     expect(v.canaryProof).toBe(false);
   });
@@ -95,7 +105,8 @@ describe('runPluginSelfCheck — never touches the live gateway under Jest', () 
     // Inject a passing probe + a synthetic loaded roster reader.
     const v = await runPluginSelfCheck(tmpHome, {
       pluginId: PLUGIN,
-      readIndex: () => loadedRoster,
+      readIndex: () => indexEnabled,
+      readLiveRoster: () => liveLoaded,
       canaryProbe: async () => passingCanary,
     });
     expect(v.ok).toBe(true);

--- a/src/__tests__/openclaw-selfcheck-wiring.test.ts
+++ b/src/__tests__/openclaw-selfcheck-wiring.test.ts
@@ -24,8 +24,28 @@ describe('install flow wires the honest-state self-check', () => {
 
   it('hard-fails (exitCode = 1) when the roster proof is missing', () => {
     const body = openclawSrc.slice(openclawSrc.indexOf('runPluginSelfCheck'));
-    expect(body).toMatch(/!check\.rosterProof/);
-    expect(body).toMatch(/process\.exitCode\s*=\s*1/);
+    // Both ways of failing the roster proof must be handled, and each must
+    // hard-fail. #152: `absent` (the gateway booted without us — proven
+    // fail-open) and `unproven` (the boot roster could not be read) are
+    // different facts and must not be reported as one another, but neither is
+    // a pass.
+    expect(body).toMatch(/rosterState\s*===\s*'absent'/);
+    expect(body).toMatch(/rosterState\s*===\s*'unproven'/);
+    expect(body.match(/process\.exitCode\s*=\s*1/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it('never accuses the host of being unprotected on an unreadable roster', () => {
+    // The #142 false alarm: "UNPROTECTED" printed off absence of evidence.
+    // Only what the OPERATOR sees counts here — comments may discuss the word.
+    const body = openclawSrc.slice(openclawSrc.indexOf('runPluginSelfCheck'));
+    const unprovenBranch = body.slice(body.indexOf("rosterState === 'unproven'"));
+    const branchText = unprovenBranch.slice(0, unprovenBranch.indexOf('} else if'));
+    const printed = [...branchText.matchAll(/console\.(?:warn|log|error)\((['"])(.*?)\1\)/g)]
+      .map(m => m[2])
+      .join(' ');
+    expect(printed).not.toBe('');
+    expect(printed).not.toMatch(/booted WITHOUT|UNPROTECTED|is NOT loaded/i);
+    expect(printed).toMatch(/INCONCLUSIVE|could not read/i);
   });
 
   it('only prints the confirmed all-clear when check.ok is true', () => {
@@ -55,5 +75,39 @@ describe('repair flow wires the metadata reconciler', () => {
   it('openclaw repair also routes through the reconciler as a first concern', () => {
     expect(openclawSrc).toMatch(/openclaw-reconcile(?:\.js)?['"]/);
     expect(openclawSrc).toMatch(/reconcileOpenClawPluginState/);
+  });
+});
+
+describe('#154 — `openclaw status` actually runs the load/enforcement check', () => {
+  // Field evidence, 1 Aug 2026: doctor sent an operator to
+  // `SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1 shieldcortex openclaw status` for the
+  // live canary. That command listed install paths, accepted the env var, and
+  // silently ignored it — the one question its name promises to answer went
+  // unanswered. These pin the wiring so the printed command and the code path
+  // cannot diverge again.
+  it('the status flow reaches runPluginSelfCheck', () => {
+    const statusBody = openclawSrc.slice(openclawSrc.indexOf('export async function openClawHookStatus'));
+    expect(statusBody).toMatch(/reportLoadAndEnforcement\(\)/);
+    const reporter = openclawSrc.slice(openclawSrc.indexOf('async function reportLoadAndEnforcement'));
+    expect(reporter).toMatch(/runPluginSelfCheck/);
+  });
+
+  it('status reports load state in all three honest flavours', () => {
+    const reporter = openclawSrc.slice(openclawSrc.indexOf('async function reportLoadAndEnforcement'));
+    expect(reporter).toMatch(/rosterState === 'loaded'/);
+    expect(reporter).toMatch(/rosterState === 'absent'/);
+    // The unproven branch must not accuse; it must say unproven.
+    expect(reporter).toMatch(/UNPROVEN/);
+  });
+
+  it('doctor names the canary command from the single shared constant, never a literal', () => {
+    const doctorSrc = fs.readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'cli', 'doctor.ts'),
+      'utf-8',
+    );
+    expect(doctorSrc).toMatch(/LIVE_CANARY_COMMAND/);
+    // The two-different-commands bug: no hardcoded canary invocation may remain.
+    const literals = doctorSrc.match(/ALLOW_GATEWAY_CANARY=1 shieldcortex [a-z ]+/g) ?? [];
+    expect(literals).toEqual([]);
   });
 });

--- a/src/__tests__/plugin-manifest.test.ts
+++ b/src/__tests__/plugin-manifest.test.ts
@@ -51,12 +51,48 @@ describe('shieldcortex-realtime plugin manifest', () => {
   });
 
   it('declares explicit startup activation policy for OpenClaw compatibility', () => {
-    expect(manifest.activation.onStartup).toBe(false);
+    // This test used to assert `onStartup: false` — pinning the exact value
+    // that left two fleet hosts silently unprotected (see the startup-intent
+    // suite below). A security interceptor is a startup plugin, full stop.
+    expect(manifest.activation.onStartup).toBe(true);
   });
 
   it('plugin package version matches the root package version', () => {
     const rootPkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8'));
     expect(pkg.version).toBe(rootPkg.version);
     expect(manifest.version).toBe(rootPkg.version);
+  });
+});
+
+/**
+ * Field incident, 1 Aug 2026 (aiquant + Michael's Mac): the 2026.7.x gateway
+ * builds its startup plugin set from DEMAND — a plugin loads at boot only if
+ * some predicate says the config needs it (configured channel, provider,
+ * harness runtime, hook capability, or `activation.onStartup === true`).
+ *
+ * Our manifest said `onStartup: false` and listed hooks under a key the
+ * loader's intent check never reads (`activation.hooks`; it reads
+ * `activation.onCapabilities`). Result: on any host whose config entry lacked
+ * an explicit `hooks` policy block, the gateway had ZERO reason to load the
+ * interceptor — enabled, allow-listed, index-coherent, and silently absent
+ * from every boot. Two fleet hosts ran unprotected this way; two others
+ * loaded only because their config entries happened to carry
+ * `hooks.allowConversationAccess`, which the loader accepts as intent.
+ *
+ * A security interceptor must never depend on a config accident to exist.
+ */
+describe('gateway startup intent (the aiquant silent-skip, 1 Aug 2026)', () => {
+  const thisFile = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'plugins', 'openclaw', 'openclaw.plugin.json'), 'utf-8'),
+  );
+
+  it('declares onStartup: true — the gateway must always consider us at boot', () => {
+    expect(manifest.activation.onStartup).toBe(true);
+  });
+
+  it('declares the hook capability in the key the loader actually reads', () => {
+    expect(manifest.activation.onCapabilities).toEqual(expect.arrayContaining(['hook']));
   });
 });

--- a/src/cli/__tests__/doctor-backup-budget-coherence.test.ts
+++ b/src/cli/__tests__/doctor-backup-budget-coherence.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Failing-first spec for #153 — the planner and the doctor must agree.
+ *
+ * Field evidence, 1 Aug 2026 (Edith). Her live DB is 48.9 MB against a 100 MB
+ * accounted budget. A repair took ONE legitimate safety copy — correctly, and
+ * exactly one, since 4.47.22 made the prune unconditional — and that took the
+ * directory to 98.8 MB. Doctor then reported:
+ *
+ *     ❌ Disk: 98.8 MB / 100 MB limit — at limit!
+ *
+ * Two internally-consistent rules that are incoherent together: the planner
+ * treats the limit as a ceiling it may fill to, and doctor treats being at that
+ * ceiling as a failure. Between them they hand an operator a state the product
+ * calls broken, produced by an operation the product recommended.
+ *
+ * The tell for where the real fault lies is doctor's own remedy, which advised
+ * "move them outside ~/.shieldcortex to keep them without spending the budget"
+ * — the exact workaround that had to be performed by hand, twice, on two
+ * different hosts. When the documented fix is "move our file out of our own
+ * folder", the accounting is wrong, not the operator.
+ *
+ * So a safety backup no longer spends the memory-system budget. It is reported
+ * separately, as cached models already are, and bounded by the keep-1 prune
+ * rather than by a limit it can deadlock against.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkDiskUsage } from '../doctor.js';
+
+const MB = 1024 * 1024;
+const LIMIT = 100 * MB;
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'sc-disk-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+function write(name: string, bytes: number): void {
+  writeFileSync(join(dir, name), Buffer.alloc(bytes));
+}
+
+describe('#153 — a safety backup must not spend the memory-system budget', () => {
+  it('passes on Edith\'s exact state: 48.9 MB DB + one 48.9 MB safety copy', async () => {
+    write('memories.db', 49 * MB);
+    write('memories.db.bak.2026-08-01T03-39-00-000Z', 49 * MB);
+
+    const r = await checkDiskUsage(dir, LIMIT) as unknown as { status: string; message: string };
+    // 98 MB of files, but only 49 MB of it is budgeted data.
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/backups/i);
+  });
+
+  it('still FAILS when the live database itself fills the budget', async () => {
+    // The condition the budget exists to catch must keep firing.
+    write('memories.db', 99 * MB);
+    const r = await checkDiskUsage(dir, LIMIT) as unknown as { status: string };
+    expect(r.status).toBe('fail');
+  });
+
+  it('reports backups separately rather than silently hiding them', async () => {
+    write('memories.db', 10 * MB);
+    write('memories.db.bak.2026-08-01T03-39-00-000Z', 40 * MB);
+    const r = await checkDiskUsage(dir, LIMIT) as unknown as { message: string };
+    // An operator must still be able to see the space is in use.
+    expect(r.message).toMatch(/40(\.0)? MB backups/i);
+  });
+
+  it('never tells the operator to move our own files out of our own directory', async () => {
+    // That advice was the symptom that located this bug.
+    write('memories.db', 20 * MB);
+    write('memories.db.bak.2026-08-01T03-39-00-000Z', 60 * MB);
+    const r = await checkDiskUsage(dir, LIMIT) as unknown as { fix?: string; message: string };
+    const text = `${r.fix ?? ''} ${r.message}`;
+    expect(text).not.toMatch(/move them outside/i);
+  });
+
+  it('counts logs and audit against the budget as before', async () => {
+    // Only backups are exempted; everything else still spends the budget.
+    write('memories.db', 10 * MB);
+    mkdirSync(join(dir, 'audit'), { recursive: true });
+    writeFileSync(join(dir, 'audit', 'realtime-2026-08-01.jsonl'), Buffer.alloc(95 * MB));
+    const r = await checkDiskUsage(dir, LIMIT) as unknown as { status: string };
+    expect(r.status).toBe('fail');
+  });
+
+  it('legacy in-place snapshots are exempted too, not just newly-named ones', async () => {
+    // Hosts upgraded from older builds carry these names; they must not keep
+    // failing after the fix lands.
+    write('memories.db', 30 * MB);
+    write('memories.db.pre-backfill', 60 * MB);
+    const r = await checkDiskUsage(dir, LIMIT) as unknown as { status: string };
+    expect(r.status).toBe('pass');
+  });
+});

--- a/src/cli/__tests__/doctor-disk-breakdown.test.ts
+++ b/src/cli/__tests__/doctor-disk-breakdown.test.ts
@@ -33,23 +33,23 @@ describe('doctor checkDiskUsage names the real disk consumer (4.45.1)', () => {
     fs.writeFileSync(fullPath, Buffer.alloc(bytes, 0));
   }
 
-  it('points at the backup copies when they dominate the budget', async () => {
+  it('backups dominating the directory is NOT a failure — they no longer spend the budget (#153)', async () => {
+    // This test previously asserted `fail` here, which encoded the #153
+    // incoherence as the expected behaviour: the planner was allowed to write
+    // a safety copy up to the limit, and doctor then called being at the limit
+    // broken. An operator could only clear that failure by deleting their own
+    // rollback point. Backups are now measured and reported but exempt from
+    // the budget, so this state is healthy — and the remedy must not blame
+    // them for an overage they can no longer cause.
     writeBytes('memories.db', 4 * KB);
     writeBytes('memories.db.pre-backfill-1700000000000', 40 * KB);
     writeBytes('memories.db.empty-live.1700000000001', 20 * KB);
     const result = await checkDiskUsage(tmpDir, 32 * KB);
-    expect(result.status).toBe('fail');
-    // Names the backup copies and the files to act on.
-    expect(result.fix).toMatch(/backup copies/i);
-    expect(result.fix).toMatch(/memories\.db/);
-    // Still NOT the old blanket "Run memories prune/dedupe" advice.
-    expect(result.fix).not.toMatch(/^Run `shieldcortex memories prune/);
-    // #148: it must no longer call these "stale migration snapshots" — on a
-    // large-DB host the dominant file is usually a safety copy written minutes
-    // earlier by a repair doctor itself recommended — nor promise an
-    // auto-prune that was never implemented.
-    expect(result.fix).not.toMatch(/stale DB backups/i);
-    expect(result.fix).not.toMatch(/auto-prune/i);
+    expect(result.status).toBe('pass');
+    // Still visible to the operator, reported alongside the budgeted figure.
+    expect(result.message).toMatch(/backups/i);
+    // #148's language rules still hold wherever backups are described.
+    expect(`${result.fix ?? ''} ${result.message}`).not.toMatch(/stale DB backups/i);
   });
 
   it('includes a DB / backups / logs breakdown in the message', async () => {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -25,6 +25,8 @@ import { runMigrations } from '../database/migrations.js';
 import { detectStaleDashboard, realDeps } from '../service/dashboard-staleness.js';
 import { MCP_LIGHT_TICK_INTERVAL_MS } from '../worker/types.js';
 import { DIRECTORY_BUDGET_BYTES } from '../limits.js';
+import { gatewayRestartAdvice } from '../setup/gateway-restart-command.js';
+import { LIVE_CANARY_COMMAND } from '../setup/openclaw-selfcheck.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../../package.json');
@@ -876,22 +878,34 @@ export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limit
       else if (entry.isDirectory() && LOG_DIRS.has(entry.name)) logsSize += sizeOf(fp);
     }
 
+    // #153: a safety backup does NOT spend the memory-system budget.
+    //
+    // The budget answers "is the memory system's footprint under control?".
+    // A rollback copy taken before a destructive repair, pruned to at most one,
+    // is under control by construction — counting it produced a FAILURE an
+    // operator could only clear by deleting their own rollback point, caused by
+    // an operation this same tool had just recommended (Edith, 1 Aug 2026:
+    // 48.9 MB DB + one 48.9 MB copy = 98.8/100, "at limit!").
+    //
+    // Cached models are already exempted and reported separately for exactly
+    // this reason. Backups now follow that precedent: still measured, still
+    // shown, no longer able to deadlock the thing that creates them.
+    dataSize -= backupsSize;
+
     const limit = limitBytes; // 100 MB by default; applies to the data portion only
     const limitMb = Math.round(limit / (1024 * 1024));
     const pct = (dataSize / limit) * 100;
     const dataStr = `${formatBytes(dataSize)} / ${limitMb} MB limit`;
     const modelsStr = modelsSize > 0 ? ` + ${formatBytes(modelsSize)} models` : '';
+    const backupsStr = backupsSize > 0 ? ` + ${formatBytes(backupsSize)} backups` : '';
     const breakdown = `DB ${formatBytes(liveDbSize)} · backups ${formatBytes(backupsSize)} · logs ${formatBytes(logsSize)}`;
 
     const remedy = (): string => {
-      if (backupsSize >= liveDbSize || backupsSize > limit * 0.15) {
-        // Do not call these "stale migration snapshots" or promise an auto-prune
-        // (#148). On a large-DB host the file filling the budget is typically a
-        // safety copy written minutes earlier by a repair THIS doctor
-        // recommended, and no auto-prune was happening. Describe what they
-        // actually are and let the operator choose.
-        return `${formatBytes(backupsSize)} is DB backup copies (memories.db.*) — safety copies taken before destructive repairs, the newest being your rollback point. Delete the older ones (the \`memories.db.{pre-backfill,empty-live,stub,bak}*\` files; the live DB is just \`memories.db\`), or move them outside ~/.shieldcortex to keep them without spending the budget. From 4.47.21 a repair prunes superseded copies and refuses rather than overfilling the limit.`;
-      }
+      // NOTE: backups no longer count toward the budget (#153), so they can no
+      // longer be the cause of an overage and must not be blamed for one. The
+      // old first branch here sent operators to delete their own rollback point
+      // — and, when that did not help, to move our files out of our own
+      // directory. Both were treating a symptom of the accounting being wrong.
       if (liveDbSize > limit * 0.5) {
         // #110 signature: a big DB whose memories table is tiny — the bulk is
         // session-capture rows. Live incident (Edith, 2026-07-21): 79.6 MB DB,
@@ -933,18 +947,18 @@ export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limit
       return {
         label: 'Disk',
         status: 'fail',
-        message: `${dataStr}${modelsStr} — at limit! (${breakdown})`,
+        message: `${dataStr}${backupsStr}${modelsStr} — at limit! (${breakdown})`,
         fix: remedy(),
       };
     } else if (pct >= 80) {
       return {
         label: 'Disk',
         status: 'warn',
-        message: `${dataStr}${modelsStr} — approaching limit (${breakdown})`,
+        message: `${dataStr}${backupsStr}${modelsStr} — approaching limit (${breakdown})`,
         fix: remedy(),
       };
     } else {
-      return { label: 'Disk', status: 'pass', message: `${dataStr}${modelsStr}` };
+      return { label: 'Disk', status: 'pass', message: `${dataStr}${backupsStr}${modelsStr}` };
     }
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -1521,7 +1535,7 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
         message:
           `verdict probes 3/3 (catastrophic→block, dangerous→approval, benign→allow) in ${elapsed}ms — ` +
           `in-process check of guard logic + this box's config; wiring proof needs the consent-gated live canary ` +
-          `(SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1 shieldcortex openclaw status)`,
+          `(${LIVE_CANARY_COMMAND})`,
       });
     } else {
       results.push({
@@ -2213,7 +2227,7 @@ export async function checkOpenClawPluginLoadState(
       return {
         label,
         status: 'pass',
-        message: `realtime plugin loaded (roster-confirmed, v${verdict.onDiskVersion ?? verdict.expectedVersion}); enforcement not probed here — run \`shieldcortex repair\` with SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1 to prove it live`,
+        message: `realtime plugin loaded (roster-confirmed, v${verdict.onDiskVersion ?? verdict.expectedVersion}); enforcement not probed here — prove it live with: ${LIVE_CANARY_COMMAND}`,
       };
   }
 }
@@ -2358,8 +2372,8 @@ export async function checkOpenClawRunningPluginVersion(
       `stale plugin loaded (v${running} running, v${diskVersion} on disk) — the gateway is still ` +
       `enforcing the older build; a gateway restart is needed to pick up the on-disk upgrade`,
     fix:
-      'Restart the OpenClaw gateway so it re-registers the on-disk plugin ' +
-      '(`systemctl --user restart openclaw-gateway`, or restart the OpenClaw process). ' +
+      'Restart the OpenClaw gateway so it re-registers the on-disk plugin:\n' +
+      `  ${gatewayRestartAdvice()}\n` +
       'Until then the live interceptor is the version shown as "running", not the one on disk.',
   };
 }

--- a/src/setup/__tests__/openclaw-selfcheck-live-roster.test.ts
+++ b/src/setup/__tests__/openclaw-selfcheck-live-roster.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Failing-first spec for #152 — the roster proof must read the LIVE roster.
+ *
+ * Field evidence, 31 Jul 2026 (Michael's MacBook). One `shieldcortex repair`
+ * run printed both of these, seconds apart:
+ *
+ *   • "ABSENT from the RUNNING gateway boot roster — interceptor not loaded,
+ *      host unprotected while status reports ON"
+ *   • "roster proof: plugin present + enabled in the loaded roster (plugins_json)"
+ *
+ * Both cannot be true. The reconciler was fixed for #103 to treat the gateway's
+ * own boot line as authoritative; `evaluateSelfCheck` was not, and still reads
+ * `installed_plugin_index.plugins_json` — INSTALL state — while calling it
+ * "the loaded roster".
+ *
+ * So the one check written specifically to catch an installed-but-not-loaded
+ * plugin cannot detect that condition, and returns PASS on a host in exactly
+ * it. That is the #74 fail-open wearing the badge of the check meant to stop it.
+ *
+ * The distinction these tests pin: ABSENT (proven fail-open) and UNPROVEN
+ * (roster unreadable) are different answers and must never collapse into each
+ * other. Neither is a pass.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { evaluateSelfCheck } from '../openclaw-selfcheck.js';
+import type { PluginIndexRow } from '../../integrations/openclaw-plugin-index.js';
+
+const PLUGIN = 'shieldcortex-realtime';
+
+/** An install index that lists the plugin as installed + enabled. */
+function indexSaysEnabled(): PluginIndexRow {
+  return {
+    installRecords: { [PLUGIN]: { source: 'npm', version: '4.47.22' } },
+    plugins: [{ pluginId: PLUGIN, enabled: true }],
+    warning: null,
+    generatedAtMs: 1,
+  };
+}
+
+const canaryPassed = { ran: true, denied: true, auditEntryFound: true };
+const canarySkipped = { ran: false, denied: false, auditEntryFound: false };
+
+describe('#152 — install state is not load state', () => {
+  it('does NOT claim a roster proof when the live roster omits the plugin', () => {
+    // The MacBook state exactly: index says enabled, gateway booted without it.
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: indexSaysEnabled(),
+      liveRoster: ['anthropic', 'acpx', 'telegram'],
+      canary: canaryPassed,
+    });
+
+    expect(v.rosterProof).toBe(false);
+    expect(v.ok).toBe(false);
+    expect(v.rosterState).toBe('absent');
+    // And it must say so in the operator's own terms.
+    expect(v.reasons.join(' ')).toMatch(/ABSENT from the RUNNING gateway boot roster/i);
+  });
+
+  it('never contradicts the reconciler: absent from the live roster is never "present in the loaded roster"', () => {
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: indexSaysEnabled(),
+      liveRoster: ['anthropic'],
+      canary: canaryPassed,
+    });
+    // The precise sentence that appeared on the Mac beneath the contradiction.
+    expect(v.reasons.join(' ')).not.toMatch(/plugin present \+ enabled in the loaded roster/i);
+  });
+
+  it('grants the roster proof when the RUNNING gateway names the plugin', () => {
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: indexSaysEnabled(),
+      liveRoster: ['anthropic', PLUGIN],
+      canary: canaryPassed,
+    });
+    expect(v.rosterProof).toBe(true);
+    expect(v.rosterState).toBe('loaded');
+    expect(v.ok).toBe(true);
+  });
+
+  it('reports UNPROVEN — not absent, not proven — when the live roster cannot be read', () => {
+    // Absence of evidence. Claiming the plugin is missing would be as
+    // dishonest as claiming it is loaded; #142 was a false UNPROTECTED from
+    // exactly this state.
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: indexSaysEnabled(),
+      liveRoster: null,
+      canary: canaryPassed,
+    });
+    expect(v.rosterState).toBe('unproven');
+    expect(v.rosterProof).toBe(false);
+    expect(v.ok).toBe(false);
+    const reasons = v.reasons.join(' ');
+    expect(reasons).toMatch(/could not read the running gateway/i);
+    // Must not accuse the host of being unprotected on unreadable evidence.
+    expect(reasons).not.toMatch(/ABSENT from the RUNNING/i);
+  });
+
+  it('an enabled install index alone is never sufficient — the #103/#152 root', () => {
+    // No live roster supplied at all: the index is optimistic, we are not.
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: indexSaysEnabled(),
+      canary: canaryPassed,
+    });
+    expect(v.rosterProof).toBe(false);
+    expect(v.ok).toBe(false);
+  });
+
+  it('a live roster hit does not rescue a missing canary', () => {
+    // Both proofs are required; neither substitutes for the other.
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: indexSaysEnabled(),
+      liveRoster: [PLUGIN],
+      canary: canarySkipped,
+    });
+    expect(v.rosterProof).toBe(true);
+    expect(v.canaryProof).toBe(false);
+    expect(v.ok).toBe(false);
+  });
+
+  it('still fails honestly when the index is unreadable AND the roster is unknown', () => {
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: null,
+      liveRoster: null,
+      canary: canaryPassed,
+    });
+    expect(v.rosterProof).toBe(false);
+    expect(v.ok).toBe(false);
+  });
+
+  it('trusts the live roster even when the install index is unreadable', () => {
+    // The gateway's own boot line is ground truth; a broken better-sqlite3
+    // binding must not be able to veto it.
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: null,
+      liveRoster: [PLUGIN],
+      canary: canaryPassed,
+    });
+    expect(v.rosterProof).toBe(true);
+    expect(v.rosterState).toBe('loaded');
+  });
+});

--- a/src/setup/deep-clean.ts
+++ b/src/setup/deep-clean.ts
@@ -19,6 +19,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { execSync } from 'child_process';
+import { gatewayRestartCommand } from './gateway-restart-command.js';
 
 const PLUGIN_ID = 'shieldcortex-realtime';
 const HOOK_NAME = 'cortex-memory';
@@ -519,10 +520,14 @@ export async function restartOpenClawGateway(): Promise<{
   }
 
   const platform = process.platform;
+  // The command strings themselves live in gateway-restart-command.ts, so the
+  // advice `doctor` PRINTS and the command this EXECUTES cannot drift apart —
+  // they did, and a Mac was told to run systemctl (#154 sibling).
+  const resolved = gatewayRestartCommand(platform);
 
   if (platform === 'linux') {
     try {
-      execSync('systemctl --user restart openclaw-gateway', {
+      execSync(resolved.command!, {
         encoding: 'utf-8',
         timeout: 10000,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -540,8 +545,7 @@ export async function restartOpenClawGateway(): Promise<{
 
   if (platform === 'darwin') {
     try {
-      const uid = process.getuid ? process.getuid() : 0;
-      execSync(`launchctl kickstart -k gui/${uid}/ai.openclaw.gateway`, {
+      execSync(resolved.command!, {
         encoding: 'utf-8',
         timeout: 10000,
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/setup/gateway-restart-command.ts
+++ b/src/setup/gateway-restart-command.ts
@@ -1,0 +1,74 @@
+/**
+ * ShieldCortex — the gateway restart command, defined once.
+ *
+ * Field evidence, 31 Jul 2026 (Michael's MacBook): `doctor` told an operator to
+ * run `systemctl --user restart openclaw-gateway`. On macOS that is
+ * `command not found`, twice, before anyone realised the tool was at fault
+ * rather than the typing.
+ *
+ * The galling part is that the codebase already knew better. `deep-clean.ts`
+ * branches on platform and uses `launchctl kickstart` for darwin; so does the
+ * install path's fallback advice. `doctor` — the one surface operators actually
+ * read when something is wrong — was the single place that hardcoded Linux.
+ *
+ * Knowing the right answer in the DOING code and printing the wrong one in the
+ * TELLING code is the same defect family as #146 and #152: the machinery is
+ * correct and the thing reporting on it is not. So the string lives here, once,
+ * and both the executor and every piece of printed advice read it from here.
+ */
+
+/** Platform values we have a specific answer for. */
+export type RestartPlatform = 'linux' | 'darwin' | string;
+
+export interface GatewayRestartCommand {
+  /** The exact command to run, or null when we genuinely do not know. */
+  command: string | null;
+  /** Short label for the mechanism, for logs and reports. */
+  method: string;
+  /** Operator-facing advice, always safe to print. */
+  advice: string;
+}
+
+/**
+ * The correct restart invocation for a platform.
+ *
+ * `uid` is only consulted on darwin, where launchd needs the GUI domain of the
+ * user whose gateway this is. It is injectable so this stays pure and testable.
+ */
+export function gatewayRestartCommand(
+  platform: RestartPlatform = process.platform,
+  uid: number | null = typeof process.getuid === 'function' ? process.getuid() : null,
+): GatewayRestartCommand {
+  if (platform === 'linux') {
+    const command = 'systemctl --user restart openclaw-gateway';
+    return { command, method: 'systemctl --user', advice: command };
+  }
+
+  if (platform === 'darwin') {
+    // `$(id -u)` keeps the printed form copy-pasteable even when we could not
+    // read a uid ourselves; the executed form always uses the real number.
+    const domain = uid == null ? '$(id -u)' : String(uid);
+    const command = `launchctl kickstart -k gui/${domain}/ai.openclaw.gateway`;
+    return {
+      command,
+      method: 'launchctl kickstart',
+      advice:
+        `${command}\n` +
+        '  (if that reports "Could not find service", the gateway is not under launchd — ' +
+        'quit and reopen the OpenClaw app/process instead)',
+    };
+  }
+
+  // Windows, BSD, or anything else: we have no verified invocation, and
+  // inventing one is how this bug happened in the first place.
+  return {
+    command: null,
+    method: 'unknown',
+    advice: 'restart the OpenClaw gateway process however it is managed on this host',
+  };
+}
+
+/** Just the operator-facing advice, for printed remediation text. */
+export function gatewayRestartAdvice(platform: RestartPlatform = process.platform): string {
+  return gatewayRestartCommand(platform).advice;
+}

--- a/src/setup/openclaw-selfcheck.ts
+++ b/src/setup/openclaw-selfcheck.ts
@@ -12,6 +12,7 @@ import {
   readInstalledRealtimePluginVersion,
   resolveRealtimePluginInstallPath,
 } from '../integrations/openclaw-plugin-state.js';
+import { readLatestBootRoster } from '../integrations/openclaw-gateway-roster.js';
 import { evaluateToolCall } from '../defence/iron-dome/tool-action-guard.js';
 
 /**
@@ -23,16 +24,41 @@ import { evaluateToolCall } from '../defence/iron-dome/tool-action-guard.js';
  * it was silently dropped from the loaded roster — the host was unprotected.
  *
  * So a flow may report success ONLY when BOTH independent proofs hold:
- *   (a) ROSTER  — OpenClaw's own loaded roster (`installed_plugin_index.
- *       plugins_json`) carries an enabled entry for the plugin, and
+ *   (a) ROSTER  — the RUNNING gateway's own boot line names the plugin, and
  *   (b) CANARY  — a live enforcement probe confirms the interceptor actually
  *       denied a known-bad operation AND wrote the corresponding audit entry.
+ *
+ * #152 (Michael's MacBook, 31 Jul 2026): the roster proof used to read
+ * `installed_plugin_index.plugins_json` and describe it as "the loaded roster".
+ * It is not — it records what OpenClaw has INSTALLED and enabled, which stays
+ * true while the gateway boots without the plugin. One repair run therefore
+ * printed "ABSENT from the RUNNING gateway boot roster" and "present + enabled
+ * in the loaded roster" seconds apart, and the check written to catch the #74
+ * fail-open returned PASS on a host sitting in it. The reconciler had already
+ * been fixed for this in #103; this module had not. The boot line is now the
+ * only thing that can grant the roster proof.
  *
  * Absence of either proof is a HARD FAIL. Silence is never success. The live
  * canary is guarded exactly like the gateway restart (JEST + explicit consent
  * env) so tests and this frozen box never trigger a live gateway operation;
  * callers inject a probe to exercise the wiring.
  */
+
+/**
+ * The ONE command that proves enforcement live. Defined here, printed nowhere
+ * else from a literal (#154).
+ *
+ * Field evidence, 1 Aug 2026: `doctor` printed two different commands for this
+ * same proof in a single run — `shieldcortex openclaw status` on the Action
+ * guard line, `shieldcortex repair` on the plugin line. Only the second reached
+ * the self-check; the first accepted the env var and silently ignored it. An
+ * operator followed the first, got a directory listing, and learned nothing
+ * about whether the host was protected.
+ *
+ * Both surfaces now run the canary, and both name it from this constant, so a
+ * future divergence has to be deliberate rather than accidental.
+ */
+export const LIVE_CANARY_COMMAND = 'SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1 shieldcortex openclaw status';
 
 export interface CanaryResult {
   /** Whether the live enforcement probe actually executed. */
@@ -44,9 +70,25 @@ export interface CanaryResult {
   detail?: string;
 }
 
+/**
+ * What we actually know about the RUNNING gateway's roster (#152).
+ *
+ * The three states must never collapse into each other:
+ *   - `loaded`   — the gateway's own boot line names the plugin. Proof.
+ *   - `absent`   — the boot line was read and does NOT name it. The #74/#103
+ *                  fail-open, proven. A hard failure.
+ *   - `unproven` — the boot line could not be read. Absence of evidence.
+ *                  Not a pass, but equally not an accusation: #142 was a false
+ *                  "UNPROTECTED" produced by treating this state as `absent`.
+ */
+export type RosterProofState = 'loaded' | 'absent' | 'unproven';
+
 export interface SelfCheckVerdict {
   ok: boolean;
+  /** True ONLY for `rosterState === 'loaded'`. */
   rosterProof: boolean;
+  /** Which of the three roster answers we actually have. */
+  rosterState: RosterProofState;
   canaryProof: boolean;
   /** onDiskVersion >= expectedVersion (inert/true when no expectedVersion given). */
   versionProof: boolean;
@@ -57,6 +99,11 @@ export interface SelfCheckInput {
   pluginId: string;
   index: PluginIndexRow | null;
   canary: CanaryResult | null;
+  /**
+   * Plugin ids named on the RUNNING gateway's boot line, or null when it could
+   * not be read. This — not the install index — is the roster proof (#152).
+   */
+  liveRoster?: string[] | null;
   /** The build the flow expects to be enforcing; enables the version proof. */
   expectedVersion?: string;
   /** Ground-truth on-disk version, for the version proof. */
@@ -76,15 +123,41 @@ export function evaluateSelfCheck(input: SelfCheckInput): SelfCheckVerdict {
   const { pluginId, index, canary } = input;
   const reasons: string[] = [];
 
-  const rosterProof = Boolean(
+  // ── Roster proof (#152) ──────────────────────────────────────────────────
+  // The RUNNING gateway's boot line is the only ground truth for what was
+  // loaded. `installed_plugin_index.plugins_json` records what is INSTALLED and
+  // enabled — a plugin can sit in it, allow-listed and enabled, while the
+  // gateway booted without it. Reading the index here and calling it "the
+  // loaded roster" is what let this check pass on a host in exactly the
+  // condition it exists to catch.
+  const liveRoster = input.liveRoster ?? null;
+  const enabledInIndex = Boolean(
     index?.plugins?.some((p) => p.pluginId === pluginId && p.enabled === true),
   );
-  if (rosterProof) {
-    reasons.push('roster proof: plugin present + enabled in the loaded roster (plugins_json)');
-  } else if (index == null) {
-    reasons.push('roster proof FAILED: could not read the plugin install index (SQLite unavailable)');
+
+  let rosterState: RosterProofState;
+  if (liveRoster == null) {
+    rosterState = 'unproven';
   } else {
-    reasons.push('roster proof FAILED: plugin ABSENT from the loaded roster — enabled in config but not loaded (the #74 silent drop)');
+    rosterState = liveRoster.includes(pluginId) ? 'loaded' : 'absent';
+  }
+  const rosterProof = rosterState === 'loaded';
+
+  if (rosterState === 'loaded') {
+    reasons.push('roster proof: plugin named on the RUNNING gateway boot roster — actually loaded, not merely installed');
+  } else if (rosterState === 'absent') {
+    reasons.push('roster proof FAILED: plugin ABSENT from the RUNNING gateway boot roster — interceptor not loaded, host unprotected while status reports ON');
+    if (enabledInIndex) {
+      reasons.push('the SQLite install index lists it as enabled — install state, not load state; the live roster is authoritative');
+    }
+  } else {
+    // Unreadable. Say only what is true: we cannot prove it either way.
+    reasons.push(
+      'roster proof FAILED: could not read the running gateway boot roster (log rotated, wiped, or written elsewhere) — cannot confirm the interceptor is loaded' +
+        (enabledInIndex
+          ? '; the SQLite install index lists it as enabled, but that is install state, not load state'
+          : ''),
+    );
   }
 
   const canaryProof = Boolean(canary && canary.ran && canary.denied && canary.auditEntryFound);
@@ -115,7 +188,7 @@ export function evaluateSelfCheck(input: SelfCheckInput): SelfCheckVerdict {
     }
   }
 
-  return { ok: rosterProof && canaryProof && versionProof, rosterProof, canaryProof, versionProof, reasons };
+  return { ok: rosterProof && canaryProof && versionProof, rosterProof, rosterState, canaryProof, versionProof, reasons };
 }
 
 export interface RunSelfCheckOptions {
@@ -126,12 +199,19 @@ export interface RunSelfCheckOptions {
   readIndex?: (home: string) => PluginIndexRow | null;
   /** Injectable on-disk version reader (defaults to the live package.json read). */
   readOnDiskVersion?: (home: string) => string | null;
+  /**
+   * Injectable live-roster reader (defaults to the gateway's newest
+   * `http server listening` boot line). Returns null when it cannot be proven.
+   */
+  readLiveRoster?: () => string[] | null;
   /** Injectable live enforcement probe (defaults to the guarded real probe). */
   canaryProbe?: (home: string, pluginId: string) => Promise<CanaryResult>;
 }
 
 export interface SelfCheckRunResult extends SelfCheckVerdict {
   index: PluginIndexRow | null;
+  /** What the running gateway's boot line said, or null when unreadable. */
+  liveRoster: string[] | null;
   canary: CanaryResult;
 }
 
@@ -148,19 +228,28 @@ export async function runPluginSelfCheck(
   const pluginId = options.pluginId ?? REALTIME_PLUGIN_ID;
   const readIndex = options.readIndex ?? ((h: string) => readPluginInstallIndex(h));
   const readOnDisk = options.readOnDiskVersion ?? ((h: string) => readInstalledRealtimePluginVersion(h));
+  // The default roster read touches the host's real gateway log dir
+  // (/tmp/openclaw), which no `home` override can redirect — so it must never
+  // fire under Jest, or a test would silently inherit THIS box's roster and
+  // prove nothing. Tests inject readLiveRoster.
+  const readRoster =
+    options.readLiveRoster ??
+    (() => (process.env.JEST_WORKER_ID !== undefined ? null : (readLatestBootRoster()?.plugins ?? null)));
   const probe = options.canaryProbe ?? defaultCanaryProbe;
 
   const index = readIndex(home);
+  const liveRoster = readRoster();
   const onDiskVersion = options.expectedVersion ? readOnDisk(home) : null;
   const canary = await probe(home, pluginId);
   const verdict = evaluateSelfCheck({
     pluginId,
     index,
+    liveRoster,
     canary,
     expectedVersion: options.expectedVersion,
     onDiskVersion,
   });
-  return { ...verdict, index, canary };
+  return { ...verdict, index, liveRoster, canary };
 }
 
 /** Injectable seams for the live enforcement canary, so the wiring is unit-tested. */

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import os from 'os';
 import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { gatewayRestartAdvice } from './gateway-restart-command.js';
 import {
   resolveRealtimePluginInstallPath,
   resolveRealtimeProjectDir,
@@ -1092,9 +1093,7 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
     } else if (result.attempted) {
       console.warn(`OpenClaw gateway restart via ${result.method} failed: ${result.detail ?? 'unknown'}`);
       console.warn('Restart it manually so the new plugin/hook take effect:');
-      console.warn(process.platform === 'linux'
-        ? '  systemctl --user restart openclaw-gateway'
-        : '  launchctl kickstart -k gui/$UID/ai.openclaw.gateway');
+      console.warn(`  ${gatewayRestartAdvice()}`);
     } else {
       console.log('Restart your agent / OpenClaw gateway to activate.');
     }
@@ -1116,10 +1115,17 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
       console.log('');
       if (check.ok) {
         console.log('✓ Honest-state self-check: plugin confirmed loaded (roster), enforcing (live canary), version ≥ expected.');
-      } else if (!check.rosterProof) {
-        console.warn('✗ Honest-state self-check FAILED: the plugin is NOT in OpenClaw\'s loaded roster after restart.');
+      } else if (check.rosterState === 'absent') {
+        console.warn('✗ Honest-state self-check FAILED: the RUNNING gateway booted WITHOUT the plugin.');
         console.warn('  Protection would report ON while actually OFF (issue #74). Reconcile the install:');
         console.warn('    SHIELDCORTEX_ALLOW_GATEWAY_RECONCILE=1 shieldcortex repair');
+        process.exitCode = 1;
+      } else if (check.rosterState === 'unproven') {
+        // Absence of evidence. Accusing a healthy host of being unprotected on
+        // an unreadable log is the #142 false alarm; say what we actually know.
+        console.warn('✗ Honest-state self-check INCONCLUSIVE: could not read the running gateway\'s boot roster,');
+        console.warn('  so the plugin is not PROVEN loaded — this is unproven, not known-broken. Check it yourself with:');
+        console.warn('    journalctl --user -u openclaw-gateway | grep "http server listening"');
         process.exitCode = 1;
       } else if (!check.versionProof) {
         console.warn('✗ Honest-state self-check FAILED: the loaded plugin version is OLDER than expected (silent downgrade, #74).');
@@ -1239,6 +1245,55 @@ export async function openClawHookStatus(): Promise<void> {
   }
   if (configState.inLegacyInstalls) {
     console.log('    note: legacy `plugins.installs` entry detected — will be cleaned on next `shieldcortex openclaw install`');
+  }
+
+  await reportLoadAndEnforcement();
+}
+
+/**
+ * Report LOAD state — and, with consent, enforcement — from `openclaw status`.
+ *
+ * #154: `doctor` used to send operators here for the live canary, but this
+ * command only ever listed install paths and silently ignored
+ * `SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1`. An operator ran it at 07:00, got a
+ * directory listing, and was no better informed about whether the host was
+ * protected — the one question the command's own name promises to answer.
+ *
+ * Everything above this point is install state. This is load state, which is
+ * the thing that actually matters, so `status` now answers it.
+ */
+async function reportLoadAndEnforcement(): Promise<void> {
+  const consented = process.env.SHIELDCORTEX_ALLOW_GATEWAY_CANARY === '1';
+  console.log('');
+
+  try {
+    const { runPluginSelfCheck } = await import('./openclaw-selfcheck.js');
+    const home = resolveUserHome();
+    const check = await runPluginSelfCheck(home, { expectedVersion: readSelfVersion() ?? undefined });
+
+    if (check.rosterState === 'loaded') {
+      console.log('  Loaded: YES — the running gateway\'s boot roster names the plugin');
+    } else if (check.rosterState === 'absent') {
+      console.log('  Loaded: NO — the running gateway booted WITHOUT the plugin; this host is NOT protected');
+      console.log('    Fix: SHIELDCORTEX_ALLOW_GATEWAY_RECONCILE=1 shieldcortex repair');
+    } else {
+      console.log('  Loaded: UNPROVEN — could not read the running gateway\'s boot roster');
+      console.log('    This is unproven, not known-broken. Check it directly:');
+      console.log('      journalctl --user -u openclaw-gateway | grep "http server listening"');
+    }
+
+    if (check.canaryProof) {
+      console.log('  Enforcing: YES — a live canary was denied by the interceptor and audited');
+    } else if (consented) {
+      // Consent was given and it still did not prove out. Say why, loudly.
+      console.log('  Enforcing: NOT PROVEN — the live canary ran but did not confirm enforcement');
+      console.log(`    ${check.canary.detail ?? 'no further detail'}`);
+    } else {
+      console.log('  Enforcing: not probed — re-run with SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1 to drive a live canary');
+    }
+  } catch (err) {
+    // Never let a diagnostic failure masquerade as a healthy status.
+    console.log(`  Loaded: UNPROVEN — the load/enforcement check could not run (${err instanceof Error ? err.message : String(err)})`);
   }
 }
 


### PR DESCRIPTION
Four fixes with one theme: the product must never state something about its own state that it has not verified, and must never accuse where it cannot know.

## #152 — roster proof reads the LIVE roster
`evaluateSelfCheck` read `installed_plugin_index.plugins_json` (install state) and printed it as "the loaded roster". The reconciler was fixed for this in #103; the self-check was not — so one repair run printed "ABSENT from the RUNNING gateway boot roster" and "present + enabled in the loaded roster" seconds apart, and the check written to catch the #74 fail-open passed on a host sitting in it.

The proof now comes only from the gateway's own boot line, with three answers kept honestly distinct:
- **loaded** — proof, grants the roster proof
- **absent** — the proven fail-open, hard fail with the accusation
- **unproven** — roster unreadable; reported as INCONCLUSIVE, never as UNPROTECTED (the #142 false-alarm class)

Field-proven within hours: aiquant's 04:02 repair printed "✓ confirmed loaded (roster)" off the install index while the gateway's boot roster had excluded the plugin six restarts running.

## #154 — one canary command, and it works
doctor printed two different commands for the same enforcement proof; the one on the Action-guard line (`openclaw status`) accepted `SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1` and silently ignored it. The command is now defined once (`LIVE_CANARY_COMMAND`), both doctor mentions read it, and `openclaw status` actually runs the load/enforcement check — reporting Loaded (yes/no/unproven) and Enforcing (proved/not-proven/not-probed).

## Platform blindness — doctor handed a Mac a Linux command
`gateway-restart-command.ts` now owns the restart invocation; doctor's advice, the install fallback text and the deep-clean executor all read it. macOS gets `launchctl kickstart` with the "Could not find service" fallback explained; unknown platforms get honesty instead of a guess.

## #153 — a safety backup no longer spends the disk budget
The planner filled to the 100 MB limit; doctor failed at the limit; the documented workaround was moving our own backup out of our own directory — which is how we knew the accounting was the bug. Backups are still measured and shown (` + N MB backups`, like models) but exempt from the budget. Edith's exact 48.9 + 48.9 state now passes; a genuinely oversized DB or audit pile still fails.

## Test integrity
- Four pre-existing tests asserted the old behaviours (index-as-roster fixtures named `loadedRoster`, the systemctl literal, backups-dominating=fail). Rewritten to the real contracts, not deleted.
- Every fix verified by deleting it and confirming its tests go red (#152: 4/8 red; #153: 3/14 red).
- New wiring tests pin `openclaw status` → `runPluginSelfCheck` and forbid any literal canary command in doctor.

302 suites / 3,408 pass / 0 fail.

Closes #152, #153, #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
