### PR TITLE
The honesty remainder: process-bounded evidence (#150/#142), post-remediation truth (#145), permission-denied honesty + exit codes (#132), CC version floor

### DIFF
--- a/src/__tests__/claude-code-version-floor.test.ts
+++ b/src/__tests__/claude-code-version-floor.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Claude Code enforcement floor — doctor reports the harness version it depends on.
+ *
+ * Motivating incident (2026-07-30, aiquant): Claude Code 2.1.76 discarded the
+ * Action Guard's `"ask"` verdict under `bypassPermissions` and ran a global npm
+ * install. The guard was correct, the audit row recorded it, and nothing was
+ * stopped — because the harness that honours our verdicts is versioned
+ * independently of us and nobody was tracking it across two install channels.
+ *
+ * These tests pin the reporting: below the floor is a FAIL (the dangerous tier
+ * is decorative on that box), an unreadable version is a WARN (unproven, not
+ * assumed fine), and no Claude Code at all is INFO (the floor does not apply).
+ */
+import path from 'path';
+import { describe, expect, it } from '@jest/globals';
+import {
+  CLAUDE_CODE_ENFORCEMENT_FLOOR,
+  classifyClaudeCodeChannel,
+  detectClaudeCode,
+  parseClaudeCodeVersion,
+  upgradeCommandFor,
+  type DetectClaudeCodeDeps,
+} from '../integrations/claude-code-version.js';
+import { checkClaudeCodeVersion } from '../cli/doctor.js';
+
+const HOME = '/home/tester';
+
+/** A detector wired to fixture values instead of the host's real install. */
+function deps(overrides: {
+  bin?: string | null;
+  real?: string | null;
+  versionOutput?: string;
+  versionThrows?: string;
+}): DetectClaudeCodeDeps {
+  return {
+    which: () => (overrides.bin === undefined ? '/home/tester/.local/bin/claude' : overrides.bin),
+    realpath: () => (overrides.real === undefined ? '/home/tester/.local/share/claude/versions/2.1.220' : overrides.real),
+    runVersion: () => {
+      if (overrides.versionThrows) throw new Error(overrides.versionThrows);
+      return overrides.versionOutput ?? '2.1.220 (Claude Code)';
+    },
+    homedir: () => HOME,
+  };
+}
+
+describe('parseClaudeCodeVersion', () => {
+  it('reads the version out of the real output shape', () => {
+    expect(parseClaudeCodeVersion('2.1.220 (Claude Code)')).toBe('2.1.220');
+  });
+
+  it('tolerates surrounding noise', () => {
+    expect(parseClaudeCodeVersion('  claude version 2.1.76 \n')).toBe('2.1.76');
+  });
+
+  it('returns null when there is no version to read', () => {
+    expect(parseClaudeCodeVersion('command not found')).toBeNull();
+    expect(parseClaudeCodeVersion('')).toBeNull();
+  });
+});
+
+describe('classifyClaudeCodeChannel', () => {
+  it('names the native installer layout', () => {
+    expect(classifyClaudeCodeChannel(path.join(HOME, '.local/share/claude/versions/2.1.220'), HOME)).toBe('native');
+  });
+
+  it('names an npm global', () => {
+    expect(
+      classifyClaudeCodeChannel('/usr/lib/node_modules/@anthropic-ai/claude-code/cli.js', HOME),
+    ).toBe('npm');
+  });
+
+  it('refuses to guess an unrecognised layout', () => {
+    expect(classifyClaudeCodeChannel('/opt/weird/claude', HOME)).toBe('unknown');
+    expect(classifyClaudeCodeChannel(null, HOME)).toBe('unknown');
+  });
+
+  it('does not mistake another user home for this one', () => {
+    expect(classifyClaudeCodeChannel('/home/someone-else/.local/share/claude/versions/2.1.220', HOME)).toBe(
+      'unknown',
+    );
+  });
+});
+
+describe('detectClaudeCode', () => {
+  it('returns null when claude is not on PATH', () => {
+    expect(detectClaudeCode(deps({ bin: null }))).toBeNull();
+  });
+
+  it('reports version, channel and paths for a healthy install', () => {
+    const install = detectClaudeCode(deps({}));
+    expect(install).toMatchObject({
+      version: '2.1.220',
+      rawVersion: '2.1.220 (Claude Code)',
+      channel: 'native',
+      binPath: '/home/tester/.local/bin/claude',
+    });
+    expect(install?.error).toBeUndefined();
+  });
+
+  it('records the failure instead of throwing when --version cannot run', () => {
+    const install = detectClaudeCode(deps({ versionThrows: 'ETIMEDOUT' }));
+    expect(install?.version).toBeNull();
+    expect(install?.error).toContain('ETIMEDOUT');
+  });
+});
+
+describe('upgradeCommandFor', () => {
+  it('gives the channel-correct instruction', () => {
+    expect(upgradeCommandFor('npm')).toContain('npm i -g @anthropic-ai/claude-code@latest');
+    expect(upgradeCommandFor('native')).toContain('claude update');
+  });
+
+  it('offers both when the channel is unknown, rather than guessing one', () => {
+    const fix = upgradeCommandFor('unknown');
+    expect(fix).toContain('claude update');
+    expect(fix).toContain('npm i -g @anthropic-ai/claude-code@latest');
+  });
+});
+
+describe('doctor check — Claude Code version', () => {
+  it('FAILS below the floor and names the actual exposure', async () => {
+    const result = await checkClaudeCodeVersion(
+      deps({ versionOutput: '2.1.76 (Claude Code)', real: '/usr/lib/node_modules/@anthropic-ai/claude-code/cli.js' }),
+    );
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('2.1.76');
+    expect(result.message).toContain(CLAUDE_CODE_ENFORCEMENT_FLOOR);
+    expect(result.message).toContain('npm channel');
+    // The operator must learn that the audit log is misleading on this box —
+    // that is the whole reason the incident went unnoticed for 144 versions.
+    expect(result.message).toContain('audit log');
+    expect(result.fix).toContain('npm i -g @anthropic-ai/claude-code@latest');
+  });
+
+  it('PASSES at the floor exactly — the floor is the lowest build proven good', async () => {
+    const result = await checkClaudeCodeVersion(deps({ versionOutput: `${CLAUDE_CODE_ENFORCEMENT_FLOOR} (Claude Code)` }));
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain(CLAUDE_CODE_ENFORCEMENT_FLOOR);
+  });
+
+  it('PASSES above the floor and states the channel', async () => {
+    const result = await checkClaudeCodeVersion(deps({}));
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('2.1.220');
+    expect(result.message).toContain('native channel');
+  });
+
+  it('WARNS rather than passing when the version cannot be read', async () => {
+    const result = await checkClaudeCodeVersion(deps({ versionThrows: 'spawn ETIMEDOUT' }));
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('cannot confirm');
+    expect(result.fix).toBeDefined();
+  });
+
+  it('WARNS when --version prints something unparseable', async () => {
+    const result = await checkClaudeCodeVersion(deps({ versionOutput: 'not a version' }));
+    expect(result.status).toBe('warn');
+  });
+
+  it('is INFO, not a fault, on a box with no Claude Code', async () => {
+    const result = await checkClaudeCodeVersion(deps({ bin: null }));
+    expect(result.status).toBe('info');
+    expect(result.message).toContain('not detected');
+  });
+
+  it('still reports the version when the channel cannot be named', async () => {
+    const result = await checkClaudeCodeVersion(deps({ real: '/opt/somewhere/claude' }));
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('unknown channel');
+  });
+});

--- a/src/__tests__/gateway-process-bound-evidence.test.ts
+++ b/src/__tests__/gateway-process-bound-evidence.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Failing-first specs for #150 and #142 — no log artifact may be treated as
+ * authoritative for process state.
+ *
+ * Three defects in one week were the same mistake wearing different clothes:
+ * #142 read a boot-time roster snapshot as a live roster; #150 read a
+ * months-stale log as the running version (a Mac reported v4.14.10 "running"
+ * off a line written in May); #145 echoed a pre-remediation snapshot as the
+ * post-remediation state. The rule pinned here: evidence about the running
+ * gateway must postdate that gateway's process start, and evidence that cannot
+ * be dated cannot be called fresh.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { readRunningGatewayProcess } from '../integrations/openclaw-gateway-process.js';
+import {
+  parseRegistrationsSince,
+  findRegistrationSince,
+} from '../integrations/openclaw-gateway-roster.js';
+import { evaluateSelfCheck } from '../setup/openclaw-selfcheck.js';
+import { reconcilePluginState, type ReconcileInput } from '../integrations/openclaw-plugin-index.js';
+import {
+  parseRunningPluginVersionSince,
+  checkOpenClawRunningPluginVersion,
+} from '../cli/doctor.js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const PLUGIN = 'shieldcortex-realtime';
+
+// ── The process-start fact ──────────────────────────────────────────────────
+
+describe('readRunningGatewayProcess — a recorded boot is only evidence while its pid lives', () => {
+  it('returns the boot row when the pid is alive', () => {
+    const proc = readRunningGatewayProcess('/nonexistent-home', {
+      readLatestBootRow: () => ({ pid: 4242, started_at_ms: 1_700_000_000_000 }),
+      isPidAlive: (pid) => pid === 4242,
+    });
+    expect(proc).toEqual({ pid: 4242, startedAtMs: 1_700_000_000_000 });
+  });
+
+  it('returns null when the recorded pid is dead — a past boot proves nothing about now', () => {
+    const proc = readRunningGatewayProcess('/nonexistent-home', {
+      readLatestBootRow: () => ({ pid: 4242, started_at_ms: 1_700_000_000_000 }),
+      isPidAlive: () => false,
+    });
+    expect(proc).toBeNull();
+  });
+
+  it('returns null when there is no lifecycle row at all', () => {
+    const proc = readRunningGatewayProcess('/nonexistent-home', {
+      readLatestBootRow: () => null,
+      isPidAlive: () => true,
+    });
+    expect(proc).toBeNull();
+  });
+});
+
+// ── Registration sightings (#142) ───────────────────────────────────────────
+
+describe('parseRegistrationsSince — dated lines only, bounded below', () => {
+  const line = (iso: string, v: string) =>
+    JSON.stringify({ time: iso, message: `[shieldcortex] v${v} registered (llm_input + before_tool_call)` });
+
+  it('returns sightings at/after the bound and drops older ones', () => {
+    const text = [
+      line('2026-05-07T10:00:00.000Z', '4.14.10'),
+      line('2026-08-01T05:52:55.000Z', '4.47.22'),
+    ].join('\n');
+    const since = Date.parse('2026-08-01T05:52:00.000Z');
+    const got = parseRegistrationsSince(text, since);
+    expect(got).toHaveLength(1);
+    expect(got[0].version).toBe('4.47.22');
+  });
+
+  it('skips registration lines that carry no parseable timestamp', () => {
+    // A line that cannot be dated cannot be called fresh.
+    const text = '[shieldcortex] v9.9.9 registered (llm_input)';
+    expect(parseRegistrationsSince(text, 0)).toHaveLength(0);
+  });
+
+  it('findRegistrationSince returns null when the log dir is unreadable', () => {
+    expect(findRegistrationSince(0, { logDir: '/definitely/not/a/dir' })).toBeNull();
+  });
+});
+
+// ── #142 in the self-check ─────────────────────────────────────────────────
+
+describe('#142 — a post-snapshot registration downgrades absent to unproven', () => {
+  const canaryPassed = { ran: true, denied: true, auditEntryFound: true };
+
+  it('absent WITHOUT a later sighting stays absent (the aiquant genuine skip)', () => {
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: null,
+      liveRoster: ['telegram'],
+      registrationSeenAfterBoot: false,
+      canary: canaryPassed,
+    });
+    expect(v.rosterState).toBe('absent');
+  });
+
+  it('absent WITH a later sighting becomes unproven — the snapshot cannot convict', () => {
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: null,
+      liveRoster: ['telegram'],
+      registrationSeenAfterBoot: true,
+      canary: canaryPassed,
+    });
+    expect(v.rosterState).toBe('unproven');
+    expect(v.reasons.join(' ')).toMatch(/registration was sighted after/i);
+    // And it must not accuse.
+    expect(v.reasons.join(' ')).not.toMatch(/host unprotected/i);
+  });
+
+  it('a later sighting never GRANTS the roster proof — CLI lines are identical', () => {
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: null,
+      liveRoster: ['telegram'],
+      registrationSeenAfterBoot: true,
+      canary: canaryPassed,
+    });
+    expect(v.rosterProof).toBe(false);
+    expect(v.ok).toBe(false);
+  });
+});
+
+// ── #142 in the reconciler ─────────────────────────────────────────────────
+
+describe('#142 — the reconciler withholds UNPROTECTED when registration raced the snapshot', () => {
+  const base: ReconcileInput = {
+    pluginId: PLUGIN,
+    expectedVersion: '4.47.23',
+    config: { enabled: true, inAllow: true },
+    installsJson: null,
+    index: {
+      installRecords: { [PLUGIN]: { source: 'npm', version: '4.47.23' } },
+      plugins: [{ pluginId: PLUGIN, enabled: true }],
+      warning: null,
+    },
+    onDiskVersion: '4.47.23',
+    projectDirs: [],
+    liveRoster: ['telegram'],
+  };
+
+  it('without a sighting: the confident fail stands (rule 2 unchanged)', () => {
+    const v = reconcilePluginState({ ...base, registrationSeenAfterBoot: false });
+    expect(v.state).toBe('enabled-not-loaded');
+    expect(v.severity).toBe('fail');
+  });
+
+  it('with a sighting: warn + unproven, pointing at the canary — never a fail', () => {
+    const v = reconcilePluginState({ ...base, registrationSeenAfterBoot: true });
+    expect(v.state).toBe('load-unproven');
+    expect(v.severity).toBe('warn');
+    expect(v.reasons.join(' ')).toMatch(/canary/i);
+  });
+});
+
+// ── #150 in doctor ─────────────────────────────────────────────────────────
+
+describe('#150 — the running version is bounded by the gateway process start', () => {
+  const journalLine = (iso: string, v: string) =>
+    JSON.stringify({ time: iso, message: `[shieldcortex] v${v} registered (llm_input)` });
+
+  it('parseRunningPluginVersionSince ignores lines older than the bound', () => {
+    const journal = [
+      journalLine('2026-05-07T10:00:00.000Z', '4.14.10'),
+      journalLine('2026-08-01T05:52:55.000Z', '4.47.22'),
+    ].join('\n');
+    expect(parseRunningPluginVersionSince(journal, Date.parse('2026-08-01T00:00:00Z'))).toBe('4.47.22');
+    expect(parseRunningPluginVersionSince(journal, Date.parse('2026-08-02T00:00:00Z'))).toBeNull();
+  });
+
+  it("the Mac's exact state: a May line + an August process start yields UNKNOWN, not v4.14.10", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-150-'));
+    try {
+      fs.mkdirSync(path.join(home, '.openclaw'), { recursive: true });
+      // Fake an installed plugin so the check proceeds to the journal.
+      const pluginDir = path.join(
+        home, '.openclaw', 'npm', 'projects', 'drakon-systems-shieldcortex-realtime-x__openclaw-generation__g-1',
+        'node_modules', '@drakon-systems', 'shieldcortex-realtime',
+      );
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ name: '@drakon-systems/shieldcortex-realtime', version: '4.47.23' }));
+      fs.writeFileSync(path.join(pluginDir, 'openclaw.plugin.json'), JSON.stringify({ id: PLUGIN, version: '4.47.23' }));
+
+      const result = await checkOpenClawRunningPluginVersion(home, {
+        readGatewayJournal: () => ({ text: journalLine('2026-05-07T10:00:00.000Z', '4.14.10'), preBounded: false }),
+        readGatewayProcessStartMs: () => Date.parse('2026-08-01T05:00:00.000Z'),
+      });
+      expect(result.status).toBe('info');
+      expect(result.message).toMatch(/UNKNOWN/);
+      // The stale figure may be mentioned as historical, never asserted as running.
+      expect(result.message).not.toMatch(/v4\.14\.10 running/);
+      expect(result.message).toMatch(/predates this process/i);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('reports honestly when the process start cannot be established', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-150b-'));
+    try {
+      fs.mkdirSync(path.join(home, '.openclaw'), { recursive: true });
+      const pluginDir = path.join(
+        home, '.openclaw', 'npm', 'projects', 'drakon-systems-shieldcortex-realtime-x__openclaw-generation__g-1',
+        'node_modules', '@drakon-systems', 'shieldcortex-realtime',
+      );
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ name: '@drakon-systems/shieldcortex-realtime', version: '4.47.23' }));
+      fs.writeFileSync(path.join(pluginDir, 'openclaw.plugin.json'), JSON.stringify({ id: PLUGIN, version: '4.47.23' }));
+
+      const result = await checkOpenClawRunningPluginVersion(home, {
+        readGatewayJournal: () => ({ text: journalLine('2026-08-01T05:52:55.000Z', '4.47.23'), preBounded: false }),
+        readGatewayProcessStartMs: () => null,
+      });
+      expect(result.status).toBe('info');
+      expect(result.message).toMatch(/start time could not be established/i);
+      // Never a confident "running" claim off unbounded evidence.
+      expect(result.message).not.toMatch(/running v4\.47\.23 matches/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('still passes when a fresh registration matches disk', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-150c-'));
+    try {
+      fs.mkdirSync(path.join(home, '.openclaw'), { recursive: true });
+      const pluginDir = path.join(
+        home, '.openclaw', 'npm', 'projects', 'drakon-systems-shieldcortex-realtime-x__openclaw-generation__g-1',
+        'node_modules', '@drakon-systems', 'shieldcortex-realtime',
+      );
+      fs.mkdirSync(pluginDir, { recursive: true });
+      fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({ name: '@drakon-systems/shieldcortex-realtime', version: '4.47.23' }));
+      fs.writeFileSync(path.join(pluginDir, 'openclaw.plugin.json'), JSON.stringify({ id: PLUGIN, version: '4.47.23' }));
+
+      const result = await checkOpenClawRunningPluginVersion(home, {
+        readGatewayJournal: () => ({ text: journalLine('2026-08-01T05:52:55.000Z', '4.47.23'), preBounded: false }),
+        readGatewayProcessStartMs: () => Date.parse('2026-08-01T05:00:00.000Z'),
+      });
+      expect(result.status).toBe('pass');
+      expect(result.message).toMatch(/running v4\.47\.23 matches/);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/reconcile-post-state-145.test.ts
+++ b/src/__tests__/reconcile-post-state-145.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Failing-first spec for #145 — repair's closing report must describe the
+ * world AFTER remediation, never echo the pre-remediation snapshot.
+ *
+ * Field evidence, 31 Jul 2026: a real operator upgrade applied its plan,
+ * reloaded the gateway, and then printed "FAILED … state: version-regressed
+ * (fail) — running version 4.47.16 is older than expected 4.47.19". The
+ * remediation had worked — the journal showed v4.47.19 registered during the
+ * very reload repair performed, and doctor seconds later agreed. The false red
+ * sends an operator to re-remediate a healthy box, and when two of our own
+ * commands disagree about the same fact, the operator cannot know which to
+ * believe.
+ */
+import { describe, it, expect } from '@jest/globals';
+import {
+  reconcileOpenClawPluginState,
+  formatReconcileReport,
+} from '../setup/openclaw-reconcile.js';
+import type { ReconcileInput, ReconcileVerdict } from '../integrations/openclaw-plugin-index.js';
+import { reconcilePluginState } from '../integrations/openclaw-plugin-index.js';
+
+const PLUGIN = 'shieldcortex-realtime';
+
+function inputWith(overrides: Partial<ReconcileInput>): ReconcileInput {
+  return {
+    pluginId: PLUGIN,
+    expectedVersion: '4.47.19',
+    config: { enabled: true, inAllow: true },
+    installsJson: null,
+    index: {
+      installRecords: { [PLUGIN]: { source: 'npm', version: '4.47.19' } },
+      plugins: [{ pluginId: PLUGIN, enabled: true }],
+      warning: null,
+    },
+    onDiskVersion: '4.47.19',
+    projectDirs: [],
+    liveRoster: [PLUGIN],
+    ...overrides,
+  };
+}
+
+/** The exact field timeline: regressed before, healthy after the reload. */
+function twoPhaseReadState(): () => { input: ReconcileInput; verdict: ReconcileVerdict } {
+  let calls = 0;
+  return () => {
+    calls += 1;
+    const input =
+      calls === 1
+        ? inputWith({ onDiskVersion: '4.47.16', index: { installRecords: { [PLUGIN]: { source: 'npm', version: '4.47.16' } }, plugins: [{ pluginId: PLUGIN, enabled: true }], warning: null } })
+        : inputWith({});
+    return { input, verdict: reconcilePluginState(input) };
+  };
+}
+
+const passingSelfCheck = {
+  ok: true,
+  rosterProof: true,
+  rosterState: 'loaded' as const,
+  canaryProof: true,
+  versionProof: true,
+  reasons: ['roster proof', 'canary proof', 'version proof'],
+  index: null,
+  liveRoster: [PLUGIN],
+  canary: { ran: true, denied: true, auditEntryFound: true },
+};
+
+describe('#145 — the closing state is re-read after remediation', () => {
+  it('reports the POST-remediation state, not the pre-remediation snapshot', async () => {
+    const result = await reconcileOpenClawPluginState({
+      expectedVersion: '4.47.19',
+      apply: true,
+      readState: twoPhaseReadState(),
+      runCommand: () => ({ status: 0, output: 'ok' }),
+      reloadGateway: async () => ({ restarted: true }),
+      selfCheck: async () => passingSelfCheck,
+      pruneDir: () => void 0,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.postVerdict).toBeDefined();
+    expect(result.postVerdict?.state).toBe('healthy');
+    // The pre state is preserved as history, clearly labelled.
+    expect(result.verdict.state).toBe('version-regressed');
+    expect(result.messages.join(' ')).toMatch(/state after remediation: healthy/);
+  });
+
+  it('the rendered report never re-prints the stale pre state under the failure banner', async () => {
+    // Failure case (canary withheld): the report must not echo the
+    // pre-remediation "version-regressed" as if it were current.
+    const result = await reconcileOpenClawPluginState({
+      expectedVersion: '4.47.19',
+      apply: true,
+      readState: twoPhaseReadState(),
+      runCommand: () => ({ status: 0, output: 'ok' }),
+      reloadGateway: async () => ({ restarted: true }),
+      selfCheck: async () => ({
+        ...passingSelfCheck,
+        ok: false,
+        canaryProof: false,
+        canary: { ran: false, denied: false, auditEntryFound: false, detail: 'no consent' },
+        reasons: ['canary proof FAILED: enforcement canary was not executed'],
+      }),
+      pruneDir: () => void 0,
+    });
+
+    const report = formatReconcileReport(result).join('\n');
+    expect(report).toMatch(/Plugin load state after remediation: healthy/);
+    // The field bug, verbatim shape: pre-state echoed after FAILED.
+    const afterFailed = report.slice(report.indexOf('FAILED'));
+    expect(afterFailed).not.toMatch(/version-regressed/);
+    expect(afterFailed).not.toMatch(/state before remediation/);
+  });
+
+  it('a dry-run carries no postVerdict — nothing changed, so there is nothing to re-read', async () => {
+    const result = await reconcileOpenClawPluginState({
+      expectedVersion: '4.47.19',
+      apply: false,
+      readState: twoPhaseReadState(),
+      runCommand: () => ({ status: 0, output: 'ok' }),
+      reloadGateway: async () => ({ restarted: true }),
+      selfCheck: async () => passingSelfCheck,
+      pruneDir: () => void 0,
+    });
+    expect(result.applied).toBe(false);
+    expect(result.postVerdict).toBeUndefined();
+  });
+});

--- a/src/cli/__tests__/doctor-permission-denied.test.ts
+++ b/src/cli/__tests__/doctor-permission-denied.test.ts
@@ -1,0 +1,273 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+import {
+  doctorExitCode,
+  probePath,
+  runDatabaseCheck,
+  runHooksCheck,
+  runMemoryStatsCheck,
+  runSchemaDriftCheck,
+  runWritePathProbe,
+  checkDiskUsage,
+  checkLockFile,
+  type CheckResult,
+} from '../doctor.js';
+
+const require = createRequire(import.meta.url);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Permission-denied is not a fresh install (#132).
+ *
+ * #131 made a missing database an informational "not initialised yet" — right
+ * for a genuine first run. It asked `fs.existsSync`, which returns false for
+ * "not there" AND for "there but unreadable", so a root-owned `~/.shieldcortex`
+ * (the classic artefact of one `sudo shieldcortex …`) started reporting a clean
+ * bill of health on a genuinely broken install. Doctor exists for exactly that
+ * user; going green on them is its worst possible failure mode.
+ *
+ * The contract locked in here:
+ *   - ENOENT  → ℹ️ "not initialised yet", exit 0 (the #129/#131 behaviour)
+ *   - EACCES/EPERM → ❌ naming ownership as the likely cause, exit 1
+ *   - any other errno → ❌ with the real error surfaced, never swallowed
+ *   - a healthy install is unchanged
+ */
+
+const errno = (code: string): NodeJS.ErrnoException => {
+  const err = new Error(`${code}: simulated`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+};
+
+const throwing = (code: string) => (): fs.Stats => { throw errno(code); };
+
+// chmod cannot deny root anything, so the filesystem-level tests are
+// meaningless when the suite runs as root (containers, some CI images). The
+// injected-statSync tests below cover every branch deterministically either
+// way; these add the proof that a real EACCES lands in the right branch.
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+const describeUnprivileged = isRoot ? describe.skip : describe;
+
+describe('doctor — probePath keeps absent, denied and broken apart', () => {
+  it('classifies ENOENT as absent — the only "fresh install" code', () => {
+    expect(probePath('/nope', throwing('ENOENT'))).toEqual({ kind: 'absent' });
+  });
+
+  it.each(['EACCES', 'EPERM'])('classifies %s as denied, not absent', (code) => {
+    const probe = probePath('/root-owned', throwing(code));
+    expect(probe.kind).toBe('denied');
+    expect(probe).toMatchObject({ code });
+  });
+
+  it('classifies any other errno as an error, keeping the code and message', () => {
+    const probe = probePath('/flaky', throwing('EIO'));
+    expect(probe.kind).toBe('error');
+    expect(probe).toMatchObject({ code: 'EIO' });
+    if (probe.kind === 'error') expect(probe.message).toMatch(/simulated/);
+  });
+
+  it('reports a readable path as present', () => {
+    const probe = probePath(__filename);
+    expect(probe.kind).toBe('present');
+  });
+});
+
+describe('doctor — exit code', () => {
+  const result = (status: CheckResult['status']): CheckResult =>
+    ({ label: 'X', status, message: 'm' });
+
+  it('exits 1 when any check failed', () => {
+    expect(doctorExitCode([result('pass'), result('fail')])).toBe(1);
+  });
+
+  it('exits 0 for a clean run', () => {
+    expect(doctorExitCode([result('pass'), result('pass')])).toBe(0);
+  });
+
+  it('exits 0 on a fresh install — info states are not failures', () => {
+    expect(doctorExitCode([result('info'), result('info'), result('pass')])).toBe(0);
+  });
+
+  it('exits 0 on warnings by default', () => {
+    expect(doctorExitCode([result('warn'), result('pass')])).toBe(0);
+  });
+
+  it('exits 1 on warnings under --strict', () => {
+    expect(doctorExitCode([result('warn')], { strict: true })).toBe(1);
+  });
+
+  it('--strict still passes a run with nothing but info/pass', () => {
+    expect(doctorExitCode([result('info'), result('pass')], { strict: true })).toBe(0);
+  });
+});
+
+describeUnprivileged('doctor — an unreadable install is ❌, never "fresh"', () => {
+  const claudeEnv = { hasClaude: true, hasOpenClaw: false, hasVSCode: false, hasCodex: false, isHeadless: false };
+
+  let tmpDir: string;
+  let scDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-denied-'));
+    scDir = path.join(tmpDir, '.shieldcortex');
+    dbPath = path.join(scDir, 'memories.db');
+    fs.mkdirSync(scDir);
+    const Database = require('better-sqlite3');
+    const db = new Database(dbPath);
+    db.exec('CREATE TABLE memories (id INTEGER PRIMARY KEY)');
+    db.close();
+  });
+
+  afterEach(() => {
+    try { fs.chmodSync(scDir, 0o755); } catch { /* already gone */ }
+    try { fs.chmodSync(path.join(tmpDir, '.claude'), 0o755); } catch { /* may not exist */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  /** Deny traversal the way a root-owned directory does to a normal user. */
+  const deny = (): void => { fs.chmodSync(scDir, 0o000); };
+
+  it('Database reports ❌ with an ownership remedy, not "not initialised yet"', () => {
+    deny();
+    const result = runDatabaseCheck(dbPath, claudeEnv);
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/permission denied/i);
+    expect(result.message).toMatch(/EACCES/);
+    expect(result.message).not.toMatch(/not initialised yet/i);
+    expect(result.fix).toMatch(/chown -R/);
+    expect(result.fix).toMatch(/sudo/i);
+  });
+
+  it.each([
+    ['Schema', () => runSchemaDriftCheck(dbPath)],
+    ['Write path', () => runWritePathProbe(dbPath)],
+    ['Memories', () => runMemoryStatsCheck(dbPath)],
+  ])('%s reports ❌ and is never collapsed into the fresh-install note', (label, run) => {
+    deny();
+    const result = run();
+
+    expect(result.label).toBe(label);
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/permission denied/i);
+    // The suppression that hides dependent checks on a fresh box must not
+    // hide a permission fault — that is the regression being closed.
+    expect(result.skipped).toBeUndefined();
+  });
+
+  it('Disk does not report a green 0 B for an unreadable directory', async () => {
+    deny();
+    const result = await checkDiskUsage(scDir);
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/permission denied/i);
+    expect(result.message).not.toMatch(/not yet created/i);
+  });
+
+  it('Lock does not report "clean" for an unreadable directory', async () => {
+    deny();
+    const result = await checkLockFile(scDir);
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/permission denied/i);
+    expect(result.message).not.toMatch(/clean/i);
+  });
+
+  it('Hooks reports ❌ for an unreadable settings.json, not "not configured yet"', () => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    const settingsPath = path.join(claudeDir, 'settings.json');
+    fs.mkdirSync(claudeDir);
+    fs.writeFileSync(settingsPath, JSON.stringify({ hooks: {} }));
+    fs.chmodSync(claudeDir, 0o000);
+
+    const result = runHooksCheck(settingsPath, claudeEnv);
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/permission denied/i);
+    expect(result.message).not.toMatch(/not configured yet/i);
+    expect(result.fix).toMatch(/ownership and permissions/i);
+  });
+
+  it('a readable database is still healthy — the check only fires on real denial', () => {
+    const result = runDatabaseCheck(dbPath, claudeEnv);
+    expect(result.status).toBe('pass');
+    expect(result.message).toMatch(/healthy/);
+  });
+
+  it('an absent database is still the friendly informational state', () => {
+    const result = runDatabaseCheck(path.join(tmpDir, 'nothing-here.db'), claudeEnv);
+    expect(result.status).toBe('info');
+    expect(result.message).toMatch(/not initialised yet/i);
+  });
+});
+
+/**
+ * End-to-end through the real CLI: the exit code is the part CI consumes, and
+ * it can only be proven by running the binary.
+ */
+describeUnprivileged('doctor — CLI exit status', () => {
+  const cliPath = path.resolve(__dirname, '..', '..', '..', 'dist', 'index.js');
+
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-doctor-home-'));
+  });
+
+  afterEach(() => {
+    try { fs.chmodSync(path.join(home, '.shieldcortex'), 0o755); } catch { /* may not exist */ }
+    try { fs.rmSync(home, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  /**
+   * A scrubbed environment: HOME points at the sandbox so doctor reads and
+   * writes nothing of the host's, and inherited SHIELDCORTEX_* would otherwise
+   * change what the checks resolve to (#125).
+   */
+  const runDoctorCli = (args: string[] = []): Promise<{ stdout: string; code: number }> =>
+    new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [cliPath, 'doctor', ...args], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { PATH: process.env.PATH ?? '/usr/bin:/bin', HOME: home },
+      });
+      let stdout = '';
+      child.stdout.on('data', (c) => { stdout += c.toString(); });
+      child.stderr.on('data', (c) => { stdout += c.toString(); });
+      child.on('error', reject);
+      child.on('close', (code) => resolve({ stdout, code: code ?? 0 }));
+    });
+
+  it('exits 0 on a fresh box — a first run must not fail a pipeline', async () => {
+    // dist is built before tests in CI; assert the invariant so a missing
+    // build fails loudly rather than green-skipping the exit-code proof.
+    expect(fs.existsSync(cliPath)).toBe(true);
+
+    const { stdout, code } = await runDoctorCli();
+    expect(stdout).toMatch(/not initialised yet/);
+    expect(stdout).not.toMatch(/failure/);
+    expect(code).toBe(0);
+  }, 60_000);
+
+  it('exits 1 with a ❌ when ~/.shieldcortex cannot be read', async () => {
+    expect(fs.existsSync(cliPath)).toBe(true);
+
+    const scDir = path.join(home, '.shieldcortex');
+    fs.mkdirSync(scDir);
+    fs.writeFileSync(path.join(scDir, 'memories.db'), '');
+    fs.chmodSync(scDir, 0o000);
+
+    const { stdout, code } = await runDoctorCli();
+    expect(stdout).toMatch(/permission denied/i);
+    expect(stdout).toMatch(/chown -R/);
+    expect(stdout).not.toMatch(/not initialised yet/);
+    expect(code).toBe(1);
+  }, 60_000);
+});

--- a/src/cli/__tests__/doctor-running-plugin-version.test.ts
+++ b/src/cli/__tests__/doctor-running-plugin-version.test.ts
@@ -71,14 +71,14 @@ describe('parseRunningPluginVersion', () => {
 
 describe('checkOpenClawRunningPluginVersion', () => {
   it('skips (info) when OpenClaw is not present', async () => {
-    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => journalWith('4.47.13') });
+    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => ({ text: journalWith('4.47.13'), preBounded: true }), readGatewayProcessStartMs: () => 1_700_000_000_000 });
     expect(r.status).toBe('info');
     expect(r.message).toMatch(/not detected|skipped/i);
   });
 
   it('passes when the running version matches the on-disk version', async () => {
     installOnDisk('4.47.13');
-    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => journalWith('4.47.8', '4.47.13') });
+    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => ({ text: journalWith('4.47.8', '4.47.13'), preBounded: true }), readGatewayProcessStartMs: () => 1_700_000_000_000 });
     expect(r.status).toBe('pass');
     expect(r.message).toMatch(/4\.47\.13/);
   });
@@ -87,7 +87,7 @@ describe('checkOpenClawRunningPluginVersion', () => {
     installOnDisk('4.47.13');
     // Gateway registered v4.47.8 at last start; disk was upgraded to v4.47.13 but
     // the gateway was never restarted — the live incident signature.
-    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => journalWith('4.47.8') });
+    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => ({ text: journalWith('4.47.8'), preBounded: true }), readGatewayProcessStartMs: () => 1_700_000_000_000 });
     expect(r.status).toBe('warn');
     expect(r.message).toMatch(/stale/i);
     expect(r.message).toMatch(/4\.47\.8 running/i);
@@ -97,7 +97,7 @@ describe('checkOpenClawRunningPluginVersion', () => {
 
   it('reports info (never a green "current") when the gateway journal is unreadable', async () => {
     installOnDisk('4.47.13');
-    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => null });
+    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => null, readGatewayProcessStartMs: () => 1_700_000_000_000 });
     expect(r.status).toBe('info');
     expect(r.message).toMatch(/cannot verify running version/i);
     expect(r.status).not.toBe('pass');
@@ -106,15 +106,16 @@ describe('checkOpenClawRunningPluginVersion', () => {
   it('reports info when the journal is readable but holds no registration line', async () => {
     installOnDisk('4.47.13');
     const r = await checkOpenClawRunningPluginVersion(home, {
-      readGatewayJournal: () => 'Jul 21 09:00:01 host openclaw-gateway[123]: starting gateway\n',
+      readGatewayJournal: () => ({ text: 'Jul 21 09:00:01 host openclaw-gateway[123]: starting gateway\n', preBounded: true }),
+      readGatewayProcessStartMs: () => 1_700_000_000_000,
     });
     expect(r.status).toBe('info');
-    expect(r.message).toMatch(/cannot verify running version/i);
+    expect(r.message).toMatch(/running version UNKNOWN/i);
   });
 
   it('skips (info) when OpenClaw is present but the realtime plugin is not installed', async () => {
     fs.mkdirSync(path.join(home, '.openclaw'), { recursive: true });
-    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => journalWith('4.47.13') });
+    const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => ({ text: journalWith('4.47.13'), preBounded: true }), readGatewayProcessStartMs: () => 1_700_000_000_000 });
     expect(r.status).toBe('info');
     expect(r.message).toMatch(/not installed|skipped/i);
   });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -19,6 +19,8 @@ import {
   isRealtimePluginDisabledInConfig,
 } from '../integrations/openclaw-plugin-state.js';
 import { gatherReconcileInput, reconcilePluginState } from '../integrations/openclaw-plugin-index.js';
+import { parseRegistrationsSince } from '../integrations/openclaw-gateway-roster.js';
+import { readRunningGatewayProcess } from '../integrations/openclaw-gateway-process.js';
 import { resolveSelfInstallDir } from '../setup/native-binding.js';
 import { getCanonicalSchema } from '../database/init.js';
 import { runMigrations } from '../database/migrations.js';
@@ -2457,6 +2459,19 @@ export async function checkOpenClawPluginLoadState(
           'cannot read OpenClaw\'s plugin roster (SQLite index unreadable — broken better-sqlite3 binding, locked DB, or pre-2026.6.1 OpenClaw) — cannot confirm the realtime plugin is loaded; NOT necessarily unprotected',
         fix,
       };
+    case 'load-unproven':
+      // #142: the boot roster snapshot races plugin registration, and a
+      // registration line was sighted after the snapshot. Neither loaded nor
+      // absent can be proven from logs — a confident UNPROTECTED here is the
+      // false alarm that trains operators to ignore the check that caught #74.
+      return {
+        label,
+        status: 'warn',
+        message:
+          'load state UNPROVEN — absent from the boot roster snapshot, but a plugin registration was sighted after it ' +
+          '(registration races the snapshot; CLI activity writes identical lines). Neither protected nor unprotected is proven',
+        fix: `Prove it live: ${LIVE_CANARY_COMMAND}`,
+      };
     case 'enabled-not-loaded':
       return {
         label,
@@ -2520,9 +2535,32 @@ export async function checkOpenClawPluginLoadState(
  * The journal reader is injected (see `realRunningPluginVersionDeps`) so the
  * check has no hard dependency on systemd being present or readable.
  */
+export interface BoundedJournal {
+  text: string;
+  /**
+   * True when the SOURCE already bounded the text at/after the requested
+   * instant (journalctl --since=@epoch). journald's default line format
+   * carries no year, so per-line dating is impossible there — bounding at the
+   * source is what keeps the #150 guarantee on systemd hosts. False means the
+   * text is a raw file read and every line must prove its own freshness.
+   */
+  preBounded: boolean;
+}
+
 export interface RunningPluginVersionDeps {
-  /** Returns the gateway journal/log text, or null when it can't be read. */
-  readGatewayJournal: () => string | null;
+  /**
+   * Returns gateway journal/log text for the window starting at `sinceMs`,
+   * or null when it can't be read.
+   */
+  readGatewayJournal: (sinceMs: number) => BoundedJournal | null;
+  /**
+   * The RUNNING gateway's process start (ms), or null when it cannot be
+   * proven. #150: a Mac reported "v4.14.10 running" off a log line written in
+   * May because nothing bounded the log by the life of the process it was
+   * being quoted about. No line older than this instant may be called
+   * "running".
+   */
+  readGatewayProcessStartMs: () => number | null;
 }
 
 /**
@@ -2544,6 +2582,16 @@ export function parseRunningPluginVersion(journal: string): string | null {
 }
 
 /**
+ * #150: the bounded variant — only registration lines dated at/after `sinceMs`
+ * count, and a line that cannot be dated cannot be called fresh. The unbounded
+ * parser above remains for callers that genuinely want "newest ever".
+ */
+export function parseRunningPluginVersionSince(journal: string, sinceMs: number): string | null {
+  const sightings = parseRegistrationsSince(journal, sinceMs);
+  return sightings.length > 0 ? sightings[sightings.length - 1].version : null;
+}
+
+/**
  * Real journal reader: prefer the user gateway service journal, fall back to
  * OpenClaw's on-disk gateway log. Returns null on ANY failure (no systemd, no
  * perms, no log file) so the check downgrades to "cannot verify" rather than a
@@ -2552,15 +2600,17 @@ export function parseRunningPluginVersion(journal: string): string | null {
  */
 export function realRunningPluginVersionDeps(home: string = os.homedir()): RunningPluginVersionDeps {
   return {
-    readGatewayJournal: (): string | null => {
-      // 1. systemd user journal for the gateway unit (the supported layout).
+    readGatewayJournal: (sinceMs: number): BoundedJournal | null => {
+      // 1. systemd user journal, bounded AT THE SOURCE (#150): journald's
+      //    default format has no year, so per-line dating is impossible —
+      //    --since makes the whole window provably fresh instead.
       try {
         const out = execFileSync(
           'journalctl',
-          ['--user', '-u', 'openclaw-gateway', '--no-pager', '-n', '2000'],
+          ['--user', '-u', 'openclaw-gateway', '--no-pager', '-n', '2000', `--since=@${Math.floor(sinceMs / 1000)}`],
           { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
         );
-        if (typeof out === 'string' && out.trim().length > 0) return out;
+        if (typeof out === 'string' && out.trim().length > 0) return { text: out, preBounded: true };
       } catch {
         // no systemd / unit unknown / no perms — fall through to the log file
       }
@@ -2575,15 +2625,38 @@ export function realRunningPluginVersionDeps(home: string = os.homedir()): Runni
         try {
           if (fs.existsSync(file)) {
             const text = fs.readFileSync(file, 'utf8');
-            if (text.trim().length > 0) return text;
+            if (text.trim().length > 0) return { text, preBounded: false };
           }
         } catch {
           // unreadable — try the next candidate
         }
       }
 
+      // 3. OpenClaw's default log dir (/tmp/openclaw/openclaw-YYYY-MM-DD.log,
+      //    ISO-dated JSON lines — the layout every current install writes).
+      try {
+        const dir = '/tmp/openclaw';
+        const logs = fs
+          .readdirSync(dir)
+          .filter((n) => n.startsWith('openclaw-') && n.endsWith('.log'))
+          .sort();
+        const parts: string[] = [];
+        for (const name of logs.slice(-2)) {
+          try {
+            parts.push(fs.readFileSync(path.join(dir, name), 'utf8'));
+          } catch {
+            // skip unreadable file
+          }
+        }
+        const text = parts.join('\n');
+        if (text.trim().length > 0) return { text, preBounded: false };
+      } catch {
+        // no default log dir either
+      }
+
       return null;
     },
+    readGatewayProcessStartMs: (): number | null => readRunningGatewayProcess(home)?.startedAtMs ?? null,
   };
 }
 
@@ -2602,7 +2675,23 @@ export async function checkOpenClawRunningPluginVersion(
     return { label, status: 'info', message: 'skipped (realtime plugin not installed)' };
   }
 
-  const journal = deps.readGatewayJournal();
+  // #150: bound the log by the life of the process it is being quoted about.
+  // A Mac reported "v4.14.10 running" off a line written two months earlier —
+  // a confident, specific claim from an artifact nothing had touched since
+  // May. Without a process-start instant to bound against, the newest line in
+  // a log proves nothing about NOW, so the honest answer is unknown.
+  const processStartMs = deps.readGatewayProcessStartMs();
+  if (processStartMs == null) {
+    return {
+      label,
+      status: 'info',
+      message:
+        `cannot verify running version (the running gateway's start time could not be established, ` +
+        `so no log line can be proven to describe the current process); on-disk v${diskVersion}`,
+    };
+  }
+
+  const journal = deps.readGatewayJournal(processStartMs);
   if (journal === null) {
     return {
       label,
@@ -2613,14 +2702,18 @@ export async function checkOpenClawRunningPluginVersion(
     };
   }
 
-  const running = parseRunningPluginVersion(journal);
+  const running = journal.preBounded
+    ? parseRunningPluginVersion(journal.text)
+    : parseRunningPluginVersionSince(journal.text, processStartMs);
   if (!running) {
+    const historic = journal.preBounded ? null : parseRunningPluginVersion(journal.text);
     return {
       label,
       status: 'info',
       message:
-        `cannot verify running version (no \`[shieldcortex] … registered\` line in the gateway journal — ` +
-        `gateway not started since logs rotated, or plugin never loaded); on-disk v${diskVersion}`,
+        `running version UNKNOWN — no \`[shieldcortex] … registered\` line since the running gateway ` +
+        `started (${new Date(processStartMs).toISOString()}); on-disk v${diskVersion}.` +
+        (historic ? ` An older line exists (v${historic}) but predates this process and proves nothing about it` : ''),
     };
   }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -63,6 +63,132 @@ function skippedNoDatabase(label: string): CheckResult {
   return { label, status: 'info', message: 'skipped — database not created yet', skipped: 'db-uninitialised' };
 }
 
+/**
+ * How a path actually failed to be readable.
+ *
+ * `fs.existsSync()` collapses three very different states into one `false`:
+ * "not created yet", "there but I'm not allowed to look at it", and "the
+ * filesystem returned something else entirely". #131 made doctor treat that
+ * `false` as the friendly fresh-install state, so a root-owned
+ * `~/.shieldcortex` — the classic artefact of a single `sudo shieldcortex …`
+ * run — reported a clean bill of health on a genuinely broken install. A
+ * diagnostic going green on the box it exists to diagnose is its worst
+ * possible failure mode (#132).
+ *
+ * probePath() keeps the cases apart. `statSync` is injectable so tests can
+ * drive every branch deterministically, including on hosts where the test
+ * runner is root and chmod cannot deny it anything.
+ */
+export type PathProbe =
+  | { kind: 'present'; stat: fs.Stats }
+  | { kind: 'absent' }
+  | { kind: 'denied'; code: string; message: string }
+  | { kind: 'error'; code: string; message: string };
+
+export function probePath(
+  target: string,
+  statSync: (p: string) => fs.Stats = fs.statSync,
+): PathProbe {
+  try {
+    return { kind: 'present', stat: statSync(target) };
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException)?.code ?? 'UNKNOWN';
+    const message = err instanceof Error ? err.message : String(err);
+    // ENOENT is the only code that means "genuinely not there yet".
+    if (code === 'ENOENT') return { kind: 'absent' };
+    if (code === 'EACCES' || code === 'EPERM') return { kind: 'denied', code, message };
+    return { kind: 'error', code, message };
+  }
+}
+
+/** True only for "this path is genuinely not there yet" — never for unreadable. */
+function isAbsent(target: string): boolean {
+  return probePath(target).kind === 'absent';
+}
+
+function tildify(target: string): string {
+  const home = os.homedir();
+  return target.startsWith(home) ? target.replace(home, '~') : target;
+}
+
+/**
+ * The remedy for the only cause worth naming: ShieldCortex state owned by a
+ * different user. Practically always one `sudo shieldcortex …` (or an install
+ * script run under sudo) leaving root-owned files behind.
+ */
+function ownershipFix(): string {
+  return (
+    'Those paths exist but this user cannot read them — almost always ShieldCortex state owned by ' +
+    'another user, typically root, left behind by one `sudo shieldcortex …` run. Restore ownership: ' +
+    '`sudo chown -R "$USER" ~/.shieldcortex` (also `~/.claude-memory` on a legacy install), then ' +
+    're-run `shieldcortex doctor`.'
+  );
+}
+
+/**
+ * Turn a non-present, non-absent probe into an honest ❌. Never swallows the
+ * underlying errno — a code we have no advice for still gets surfaced verbatim
+ * rather than being reported as a healthy or fresh install.
+ *
+ * `opts.fix` overrides the remedy: a string for a path the ownership hint does
+ * not fit, `false` for a dependent check whose root cause is already reported
+ * (repeating one remedy per affected check reads as several problems).
+ */
+function unreadableResult(
+  label: string,
+  target: string,
+  probe: Extract<PathProbe, { kind: 'denied' | 'error' }>,
+  opts: { fix?: string | false } = {},
+): CheckResult {
+  const defaultFix = probe.kind === 'denied'
+    ? ownershipFix()
+    : `Resolve the filesystem error above on ${tildify(target)}, then re-run \`shieldcortex doctor\`.`;
+  const fix = opts.fix === undefined ? defaultFix : opts.fix;
+  return {
+    label,
+    status: 'fail',
+    message: probe.kind === 'denied'
+      ? `permission denied reading ${tildify(target)} (${probe.code})`
+      : `cannot read ${tildify(target)} — ${probe.code}: ${probe.message}`,
+    ...(fix === false ? {} : { fix }),
+  };
+}
+
+/**
+ * Upgrade a caught filesystem error to a permission ❌ when that is what it is.
+ * Returns null for anything else so the caller keeps its own handling.
+ */
+function permissionFailure(
+  label: string,
+  target: string,
+  err: unknown,
+  opts: { fix?: string | false } = {},
+): CheckResult | null {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  if (code === 'EACCES' || code === 'EPERM') {
+    const fix = opts.fix === undefined ? ownershipFix() : opts.fix;
+    return {
+      label,
+      status: 'fail',
+      message: `permission denied reading ${tildify(target)} (${code})`,
+      ...(fix === false ? {} : { fix }),
+    };
+  }
+  return null;
+}
+
+/** better-sqlite3 surfaces a denied open as SQLITE_CANTOPEN, not EACCES. */
+function looksLikePermissionError(err: unknown, msg: string): boolean {
+  const code = (err as NodeJS.ErrnoException)?.code ?? '';
+  return (
+    code === 'EACCES' ||
+    code === 'EPERM' ||
+    code === 'SQLITE_CANTOPEN' ||
+    code === 'SQLITE_READONLY' ||
+    /EACCES|EPERM|permission denied|unable to open database file/i.test(msg)
+  );
+}
+
 function icon(status: CheckStatus): string {
   switch (status) {
     case 'pass': return `${green}\u2705${reset}`;
@@ -115,8 +241,12 @@ function detectEnvironment(): Environment {
 function getDbPath(): string {
   const newPath = path.join(getShieldCortexDir(), 'memories.db');
   const legacyPath = path.join(os.homedir(), '.claude-memory', 'memories.db');
-  if (fs.existsSync(newPath)) return newPath;
-  if (fs.existsSync(legacyPath)) return legacyPath;
+  // Probe rather than existsSync: an unreadable DB at the canonical path must
+  // still resolve to that path, so the checks report the permission fault
+  // against the real install instead of silently falling back to the legacy
+  // location (or to "fresh install") (#132).
+  if (!isAbsent(newPath)) return newPath;
+  if (!isAbsent(legacyPath)) return legacyPath;
   return newPath; // default expected path
 }
 
@@ -127,7 +257,15 @@ function getDbPath(): string {
  * getDbPath().
  */
 export function runDatabaseCheck(dbPath: string, env: Environment = detectEnvironment()): CheckResult {
-  if (!fs.existsSync(dbPath)) {
+  const probe = probePath(dbPath);
+
+  if (probe.kind === 'denied' || probe.kind === 'error') {
+    // There IS something at this path, we just cannot read it. Never the
+    // friendly fresh-install line — that is the #131 regression this closes.
+    return unreadableResult('Database', dbPath, probe);
+  }
+
+  if (probe.kind === 'absent') {
     // Not a failure. The database is created lazily on the first memory
     // operation, so "no database yet" is the normal state of a fresh install —
     // and doctor is exactly the command a new user runs to check the install
@@ -180,19 +318,44 @@ export function runDatabaseCheck(dbPath: string, env: Environment = detectEnviro
     }
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
+    const isNativeBindingFault = /bindings file|napi|abi|MODULE_VERSION|was compiled against/i.test(msg);
+    // A stat'able DB can still be unopenable because the file itself is owned
+    // by another user (mode 600 root:root — the other half of the sudo
+    // artefact). Telling that user to delete their database is bad advice.
+    const fix = isNativeBindingFault
+      ? `Native DB engine failed to load. Run \`shieldcortex repair\` (compiles better-sqlite3 from source + re-verifies), or manually: cd "${path.join(resolveSelfInstallDir(), 'node_modules', 'better-sqlite3')}" && npm run build-release`
+      : looksLikePermissionError(err, msg)
+        ? ownershipFix()
+        : 'Back up and delete `~/.shieldcortex/memories.db`, then restart the MCP server';
     return {
       label: 'Database',
       status: 'fail',
       message: `cannot open — ${msg}`,
-      fix: /bindings file|napi|abi|MODULE_VERSION|was compiled against/i.test(msg)
-        ? `Native DB engine failed to load. Run \`shieldcortex repair\` (compiles better-sqlite3 from source + re-verifies), or manually: cd "${path.join(resolveSelfInstallDir(), 'node_modules', 'better-sqlite3')}" && npm run build-release`
-        : 'Back up and delete `~/.shieldcortex/memories.db`, then restart the MCP server',
+      fix,
     };
   }
 }
 
 async function checkDatabase(): Promise<CheckResult> {
   return runDatabaseCheck(getDbPath());
+}
+
+/**
+ * Gate for the checks that can say nothing without a readable database.
+ * Returns the result to return early with, or null to carry on.
+ *
+ * The three states are deliberately distinct: absent is the friendly
+ * fresh-install skip, unreadable is a ❌ that must never be collapsed into it
+ * (#132), readable proceeds to the real check.
+ */
+function databasePrerequisite(label: string, dbPath: string): CheckResult | null {
+  const probe = probePath(dbPath);
+  if (probe.kind === 'absent') return skippedNoDatabase(label);
+  if (probe.kind === 'present') return null;
+  // No fix line here on purpose: the Database check already carries the
+  // ownership remedy, and repeating it per dependent check turns "Suggested
+  // fixes" into four copies of one sentence.
+  return unreadableResult(label, dbPath, probe, { fix: false });
 }
 
 // ── Check 2: Schema version ──────────────────────────────
@@ -210,9 +373,8 @@ async function checkDatabase(): Promise<CheckResult> {
  * long-lived DBs) are harmless and stay silent.
  */
 export function runSchemaDriftCheck(dbPath: string): CheckResult {
-  if (!fs.existsSync(dbPath)) {
-    return skippedNoDatabase('Schema');
-  }
+  const prerequisite = databasePrerequisite('Schema', dbPath);
+  if (prerequisite) return prerequisite;
 
   try {
     const Database = require('better-sqlite3');
@@ -263,9 +425,8 @@ async function checkSchema(): Promise<CheckResult> {
  * against a temp database instead of the homedir install.
  */
 export function runMemoryStatsCheck(dbPath: string): CheckResult {
-  if (!fs.existsSync(dbPath)) {
-    return skippedNoDatabase('Memories');
-  }
+  const prerequisite = databasePrerequisite('Memories', dbPath);
+  if (prerequisite) return prerequisite;
 
   try {
     const Database = require('better-sqlite3');
@@ -329,9 +490,8 @@ async function checkMemoryStats(): Promise<CheckResult> {
  * without going through doctor's homedir-derived getDbPath().
  */
 export function runWritePathProbe(dbPath: string, env: Environment = detectEnvironment()): CheckResult {
-  if (!fs.existsSync(dbPath)) {
-    return skippedNoDatabase('Write path');
-  }
+  const prerequisite = databasePrerequisite('Write path', dbPath);
+  if (prerequisite) return prerequisite;
 
   let db: any = null;
   const probeUuid = `doctor-probe-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
@@ -424,7 +584,18 @@ async function checkWritePath(): Promise<CheckResult> {
  * real homedir.
  */
 export function runHooksCheck(settingsPath: string, env: Environment = detectEnvironment()): CheckResult {
-  if (!fs.existsSync(settingsPath)) {
+  const probe = probePath(settingsPath);
+
+  if (probe.kind === 'denied' || probe.kind === 'error') {
+    // A settings.json we cannot read is not "not configured yet" — doctor
+    // simply cannot tell whether the hooks are wired, and saying so is the
+    // only honest answer (#132).
+    return unreadableResult('Hooks', settingsPath, probe, {
+      fix: `Check ownership and permissions of ${tildify(settingsPath)} — while it is unreadable, doctor cannot tell whether the hooks are wired.`,
+    });
+  }
+
+  if (probe.kind === 'absent') {
     // No settings.json is not a fault. Either Claude Code isn't on this box at
     // all (OpenClaw-only / headless installs never grow one), or it is and the
     // user hasn't run `shieldcortex install` yet — the exact state of every
@@ -486,6 +657,12 @@ export function runHooksCheck(settingsPath: string, env: Environment = detectEnv
       };
     }
   } catch (err: unknown) {
+    // A settings.json that stats but will not open (mode 000) is a permission
+    // fault, not an inconclusive check.
+    const denied = permissionFailure('Hooks', settingsPath, err, {
+      fix: `Check ownership and permissions of ${tildify(settingsPath)} — while it is unreadable, doctor cannot tell whether the hooks are wired.`,
+    });
+    if (denied) return denied;
     const msg = err instanceof Error ? err.message : String(err);
     return { label: 'Hooks', status: 'warn', message: `check failed — ${msg}` };
   }
@@ -784,7 +961,14 @@ function readDbRowConsumers(dbPath: string): DbRowConsumers | null {
 }
 
 export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limitBytes: number = 100 * 1024 * 1024): Promise<CheckResult> {
-  if (!fs.existsSync(scDir)) {
+  const dirProbe = probePath(scDir);
+  if (dirProbe.kind === 'denied' || dirProbe.kind === 'error') {
+    // "Directory not yet created" is a ✅. An unreadable one is not — this is
+    // the same false-clean shape as the Database check, on the same directory
+    // (#132).
+    return unreadableResult('Disk', scDir, dirProbe);
+  }
+  if (dirProbe.kind === 'absent') {
     return { label: 'Disk', status: 'pass', message: '0 B / 100 MB limit (directory not yet created)' };
   }
 
@@ -917,6 +1101,10 @@ export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limit
       return { label: 'Disk', status: 'pass', message: `${dataStr}${modelsStr}` };
     }
   } catch (err: unknown) {
+    // A directory that stats but cannot be listed (mode 700, another owner) is
+    // a permission fault, not an inconclusive check.
+    const denied = permissionFailure('Disk', scDir, err);
+    if (denied) return denied;
     const msg = err instanceof Error ? err.message : String(err);
     return { label: 'Disk', status: 'warn', message: `check failed — ${msg}` };
   }
@@ -930,7 +1118,11 @@ export async function checkDiskUsage(scDir: string = getShieldCortexDir(), limit
 // to delete a file that is still in active use.
 export async function checkLockFile(scDir: string = getShieldCortexDir()): Promise<CheckResult> {
 
-  if (!fs.existsSync(scDir)) {
+  const dirProbe = probePath(scDir);
+  if (dirProbe.kind === 'denied' || dirProbe.kind === 'error') {
+    return unreadableResult('Lock', scDir, dirProbe, { fix: false });
+  }
+  if (dirProbe.kind === 'absent') {
     return { label: 'Lock', status: 'pass', message: 'clean' };
   }
 
@@ -999,6 +1191,8 @@ export async function checkLockFile(scDir: string = getShieldCortexDir()): Promi
 
     return { label: 'Lock', status: 'pass', message: `clean (${active.length} active lock${active.length !== 1 ? 's' : ''})` };
   } catch (err: unknown) {
+    const denied = permissionFailure('Lock', scDir, err, { fix: false });
+    if (denied) return denied;
     const msg = err instanceof Error ? err.message : String(err);
     return { label: 'Lock', status: 'warn', message: `check failed — ${msg}` };
   }
@@ -1712,8 +1906,16 @@ export async function checkBrainWorker(): Promise<CheckResult> {
     };
   }
   const statePath = path.join(getShieldCortexDir(), 'state', 'worker.json');
-  if (!fs.existsSync(statePath)) {
-    return missingWorkerStateResult(fs.existsSync(getDbPath()));
+  const stateProbe = probePath(statePath);
+  if (stateProbe.kind === 'denied' || stateProbe.kind === 'error') {
+    // Unreadable state is not "the worker has not run yet" (#132).
+    return unreadableResult('Brain worker', statePath, stateProbe);
+  }
+  if (stateProbe.kind === 'absent') {
+    // isAbsent, not existsSync: an unreadable database means something HAS
+    // been installed here, so a missing worker.json is a real gap, not the
+    // fresh-install state.
+    return missingWorkerStateResult(!isAbsent(getDbPath()));
   }
   try {
     const raw = JSON.parse(fs.readFileSync(statePath, 'utf-8')) as {
@@ -2418,7 +2620,36 @@ export function partitionUninitialisedSkips(
   };
 }
 
-export async function runDoctor(args: string[] = []): Promise<void> {
+/**
+ * What `shieldcortex doctor` reports back to its caller — and to the shell.
+ */
+export interface DoctorSummary {
+  passed: number;
+  warnings: number;
+  failures: number;
+  infos: number;
+  total: number;
+  exitCode: number;
+}
+
+/**
+ * Exit-code policy.
+ *
+ * doctor used to always exit 0, so `shieldcortex doctor && …` succeeded on a
+ * broken install and CI could not gate on it (#132). A ❌ now means exit 1.
+ *
+ * Warnings and info stay 0 deliberately: fresh-install states are ℹ️ (#129),
+ * and a first run must not fail anyone's pipeline for being a first run.
+ * `--strict` opts into escalating ⚠️ as well, for callers that want a
+ * zero-tolerance gate.
+ */
+export function doctorExitCode(results: CheckResult[], opts: { strict?: boolean } = {}): number {
+  if (results.some(r => r.status === 'fail')) return 1;
+  if (opts.strict && results.some(r => r.status === 'warn')) return 1;
+  return 0;
+}
+
+export async function runDoctor(args: string[] = []): Promise<DoctorSummary> {
   console.log(`\n${bold}ShieldCortex Doctor${reset} v${pkg.version}\n`);
 
   const results: CheckResult[] = [];
@@ -2517,12 +2748,14 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   if (infos > 0) parts.push(`${infos} info`);
   console.log(`  ${parts.join(', ')}`);
 
-  // Suggested fixes
-  const fixes = visible.filter(r => r.fix);
+  // Suggested fixes. Deduplicated: one root cause can fail several checks at
+  // once (a root-owned ~/.shieldcortex fails Database, Disk and Lock), and
+  // printing the same remedy three times reads as three separate problems.
+  const fixes = [...new Set(visible.filter(r => r.fix).map(r => r.fix as string))];
   if (fixes.length > 0) {
     console.log(`\n  ${bold}Suggested fixes:${reset}`);
     for (const f of fixes) {
-      console.log(`  ${dim}\u2192${reset} ${f.fix}`);
+      console.log(`  ${dim}\u2192${reset} ${f}`);
     }
   }
 
@@ -2530,5 +2763,20 @@ export async function runDoctor(args: string[] = []): Promise<void> {
   // Free + Enterprise repricing \u2014 there is no self-serve tier to nudge
   // towards. `config --upsell-mute/--upsell-unmute` remain accepted no-ops.)
 
+  // Exit code. Set rather than process.exit() so buffered stdout is flushed
+  // in full (doctor's report is long and often piped), and only ever set to
+  // a failure \u2014 never reset to 0 over an exit code someone else set.
+  const strict = args.includes('--strict');
+  const exitCode = doctorExitCode(visible, { strict });
+  if (exitCode !== 0) {
+    process.exitCode = exitCode;
+    const reason = failures > 0
+      ? `${failures} failed check${failures !== 1 ? 's' : ''}`
+      : `${warnings} warning${warnings !== 1 ? 's' : ''} (--strict)`;
+    console.log(`  ${dim}exit ${exitCode} \u2014 ${reason}${reset}`);
+  }
+
   console.log('');
+
+  return { passed, warnings, failures, infos, total, exitCode };
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -23,6 +23,12 @@ import { getCanonicalSchema } from '../database/init.js';
 import { runMigrations } from '../database/migrations.js';
 import { detectStaleDashboard, realDeps } from '../service/dashboard-staleness.js';
 import { MCP_LIGHT_TICK_INTERVAL_MS } from '../worker/types.js';
+import {
+  CLAUDE_CODE_ENFORCEMENT_FLOOR,
+  detectClaudeCode,
+  upgradeCommandFor,
+  type DetectClaudeCodeDeps,
+} from '../integrations/claude-code-version.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../../package.json');
@@ -1561,6 +1567,65 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
   return results;
 }
 
+// ── Check 8b: Claude Code enforcement floor ───────────────
+/**
+ * The Action Guard's Claude Code surface is only as strong as the harness that
+ * honours its verdicts, and that harness is versioned independently of us.
+ *
+ * On 2026-07-30 a box running Claude Code 2.1.76 was found discarding hook
+ * `"ask"` decisions under `bypassPermissions` and executing the command — the
+ * audit log recorded the guard firing, the command ran anyway, and this went
+ * unnoticed because nobody tracked the harness version. See
+ * `claude-code-version.ts` for the mechanism and how the floor was set.
+ *
+ * A below-floor build is a `fail`, not a warning: on that box the guard's
+ * dangerous tier is decorative, and the operator has no other signal that it is.
+ */
+export async function checkClaudeCodeVersion(
+  deps: DetectClaudeCodeDeps = {},
+): Promise<CheckResult> {
+  const label = 'Claude Code version';
+
+  const install = detectClaudeCode(deps);
+  if (!install) {
+    return { label, status: 'info', message: 'skipped (Claude Code not detected on PATH)' };
+  }
+
+  const where = `${install.channel} channel`;
+
+  if (!install.version) {
+    return {
+      label,
+      status: 'warn',
+      message:
+        `could not read a version from \`${install.binPath} --version\` ` +
+        `(${install.error ?? `output: ${install.rawVersion ?? 'empty'}`}) — ` +
+        `cannot confirm this build honours the guard's approval verdicts ` +
+        `(floor ${CLAUDE_CODE_ENFORCEMENT_FLOOR})`,
+      fix: `Run \`claude --version\` by hand; if it is below ${CLAUDE_CODE_ENFORCEMENT_FLOOR}, upgrade with \`${upgradeCommandFor(install.channel)}\`.`,
+    };
+  }
+
+  if (semver.lt(install.version, CLAUDE_CODE_ENFORCEMENT_FLOOR)) {
+    return {
+      label,
+      status: 'fail',
+      message:
+        `${install.version} (${where}) is below the enforcement floor ${CLAUDE_CODE_ENFORCEMENT_FLOOR} — ` +
+        `builds this old discard the Action Guard's approval verdicts in promptless modes ` +
+        `(e.g. \`--permission-mode bypassPermissions\`) and run the command anyway. ` +
+        `The audit log will show the guard firing while nothing was actually stopped.`,
+      fix: `Upgrade Claude Code: \`${upgradeCommandFor(install.channel)}\`. Sessions already running keep the old build in memory until they cycle.`,
+    };
+  }
+
+  return {
+    label,
+    status: 'pass',
+    message: `${install.version} (${where}) — at or above the ${CLAUDE_CODE_ENFORCEMENT_FLOOR} enforcement floor`,
+  };
+}
+
 /** Read a package's `version` field; returns null on any failure. */
 function readPkgVersion(pkgJson: string): string | null {
   try {
@@ -2450,6 +2515,7 @@ export async function runDoctor(args: string[] = []): Promise<void> {
     checkOpenClawApprovalButtons,
     checkDefenceCanary,
     checkActionGuard,
+    checkClaudeCodeVersion,
     checkModelCache,
   ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -638,7 +638,7 @@ ${bold}COMMANDS${reset}
   ${cyan}dashboard${reset}             Open the local security dashboard
   ${cyan}worker${reset}                Run headless background sync + heartbeat worker
   ${cyan}status${reset}                Show current protection status
-  ${cyan}doctor${reset}                Diagnose installation issues
+  ${cyan}doctor${reset}                Diagnose installation issues (exits 1 on a ❌; --strict also fails on ⚠️)
   ${cyan}vacuum${reset}                Compact the memory DB, reclaiming free pages (no sqlite3 CLI needed)
   ${cyan}sessions${reset} prune        Delete old session-capture events (dry-run; --days N, --execute)
   ${cyan}quickstart${reset} [target]    Detect integrations and guide/install setup

--- a/src/integrations/claude-code-version.ts
+++ b/src/integrations/claude-code-version.ts
@@ -1,0 +1,174 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Detecting the installed Claude Code build, and whether it is new enough to
+ * enforce the Action Guard's verdicts.
+ *
+ * Incident, 2026-07-30 (aiquant): under `--permission-mode bypassPermissions`,
+ * Claude Code 2.1.76 converts a PreToolUse hook's `"ask"` decision into
+ * `allow` and runs the command. The permission resolver preserves `"ask"` only
+ * for `decisionReason.type === "rule"` or tools that require user interaction;
+ * a hook-ask is type `"hook"`, so in a promptless mode it falls through to
+ * mode-allow. `deny` is honoured unconditionally in every build we have
+ * examined. A global `npm i -g` earned `require_approval` at 06:53:23Z, was
+ * written to the audit log as gated, and installed anyway.
+ *
+ * The guard-side fix is to deny rather than ask when no prompt surface can be
+ * confirmed. But the deeper condition is that the harness ShieldCortex depends
+ * on for enforcement was 144 versions stale on one box and nobody knew: it is
+ * distributed through two channels (npm global and the native installer),
+ * neither of which anyone was tracking. A guard that silently depends on an
+ * untracked version of something else is not a guard. So doctor reads the
+ * version and says so.
+ *
+ * The floor is behavioural, not theoretical: 2.1.215 (native) and 2.1.220
+ * (npm) were both observed honouring a hook-ask under `bypassPermissions` on
+ * separate hosts; 2.1.76 was observed discarding it. We have not bisected the
+ * range between, so the floor is the lowest build actually proven good.
+ */
+
+/**
+ * Lowest Claude Code version observed to honour a hook `"ask"` in a promptless
+ * mode. Below this, hook verdicts requiring approval may be silently discarded.
+ */
+export const CLAUDE_CODE_ENFORCEMENT_FLOOR = '2.1.215';
+
+/** Where a Claude Code build came from — the two channels differ in upgrade path. */
+export type ClaudeCodeChannel = 'native' | 'npm' | 'unknown';
+
+export interface ClaudeCodeInstall {
+  /** Parsed `major.minor.patch`, or null when the output could not be parsed. */
+  version: string | null;
+  /** Exactly what `claude --version` printed, for operator-facing evidence. */
+  rawVersion: string | null;
+  /** The `claude` that PATH resolves to. */
+  binPath: string;
+  /** `binPath` with symlinks followed, when resolvable — this is what names the channel. */
+  realPath: string | null;
+  channel: ClaudeCodeChannel;
+  /** Set when the binary exists but `--version` could not be run or read. */
+  error?: string;
+}
+
+export interface DetectClaudeCodeDeps {
+  /** Resolve `claude` on PATH; return null when it is not installed. */
+  which?: (cmd: string) => string | null;
+  /** Follow symlinks; return null when the path cannot be resolved. */
+  realpath?: (p: string) => string | null;
+  /** Run `claude --version` and return stdout; throw when it cannot be run. */
+  runVersion?: (bin: string) => string;
+  homedir?: () => string;
+}
+
+/** Resolve a command through PATH without a shell. */
+function defaultWhich(cmd: string): string | null {
+  const pathEnv = process.env.PATH;
+  if (!pathEnv) return null;
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, cmd);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      /* not here — keep walking PATH */
+    }
+  }
+  return null;
+}
+
+function defaultRealpath(p: string): string | null {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `claude --version` is a fast local print, but doctor must never hang on a
+ * wedged binary — hence the timeout and the empty-stdin redirect, which stops
+ * a build that decides to read stdin from blocking forever.
+ */
+function defaultRunVersion(bin: string): string {
+  return execFileSync(bin, ['--version'], {
+    encoding: 'utf-8',
+    timeout: 10_000,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+/** First `x.y.z` in the output — builds print `2.1.220 (Claude Code)`. */
+export function parseClaudeCodeVersion(output: string): string | null {
+  const match = /(\d+\.\d+\.\d+)/.exec(output);
+  return match ? match[1] : null;
+}
+
+/**
+ * Name the distribution channel from the resolved binary path.
+ *
+ * Native installs live under `~/.local/share/claude/versions/<version>` with a
+ * shim in `~/.local/bin`; npm globals resolve into a
+ * `node_modules/@anthropic-ai/claude-code` directory. Anything else is
+ * `unknown` — a channel we cannot name is reported as such rather than guessed,
+ * because the upgrade instruction differs per channel and a wrong one wastes
+ * an operator's time.
+ */
+export function classifyClaudeCodeChannel(realPath: string | null, homedir: string): ClaudeCodeChannel {
+  if (!realPath) return 'unknown';
+  const normalised = realPath.split(path.sep).join('/');
+  if (normalised.includes('/node_modules/@anthropic-ai/claude-code')) return 'npm';
+  const nativeRoot = path.join(homedir, '.local', 'share', 'claude').split(path.sep).join('/');
+  if (normalised.startsWith(nativeRoot)) return 'native';
+  return 'unknown';
+}
+
+/**
+ * Locate Claude Code and read its version. Returns null when no `claude` is on
+ * PATH at all — that is not a fault, it just means this box does not run the
+ * Claude Code surface and the version floor does not apply to it.
+ */
+export function detectClaudeCode(deps: DetectClaudeCodeDeps = {}): ClaudeCodeInstall | null {
+  const which = deps.which ?? defaultWhich;
+  const realpath = deps.realpath ?? defaultRealpath;
+  const runVersion = deps.runVersion ?? defaultRunVersion;
+  const homedir = deps.homedir ?? os.homedir;
+
+  const binPath = which('claude');
+  if (!binPath) return null;
+
+  const realPath = realpath(binPath);
+  const channel = classifyClaudeCodeChannel(realPath, homedir());
+
+  let rawVersion: string | null = null;
+  let error: string | undefined;
+  try {
+    rawVersion = runVersion(binPath).trim();
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  return {
+    version: rawVersion ? parseClaudeCodeVersion(rawVersion) : null,
+    rawVersion,
+    binPath,
+    realPath,
+    channel,
+    ...(error ? { error } : {}),
+  };
+}
+
+/** Per-channel upgrade instruction, so the fix text is actionable as printed. */
+export function upgradeCommandFor(channel: ClaudeCodeChannel): string {
+  switch (channel) {
+    case 'npm':
+      return `npm i -g @anthropic-ai/claude-code@latest`;
+    case 'native':
+      return `claude update`;
+    default:
+      return `re-run the Claude Code installer for whichever channel this box uses (\`claude update\` for the native installer, \`npm i -g @anthropic-ai/claude-code@latest\` for the npm global)`;
+  }
+}

--- a/src/integrations/openclaw-gateway-process.ts
+++ b/src/integrations/openclaw-gateway-process.ts
@@ -1,0 +1,93 @@
+/**
+ * ShieldCortex — the RUNNING gateway process, as a fact (#150, #142).
+ *
+ * Three defects in one week were the same mistake wearing different clothes:
+ * a convenient artifact trusted as a proxy for process state. #142 read a
+ * boot-time roster snapshot as a live roster; #150 read a months-stale log as
+ * the running version (a Mac reported v4.14.10 "running" off a line written in
+ * May); #145 echoed a pre-remediation snapshot as the post-remediation state.
+ *
+ * The rule this module exists to enforce: **no log line may be treated as
+ * evidence about the running gateway unless it postdates that gateway's
+ * process start.** OpenClaw records every boot in its own SQLite
+ * (`gateway_boot_lifecycle`: boot_id, pid, started_at_ms), which gives us the
+ * process-start instant without platform-specific service-manager queries.
+ * We corroborate the row by checking its pid is actually alive — a recorded
+ * boot whose process has exited proves nothing about "now".
+ *
+ * Best-effort and read-only: any failure returns null, and callers must treat
+ * null as "cannot bound the evidence" — degrade to UNKNOWN/unproven, never to
+ * a confident claim in either direction.
+ */
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+
+export interface RunningGatewayProcess {
+  pid: number;
+  startedAtMs: number;
+}
+
+export interface ReadGatewayProcessOptions {
+  /** Injectable liveness probe (defaults to signal-0). */
+  isPidAlive?: (pid: number) => boolean;
+  /** Injectable row reader, for tests without a SQLite fixture. */
+  readLatestBootRow?: (home: string) => { pid: number; started_at_ms: number } | null;
+}
+
+function defaultIsPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the process exists but is not ours to signal — still alive.
+    return (err as NodeJS.ErrnoException)?.code === 'EPERM';
+  }
+}
+
+function defaultReadLatestBootRow(home: string): { pid: number; started_at_ms: number } | null {
+  const dbPath = path.join(home, '.openclaw', 'state', 'openclaw.sqlite');
+  if (!fs.existsSync(dbPath)) return null;
+  let db: import('better-sqlite3').Database | null = null;
+  try {
+    const require = createRequire(import.meta.url);
+    const Database = require('better-sqlite3') as typeof import('better-sqlite3');
+    db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    const row = db
+      .prepare('SELECT pid, started_at_ms FROM gateway_boot_lifecycle ORDER BY started_at_ms DESC LIMIT 1')
+      .get() as { pid: number; started_at_ms: number } | undefined;
+    return row ?? null;
+  } catch {
+    return null;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/**
+ * The currently-running gateway process, or null when it cannot be PROVEN.
+ *
+ * Null covers: no SQLite, no lifecycle table, no rows, or a newest row whose
+ * pid is no longer alive (gateway stopped, or the row belongs to a previous
+ * boot on a host where the table lagged). Callers must read null as "unknown",
+ * never as "not running" and never as licence to trust unbounded logs.
+ */
+export function readRunningGatewayProcess(
+  home: string,
+  options: ReadGatewayProcessOptions = {},
+): RunningGatewayProcess | null {
+  const readRow = options.readLatestBootRow ?? defaultReadLatestBootRow;
+  const isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
+
+  const row = readRow(home);
+  if (!row) return null;
+  if (typeof row.pid !== 'number' || typeof row.started_at_ms !== 'number') return null;
+  if (!Number.isFinite(row.started_at_ms) || row.started_at_ms <= 0) return null;
+  if (!isPidAlive(row.pid)) return null;
+  return { pid: row.pid, startedAtMs: row.started_at_ms };
+}

--- a/src/integrations/openclaw-gateway-roster.ts
+++ b/src/integrations/openclaw-gateway-roster.ts
@@ -177,3 +177,78 @@ export function readLatestBootRoster(options: ReadBootRosterOptions = {}): BootR
   }
   return null;
 }
+
+// ── Registration lines (#142) ───────────────────────────────────────────────
+//
+// The boot roster line is a snapshot taken at one instant during boot, and
+// plugin registration RACES it: on a passing box the margin was 169 ms. It is
+// also not a boot-only event — registrations appear mid-life. So absence from
+// the boot line must not be read as "not registered now" when a registration
+// line postdates that boot: the honest verdict there is UNPROVEN, and the
+// consent-gated live canary is the arbiter.
+//
+// Caveat carried deliberately: CLI processes write identical registration
+// lines into the shared log, so a post-boot registration is AMBIGUOUS evidence
+// of gateway state — enough to withhold an UNPROTECTED accusation, never
+// enough to grant a loaded proof.
+
+/** Matches "[shieldcortex] v4.47.8 registered (...)" incl. semver suffixes. */
+const REGISTRATION_RE = /\[shieldcortex\]\s+v(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\s+registered/;
+
+export interface RegistrationSighting {
+  version: string;
+  atMs: number;
+}
+
+/**
+ * Scan text for plugin registration lines at/after `sinceMs`, newest last.
+ * PURE. Lines without a parseable timestamp are skipped — a line that cannot
+ * be dated cannot be called fresh.
+ */
+export function parseRegistrationsSince(text: string, sinceMs: number): RegistrationSighting[] {
+  const out: RegistrationSighting[] = [];
+  for (const line of text.split('\n')) {
+    const m = REGISTRATION_RE.exec(line);
+    if (!m) continue;
+    const ts = parseTimestamp(line);
+    if (ts == null || ts < sinceMs) continue;
+    out.push({ version: m[1], atMs: ts });
+  }
+  return out;
+}
+
+/**
+ * Newest registration sighting at/after `sinceMs` across the gateway's log
+ * files, or null. Same file discovery as {@link readLatestBootRoster}; same
+ * honesty contract — null means "no dated sighting", never "not registered".
+ */
+export function findRegistrationSince(
+  sinceMs: number,
+  options: ReadBootRosterOptions = {},
+): RegistrationSighting | null {
+  const logDir = options.logDir ?? DEFAULT_LOG_DIR;
+  const readDir = options.readDir ?? ((d: string) => fs.readdirSync(d));
+  const readFile = options.readFile ?? ((f: string) => fs.readFileSync(f, 'utf-8'));
+
+  let names: string[];
+  try {
+    names = readDir(logDir);
+  } catch {
+    return null;
+  }
+
+  let newest: RegistrationSighting | null = null;
+  for (const name of names) {
+    if (!name.startsWith('openclaw-') || !name.endsWith('.log')) continue;
+    let text: string;
+    try {
+      text = readFile(path.join(logDir, name));
+    } catch {
+      continue;
+    }
+    for (const sighting of parseRegistrationsSince(text, sinceMs)) {
+      if (!newest || sighting.atMs > newest.atMs) newest = sighting;
+    }
+  }
+  return newest;
+}

--- a/src/integrations/openclaw-plugin-index.ts
+++ b/src/integrations/openclaw-plugin-index.ts
@@ -6,7 +6,8 @@ import {
   resolveRealtimePluginInstallPath,
   readInstalledRealtimePluginVersion,
 } from './openclaw-plugin-state.js';
-import { readLatestBootRoster } from './openclaw-gateway-roster.js';
+import { readLatestBootRoster, findRegistrationSince } from './openclaw-gateway-roster.js';
+import { readRunningGatewayProcess } from './openclaw-gateway-process.js';
 
 /**
  * Reconciling OpenClaw plugin-install state across its three authoritative
@@ -82,6 +83,13 @@ export interface ReconcileInput {
    * installed and enabled. Null means "cannot prove", never "healthy".
    */
   liveRoster?: string[] | null;
+  /**
+   * A plugin registration line was sighted AFTER the boot roster snapshot
+   * (#142). The snapshot races registration (169 ms margin observed live), so
+   * absence-from-snapshot plus a later sighting is ambiguous — CLI processes
+   * write identical lines — and must not convict the host as UNPROTECTED.
+   */
+  registrationSeenAfterBoot?: boolean;
 }
 
 export type PluginLoadState =
@@ -89,6 +97,7 @@ export type PluginLoadState =
   | 'not-installed'
   | 'enabled-not-loaded'
   | 'index-unreadable'
+  | 'load-unproven'
   | 'version-regressed'
   | 'conflicted-metadata'
   | 'duplicate-install';
@@ -217,6 +226,16 @@ export function reconcilePluginState(input: ReconcileInput): ReconcileVerdict {
   if (!installed) {
     reasons.push('plugin not installed on this host (no config, installs.json, index record, or on-disk build)');
     return { ...base, state: 'not-installed', severity: 'ok', recommendedAction: 'install', reasons };
+  }
+
+  // 2a. #142 guard on rule 2: the boot line is a snapshot and registration
+  //     races it. When a registration line postdates the snapshot, absence
+  //     from the snapshot cannot convict — but CLI processes write identical
+  //     lines, so it cannot acquit either. Report the ambiguity as a warn and
+  //     point at the canary, never a confident UNPROTECTED on a maybe.
+  if (enabledInConfig && loadedInLiveRoster === false && input.registrationSeenAfterBoot === true) {
+    reasons.push('absent from the boot roster snapshot, but a plugin registration was sighted after that snapshot — registration races the boot line and CLI processes write identical lines, so load state is UNPROVEN; the consent-gated live canary is the arbiter');
+    return { ...base, state: 'load-unproven', severity: 'warn', recommendedAction: 'none', reasons };
   }
 
   // 2. THE #103 silent drop: the RUNNING gateway's boot roster does not name
@@ -541,9 +560,27 @@ export function gatherReconcileInput(home: string, options: GatherOptions): Reco
   // The default roster read touches the host's real gateway log dir (/tmp/openclaw),
   // which no `home` override can redirect — so it must never fire under Jest, or a
   // test would silently inherit THIS box's roster. Tests inject readLiveRoster.
+  // #142/#150: bound the boot line by the RUNNING gateway's process start
+  // (from OpenClaw's boot-lifecycle table). A line from a previous process, or
+  // one we cannot bound, yields null — "cannot prove", never a stale answer.
+  let bootAtMs: number | null = null;
   const readRoster =
     options.readLiveRoster ??
-    (() => (process.env.JEST_WORKER_ID !== undefined ? null : (readLatestBootRoster()?.plugins ?? null)));
+    (() => {
+      if (process.env.JEST_WORKER_ID !== undefined) return null;
+      const proc = readRunningGatewayProcess(home);
+      if (!proc) return null;
+      const boot = readLatestBootRoster({ processStartedAtMs: proc.startedAtMs });
+      bootAtMs = boot?.atMs ?? null;
+      return boot?.plugins ?? null;
+    });
+  const liveRoster = readRoster();
+  const registrationSeenAfterBoot =
+    liveRoster != null &&
+    !liveRoster.includes(pluginId) &&
+    process.env.JEST_WORKER_ID === undefined &&
+    bootAtMs != null &&
+    findRegistrationSince(bootAtMs) != null;
   return {
     pluginId,
     expectedVersion: options.expectedVersion,
@@ -552,7 +589,8 @@ export function gatherReconcileInput(home: string, options: GatherOptions): Reco
     index: readIndex(home),
     onDiskVersion: readInstalledRealtimePluginVersion(home),
     projectDirs: scanProjectDirs(home, pluginId),
-    liveRoster: readRoster(),
+    liveRoster,
+    registrationSeenAfterBoot,
   };
 }
 

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { spawnSync } from 'child_process';
 import {
+  type ReconcileInput,
   gatherReconcileInput,
   reconcilePluginState,
   planReconcileActions,
@@ -40,7 +41,16 @@ export interface StepResult {
 }
 
 export interface ReconcileExecResult {
+  /** The state BEFORE remediation — what the plan was computed from. */
   verdict: ReconcileVerdict;
+  /**
+   * The state re-read AFTER remediation (#145). The closing report must be
+   * shaped by this, never by `verdict`: echoing the pre-remediation snapshot
+   * produced "FAILED: version-regressed (4.47.16 running)" seconds after a
+   * successful upgrade to 4.47.19 — a false red that sends operators to
+   * re-remediate a healthy box. Absent on dry-runs (nothing changed).
+   */
+  postVerdict?: ReconcileVerdict;
   plan: ReconcileStep[];
   applied: boolean;
   stepResults: StepResult[];
@@ -67,6 +77,13 @@ export interface ReconcileOptions {
   selfCheck?: (home: string, pluginId: string) => Promise<SelfCheckRunResult>;
   /** Injectable duplicate-dir pruner (defaults to rm -rf of the project dir). */
   pruneDir?: (home: string, dirName: string) => void;
+  /**
+   * Injectable state reader, used for the pre-remediation read AND the #145
+   * post-remediation re-read (defaults to gather + reconcile against the
+   * host). One seam for both so a test cannot accidentally pin only the pre
+   * path and leave the re-read unproven.
+   */
+  readState?: () => { input: ReconcileInput; verdict: ReconcileVerdict };
 }
 
 function defaultApply(): boolean {
@@ -116,9 +133,14 @@ export async function reconcileOpenClawPluginState(options: ReconcileOptions): P
   const pruneDir = options.pruneDir ?? defaultPruneDir;
 
   const messages: string[] = [];
-  const input = gatherReconcileInput(home, { pluginId, expectedVersion: options.expectedVersion });
-  const verdict = reconcilePluginState(input);
-  messages.push(`state: ${verdict.state} (${verdict.severity}) — ${verdict.reasons[verdict.reasons.length - 1] ?? ''}`);
+  const readState =
+    options.readState ??
+    (() => {
+      const i = gatherReconcileInput(home, { pluginId, expectedVersion: options.expectedVersion });
+      return { input: i, verdict: reconcilePluginState(i) };
+    });
+  const { input, verdict } = readState();
+  messages.push(`state before remediation: ${verdict.state} (${verdict.severity}) — ${verdict.reasons[verdict.reasons.length - 1] ?? ''}`);
 
   // Determine which duplicate dirs are prunable. The keep-dir is resolved from
   // the AUTHORITATIVE SQLite index (never installs.json, which in a conflicted
@@ -185,6 +207,12 @@ export async function reconcileOpenClawPluginState(options: ReconcileOptions): P
     if (!ok) messages.push(`command failed (openclaw ${(step.command ?? []).join(' ')}): ${r.output.trim().split('\n').slice(-1)[0] ?? ''}`);
   }
 
+  // #145: re-read the state AFTER remediation. The pre-remediation snapshot is
+  // now history — a closing line shaped by it reported "version-regressed
+  // (4.47.16 running)" seconds after the very reload that fixed it.
+  const postVerdict = readState().verdict;
+  messages.push(`state after remediation: ${postVerdict.state} (${postVerdict.severity}) — ${postVerdict.reasons[postVerdict.reasons.length - 1] ?? ''}`);
+
   // Honest-state contract: overall success ONLY if the self-check ran AND passed.
   const selfCheckOk = Boolean(selfCheckResult?.ok);
   const commandsOk = stepResults.filter((s) => s.kind.startsWith('openclaw')).every((s) => s.ok);
@@ -204,7 +232,7 @@ export async function reconcileOpenClawPluginState(options: ReconcileOptions): P
     messages.push('reconciled: plugin confirmed loaded (roster) and enforcing (canary)');
   }
 
-  return { verdict, plan, applied: true, stepResults, selfCheck: selfCheckResult, ok, messages };
+  return { verdict, postVerdict, plan, applied: true, stepResults, selfCheck: selfCheckResult, ok, messages };
 }
 
 /**
@@ -244,11 +272,21 @@ export function formatReconcileReport(result: ReconcileExecResult): string[] {
   lines.push('Applied remediation:');
   for (const s of result.stepResults) lines.push(`  ${s.ok ? '✓' : '✗'} ${s.kind}: ${s.detail}`);
   lines.push('');
+  // #145: everything below this line describes the world AFTER remediation.
+  if (result.postVerdict) {
+    lines.push(`Plugin load state after remediation: ${result.postVerdict.state} [${result.postVerdict.severity}]`);
+    for (const r of result.postVerdict.reasons) lines.push(`  • ${r}`);
+    lines.push('');
+  }
   if (result.ok) {
     lines.push('✓ reconciled: plugin confirmed loaded (roster) and enforcing (canary).');
   } else {
     lines.push('✗ FAILED: could not confirm the plugin is loaded AND enforcing.');
     for (const m of result.messages) {
+      // Never echo the PRE-remediation state under the failure banner — that
+      // is the exact false red #145 documents. Post-state and self-check
+      // messages carry the current truth.
+      if (m.startsWith('state before remediation')) continue;
       if (/fail|not confirmed|not run|did not/i.test(m)) lines.push(`  ${m}`);
     }
   }

--- a/src/setup/openclaw-selfcheck.ts
+++ b/src/setup/openclaw-selfcheck.ts
@@ -12,7 +12,8 @@ import {
   readInstalledRealtimePluginVersion,
   resolveRealtimePluginInstallPath,
 } from '../integrations/openclaw-plugin-state.js';
-import { readLatestBootRoster } from '../integrations/openclaw-gateway-roster.js';
+import { readLatestBootRoster, findRegistrationSince, type BootRoster } from '../integrations/openclaw-gateway-roster.js';
+import { readRunningGatewayProcess } from '../integrations/openclaw-gateway-process.js';
 import { evaluateToolCall } from '../defence/iron-dome/tool-action-guard.js';
 
 /**
@@ -104,6 +105,14 @@ export interface SelfCheckInput {
    * not be read. This — not the install index — is the roster proof (#152).
    */
   liveRoster?: string[] | null;
+  /**
+   * A plugin registration line was sighted AFTER the boot roster snapshot
+   * (#142). Registration races the snapshot (169 ms margin observed live) and
+   * also happens mid-life, so absence-from-snapshot plus a later sighting is
+   * AMBIGUOUS — CLI processes write identical lines — and must yield
+   * `unproven`, never `absent`. It never grants `loaded`; the canary does.
+   */
+  registrationSeenAfterBoot?: boolean;
   /** The build the flow expects to be enforcing; enables the version proof. */
   expectedVersion?: string;
   /** Ground-truth on-disk version, for the version proof. */
@@ -138,8 +147,15 @@ export function evaluateSelfCheck(input: SelfCheckInput): SelfCheckVerdict {
   let rosterState: RosterProofState;
   if (liveRoster == null) {
     rosterState = 'unproven';
+  } else if (liveRoster.includes(pluginId)) {
+    rosterState = 'loaded';
+  } else if (input.registrationSeenAfterBoot === true) {
+    // #142: the boot line is a snapshot and registration races it. A sighting
+    // after the snapshot means the snapshot cannot convict — but because CLI
+    // processes write identical lines, it cannot acquit either.
+    rosterState = 'unproven';
   } else {
-    rosterState = liveRoster.includes(pluginId) ? 'loaded' : 'absent';
+    rosterState = 'absent';
   }
   const rosterProof = rosterState === 'loaded';
 
@@ -150,6 +166,12 @@ export function evaluateSelfCheck(input: SelfCheckInput): SelfCheckVerdict {
     if (enabledInIndex) {
       reasons.push('the SQLite install index lists it as enabled — install state, not load state; the live roster is authoritative');
     }
+  } else if (liveRoster != null && input.registrationSeenAfterBoot === true) {
+    reasons.push(
+      'roster proof INCONCLUSIVE: absent from the boot roster snapshot, but a plugin registration was sighted after that snapshot — ' +
+        'registration races the boot line and CLI processes write identical lines, so neither loaded nor absent can be proven; ' +
+        'the consent-gated live canary is the arbiter',
+    );
   } else {
     // Unreadable. Say only what is true: we cannot prove it either way.
     reasons.push(
@@ -201,9 +223,17 @@ export interface RunSelfCheckOptions {
   readOnDiskVersion?: (home: string) => string | null;
   /**
    * Injectable live-roster reader (defaults to the gateway's newest
-   * `http server listening` boot line). Returns null when it cannot be proven.
+   * `http server listening` boot line, bounded by the running gateway's
+   * process start — a line from a previous process proves nothing, #142/#150).
+   * Returns null when it cannot be proven.
    */
   readLiveRoster?: () => string[] | null;
+  /**
+   * Injectable post-boot registration sighting (defaults to scanning the
+   * gateway logs for a `[shieldcortex] … registered` line newer than the boot
+   * roster snapshot, #142). Only consulted when the roster omits the plugin.
+   */
+  readRegistrationSeenAfterBoot?: () => boolean;
   /** Injectable live enforcement probe (defaults to the guarded real probe). */
   canaryProbe?: (home: string, pluginId: string) => Promise<CanaryResult>;
 }
@@ -232,19 +262,44 @@ export async function runPluginSelfCheck(
   // (/tmp/openclaw), which no `home` override can redirect — so it must never
   // fire under Jest, or a test would silently inherit THIS box's roster and
   // prove nothing. Tests inject readLiveRoster.
+  //
+  // #142/#150: the roster line is bounded by the RUNNING gateway's process
+  // start (from OpenClaw's own boot-lifecycle table). A boot line from a
+  // previous process, or one we cannot bound, yields null — "cannot prove",
+  // never a stale answer wearing a fresh badge.
+  let latestBoot: BootRoster | null | undefined;
   const readRoster =
     options.readLiveRoster ??
-    (() => (process.env.JEST_WORKER_ID !== undefined ? null : (readLatestBootRoster()?.plugins ?? null)));
+    (() => {
+      if (process.env.JEST_WORKER_ID !== undefined) return null;
+      const proc = readRunningGatewayProcess(home);
+      if (!proc) return null;
+      latestBoot = readLatestBootRoster({ processStartedAtMs: proc.startedAtMs });
+      return latestBoot?.plugins ?? null;
+    });
+  // Only meaningful when the bounded boot line exists yet omits the plugin:
+  // a registration sighted after that snapshot means the snapshot cannot
+  // convict (#142's 169 ms race), though it also cannot acquit.
+  const readRegistration =
+    options.readRegistrationSeenAfterBoot ??
+    (() => {
+      if (process.env.JEST_WORKER_ID !== undefined) return false;
+      if (latestBoot?.atMs == null) return false;
+      return findRegistrationSince(latestBoot.atMs) != null;
+    });
   const probe = options.canaryProbe ?? defaultCanaryProbe;
 
   const index = readIndex(home);
   const liveRoster = readRoster();
+  const registrationSeenAfterBoot =
+    liveRoster != null && !liveRoster.includes(pluginId) ? readRegistration() : false;
   const onDiskVersion = options.expectedVersion ? readOnDisk(home) : null;
   const canary = await probe(home, pluginId);
   const verdict = evaluateSelfCheck({
     pluginId,
     index,
     liveRoster,
+    registrationSeenAfterBoot,
     canary,
     expectedVersion: options.expectedVersion,
     onDiskVersion,


### PR DESCRIPTION
Completes the honesty cluster. One rule applied everywhere it was being broken: **no log artifact may be treated as authoritative for process state, and no report may describe a state it has not just read.**

## Foundation
`openclaw-gateway-process.ts` — the running gateway's process start, read from OpenClaw's own `gateway_boot_lifecycle` table and corroborated by pid liveness. Null means "cannot bound the evidence", and every consumer degrades to UNKNOWN/unproven rather than quoting an unbounded log.

## #150 — running version bounded by process start
The Mac reported "v4.14.10 running" off a line written in May. journald is now bounded **at the source** (`--since=@epoch` — its default format carries no year, so per-line dating is impossible there); file logs get per-line ISO dating, and an undatable line cannot be called fresh. No provable line since boot → `running version UNKNOWN`, older sightings labelled as history. Log discovery also gains `/tmp/openclaw` — the layout every current install actually writes, which the old candidate list missed entirely.

## #142 — the boot snapshot can no longer convict alone
- The `processStartedAtMs` guard is wired in production (it was dead code reachable only from tests — suite green, protection absent).
- A registration line sighted **after** the snapshot downgrades absent → new `load-unproven` state (warn): registration races the snapshot (169 ms margin observed live) and CLI processes write identical lines, so a late sighting can neither convict nor acquit. Doctor's message points at the live canary as the arbiter.
- A genuine absence (no sighting) still hard-fails exactly as before — aiquant's real skip remains detectable, pinned by test.

## #145 — repair reports the world after remediation
The state is re-read through the same injectable seam as the pre-read (one seam, so a test cannot pin only half), reported as "state after remediation", and the pre-remediation snapshot can never be echoed under the failure banner. The field case — `FAILED: version-regressed (4.47.16 running)` seconds after a successful upgrade — is a fixture.

## Folded stale PRs
- **#133 (closes #132):** permission-denied is no longer read as a pristine fresh install (errno-split `probePath`), and doctor exits non-zero on failing checks. Semantic-clobber during the merge was caught by the folded tests themselves (the dist was stale — rebuilt, green).
- **#140:** doctor reports the Claude Code version the guard's hook surface depends on, against the enforcement floor. (#139 remains untouched — it changes unattended-session defaults and stays Michael-gated.)

## Verification
- All three new mechanisms delete-verified: remove the fix, its tests go red (4 red on the batch delete).
- 306 suites / 3,469 pass / 0 fail.

Closes #150. Closes #145. Closes #142. Closes #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
