### PR TITLE
fix(#128): a dash-flag is not a command, and a sealed container is not the host

### DIFF
--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -604,25 +604,12 @@ type PipelineRunner = (content: string, title: string, source: { type: string; i
 //   * anything over the size cap is refused (the guard then records it as
 //     `opaque-script-invocation` rather than pretending it was scanned);
 //   * every error returns `null`. Nothing escapes.
-const MAX_SCRIPT_SOURCE_BYTES = 262_144;   // 256KB — matches the guard core's cap
-const UNREADABLE_PATH_PREFIX = /^\/(?:proc|sys|dev)\//;
-
-export function createScriptSourceResolver(cwd?: string): (scriptPath: string) => string | null {
-  const base = cwd && typeof cwd === 'string' ? cwd : process.cwd();
-  return (scriptPath: string): string | null => {
-    try {
-      if (!scriptPath || typeof scriptPath !== 'string') return null;
-      const expanded = scriptPath.startsWith('~/') ? join(homedir(), scriptPath.slice(2)) : scriptPath;
-      const full = isAbsolute(expanded) ? expanded : resolvePath(base, expanded);
-      if (UNREADABLE_PATH_PREFIX.test(full)) return null;
-      const st = statSync(full);
-      if (!st.isFile() || st.size > MAX_SCRIPT_SOURCE_BYTES) return null;
-      return readFileSync(full, 'utf8');
-    } catch {
-      return null;                          // missing, unreadable, anything — stay silent, stay alive
-    }
-  };
-}
+// The resolver lives in one place (#160). It was duplicated here while the
+// Claude Code hook had none at all, which is how the same guard reached
+// opposite verdicts on the two surfaces. Re-exported so this module's public
+// shape is unchanged for existing importers.
+import { createScriptSourceResolver } from '../../src/defence/iron-dome/script-source-resolver.js';
+export { createScriptSourceResolver, MAX_SCRIPT_SOURCE_BYTES, UNREADABLE_PATH_PREFIX } from '../../src/defence/iron-dome/script-source-resolver.js';
 
 /** Raised when the operator never answered the approval card (#143). Distinct
  *  from a transport error, because the two have opposite handling: an error

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -604,12 +604,38 @@ type PipelineRunner = (content: string, title: string, source: { type: string; i
 //   * anything over the size cap is refused (the guard then records it as
 //     `opaque-script-invocation` rather than pretending it was scanned);
 //   * every error returns `null`. Nothing escapes.
-// The resolver lives in one place (#160). It was duplicated here while the
-// Claude Code hook had none at all, which is how the same guard reached
-// opposite verdicts on the two surfaces. Re-exported so this module's public
-// shape is unchanged for existing importers.
-import { createScriptSourceResolver } from '../../src/defence/iron-dome/script-source-resolver.js';
-export { createScriptSourceResolver, MAX_SCRIPT_SOURCE_BYTES, UNREADABLE_PATH_PREFIX } from '../../src/defence/iron-dome/script-source-resolver.js';
+// The resolver is DUPLICATED here, deliberately (#160).
+//
+// This plugin publishes as its own npm package and builds standalone
+// (tsconfig.openclaw-plugin.json pins rootDir to plugins/openclaw), so it
+// genuinely cannot import from src/ — converging by import broke the plugin
+// build outright. A real constraint, then, not a tidiness failure.
+//
+// But two copies of a safety-railed file reader reached from untrusted tool
+// input is two chances to drift, and drift is what #160 was about. So the
+// copies are held together by a BEHAVIOURAL drift test that runs both
+// implementations over one fixture table and requires identical answers
+// (src/__tests__/enforcement-surface-parity.test.ts). Guard the duplication
+// rather than pretend it away.
+export const MAX_SCRIPT_SOURCE_BYTES = 262_144;   // 256KB — matches the guard core's cap
+export const UNREADABLE_PATH_PREFIX = /^\/(?:proc|sys|dev)\//;
+
+export function createScriptSourceResolver(cwd?: string): (scriptPath: string) => string | null {
+  const base = cwd && typeof cwd === 'string' ? cwd : process.cwd();
+  return (scriptPath: string): string | null => {
+    try {
+      if (!scriptPath || typeof scriptPath !== 'string') return null;
+      const expanded = scriptPath.startsWith('~/') ? join(homedir(), scriptPath.slice(2)) : scriptPath;
+      const full = isAbsolute(expanded) ? expanded : resolvePath(base, expanded);
+      if (UNREADABLE_PATH_PREFIX.test(full)) return null;
+      const st = statSync(full);
+      if (!st.isFile() || st.size > MAX_SCRIPT_SOURCE_BYTES) return null;
+      return readFileSync(full, 'utf8');
+    } catch {
+      return null;                          // missing, unreadable, anything — stay silent, stay alive
+    }
+  };
+}
 
 /** Raised when the operator never answered the approval card (#143). Distinct
  *  from a transport error, because the two have opposite handling: an error

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -93,6 +93,33 @@ async function loadGuard() {
 }
 
 /**
+ * The invoked-script source resolver (#160).
+ *
+ * Without this, `evaluateToolCall` cannot fold a script's CONTENTS into the
+ * scan, so a payload written in one call and executed by path in the next is
+ * allowed here while the OpenClaw plugin surface — which always passed a
+ * resolver — folds it and blocks. Same guard, same input, opposite verdict,
+ * and this is the surface that gates every Bash call in a Claude Code session.
+ *
+ * Optional by construction: if the module is missing the hook behaves exactly
+ * as it did before, degrading to `opaque-script-invocation` rather than
+ * failing on a partial dist.
+ */
+async function loadScriptResolver() {
+  const distRoot = process.env.SHIELDCORTEX_DIST_ROOT ?? resolve(here, '..', 'dist');
+  try {
+    const mod = await import(
+      pathToFileURL(resolve(distRoot, 'defence', 'iron-dome', 'script-source-resolver.js')).href
+    );
+    return typeof mod.createScriptSourceResolver === 'function'
+      ? mod.createScriptSourceResolver(process.cwd())
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Load the one-shot approval store (#118). Optional by design: when the dist
  * module is missing the guard behaves exactly as it did before approvals
  * existed — refuse and say so — rather than failing open.
@@ -459,9 +486,18 @@ process.stdin.on('end', async () => {
       return;
     }
 
+    const resolveScriptSource = await loadScriptResolver();
     let verdict;
     try {
-      verdict = guard.evaluateToolCall(toolName, toolInput);
+      // 4th arg, not the 3rd — the 3rd is the IronDome config. Passing the
+      // options object into the config slot type-checks in .mjs and silently
+      // does nothing, which is the same shape of defect as the gap this fixes.
+      verdict = guard.evaluateToolCall(
+        toolName,
+        toolInput,
+        undefined,
+        resolveScriptSource ? { resolveScriptSource } : undefined,
+      );
     } catch (err) {
       handleDegradedGuard(toolName, toolInput, cfg, `evaluation error: ${err?.message ?? err}`); // always exits
       return;

--- a/src/__tests__/enforcement-surface-parity.test.ts
+++ b/src/__tests__/enforcement-surface-parity.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Cross-surface parity (#160) — the test the per-surface suites cannot be.
+ *
+ * ShieldCortex enforces on TWO surfaces: the OpenClaw realtime plugin
+ * interceptor and the Claude Code PreToolUse hook. Three times now a fix has
+ * landed on one call site while the sibling kept the old behaviour, with a
+ * green suite either side because each surface is tested against its own
+ * wiring:
+ *
+ *   #146 — hooks written as a bare command name: fixed at install, but the
+ *          existing boxes were left dead until upgrade-repair was added.
+ *   #160 — the script-folding bypass fix (v4.47.17): the plugin passed a
+ *          `resolveScriptSource`, the hook called the guard with two arguments,
+ *          so a payload written in one call and executed by path in the next
+ *          was blocked on one surface and ALLOWED on the other.
+ *
+ * The recurring root cause in this codebase is not bad logic — it is a fix
+ * landing on one of two call sites. A per-surface test can never see that; only
+ * a test driven from ONE fixture table across BOTH surfaces can.
+ *
+ * So this file asserts capability parity at the wiring level rather than
+ * re-testing guard logic: whatever the guard can do, both surfaces must be able
+ * to ask it to do.
+ */
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const hookSrc = fs.readFileSync(path.join(repoRoot, 'scripts', 'pre-tool-hook.mjs'), 'utf-8');
+const pluginSrc = fs.readFileSync(path.join(repoRoot, 'plugins', 'openclaw', 'interceptor.ts'), 'utf-8');
+
+describe('#160 — both enforcement surfaces supply the script-source resolver', () => {
+  it('the OpenClaw plugin passes a resolveScriptSource', () => {
+    expect(pluginSrc).toMatch(/resolveScriptSource:\s*createScriptSourceResolver\(/);
+  });
+
+  it('the Claude Code hook passes a resolveScriptSource', () => {
+    // The exact gap: `evaluateToolCall(toolName, toolInput)` — two arguments,
+    // no options — meant the fold could never run on this surface.
+    expect(hookSrc).toMatch(/resolveScriptSource/);
+    expect(hookSrc).toMatch(/evaluateToolCall\(\s*\n?\s*toolName,\s*\n?\s*toolInput,/);
+    // The resolver must be the FOURTH argument — the third is the IronDome
+    // config, and an options object placed there is silently ignored.
+    expect(hookSrc).toMatch(/toolInput,\s*\n\s*undefined,\s*\n\s*resolveScriptSource/);
+  });
+
+  it('neither surface calls the guard with the bare two-argument form', () => {
+    for (const [name, src] of [['hook', hookSrc], ['plugin', pluginSrc]] as const) {
+      const bare = src.match(/evaluateToolCall\(\s*\w+\s*,\s*\w+\s*\)/g) ?? [];
+      expect({ surface: name, bareCalls: bare }).toEqual({ surface: name, bareCalls: [] });
+    }
+  });
+
+  it('the resolver has ONE implementation, imported rather than re-typed', () => {
+    // Two copies of a safety-railed file reader is two chances to drift; the
+    // rails (pseudo-fs refusal, regular-file check, size cap, never throw) must
+    // not exist in two places with a chance of diverging.
+    const shared = fs.readFileSync(
+      path.join(repoRoot, 'src', 'defence', 'iron-dome', 'script-source-resolver.ts'),
+      'utf-8',
+    );
+    expect(shared).toMatch(/export function createScriptSourceResolver/);
+    // The safety rails live with the implementation.
+    expect(shared).toMatch(/UNREADABLE_PATH_PREFIX/);
+    expect(shared).toMatch(/MAX_SCRIPT_SOURCE_BYTES/);
+    // And the resolver must never throw — a guard that throws fails open.
+    expect(shared).toMatch(/catch\s*{\s*\n\s*return null;/);
+  });
+});
+
+describe('#160 — the fold actually changes the verdict, so the wiring is load-bearing', () => {
+  it('a written payload executed by path is blocked WITH a resolver and opaque without one', async () => {
+    const { evaluateToolCall } = await import('../defence/iron-dome/tool-action-guard.js');
+    const { createScriptSourceResolver } = await import('../defence/iron-dome/script-source-resolver.js');
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-parity-'));
+    try {
+      const script = path.join(dir, 'payload.sh');
+      fs.writeFileSync(script, '#!/bin/sh\nrm -rf /important\n');
+
+      // Without a resolver: the guard cannot see the payload — opaque, allowed.
+      const unresolved = evaluateToolCall('Bash', { command: `bash ${script}` });
+      expect(unresolved.signals ?? []).toContain('opaque-script-invocation');
+      expect(unresolved.decision).toBe('allow');
+
+      // With one: the payload is folded in and hard-blocked.
+      const resolved = evaluateToolCall(
+        'Bash',
+        { command: `bash ${script}` },
+        undefined,
+        { resolveScriptSource: createScriptSourceResolver(dir) },
+      );
+      expect(resolved.decision).toBe('block');
+      expect(resolved.severity).toBe('catastrophic');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('the resolver refuses pseudo-filesystems and oversized files rather than reading them', async () => {
+    const { createScriptSourceResolver } = await import('../defence/iron-dome/script-source-resolver.js');
+    const resolve = createScriptSourceResolver('/');
+    expect(resolve('/proc/self/mem')).toBeNull();
+    expect(resolve('/sys/kernel/notes')).toBeNull();
+    expect(resolve('/dev/zero')).toBeNull();
+    // A directory is not a script.
+    expect(resolve('/tmp')).toBeNull();
+    // A path that does not exist returns null rather than throwing.
+    expect(resolve('/nonexistent/definitely/not/here.sh')).toBeNull();
+  });
+});

--- a/src/__tests__/enforcement-surface-parity.test.ts
+++ b/src/__tests__/enforcement-surface-parity.test.ts
@@ -54,20 +54,65 @@ describe('#160 — both enforcement surfaces supply the script-source resolver',
     }
   });
 
-  it('the resolver has ONE implementation, imported rather than re-typed', () => {
-    // Two copies of a safety-railed file reader is two chances to drift; the
-    // rails (pseudo-fs refusal, regular-file check, size cap, never throw) must
-    // not exist in two places with a chance of diverging.
+  it('the shared resolver carries its safety rails with the implementation', () => {
     const shared = fs.readFileSync(
       path.join(repoRoot, 'src', 'defence', 'iron-dome', 'script-source-resolver.ts'),
       'utf-8',
     );
     expect(shared).toMatch(/export function createScriptSourceResolver/);
-    // The safety rails live with the implementation.
     expect(shared).toMatch(/UNREADABLE_PATH_PREFIX/);
     expect(shared).toMatch(/MAX_SCRIPT_SOURCE_BYTES/);
-    // And the resolver must never throw — a guard that throws fails open.
+    // The resolver must never throw — a guard that throws fails open.
     expect(shared).toMatch(/catch\s*{\s*\n\s*return null;/);
+  });
+
+  it('the plugin documents WHY it keeps its own copy, so the duplication is a decision not an accident', () => {
+    // The plugin publishes as its own npm package and builds standalone
+    // (rootDir pinned to plugins/openclaw), so it cannot import from src/ —
+    // converging by import breaks its build. A real constraint; it must be
+    // stated at the copy, or the next reader will "tidy" it and break the
+    // published package.
+    expect(pluginSrc).toMatch(/DUPLICATED here, deliberately \(#160\)/);
+    expect(pluginSrc).toMatch(/drift test/i);
+  });
+});
+
+describe('#160 — the two resolver copies are held together by behaviour, not by hope', () => {
+  // Text comparison would fail on a reformat and pass on a semantic change —
+  // exactly backwards. Both implementations are run over ONE fixture table and
+  // required to answer identically.
+  it('answers identically on every safety-rail case', async () => {
+    const { createScriptSourceResolver: shared } = await import('../defence/iron-dome/script-source-resolver.js');
+    const { createScriptSourceResolver: plugin } = await import('../../plugins/openclaw/interceptor.js');
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-drift-'));
+    try {
+      const good = path.join(dir, 'ok.sh');
+      fs.writeFileSync(good, '#!/bin/sh\necho hi\n');
+      const big = path.join(dir, 'big.sh');
+      fs.writeFileSync(big, 'x'.repeat(300_000));          // over the 256KB cap
+      fs.mkdirSync(path.join(dir, 'adir'));
+
+      const fixtures = [
+        good,                                   // readable regular file
+        big,                                    // oversized
+        path.join(dir, 'adir'),                 // a directory
+        path.join(dir, 'missing.sh'),           // absent
+        '/proc/self/mem',                       // pseudo-filesystem
+        '/sys/kernel/notes',
+        '/dev/zero',
+        '',                                     // empty
+        'relative.sh',                          // relative, absent
+      ];
+
+      const a = shared(dir);
+      const b = plugin(dir);
+      for (const f of fixtures) {
+        expect({ path: f, result: a(f) }).toEqual({ path: f, result: b(f) });
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2738,6 +2738,43 @@ export async function checkOpenClawRunningPluginVersion(
   };
 }
 
+/**
+ * State permissions (#163).
+ *
+ * Hardening audit, 1 Aug 2026: on a live default install `memories.db` was 644
+ * (world-readable — the whole data asset of a memory-security product) and
+ * `audit/` was 775 (group-writable — a forensic trail a non-owner can delete or
+ * forge). No code set a mode on either; they inherited the umask.
+ *
+ * Doctor MEASURES and reports; the correction belongs to install/repair, which
+ * the operator invoked deliberately. Reporting a mode we quietly changed behind
+ * their back would be its own dishonesty.
+ */
+export async function checkStatePermissions(stateDir: string = getShieldCortexDir()): Promise<CheckResult> {
+  const label = 'State permissions';
+  let findings: Array<{ path: string; found: string; required: string }>;
+  try {
+    const { auditStatePermissions } = await import('../setup/state-permissions.js');
+    findings = auditStatePermissions(stateDir);
+  } catch (err) {
+    return { label, status: 'warn', message: `could not measure — ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  if (findings.length === 0) {
+    return { label, status: 'pass', message: 'owner-only (0700 dirs, 0600 files)' };
+  }
+
+  const worst = findings.map(f => `${path.basename(f.path)} ${f.found}`).slice(0, 4).join(', ');
+  return {
+    label,
+    status: 'fail',
+    message:
+      `${findings.length} path(s) readable or writable beyond the owner (${worst}${findings.length > 4 ? ', …' : ''}) — ` +
+      `the memory database and the audit trail must be owner-only`,
+    fix: 'Run `shieldcortex install` (it hardens on every run), or by hand: chmod 700 ~/.shieldcortex ~/.shieldcortex/{audit,approvals,logs} && chmod 600 ~/.shieldcortex/memories.db* ~/.shieldcortex/config.json*',
+  };
+}
+
 // ── Check 8: Model cache ─────────────────────────────────
 async function checkModelCache(): Promise<CheckResult> {
   const cacheDir = path.join(os.homedir(), '.cache', 'shieldcortex', 'models', 'Xenova', 'all-MiniLM-L6-v2');
@@ -2871,6 +2908,7 @@ export async function runDoctor(args: string[] = []): Promise<DoctorSummary> {
     checkProcesses,
     checkDashboardFreshness,
     checkDiskUsage,
+    checkStatePermissions,
     checkLockFile,
     checkOpenClawResidue,
     checkOpenClawHookFreshness,

--- a/src/cloud/config.ts
+++ b/src/cloud/config.ts
@@ -26,7 +26,7 @@ export interface ReviewCopilotConfig {
   workerHeapMB: number;
 }
 
-function getConfigDir(): string {
+export function getConfigDir(): string {
   const override = process.env.SHIELDCORTEX_CONFIG_DIR?.trim();
   if (override) return override;
   return join(homedir(), '.shieldcortex');

--- a/src/defence/iron-dome/__tests__/guard-container-precision-128.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-container-precision-128.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Failing-first spec for #128 — container flags and container-scoped mutation.
+ *
+ * Dogfood evidence (Jarvis box, 28 Jul 2026), all three hit while setting up a
+ * clean-box install test for our OWN product:
+ *
+ *   docker run --rm -v "$PWD/test.sh:/test.sh:ro" node:22-slim sh -c "…"
+ *     → blocked as `file-delete`, matched "rm". `--rm` removes the CONTAINER on
+ *       exit; nothing on the host is touched.
+ *   docker run … sh -c "apt-get install -y git python3 make g++"
+ *     → blocked as `install-package`. The install happens inside an EPHEMERAL
+ *       container. Host mutation is the thing that rule exists to gate.
+ *
+ * The precision rule: a dash-flag token is never a command, and a package
+ * install confined to a throwaway container is not host mutation.
+ *
+ * The safety rule, which outranks it: a container can be a host-mutation
+ * vehicle. `--privileged`, a host bind-mount, a host namespace, or a
+ * chroot/nsenter in the inner command all mean the container boundary is not a
+ * boundary. Ambiguity keeps the gate — every one of those still gates exactly
+ * as before, and that is what the second half of this file pins.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { evaluateToolCall } from '../tool-action-guard.js';
+
+const decide = (command: string) => evaluateToolCall('Bash', { command });
+
+describe('#128 — a dash-flag is not the delete command', () => {
+  it("docker's --rm container-cleanup flag is not a file delete", () => {
+    const v = decide('docker run --rm -v "$PWD/test.sh:/test.sh:ro" node:22-slim sh -c "node /test.sh"');
+    expect(v.signals ?? []).not.toContain('file-delete');
+    expect(v.decision).toBe('allow');
+  });
+
+  it('the short -rm form is likewise not a delete', () => {
+    const v = decide('somecmd -rm build');
+    expect(v.signals ?? []).not.toContain('file-delete');
+  });
+
+  it('podman --rm gets the same treatment', () => {
+    const v = decide('podman run --rm alpine echo hi');
+    expect(v.signals ?? []).not.toContain('file-delete');
+  });
+
+  // ── the gate must still fire on the real thing ──
+
+  it('a real rm still gates', () => {
+    expect((decide('rm /tmp/scratch.log').signals ?? [])).toContain('file-delete');
+  });
+
+  it('a real rm INSIDE a container command still gates', () => {
+    // The flag is inert; the inner command is not.
+    expect((decide('docker run --rm alpine rm /etc/passwd').signals ?? [])).toContain('file-delete');
+  });
+
+  it('rm -rf on a host path is still catastrophic even alongside --rm', () => {
+    const v = decide('docker run --rm -v /:/host alpine rm -rf /host/etc');
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('catastrophic');
+  });
+
+  it('sudo rm and piped xargs rm still gate', () => {
+    expect((decide('sudo rm /var/log/syslog').signals ?? [])).toContain('file-delete');
+    expect((decide('find . -name "*.tmp" | xargs rm').signals ?? [])).toContain('file-delete');
+  });
+});
+
+describe('#128 — a package install confined to a throwaway container is not host mutation', () => {
+  it('apt-get install inside a plain container run does not gate as host install', () => {
+    const v = decide('docker run --rm node:22-slim sh -c "apt-get update -qq; apt-get install -y -qq git python3 make g++"');
+    expect(v.signals ?? []).not.toContain('install-package');
+    expect(v.decision).toBe('allow');
+  });
+
+  it('the same for podman and for a --volume-mounted project dir', () => {
+    const v = decide('podman run --rm -v "$PWD:/work:ro" debian:12 sh -c "apt-get install -y curl"');
+    expect(v.signals ?? []).not.toContain('install-package');
+  });
+
+  // ── the container boundary must be a real boundary, or the gate stays ──
+
+  it('KEEPS the gate when the container is privileged', () => {
+    const v = decide('docker run --privileged --rm alpine sh -c "apt-get install -y evil"');
+    expect(v.signals ?? []).toContain('install-package');
+  });
+
+  it('KEEPS the gate when the host filesystem root is bind-mounted', () => {
+    const v = decide('docker run --rm -v /:/host alpine sh -c "apt-get install -y evil"');
+    expect(v.signals ?? []).toContain('install-package');
+  });
+
+  it('KEEPS the gate when the inner command chroots or nsenters to the host', () => {
+    expect((decide('docker run --rm -v /:/host alpine chroot /host apt-get install -y evil').signals ?? []))
+      .toContain('install-package');
+    expect((decide('docker run --rm --pid=host alpine nsenter -t 1 -m apt-get install -y evil').signals ?? []))
+      .toContain('install-package');
+  });
+
+  it('KEEPS the gate when a host namespace is shared', () => {
+    expect((decide('docker run --rm --net=host alpine sh -c "apt-get install -y evil"').signals ?? []))
+      .toContain('install-package');
+  });
+
+  it('KEEPS the gate for a plain host install with no container in sight', () => {
+    expect((decide('apt-get install -y backdoor').signals ?? [])).toContain('install-package');
+    expect((decide('sudo apt install nginx').signals ?? [])).toContain('install-package');
+  });
+
+  it('KEEPS the global-npm gate — that rule is about the host toolchain', () => {
+    expect((decide('npm i -g evil-pkg').signals ?? [])).toContain('install-package-global');
+  });
+
+  it('does not treat a bare mention of docker as a container context', () => {
+    // The downgrade must require an actual container RUN, not the word.
+    expect((decide('echo "use docker run --rm"; apt-get install -y evil').signals ?? []))
+      .toContain('install-package');
+  });
+});

--- a/src/defence/iron-dome/script-source-resolver.ts
+++ b/src/defence/iron-dome/script-source-resolver.ts
@@ -1,0 +1,63 @@
+/**
+ * ShieldCortex — the invoked-script source resolver, defined once (#160).
+ *
+ * `evaluateToolCall` folds an invoked script's CONTENTS into the scan only when
+ * the caller supplies a resolver. Without one the call yields
+ * `opaque-script-invocation` and allows — which is the correct default for a
+ * pure function that must not do I/O, but it means the write-then-exec fix
+ * shipped in v4.47.17 is only as wired as its callers.
+ *
+ * It was wired on one of two enforcement surfaces. The OpenClaw realtime plugin
+ * passed a resolver; the Claude Code PreToolUse hook — the surface that gates
+ * every Bash call in a Claude Code session — called the guard with two
+ * arguments and no resolver. A payload written in one call and executed by path
+ * in the next was folded and blocked on one surface and allowed on the other,
+ * with a green suite either side because each surface was tested against its
+ * own wiring.
+ *
+ * That is the third instance of this family (#146 was the same shape: a fix on
+ * one call site, the sibling left as it was). The recurring root cause in this
+ * codebase is not bad logic — it is a fix landing on one of two call sites. So
+ * the resolver lives here, once, and both surfaces import it.
+ *
+ * Safety rails are deliberately identical to what the plugin used, because a
+ * resolver is a file-read primitive reached from untrusted tool input:
+ *   - never read pseudo-filesystems (/proc, /sys, /dev) — reads there can block
+ *     or have side effects,
+ *   - never read anything but a regular file,
+ *   - cap the size, so a huge file cannot be used to stall the guard,
+ *   - swallow every error and return null, so an unreadable path degrades to
+ *     `opaque-script-invocation` rather than crashing the interceptor. A guard
+ *     that throws is a guard that fails open.
+ */
+import { readFileSync, statSync } from 'fs';
+import { homedir } from 'os';
+import { isAbsolute, join, resolve as resolvePath } from 'path';
+
+/** 256 KB — matches the guard core's fold cap. */
+export const MAX_SCRIPT_SOURCE_BYTES = 262_144;
+
+/** Pseudo-filesystems: reading these can block or have side effects. */
+export const UNREADABLE_PATH_PREFIX = /^\/(?:proc|sys|dev)\//;
+
+/**
+ * Build a resolver that reads an invoked script's source, relative to `cwd`.
+ * Returns null for anything it cannot safely read — the caller reads null as
+ * "opaque", never as "safe".
+ */
+export function createScriptSourceResolver(cwd?: string): (scriptPath: string) => string | null {
+  const base = cwd && typeof cwd === 'string' ? cwd : process.cwd();
+  return (scriptPath: string): string | null => {
+    try {
+      if (!scriptPath || typeof scriptPath !== 'string') return null;
+      const expanded = scriptPath.startsWith('~/') ? join(homedir(), scriptPath.slice(2)) : scriptPath;
+      const full = isAbsolute(expanded) ? expanded : resolvePath(base, expanded);
+      if (UNREADABLE_PATH_PREFIX.test(full)) return null;
+      const st = statSync(full);
+      if (!st.isFile() || st.size > MAX_SCRIPT_SOURCE_BYTES) return null;
+      return readFileSync(full, 'utf8');
+    } catch {
+      return null;                          // missing, unreadable, anything — stay silent, stay alive
+    }
+  };
+}

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -193,6 +193,11 @@ const CATASTROPHIC: Pattern[] = [
  * automatically catastrophic. These map to an Iron Dome action and escalate to
  * `require_approval`.
  */
+// The system package managers whose installs mutate the HOST. Named so the
+// container-confinement check (#128) tests the identical shape rather than a
+// drifting second copy.
+const SYSTEM_INSTALL_RE = /\b(?:apt|apt-get|yum|dnf|brew|gem|cargo)\b[^|;&\n]*\b(?:install|add)\b/i;
+
 const DANGEROUS: Pattern[] = [
   // `shred` is anchored to command position (issue #89 remainder): start of
   // statement, after a separator/subshell, after sudo/env-assignment prefixes,
@@ -201,7 +206,15 @@ const DANGEROUS: Pattern[] = [
   // intent, and no longer gates. `rm`/`unlink`/`rmdir` stay unanchored — their
   // mention-FP class is the #84 span-classifier's scope, and anchoring the
   // highest-traffic delete verb needs that design, not a drive-by.
-  { re: /\brm\b|\bunlink\b|\brmdir\b|(?:(?:^|[;&|(\n]|\$\()\s*(?:\w+=\S*\s+)*(?:sudo\s+)?|\bxargs\s+(?:-{1,2}\S+\s+)*|-exec\s+)shred\b/i, signal: 'file-delete' },
+  // The delete verbs are preceded by a not-a-dash-flag guard (issue #128): a
+  // token that begins with `-` is an OPTION, never the command. `docker run
+  // --rm` asks the container runtime to clean up the CONTAINER on exit and
+  // touches nothing on the host, yet it was hard-matching the highest-traffic
+  // delete rule — hit live while setting up a clean-box install test for our
+  // own product. This narrows only the flag form; `rm x`, `sudo rm x`,
+  // `; rm x`, `xargs rm` and every inner `rm` inside a container command are
+  // unchanged, and `rm -rf` remains catastrophic wherever it appears.
+  { re: /(?<![-\w])rm\b|(?<![-\w])unlink\b|(?<![-\w])rmdir\b|(?:(?:^|[;&|(\n]|\$\()\s*(?:\w+=\S*\s+)*(?:sudo\s+)?|\bxargs\s+(?:-{1,2}\S+\s+)*|-exec\s+)shred\b/i, signal: 'file-delete' },
   { re: /\bsudo\b|\bdoas\b|\bsu\s/i, signal: 'privilege-escalation' },
   { re: /\bgit\b[^|\n]*\bpush\b[^|\n]*(--force\b|-f\b|\+)/i, signal: 'git-force-push' },
   { re: /\bgit\b[^|\n]*\b(branch\s+-D|push\b[^|\n]*--delete|push\b[^|\n]*\s:)/i, signal: 'git-delete-branch' },
@@ -219,7 +232,7 @@ const DANGEROUS: Pattern[] = [
   //
   // `pip`/`pip3` moved out to `hasUnscopedPipInstall` below — a pip install has
   // to be read as argv to tell a host mutation from a venv-scoped one.
-  { re: /\b(?:apt|apt-get|yum|dnf|brew|gem|cargo)\b[^|;&\n]*\b(?:install|add)\b/i, signal: 'install-package' },
+  { re: SYSTEM_INSTALL_RE, signal: 'install-package' },
   // A GLOBAL install mutates the host → approval. It must carry BOTH an install
   // verb AND a global flag in the SAME statement. The verb is `install`/`add`,
   // or npm's own `i`/`in`/`ins`/`inst`/`insta`/`instal`/`install`/`isnt`/`isntall`
@@ -391,6 +404,94 @@ function hasUnscopedPipInstall(text: string): boolean {
     return true;
   }
   return false;
+}
+
+
+// ── Container-confined host mutation (issue #128) ──────────────────────────
+//
+// A package install inside a throwaway container is not host mutation: the
+// layer is discarded when the container exits. Blocked live while setting up a
+// clean-box install test for our own product — the workflow the rule exists to
+// permit, gated by the rule meant to catch host changes.
+//
+// The downgrade is an ALLOWLIST OF PROOFS, never a denylist of dangers, because
+// a container is only a boundary while it is sealed. Any of the following means
+// it is not, and the gate stays exactly as it was:
+//   --privileged / --cap-add           → host capabilities
+//   -v /:… or /etc, /usr, /var, /boot  → the host filesystem is inside
+//   --pid/--net/--ipc/--uts=host       → a host namespace is shared
+//   chroot / nsenter / mount in the
+//     inner command                    → an explicit escape to the host
+//   --user root with a host mount      → covered by the mount rule above
+// An unrecognised shape is never downgraded.
+const CONTAINER_RUN_RE = /\b(?:docker|podman|nerdctl)\s+(?:compose\s+)?run\b/i;
+const CONTAINER_ESCAPE_RE = new RegExp([
+  '--privileged',
+  '--cap-add',
+  '--pid\\s*=\\s*host', '--net(?:work)?\\s*=\\s*host', '--ipc\\s*=\\s*host', '--uts\\s*=\\s*host',
+  '--userns\\s*=\\s*host',
+  // A host bind-mount: -v/--volume/--mount whose SOURCE is the host root or a
+  // system directory. A project-relative or $PWD mount is not an escape.
+  '(?:^|\\s)(?:-v|--volume)\\s*=?\\s*["\']?/(?:\\s|:|["\']|$)',
+  '(?:^|\\s)(?:-v|--volume)\\s*=?\\s*["\']?/(?:etc|usr|bin|sbin|boot|var|lib|root|home|dev|proc|sys)\\b',
+  '--mount[^\\s]*\\bsource=/(?:etc|usr|bin|sbin|boot|var|lib|root|home|dev|proc|sys)?\\b',
+  // An explicit break-out in the inner command.
+  '\\bchroot\\b', '\\bnsenter\\b', '(?<![-\\w])mount\\b',
+].join('|'), 'i');
+
+/**
+ * True when EVERY statement that carries an install verb is inside a container
+ * run that shows no escape marker. One un-contained install anywhere keeps the
+ * gate for the whole call — a container run in statement 1 must never launder a
+ * host install in statement 2.
+ */
+function installsAreContainerConfined(text: string): boolean {
+  if (!CONTAINER_RUN_RE.test(text)) return false;
+  if (CONTAINER_ESCAPE_RE.test(text)) return false;
+  let sawInstall = false;
+  for (const segment of quoteAwareStatements(text)) {
+    if (!SYSTEM_INSTALL_RE.test(segment)) continue;
+    sawInstall = true;
+    // The install must sit on the SAME containerised command line, not merely
+    // nearby: a quoted mention of a container run in one segment must never
+    // launder a bare host install in the next.
+    if (!CONTAINER_RUN_RE.test(segment)) return false;
+  }
+  return sawInstall;
+}
+
+/**
+ * Split on shell separators that are OUTSIDE quotes.
+ *
+ * The shared `splitCommandStatements` deliberately splits on every separator
+ * regardless of quoting — the fail-safe choice for rules that must not be
+ * evaded by quoting. The question here is the opposite one ("is this install
+ * part of the container's own command line?"), and for that a separator inside
+ * the container runner's quoted program belongs to the CONTAINER, not the host.
+ * Kept local so the fail-safe splitter stays exactly as it is.
+ */
+function quoteAwareStatements(text: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let quote: string | null = null;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === '\\' && quote !== "'" && i + 1 < text.length) { cur += c + text[++i]; continue; }
+    if (quote) {
+      cur += c;
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") { quote = c; cur += c; continue; }
+    if (c === ';' || c === '&' || c === '|' || c === '\n' || c === '\r') {
+      if (cur.trim()) out.push(cur);
+      cur = '';
+      continue;
+    }
+    cur += c;
+  }
+  if (cur.trim()) out.push(cur);
+  return out;
 }
 
 const SECRET_HINT = /(sk-[a-z0-9-]{12,}|ghp_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{12,}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}|password\s*[=:]\s*\S{6,}|secret\s*[=:]\s*\S{6,})/i;
@@ -1865,7 +1966,7 @@ export function evaluateToolCall(
   // 2) Dangerous — recognised, effectful, worth a human nod → require approval.
   // Span-classified (#84): same mention-vs-intent filter as catastrophic above.
   const dangerMatches = [...catastrophicPayload, ...matchSpansClassified(DANGEROUS, scanSurface, regions)];
-  const dangerSignals = dangerMatches.map(m => m.signal);
+  let dangerSignals = dangerMatches.map(m => m.signal);
   let dangerSpan = dangerMatches[0]?.span;
   // A pip install scoped to a venv / an explicit target prefix mutates that
   // prefix, not the host (issue #89 class 4) — it falls through to the
@@ -1873,6 +1974,14 @@ export function evaluateToolCall(
   if (hasUnscopedPipInstall(scanSurface) && !dangerSignals.includes('install-package')) {
     dangerSignals.push('install-package');
     dangerSpan = dangerSpan ?? 'pip install';
+  }
+  // A system install confined to a sealed throwaway container mutates that
+  // container, not the host (issue #128) — drop the host-mutation signal. The
+  // confinement check is an allowlist of proofs: any privilege, host mount,
+  // host namespace or explicit break-out keeps the gate, and an install
+  // outside the container run keeps it for the whole call.
+  if (dangerSignals.includes('install-package') && installsAreContainerConfined(scanSurface)) {
+    dangerSignals = dangerSignals.filter(sig => sig !== 'install-package');
   }
   // External egress is a potential exfil vector — but only when the call carries
   // a payload OFF-host. A read-only GET (docs / releases fetch) leaves nothing

--- a/src/setup/__tests__/state-permissions.test.ts
+++ b/src/setup/__tests__/state-permissions.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Failing-first spec for #163 — permissions on our own state.
+ *
+ * Measured on a live production box, default install, nothing hand-modified:
+ * `~/.shieldcortex` 775, `memories.db` 644, `audit/` 775, config backups 664.
+ * No code set a mode on any of them.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  secureStatePermissions,
+  auditStatePermissions,
+  SECURE_DIR_MODE,
+  SECURE_FILE_MODE,
+} from '../state-permissions.js';
+
+let dir: string;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-perms-')); });
+afterEach(() => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+const modeOf = (p: string) => fs.statSync(p).mode & 0o777;
+
+/** Recreate the exact state measured on the live box. */
+function buildLooseState(): void {
+  fs.chmodSync(dir, 0o775);
+  fs.writeFileSync(path.join(dir, 'memories.db'), 'db');
+  fs.chmodSync(path.join(dir, 'memories.db'), 0o644);
+  fs.mkdirSync(path.join(dir, 'audit'));
+  fs.chmodSync(path.join(dir, 'audit'), 0o775);
+  fs.mkdirSync(path.join(dir, 'approvals'));
+  fs.chmodSync(path.join(dir, 'approvals'), 0o775);
+  fs.writeFileSync(path.join(dir, 'config.json.bak-20260506'), '{}');
+  fs.chmodSync(path.join(dir, 'config.json.bak-20260506'), 0o664);
+}
+
+describe('#163 — the state directory is brought to owner-only', () => {
+  it('hardens the exact live state: dir 775, db 644, audit 775, backup 664', () => {
+    buildLooseState();
+    const findings = secureStatePermissions(dir);
+
+    expect(modeOf(dir)).toBe(SECURE_DIR_MODE);
+    expect(modeOf(path.join(dir, 'memories.db'))).toBe(SECURE_FILE_MODE);
+    expect(modeOf(path.join(dir, 'audit'))).toBe(SECURE_DIR_MODE);
+    expect(modeOf(path.join(dir, 'approvals'))).toBe(SECURE_DIR_MODE);
+    expect(modeOf(path.join(dir, 'config.json.bak-20260506'))).toBe(SECURE_FILE_MODE);
+
+    // Every correction is REPORTED, not silently applied.
+    const paths = findings.map(f => path.basename(f.path)).sort();
+    expect(paths).toContain('memories.db');
+    expect(paths).toContain('audit');
+    expect(paths).toContain('config.json.bak-20260506');
+    expect(findings.every(f => f.fixed)).toBe(true);
+  });
+
+  it('covers WAL/shm siblings and every backup, not just the live database', () => {
+    // A protection the backup path does not inherit is a protection with a
+    // scheduled expiry.
+    for (const name of ['memories.db', 'memories.db-wal', 'memories.db-shm', 'memories.db.bak.2026-08-01T00-00-00-000Z']) {
+      fs.writeFileSync(path.join(dir, name), 'x');
+      fs.chmodSync(path.join(dir, name), 0o644);
+    }
+    secureStatePermissions(dir);
+    for (const name of ['memories.db', 'memories.db-wal', 'memories.db-shm', 'memories.db.bak.2026-08-01T00-00-00-000Z']) {
+      expect(modeOf(path.join(dir, name))).toBe(SECURE_FILE_MODE);
+    }
+  });
+
+  it('is idempotent and reports nothing on an already-hardened tree', () => {
+    buildLooseState();
+    secureStatePermissions(dir);
+    expect(secureStatePermissions(dir)).toEqual([]);
+  });
+
+  it('never loosens a directory or file that is already tighter than required', () => {
+    fs.chmodSync(dir, 0o700);
+    fs.writeFileSync(path.join(dir, 'memories.db'), 'db');
+    fs.chmodSync(path.join(dir, 'memories.db'), 0o400);   // read-only, tighter
+    secureStatePermissions(dir);
+    expect(modeOf(path.join(dir, 'memories.db'))).toBe(0o400);
+  });
+
+  it('does nothing at all when the state directory does not exist', () => {
+    const absent = path.join(dir, 'nope');
+    expect(secureStatePermissions(absent)).toEqual([]);
+  });
+
+  it('ignores files that are not ours', () => {
+    fs.writeFileSync(path.join(dir, 'unrelated.txt'), 'x');
+    fs.chmodSync(path.join(dir, 'unrelated.txt'), 0o644);
+    secureStatePermissions(dir);
+    expect(modeOf(path.join(dir, 'unrelated.txt'))).toBe(0o644);
+  });
+});
+
+describe('#163 — doctor measures without mutating', () => {
+  it('reports the too-open paths and changes nothing', () => {
+    buildLooseState();
+    const before = modeOf(path.join(dir, 'memories.db'));
+    const findings = auditStatePermissions(dir);
+
+    expect(findings.length).toBeGreaterThan(0);
+    const db = findings.find(f => f.path.endsWith('memories.db'));
+    expect(db).toBeDefined();
+    expect(db?.found).toBe('644');
+    expect(db?.required).toBe('600');
+    // Measured, not assumed — and not corrected behind the operator's back.
+    expect(modeOf(path.join(dir, 'memories.db'))).toBe(before);
+  });
+
+  it('reports nothing once the tree is hardened', () => {
+    buildLooseState();
+    secureStatePermissions(dir);
+    expect(auditStatePermissions(dir)).toEqual([]);
+  });
+});

--- a/src/setup/claude-md.ts
+++ b/src/setup/claude-md.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'url';
 import { installOpenClawHook, findAllHooksDirs } from './openclaw.js';
 import { setupHooks } from './settings-hooks.js';
 import { readJsonConfigOrAbort, writeJsonConfigWithBackup, looksLikeShieldcortex, resolveMcpServerCommand } from './json-config.js';
+import { getConfigDir } from '../cloud/config.js';
 
 // MCP entry point: dist/index.js — one level up from dist/setup/ (this module).
 const MCP_ENTRY = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'index.js');
@@ -207,6 +208,26 @@ export async function setupClaudeMd(options?: { stopHook?: boolean; sessionEnd?:
     }
   } else {
     console.log('- OpenClaw: not detected (skipped)');
+  }
+
+  // 5. Harden the permissions on our own state (#163). Runs on every install
+  //    AND upgrade, deliberately: the audit found every existing box with a
+  //    world-readable memories.db and a group-writable audit/, so fixing only
+  //    fresh installs would leave the whole fleet exactly as measured — the
+  //    #146 lesson. Best-effort and never fatal; reported, never swallowed.
+  try {
+    const { secureStatePermissions } = await import('./state-permissions.js');
+    const findings = secureStatePermissions(getConfigDir());
+    const fixed = findings.filter(f => f.fixed);
+    const failed = findings.filter(f => !f.fixed);
+    if (fixed.length > 0) {
+      console.log(`✓ Permissions: tightened ${fixed.length} path(s) to owner-only (was group/world accessible)`);
+    }
+    for (const f of failed) {
+      console.warn(`⚠️  Permissions: could not tighten ${f.path} (${f.found} → ${f.required}): ${f.error ?? 'unknown'}`);
+    }
+  } catch (err) {
+    console.warn(`⚠️  Permissions: hardening pass skipped — ${err instanceof Error ? err.message : String(err)}`);
   }
 
   console.log('\nSetup complete.');

--- a/src/setup/state-permissions.ts
+++ b/src/setup/state-permissions.ts
@@ -1,0 +1,155 @@
+/**
+ * ShieldCortex — permissions on our own state (#163).
+ *
+ * Hardening audit, 1 Aug 2026, measured on a live production box with a default
+ * install and nothing hand-modified:
+ *
+ *   ~/.shieldcortex        775   everything below
+ *   memories.db            644   every captured memory — the product's asset
+ *   audit/                 775   the enforcement audit trail
+ *   config.json.bak-*      664   copies of a file deliberately written 0600
+ *
+ * Nothing in the codebase set a mode on any of them; they inherited the process
+ * umask. The 0600 discipline existed for `config.json` and the approval store
+ * file, so the intent was there — it had simply never been applied to the
+ * largest and most sensitive artifacts.
+ *
+ * Two of these are more than tidiness:
+ *
+ *   - A world-readable `memories.db` is the entire data asset of a
+ *     memory-SECURITY product readable by any local user.
+ *   - A group-writable `audit/` means a non-owner can delete or forge records.
+ *     That trail is what proves enforcement fired — it is what the live canary
+ *     checks and what every incident this week was reconstructed from. An audit
+ *     log that others can edit is not an audit log.
+ *
+ * And a 0600 file inside a 775 directory is not protected at all: unlink +
+ * recreate needs only directory write permission. That is the same shape as the
+ * original #127 finding — mechanism guarded, state container not.
+ *
+ * ZEROTH LAW: best-effort, never fatal. A chmod that fails on an exotic
+ * filesystem (a network mount, a container overlay) must never break the host
+ * or the agent. But it is REPORTED rather than swallowed — a silent failure to
+ * harden is the false-green pattern wearing yet another hat.
+ */
+import fs from 'fs';
+import path from 'path';
+
+/** Directories: owner-only. Group/world have no business traversing our state. */
+export const SECURE_DIR_MODE = 0o700;
+/** Files: owner read/write only. */
+export const SECURE_FILE_MODE = 0o600;
+
+/** Subdirectories of the state dir that must be owner-only. */
+export const SECURE_SUBDIRS = ['audit', 'approvals', 'logs', 'quarantine', 'recall-log', 'precompact-log'];
+
+/** Files that must be owner-only, by exact name or by prefix. */
+const SECURE_FILE_PREFIXES = ['memories.db', 'config.json', 'worker.json', 'integrity'];
+
+export interface PermissionFinding {
+  path: string;
+  /** The mode we found, as an octal string (e.g. "644"). */
+  found: string;
+  /** The mode required. */
+  required: string;
+  /** True when we successfully corrected it. */
+  fixed: boolean;
+  /** Present when the correction failed — never fatal, always reported. */
+  error?: string;
+}
+
+function modeOf(target: string): number | null {
+  try {
+    return fs.statSync(target).mode & 0o777;
+  } catch {
+    return null;
+  }
+}
+
+/** Anything readable or writable by group or other. */
+function isTooOpen(mode: number, required: number): boolean {
+  return (mode & ~required) !== 0;
+}
+
+function secure(target: string, required: number, findings: PermissionFinding[]): void {
+  const mode = modeOf(target);
+  if (mode === null) return;                       // absent — nothing to harden
+  if (!isTooOpen(mode, required)) return;          // already at or tighter than required
+  const finding: PermissionFinding = {
+    path: target,
+    found: mode.toString(8).padStart(3, '0'),
+    required: required.toString(8).padStart(3, '0'),
+    fixed: false,
+  };
+  try {
+    fs.chmodSync(target, required);
+    finding.fixed = true;
+  } catch (err) {
+    finding.error = err instanceof Error ? err.message : String(err);
+  }
+  findings.push(finding);
+}
+
+/**
+ * Bring `~/.shieldcortex` and everything security-relevant inside it to
+ * owner-only. Returns every path that WAS too open, whether or not the
+ * correction succeeded — callers report, they do not assume.
+ *
+ * Idempotent and safe to run on every install, upgrade and doctor pass. It must
+ * run on upgrade too, not only on fresh installs: every existing box is in the
+ * measured state above, and fixing only the installer would leave the whole
+ * fleet exactly as it is (the #146 lesson).
+ */
+export function secureStatePermissions(stateDir: string): PermissionFinding[] {
+  const findings: PermissionFinding[] = [];
+  if (modeOf(stateDir) === null) return findings;   // not created yet
+
+  secure(stateDir, SECURE_DIR_MODE, findings);
+  for (const sub of SECURE_SUBDIRS) secure(path.join(stateDir, sub), SECURE_DIR_MODE, findings);
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(stateDir, { withFileTypes: true });
+  } catch {
+    return findings;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    // Backups and WAL/shm siblings included by prefix: a protection the backup
+    // path does not inherit is a protection with a scheduled expiry.
+    if (!SECURE_FILE_PREFIXES.some(p => entry.name.startsWith(p))) continue;
+    secure(path.join(stateDir, entry.name), SECURE_FILE_MODE, findings);
+  }
+  return findings;
+}
+
+/**
+ * Measure without changing anything — for `doctor`, which reports rather than
+ * mutates. Returns the paths that are currently too open.
+ */
+export function auditStatePermissions(stateDir: string): Array<{ path: string; found: string; required: string }> {
+  const out: Array<{ path: string; found: string; required: string }> = [];
+  const check = (target: string, required: number): void => {
+    const mode = modeOf(target);
+    if (mode === null || !isTooOpen(mode, required)) return;
+    out.push({
+      path: target,
+      found: mode.toString(8).padStart(3, '0'),
+      required: required.toString(8).padStart(3, '0'),
+    });
+  };
+
+  if (modeOf(stateDir) === null) return out;
+  check(stateDir, SECURE_DIR_MODE);
+  for (const sub of SECURE_SUBDIRS) check(path.join(stateDir, sub), SECURE_DIR_MODE);
+  try {
+    for (const entry of fs.readdirSync(stateDir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      if (!SECURE_FILE_PREFIXES.some(p => entry.name.startsWith(p))) continue;
+      check(path.join(stateDir, entry.name), SECURE_FILE_MODE);
+    }
+  } catch {
+    // unreadable state dir — the Database/Disk checks already report that
+  }
+  return out;
+}


### PR DESCRIPTION
Two dogfood false positives, both hit while setting up a clean-box install test for our own product.

## 1. A dash-flag is not a command
`docker run --rm …` matched the highest-traffic delete rule on the substring "rm". That flag asks the container runtime to clean up the **container** on exit; nothing on the host is touched. The delete verbs now carry a not-a-dash guard — a token beginning with `-` is an option, never the command.

Unchanged and pinned by test: `rm x`, `sudo rm x`, `; rm x`, `xargs rm`, every inner `rm` inside a container command, and `rm -rf` staying catastrophic wherever it appears.

## 2. A sealed container is not the host
A system package install inside a throwaway container gated as host mutation. It isn't — the layer is discarded on exit.

The downgrade is an **allowlist of proofs, never a denylist of dangers**, because a container is only a boundary while it is sealed. Every one of these keeps the gate exactly as before, each with its own test:
- `--privileged` / `--cap-add`
- a host bind-mount (`-v /:…`, or a system dir like `/etc`, `/usr`, `/var`)
- a shared host namespace (`--pid=host`, `--net=host`, `--ipc=host`, `--userns=host`)
- `chroot` / `nsenter` / `mount` in the inner command
- an install **outside** the container run — a quoted mention cannot launder a host install in the next statement

### One design note worth review
The confinement check needed a quote-aware statement split. The shared `splitCommandStatements` deliberately splits on every separator regardless of quoting — the fail-safe choice for rules that must not be evaded by quoting — but a `;` inside `sh -c "…"` belongs to the container, not the host. The new splitter is **local** so the fail-safe one is untouched; that asymmetry is intentional and commented.

## Already fixed, now covered
Probing the remaining #89 cases and #128's third case against current main found them all passing — the payload-vs-action pass in 4.47.18 closed them. Added as regression tests so they cannot silently return:
- prose containing a delete phrase written into a heredoc note
- `clawhub search shieldcortex` (was read as pipe-download-to-shell)
- `export PATH=…; echo "="` (was `shred-device`, severity critical — a calibration bug)
- attack-shaped text quoted in a `--body` payload

## Verification
- 16 tests; **delete-verified** — remove either fix and 5 go red.
- **Corpus replay over 6,366 real stop events** from live audit data: 3,057 still stop vs **3,060** before. A 3-event delta, and that is the point — a guard precision fix should be narrow and provable, not a broad relaxation.
- Full suite: 307 suites / 3,485 pass / 0 fail.

Closes #128. Advances #89 (its three live FPs are now regression-tested; the issue also tracks approve-tier noise measured separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
