### PR TITLE
fix: surface silent memory-capture drops (#137) and honest packaging/exports (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,30 @@ SHIELDCORTEX_RANKER=legacy npm run bench   # env var overrides config for a sing
 
 <br>
 
+### ESM only
+
+`shieldcortex` ships as ESM only (`"type": "module"`, no CommonJS build) — this is a
+deliberate choice, not an oversight, and it won't change silently. Every entry point
+(`shieldcortex`, `shieldcortex/defence`, `shieldcortex/scan`, `shieldcortex/lib`,
+`shieldcortex/integrations/*`, `shieldcortex/environment`) works with:
+
+```js
+import shieldcortex from 'shieldcortex';
+// or, from CommonJS:
+const shieldcortex = await import('shieldcortex');
+```
+
+A bare `require('shieldcortex')` fails on purpose, with an error that says exactly
+that and how to fix it, instead of Node's opaque default
+`ERR_PACKAGE_PATH_NOT_EXPORTED` (issue [#134](https://github.com/Drakon-Systems-Ltd/ShieldCortex/issues/134)).
+There is no CJS build to point `require` at — a synchronous `require()` of ESM
+output isn't a working substitute, it just fails a different, more confusing way
+at runtime, so we don't pretend to offer one. If your project is CommonJS, either
+`await import('shieldcortex')` from an async context or add `"type": "module"`
+(or a `.mjs` extension) to the consuming file.
+
+<br>
+
 ## 💻 CLI
 
 <details>

--- a/package.json
+++ b/package.json
@@ -7,39 +7,48 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
+      "require": "./scripts/lib/cjs-not-supported.cjs",
       "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json",
     "./integrations/langchain": {
       "import": "./dist/integrations/langchain.js",
+      "require": "./scripts/lib/cjs-not-supported.cjs",
       "types": "./dist/integrations/langchain.d.ts"
     },
     "./integrations/universal": {
       "import": "./dist/integrations/universal.js",
+      "require": "./scripts/lib/cjs-not-supported.cjs",
       "types": "./dist/integrations/universal.d.ts"
     },
     "./integrations/openclaw": {
       "import": "./dist/integrations/openclaw.js",
+      "require": "./scripts/lib/cjs-not-supported.cjs",
       "types": "./dist/integrations/openclaw.d.ts"
     },
     "./integrations": {
       "import": "./dist/integrations/index.js",
+      "require": "./scripts/lib/cjs-not-supported.cjs",
       "types": "./dist/integrations/index.d.ts"
     },
     "./defence": {
       "import": "./dist/defence/index.js",
+      "require": "./scripts/lib/cjs-not-supported.cjs",
       "types": "./dist/defence/index.d.ts"
     },
     "./scan": {
       "import": "./dist/scan-only.js",
+      "require": "./scripts/lib/cjs-not-supported.cjs",
       "types": "./dist/scan-only.d.ts"
     },
     "./environment": {
       "import": "./dist/environment/index.js",
+      "require": "./scripts/lib/cjs-not-supported.cjs",
       "types": "./dist/environment/index.d.ts"
     },
     "./lib": {
       "import": "./dist/lib.js",
+      "require": "./scripts/lib/cjs-not-supported.cjs",
       "types": "./dist/lib.d.ts"
     }
   },

--- a/plugins/openclaw/__tests__/registration-failure-134.test.ts
+++ b/plugins/openclaw/__tests__/registration-failure-134.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import plugin, { __resetConfigStateForTest } from '../index.js';
+
+/**
+ * Issue #134 §2 — a security plugin going inert must be loud, not a bare
+ * console.warn.
+ *
+ * register() wraps its whole body in try/catch so a plugin failure can never
+ * block channel startup — that part is correct and stays. Two things were
+ * wrong with how the failure was reported:
+ *
+ *  1. It used `console.warn` directly, which bypasses the gateway's
+ *     structured log (`api.logger`). Real-time scanning, memory capture and
+ *     the Action Guard before_tool_call hook all go dark with no `[plugins]`
+ *     line anywhere an operator actually looks.
+ *  2. `/shieldcortex-status` was registered INSIDE the same try block that
+ *     could throw, so a crash before that line meant the command never
+ *     existed — the plugin couldn't even honestly report its own death.
+ *
+ * Reproduced here by forcing `applyPluginConfigOverride()` to throw (a bad
+ * `api.runtime.config.current()`), which is the very first statement in the
+ * try block — so under the OLD code NEITHER the status command NOR any
+ * api.logger.warn call would ever happen.
+ */
+
+type Hooks = Record<string, (...args: any[]) => any>;
+type Commands = Record<string, { name: string; handler: () => Promise<{ text: string }> }>;
+
+function makeBrokenApi(): { api: any; hooks: Hooks; commands: Commands; log: string[] } {
+  const hooks: Hooks = {};
+  const commands: Commands = {};
+  const log: string[] = [];
+  const api = {
+    id: 'shieldcortex-realtime',
+    name: 'ShieldCortex Real-time Scanner',
+    logger: {
+      info: (m: string) => { log.push(`info: ${m}`); },
+      warn: (m: string) => { log.push(`warn: ${m}`); },
+    },
+    on: (name: string, handler: (...args: any[]) => any) => { hooks[name] = handler; },
+    registerCommand: (cmd: any) => { commands[cmd.name] = cmd; },
+    runtime: {
+      config: {
+        // Throws synchronously — the first thing applyPluginConfigOverride()
+        // does inside register()'s try block.
+        current: () => { throw new Error('injected host config failure'); },
+      },
+    },
+  };
+  return { api, hooks, commands, log };
+}
+
+beforeEach(() => {
+  __resetConfigStateForTest();
+});
+
+describe('#134 §2 — registration failure is surfaced loudly, not swallowed', () => {
+  it('routes the failure through api.logger.warn, not a bare console.warn', () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { api, log } = makeBrokenApi();
+      plugin.register(api);
+
+      expect(log.some((m) => m.includes('warn:') && m.includes('Plugin failed to initialize'))).toBe(true);
+      expect(log.some((m) => m.includes('warn:') && m.includes('Real-time scanning is disabled'))).toBe(true);
+      // The whole point: the gateway's structured logger carried this, not
+      // stdout that a hook context usually discards.
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it('/shieldcortex-status exists even though registration crashed, and reports DEGRADED honestly', async () => {
+    const { api, commands } = makeBrokenApi();
+    plugin.register(api);
+
+    expect(commands['shieldcortex-status']).toBeDefined();
+    const status = await commands['shieldcortex-status'].handler();
+    expect(status.text).toMatch(/DEGRADED/);
+    expect(status.text).toMatch(/INACTIVE/);
+    expect(status.text).toMatch(/injected host config failure/);
+  });
+});

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -184,6 +184,7 @@ export function __resetConfigStateForTest(): void {
   _lastShieldConfigRef = null;
   _registered = false;
   _beforeToolCallRegistered = false;
+  _registrationError = null;
 }
 
 type LlmInputEvent = {
@@ -447,6 +448,15 @@ let _registered = false;
 // unattended Codex agents even a no-op registered hook changes how OpenClaw
 // resolves approvals).
 let _beforeToolCallRegistered = false;
+// #134 §2: register() wraps its whole body in try/catch so a plugin failure
+// never blocks channel startup — correct, but it used to report the failure
+// with a bare console.warn (bypasses the gateway's structured log, so the
+// operator's only view of a dead security plugin is stdout no one reads) and
+// the /shieldcortex-status command lived INSIDE the same try block, so a
+// crash before that line meant the command never existed at all — the plugin
+// couldn't even honestly report its own death. Set here so the status handler
+// (registered unconditionally, before the risky init work) can read it.
+let _registrationError: string | null = null;
 
 function normaliseConfig(raw: unknown): SCConfig {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
@@ -1129,12 +1139,73 @@ export default {
   register(api: PluginApi) {
     if (_registered) return;
     _registered = true;
-    try {
-    applyPluginConfigOverride(api);
 
     // --- Interceptor (lazy init) ---
     let interceptorReady: ReturnType<typeof createInterceptor> | null = null;
     let interceptorInitAttempted = false;
+
+    // #134 §2: registered UNCONDITIONALLY, before the try block below that can
+    // throw. Previously this command lived inside that try, so a plugin crash
+    // meant the operator had no /shieldcortex-status to run at all — the one
+    // place they'd look reported nothing, same as it not existing. Now it
+    // always exists, and honestly reports DEGRADED when init failed instead of
+    // rendering config-derived lines that describe a state the plugin never
+    // reached.
+    try {
+      api.registerCommand({
+        name: "shieldcortex-status",
+        description: "Show ShieldCortex real-time scanner status",
+        async handler() {
+          if (_registrationError) {
+            return {
+              text:
+                `ShieldCortex v${_version}\n` +
+                `  STATUS: DEGRADED — plugin failed to initialize: ${_registrationError}\n` +
+                `  Real-time scanning, memory capture and the Action Guard before_tool_call\n` +
+                `  hook are ALL INACTIVE. Channels started normally (fail-open by design —\n` +
+                `  a broken security plugin must never block the gateway), but this plugin\n` +
+                `  is doing nothing until the underlying error is fixed and the gateway is\n` +
+                `  restarted.`,
+            };
+          }
+          const cfg = await loadConfig();
+          const autoMemory = isAutoMemoryEnabled(cfg) ? "on" : "off";
+          const dedupe = isAutoMemoryDedupeEnabled(cfg) ? "on" : "off";
+          const cloud = cfg.cloudApiKey ? "configured" : "not configured";
+          // Resolve the Action Guard state the same way initInterceptor() does,
+          // so the status line reflects what before_tool_call will actually do.
+          const rawInterceptor = cfg.interceptor;
+          const guardCfg = {
+            ...(DEFAULT_INTERCEPTOR_CONFIG.actionGuard ?? { enabled: true, enforce: true, autoApprove: [] }),
+            ...(rawInterceptor && typeof rawInterceptor === 'object' ? rawInterceptor.actionGuard ?? {} : {}),
+          };
+          const interceptorOn = (rawInterceptor && typeof rawInterceptor === 'object' ? rawInterceptor.enabled : undefined) ?? DEFAULT_INTERCEPTOR_CONFIG.enabled;
+          const autoApproved = Array.isArray(guardCfg.autoApprove) ? guardCfg.autoApprove.length : 0;
+          const guardState = !_beforeToolCallRegistered
+            ? "off (before_tool_call not registered — interceptor disabled in plugin config)"
+            : !interceptorOn || !guardCfg.enabled
+              ? "off"
+              : `${guardCfg.enforce ? "enforce" : "warn"}${autoApproved > 0 ? ` (${autoApproved} auto-approved)` : ""}${interceptorReady ? "" : " — not yet initialised this session"}`;
+          const hooksLine = _beforeToolCallRegistered
+            ? "llm_input (scan), llm_output (memory), before_tool_call (action guard), session_end (cache reset)"
+            : "llm_input (scan), llm_output (memory)";
+          return {
+            text:
+              `ShieldCortex v${_version}\n` +
+              `  Hooks: ${hooksLine}\n` +
+              `  Action guard: ${guardState}\n` +
+              `  Auto memory: ${autoMemory} | Dedupe: ${dedupe}\n` +
+              `  Cloud sync: ${cloud}`,
+          };
+        },
+      });
+    } catch {
+      // Host doesn't support registerCommand at all — nothing more to do here;
+      // the try/catch below still logs the substantive init failure loudly.
+    }
+
+    try {
+    applyPluginConfigOverride(api);
 
     async function initInterceptor(): Promise<ReturnType<typeof createInterceptor> | null> {
       if (interceptorInitAttempted) return interceptorReady;
@@ -1231,49 +1302,27 @@ export default {
     api.on("llm_input", handleLlmInput, { timeoutMs: 30_000 });
     api.on("llm_output", handleLlmOutput, { timeoutMs: 30_000 });
 
-    // Register a lightweight status command so the plugin is not hook-only
-    api.registerCommand({
-      name: "shieldcortex-status",
-      description: "Show ShieldCortex real-time scanner status",
-      async handler() {
-        const cfg = await loadConfig();
-        const autoMemory = isAutoMemoryEnabled(cfg) ? "on" : "off";
-        const dedupe = isAutoMemoryDedupeEnabled(cfg) ? "on" : "off";
-        const cloud = cfg.cloudApiKey ? "configured" : "not configured";
-        // Resolve the Action Guard state the same way initInterceptor() does,
-        // so the status line reflects what before_tool_call will actually do.
-        const rawInterceptor = cfg.interceptor;
-        const guardCfg = {
-          ...(DEFAULT_INTERCEPTOR_CONFIG.actionGuard ?? { enabled: true, enforce: true, autoApprove: [] }),
-          ...(rawInterceptor && typeof rawInterceptor === 'object' ? rawInterceptor.actionGuard ?? {} : {}),
-        };
-        const interceptorOn = (rawInterceptor && typeof rawInterceptor === 'object' ? rawInterceptor.enabled : undefined) ?? DEFAULT_INTERCEPTOR_CONFIG.enabled;
-        const autoApproved = Array.isArray(guardCfg.autoApprove) ? guardCfg.autoApprove.length : 0;
-        const guardState = !_beforeToolCallRegistered
-          ? "off (before_tool_call not registered — interceptor disabled in plugin config)"
-          : !interceptorOn || !guardCfg.enabled
-            ? "off"
-            : `${guardCfg.enforce ? "enforce" : "warn"}${autoApproved > 0 ? ` (${autoApproved} auto-approved)` : ""}${interceptorReady ? "" : " — not yet initialised this session"}`;
-        const hooksLine = _beforeToolCallRegistered
-          ? "llm_input (scan), llm_output (memory), before_tool_call (action guard), session_end (cache reset)"
-          : "llm_input (scan), llm_output (memory)";
-        return {
-          text:
-            `ShieldCortex v${_version}\n` +
-            `  Hooks: ${hooksLine}\n` +
-            `  Action guard: ${guardState}\n` +
-            `  Auto memory: ${autoMemory} | Dedupe: ${dedupe}\n` +
-            `  Cloud sync: ${cloud}`,
-        };
-      },
-    });
-
     api.logger.info(`[shieldcortex] v${_version} registered (llm_input + llm_output${_beforeToolCallRegistered ? " + before_tool_call" : ""} + /shieldcortex-status)`);
     } catch (err) {
-      // Plugin must never block channel startup — warn and bail gracefully
+      // Plugin must never block channel startup — warn and bail gracefully.
+      // #134 §2: this used to be a bare console.warn, which bypasses the
+      // gateway's structured log entirely — real-time scanning, memory
+      // capture and the Action Guard before_tool_call hook all go dark with
+      // no [plugins] line anywhere an operator looks. Route through
+      // api.logger.warn (the structured channel) and only fall back to
+      // console.error — never console.warn, so a fallback line is visibly
+      // distinct from a routed one — if the host doesn't even provide a
+      // logger, which would itself be a broken host.
       const msg = err instanceof Error ? err.message : String(err);
-      console.warn(`[shieldcortex] WARNING: Plugin failed to initialize: ${msg}`);
-      console.warn('[shieldcortex] Real-time scanning is disabled. Channels will start normally.');
+      _registrationError = msg;
+      const warn = (api.logger as any)?.warn;
+      if (typeof warn === 'function') {
+        warn.call(api.logger, `[shieldcortex] WARNING: Plugin failed to initialize: ${msg}`);
+        warn.call(api.logger, '[shieldcortex] Real-time scanning is disabled. Channels will start normally.');
+      } else {
+        console.error(`[shieldcortex] WARNING: Plugin failed to initialize (no api.logger available): ${msg}`);
+        console.error('[shieldcortex] Real-time scanning is disabled. Channels will start normally.');
+      }
     }
   },
 };

--- a/scripts/lib/cjs-not-supported.cjs
+++ b/scripts/lib/cjs-not-supported.cjs
@@ -1,0 +1,31 @@
+// shieldcortex is published ESM-only (package.json "type": "module") — there
+// is no CommonJS build, and there deliberately never will be a fake one:
+// pointing the "require" condition at the compiled ESM output would just
+// swap one runtime error (this one) for a worse one (ERR_REQUIRE_ESM, or a
+// silent wrong-module load on Node 22+'s experimental require(esm)).
+//
+// Before this file existed, `require('shieldcortex')` (or any subpath) fell
+// through Node's default `exports` resolution — no "require" condition, no
+// "default" — and Node raised a bare ERR_PACKAGE_PATH_NOT_EXPORTED that names
+// neither shieldcortex nor the real cause. That cost a fleet agent real
+// diagnostic time: it root-caused an unrelated plugin failure to this exact
+// string and stood down waiting on a rebuild that would never have helped
+// (issue #134).
+//
+// This file is wired as the "require" condition on every `exports` entry in
+// package.json, so a CJS `require()` call resolves HERE — a real, loadable
+// CommonJS module (the .cjs extension makes Node treat it as CJS regardless
+// of the package's "type": "module") — and fails with a message that says
+// exactly what's wrong and how to fix it, instead of Node's opaque default.
+'use strict';
+
+throw new Error(
+  '[shieldcortex] This package is ESM-only — there is no CommonJS build, by ' +
+    'design (see README.md "ESM only"). `require("shieldcortex")` (or any ' +
+    'shieldcortex/* subpath) cannot work and never silently will. Fix your ' +
+    'importing code instead: use a dynamic import — ' +
+    '`const shieldcortex = await import("shieldcortex")` — or convert the ' +
+    'consuming file/package to ESM (add "type": "module" to its ' +
+    'package.json, or use a .mjs extension). ' +
+    'https://github.com/Drakon-Systems-Ltd/ShieldCortex#esm-only',
+);

--- a/src/__tests__/packaging-cjs-exports-134.test.ts
+++ b/src/__tests__/packaging-cjs-exports-134.test.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * Issue #134 §1 — `shieldcortex` is ESM-only at the package root and every
+ * subpath, and `require('shieldcortex')` used to fail with a bare
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` that names neither shieldcortex nor the
+ * real cause (repro: `node -e "require('shieldcortex')"`).
+ *
+ * Decision taken (documented in README.md "ESM only" + the PR): stay
+ * ESM-only — there is no CJS build, and pointing `require` at the compiled
+ * ESM output would just trade one confusing runtime failure for another
+ * (ERR_REQUIRE_ESM). Instead, every `exports` entry gets an explicit
+ * "require" condition pointing at a real, loadable CommonJS file
+ * (scripts/lib/cjs-not-supported.cjs) that throws an actionable error
+ * naming the package, the cause, and the fix. `import`/`import()` keep
+ * resolving to the real ESM build untouched.
+ */
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf-8'));
+
+const SUBPATH_EXPORTS = [
+  '.',
+  './integrations/langchain',
+  './integrations/universal',
+  './integrations/openclaw',
+  './integrations',
+  './defence',
+  './scan',
+  './environment',
+  './lib',
+];
+
+describe('#134 §1 — package.json exports honestly handle require()', () => {
+  it.each(SUBPATH_EXPORTS)('exports[%s] declares a "require" condition (not silence, not ESM output)', (key) => {
+    const entry = pkg.exports[key];
+    expect(entry).toBeDefined();
+    expect(typeof entry).toBe('object');
+    expect(entry.require).toBe('./scripts/lib/cjs-not-supported.cjs');
+    // Must NOT point require at the ESM build — that fails a DIFFERENT,
+    // equally-confusing way (ERR_REQUIRE_ESM) instead of not working at all.
+    expect(entry.require).not.toBe(entry.import);
+  });
+
+  it.each(SUBPATH_EXPORTS)('exports[%s] still resolves "import" to the real ESM build (unchanged)', (key) => {
+    const entry = pkg.exports[key];
+    expect(typeof entry.import).toBe('string');
+    expect(entry.import.startsWith('./dist/')).toBe(true);
+  });
+
+  it('the require-condition target file actually exists in the package', () => {
+    const shimPath = path.join(repoRoot, 'scripts', 'lib', 'cjs-not-supported.cjs');
+    expect(fs.existsSync(shimPath)).toBe(true);
+  });
+
+  it('is listed in package.json "files" so it actually ships in the published tarball', () => {
+    expect(Array.isArray(pkg.files)).toBe(true);
+    // scripts/lib as a whole directory is already whitelisted — confirm that
+    // stays true rather than assuming; a narrower "files" edit elsewhere
+    // could silently drop this file from the tarball.
+    expect(pkg.files).toContain('scripts/lib');
+  });
+
+  it('require()ing the shim throws an actionable, shieldcortex-specific error — not a bare Node resolution error', () => {
+    const shimPath = path.join(repoRoot, 'scripts', 'lib', 'cjs-not-supported.cjs');
+    let thrown: unknown = null;
+    try {
+      require(shimPath);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toMatch(/shieldcortex/i);
+    expect(message).toMatch(/ESM.only/i);
+    expect(message).toMatch(/import/i);
+    // The specific opaque error this replaces — must never resemble it.
+    expect(message).not.toMatch(/ERR_PACKAGE_PATH_NOT_EXPORTED/);
+  });
+});

--- a/src/cli/__tests__/doctor-memory-capture-dist-137.test.ts
+++ b/src/cli/__tests__/doctor-memory-capture-dist-137.test.ts
@@ -1,0 +1,162 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { runMemoryCaptureDistCheck, runMemoryCaptureDropsCheck } from '../doctor.js';
+import { closeDatabase, initDatabase } from '../../database/init.js';
+import Database from 'better-sqlite3';
+
+/**
+ * Issue #137 — memory capture fails SILENTLY when dist/ is stale or partial.
+ *
+ * `scripts/lib/save-memory.mjs:loadDefenceModules()` returns null (and the
+ * hook fail-closes, dropping the write with only a discarded stderr line and
+ * a synthetic `defence_audit` row) when any of runDefencePipeline,
+ * initDatabase, or resolveDisposition is missing from dist/. Fail-closed
+ * there is correct and untouched by this fix — these tests exist to pin the
+ * OBSERVABILITY doctor must now provide: a hard FAIL that names the missing
+ * piece and the fix command, plus a separate check that surfaces PAST drops
+ * recorded in defence_audit even after the dist build has been repaired.
+ */
+describe('doctor: memory-capture dist completeness (#137)', () => {
+  let pkgRoot: string;
+
+  beforeEach(() => {
+    pkgRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-doctor-dist-'));
+    // Real dist output is ESM ("type": "module" at the package root) — mirror
+    // that so dynamic import() resolves these .js files the same way it
+    // would resolve the real build, not as CommonJS.
+    fs.writeFileSync(path.join(pkgRoot, 'package.json'), JSON.stringify({ type: 'module' }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(pkgRoot, { recursive: true, force: true });
+  });
+
+  function writeDistFile(rel: string, content: string): void {
+    const full = path.join(pkgRoot, 'dist', rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+
+  function writeCompleteDist(): void {
+    writeDistFile(path.join('defence', 'pipeline.js'), 'export function runDefencePipeline() { return null; }\n');
+    writeDistFile(path.join('database', 'init.js'), 'export function initDatabase() { return null; }\n');
+    writeDistFile(path.join('defence', 'disposition.js'), 'export function resolveDisposition() { return null; }\n');
+  }
+
+  it('FAILs when dist/ does not exist at all (fresh checkout, no build yet)', async () => {
+    const result = await runMemoryCaptureDistCheck(pkgRoot);
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/pipeline\.js/);
+    expect(result.message).toMatch(/init\.js/);
+    expect(result.message).toMatch(/disposition\.js/);
+    expect(result.message).toMatch(/silently drop/i);
+    expect(result.fix).toMatch(/build:ts|repair/);
+  });
+
+  it('FAILs when dist/ is PARTIAL — only some of the three required modules exist', async () => {
+    // Reproduces the exact #137 repro: dist carried an 11 Jul build missing
+    // dist/defence/disposition.js. 100% of saves were silently dropped.
+    writeDistFile(path.join('defence', 'pipeline.js'), 'export function runDefencePipeline() { return null; }\n');
+    writeDistFile(path.join('database', 'init.js'), 'export function initDatabase() { return null; }\n');
+    // defence/disposition.js deliberately missing.
+
+    const result = await runMemoryCaptureDistCheck(pkgRoot);
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/disposition\.js/);
+    expect(result.message).not.toMatch(/pipeline\.js is missing|init\.js is missing/);
+  });
+
+  it('FAILs when a required module exists but does not export the expected symbol (corrupt/partial build)', async () => {
+    writeDistFile(path.join('defence', 'pipeline.js'), 'export function runDefencePipeline() { return null; }\n');
+    writeDistFile(path.join('database', 'init.js'), 'export function initDatabase() { return null; }\n');
+    // Present on disk, but the named export doctor (and the real hook) needs
+    // is missing — same effective failure as the file being absent.
+    writeDistFile(path.join('defence', 'disposition.js'), 'export function somethingElse() { return null; }\n');
+
+    const result = await runMemoryCaptureDistCheck(pkgRoot);
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/resolveDisposition/);
+    expect(result.fix).toBeTruthy();
+  });
+
+  it('PASSes when all three modules are present and export the right functions', async () => {
+    writeCompleteDist();
+    const result = await runMemoryCaptureDistCheck(pkgRoot);
+    expect(result.status).toBe('pass');
+  });
+});
+
+describe('doctor: memory-capture recent drops (#137)', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-doctor-drops-'));
+    dbPath = path.join(tmpDir, 'memories.db');
+  });
+
+  afterEach(() => {
+    try { closeDatabase(); } catch { /* ignore */ }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function insertFallbackAudit(reason: string, timestamp: string): void {
+    const db = new Database(dbPath);
+    try {
+      db.prepare(`
+        INSERT INTO defence_audit (
+          memory_id, project, timestamp, source_type, source_identifier,
+          trust_score, sensitivity_level, firewall_result,
+          anomaly_score, threat_indicators, blocked_patterns, reason
+        ) VALUES (NULL, NULL, ?, 'hook', 'stop-hook', 0, 'INTERNAL', 'BLOCK', 0, '[]', '[]', ?)
+      `).run(timestamp, reason);
+    } finally {
+      db.close();
+    }
+  }
+
+  it('skips (info) when the database does not exist yet', () => {
+    const result = runMemoryCaptureDropsCheck(dbPath);
+    expect(result.status).toBe('info');
+    expect(result.skipped).toBe('db-uninitialised');
+  });
+
+  it('PASSes on a healthy database with no fallback-audit rows', () => {
+    initDatabase(dbPath);
+    closeDatabase();
+    const result = runMemoryCaptureDropsCheck(dbPath);
+    expect(result.status).toBe('pass');
+  });
+
+  it('FAILs when a defence_pipeline_unavailable row landed in the last 24h — this is the #137 silent-drop signal', () => {
+    initDatabase(dbPath);
+    closeDatabase();
+    insertFallbackAudit('defence_pipeline_unavailable: dist build missing', new Date().toISOString());
+
+    const result = runMemoryCaptureDropsCheck(dbPath);
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/1 memory capture/);
+    expect(result.message).toMatch(/DROPPED/);
+  });
+
+  it('does NOT count drops older than 24h (surfaces the live problem, not ancient history)', () => {
+    initDatabase(dbPath);
+    closeDatabase();
+    const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    insertFallbackAudit('defence_pipeline_unavailable: dist build missing', twoDaysAgo);
+
+    const result = runMemoryCaptureDropsCheck(dbPath);
+    expect(result.status).toBe('pass');
+  });
+
+  it('does NOT count unrelated defence_audit rows (e.g. real QUARANTINE holds)', () => {
+    initDatabase(dbPath);
+    closeDatabase();
+    insertFallbackAudit('injection pattern matched', new Date().toISOString());
+
+    const result = runMemoryCaptureDropsCheck(dbPath);
+    expect(result.status).toBe('pass');
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -9,6 +9,7 @@ import os from 'os';
 import semver from 'semver';
 import { execFileSync } from 'child_process';
 import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
 import { REQUIRED_HOOK_NAMES } from '../setup/settings-hooks.js';
 import { hookCommandResolves } from '../setup/hook-command-resolution.js';
 import {
@@ -1942,6 +1943,142 @@ async function checkAutoMemorySampling(): Promise<CheckResult> {
   }
 }
 
+// ── Check 9b: Memory-capture dist completeness (#137) ─────
+/**
+ * `scripts/lib/save-memory.mjs` (the single write path for the session-end,
+ * pre-compact and stop hooks) routes every captured memory through
+ * `loadDefenceModules()`, which dynamically imports three dist/ modules. If
+ * ANY of them is missing — a stale checkout, an interrupted install, a
+ * partial rebuild — `loadDefenceModules()` returns null, the hook writes a
+ * synthetic `defence_audit` row and a stderr line, and returns NORMALLY.
+ * Fail-closed there is correct: an unscanned memory must never be stored.
+ * This check does not touch that decision. What it fixes is that nothing
+ * used to surface the state — hook stderr is usually discarded, and the
+ * fallback audit row is otherwise invisible — so EVERY captured memory was
+ * silently dropped for as long as the condition held, and the only sign was
+ * a user noticing amnesia weeks later (#137).
+ *
+ * Mirrors loadDefenceModules()'s own resolution EXACTLY: same three files,
+ * same distRoot (package root + 'dist' — save-memory.mjs computes this two
+ * directories up from scripts/lib/, which is the same package root
+ * resolveSelfInstallDir() returns for doctor's own dist/cli/doctor.js).
+ */
+const MEMORY_CAPTURE_REQUIRED_MODULES: Array<{ rel: string; symbol: string }> = [
+  { rel: path.join('defence', 'pipeline.js'), symbol: 'runDefencePipeline' },
+  { rel: path.join('database', 'init.js'), symbol: 'initDatabase' },
+  { rel: path.join('defence', 'disposition.js'), symbol: 'resolveDisposition' },
+];
+
+const MEMORY_CAPTURE_FIX =
+  'Run `npm run build:ts` (dev checkout), or on an installed box reinstall + repair: ' +
+  '`npm i -g shieldcortex@latest && shieldcortex repair`.';
+
+/**
+ * Pure helper for the dist-completeness half. Exported so tests can point it
+ * at any temp "package root" instead of the real install.
+ */
+export async function runMemoryCaptureDistCheck(pkgRoot: string): Promise<CheckResult> {
+  const label = 'Memory capture: dist build';
+  const distRoot = path.join(pkgRoot, 'dist');
+
+  const missingFiles = MEMORY_CAPTURE_REQUIRED_MODULES.filter(
+    (m) => !fs.existsSync(path.join(distRoot, m.rel)),
+  );
+  if (missingFiles.length > 0) {
+    return {
+      label,
+      status: 'fail',
+      message:
+        `dist build is missing ${missingFiles.map((m) => m.rel).join(', ')} — the memory-capture ` +
+        `hooks (session-end, pre-compact, stop) fail CLOSED on this and silently drop every ` +
+        `captured memory while it holds.`,
+      fix: MEMORY_CAPTURE_FIX,
+    };
+  }
+
+  const brokenExports: string[] = [];
+  for (const m of MEMORY_CAPTURE_REQUIRED_MODULES) {
+    try {
+      const mod = await import(pathToFileURL(path.join(distRoot, m.rel)).href);
+      if (typeof (mod as Record<string, unknown>)[m.symbol] !== 'function') {
+        brokenExports.push(`${m.rel} is missing export ${m.symbol}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      brokenExports.push(`${m.rel} failed to import — ${msg}`);
+    }
+  }
+
+  if (brokenExports.length > 0) {
+    return {
+      label,
+      status: 'fail',
+      message: `dist build present but partial/corrupt — ${brokenExports.join('; ')} — memory capture is silently dropping every write.`,
+      fix: MEMORY_CAPTURE_FIX,
+    };
+  }
+
+  return {
+    label,
+    status: 'pass',
+    message: 'defence pipeline modules present (pipeline.js, database/init.js, disposition.js)',
+  };
+}
+
+/**
+ * Pure helper for the "did this already happen" half. Exported so tests can
+ * drive it against a temp database. Looks for the synthetic `defence_audit`
+ * rows `writeFallbackAudit()` writes when the pipeline is unavailable — these
+ * are the only trace a drop leaves. A hit here means real memories were lost
+ * even if the dist build has SINCE been fixed (the drops already happened and
+ * cannot be recovered — the content was never stored anywhere).
+ */
+export function runMemoryCaptureDropsCheck(dbPath: string): CheckResult {
+  const label = 'Memory capture: recent drops';
+  const prerequisite = databasePrerequisite(label, dbPath);
+  if (prerequisite) return prerequisite;
+
+  try {
+    const Database = require('better-sqlite3');
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      // 24h window: long enough to catch a stale dist build that has been
+      // silently dropping captures since the last session, short enough that
+      // a FAIL here means "look at this host now" rather than raking up
+      // ancient, already-actioned history.
+      const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      const row = db.prepare(
+        `SELECT COUNT(*) as count, MAX(timestamp) as latest FROM defence_audit
+           WHERE reason LIKE 'defence_pipeline_unavailable%' AND timestamp >= ?`,
+      ).get(since) as { count: number; latest: string | null };
+
+      if (row.count > 0) {
+        return {
+          label,
+          status: 'fail',
+          message:
+            `${row.count} memory capture(s) were DROPPED in the last 24h because the defence ` +
+            `pipeline was unavailable at write time (most recent: ${row.latest}). Fail-closed is ` +
+            `correct — nothing unscanned was stored — but the content itself is gone.`,
+          fix: `${MEMORY_CAPTURE_FIX} Historical drops cannot be recovered; check the "Memory capture: dist build" line above for whether the underlying cause is still live.`,
+        };
+      }
+      return { label, status: 'pass', message: 'no defence_pipeline_unavailable drops in the last 24h' };
+    } finally {
+      db.close();
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { label, status: 'warn', message: `check failed — ${msg}` };
+  }
+}
+
+async function checkMemoryCaptureDist(): Promise<CheckResult[]> {
+  const distResult = await runMemoryCaptureDistCheck(resolveSelfInstallDir());
+  const dropsResult = runMemoryCaptureDropsCheck(getDbPath());
+  return [distResult, dropsResult];
+}
+
 // ── Check 10: Brain-worker freshness (#45) ────────────────
 /**
  * The MCP server starts a lite-profile brain worker on connect (v4.14.0).
@@ -2866,6 +3003,7 @@ export async function runDoctor(args: string[] = []): Promise<DoctorSummary> {
     checkHookTimeouts,
     checkAutoMemoryHooks,
     checkAutoMemorySampling,
+    checkMemoryCaptureDist,
     checkBrainWorker,
     checkProjectKeyConsistency,
     checkProcesses,


### PR DESCRIPTION
## Summary

**#137 — memory capture fails silently when dist/ is stale or partial**
- `loadDefenceModules()` in `scripts/lib/save-memory.mjs` is correctly fail-closed when `dist/defence/pipeline.js`, `dist/database/init.js`, or `dist/defence/disposition.js` is missing/broken — an unscanned memory must never be stored, and that decision is untouched.
- What was missing was observability: a discarded stderr line and a fallback `defence_audit` row nobody looked at, so every captured memory silently dropped until someone noticed amnesia weeks later.
- `shieldcortex doctor` now runs two new checks, mirroring the hook's exact module resolution:
  - **"Memory capture: dist build"** — probes the same three dist modules for existence *and* export shape. FAILs with the exact missing piece and the fix command (`npm run build:ts` / `shieldcortex repair`).
  - **"Memory capture: recent drops"** — queries `defence_audit` for `defence_pipeline_unavailable` fallback rows in the last 24h, so a *since-fixed* dist build doesn't hide that real content was already lost (drops aren't recoverable — the content was never stored).

**#134 §1 — ESM-only exports break CJS consumers with an opaque error**
- `require('shieldcortex')` used to throw Node's bare `ERR_PACKAGE_PATH_NOT_EXPORTED`, naming neither the package nor the cause. Cost a fleet agent real diagnostic time chasing an unrelated plugin bug.
- **Decision (stated per the issue's ask): stay ESM-only.** There is no CJS build, and pointing `"require"` at the compiled ESM output (`dist/index.js`) would just trade this opaque failure for a different one (`ERR_REQUIRE_ESM`) — not a real fix.
- Every `exports` entry now declares a `"require"` condition pointing at `scripts/lib/cjs-not-supported.cjs` — a real, loadable `.cjs` file (so Node can actually load it despite `"type": "module"`) that throws a shieldcortex-specific, actionable error explaining the situation and how to fix it (`await import(...)` or convert the consumer to ESM). Documented in README under "ESM only".
- `main` is left as `dist/index.js` deliberately: it's completely inert for every exports-aware consumer (the entire modern ecosystem, including the issue's own repro command), and only reachable by exports-ignorant legacy tooling — for which Node's own `ERR_REQUIRE_ESM` is already more informative than the opaque error this PR removes. Changing it risks side effects in tooling I can't fully verify in this timeframe, for a code path this fix doesn't reach anyway.

**#134 §2 — realtime plugin reports its own death to console.warn**
- `register()`'s catch block used a bare `console.warn`, bypassing the gateway's structured log — real-time scanning, memory capture, and the Action Guard `before_tool_call` hook all went dark with no `[plugins]` line anywhere an operator looks.
- Worse: `/shieldcortex-status` was registered *inside* the same try block that could throw, so a crash meant the one diagnostic command an operator would reach for didn't even exist.
- Fixed: `/shieldcortex-status` now registers unconditionally, before the risky init work, and reports `STATUS: DEGRADED — plugin failed to initialize: <real error>` when registration failed. The catch block routes both warnings through `api.logger.warn`, falling back to `console.error` (never `console.warn`, so a fallback is visibly distinct) only if the host provides no logger at all.

## What the issues did not mention

- The issue's prose for #137 mentions `dist/memory/disposition.js`; the actual code path (`save-memory.mjs`) resolves `dist/defence/disposition.js`. Verified against source (`src/defence/disposition.ts`) and used the real path.
- While manually verifying the dist-completeness check against the live build, I found that `dist/memory/store.js` *statically* imports `disposition.js` — so an entirely-missing or export-mismatched file there already crashes the whole CLI (MCP server, all CLI commands, `doctor` itself) via Node's own module loader, loudly. Only `save-memory.mjs`'s hook path — the one place using a *dynamic* import specifically so it can fail closed instead of crashing the process — stays silent. That's the real shape of the bug, and it's why the new doctor check is exercised via isolated temp `pkgRoot` fixtures in tests rather than by corrupting the live `dist/`: doing the latter for real crashes the test runner itself, exactly as it would in production.

## Test plan

- [x] All new tests written first and delete-verified: reverted each fix, confirmed the corresponding test(s) went RED, then restored and confirmed GREEN.
  - `plugins/openclaw/__tests__/registration-failure-134.test.ts` (2 tests) — red without the fix (console.warn used instead of api.logger.warn; `/shieldcortex-status` undefined after a crash).
  - `src/cli/__tests__/doctor-memory-capture-dist-137.test.ts` (9 tests) — red without the fix (module doesn't export the check functions at all).
  - `src/__tests__/packaging-cjs-exports-134.test.ts` (21 tests) — red without the fix (11 failures, including hitting the real `ModuleNotFoundError`/opaque-resolution shape directly).
- [x] `node scripts/run-jest.mjs` — 309 suites, 3501 passed, 7 skipped, 0 failures (one `claude-md-refresh.test.ts` flake during a full parallel run, an `afterEach` temp-dir cleanup race unrelated to this change — reproduced independently in isolation: passes clean).
- [x] `npx tsc --noEmit -p tsconfig.json` — 0 new errors in any file touched (168 pre-existing errors elsewhere, none in `plugins/openclaw/index.ts`, `src/cli/doctor.ts`, or the new test files).
- [x] `node scripts/check-no-bare-require.mjs` (`test:dist`) — OK, no ESM-unsafe `require()` in dist.
- [x] Verified against a real `npm pack` tarball, extracted and installed as a dependency in throwaway CJS and ESM consumer projects:
  - `require('shieldcortex')` and `require('shieldcortex/defence')` both throw the new actionable error (not `ERR_PACKAGE_PATH_NOT_EXPORTED`).
  - `import('shieldcortex')` still resolves 150 exports; `import('shieldcortex/defence')` resolves 81.
  - The CLI binary (`dist/index.js --version`) still runs correctly from the packed tree.
  - `shieldcortex doctor` run against the real built dist on a fresh HOME: new "Memory capture: dist build" line shows ✅ PASS, drops-check correctly collapses into the "checked once the database exists" note; exit code 0 (confirms the new check doesn't false-positive on a healthy install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)