### PR TITLE
fix(#171): shieldcortex update reaches the #163 hardening and ends with the repair verify

### DIFF
--- a/src/cli/__tests__/update-install-parity-171.test.ts
+++ b/src/cli/__tests__/update-install-parity-171.test.ts
@@ -1,0 +1,79 @@
+/**
+ * #171 — `shieldcortex update` must reach the same fixes as `install`.
+ *
+ * Field question, 1 Aug 2026, after the operator-experience release: "what
+ * about shieldcortex update — does that still work?" Auditing it found the
+ * recurring codebase defect, again: two fixes had landed on the install path
+ * and never reached update's parallel flow.
+ *
+ *   - #163 permission hardening lives in `setupClaudeMd()` step 5; update
+ *     calls `setupHooks()` directly and skipped it — so a box that upgraded
+ *     via `update` kept its world-readable memories.db.
+ *   - update force-installed the plugin and LEFT THE GATEWAY RUNNING THE OLD
+ *     BUILD, with one gray "restart …" hint. On-disk current + gateway stale
+ *     is the state three fleet boxes spent the week stuck in.
+ *
+ * These are wiring tests in the #146/#160 tradition: the helpers are tested
+ * elsewhere; what rotted was whether THIS caller invokes them. Source-level,
+ * like enforcement-surface-parity — a runtime test of `runUpdate()` would need
+ * npm, a registry and a gateway.
+ */
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const updateSrc = fs.readFileSync(path.join(repoRoot, 'src', 'cli', 'update.ts'), 'utf-8');
+
+function bodyOf(fnName: string): string {
+  const at = updateSrc.indexOf(`async function ${fnName}`);
+  expect({ fn: fnName, found: at >= 0 }).toEqual({ fn: fnName, found: true });
+  return updateSrc.slice(at, updateSrc.indexOf('\n}', at));
+}
+
+describe('#171 — update runs the #163 permission hardening', () => {
+  it('a state-permissions stage exists and calls the shared helper', () => {
+    const body = bodyOf('stepStatePermissions');
+    expect(body).toMatch(/secureStatePermissions\(/);
+    // The SAME directory install hardens — not a re-derived path.
+    expect(body).toMatch(/getConfigDir\(\)/);
+  });
+
+  it('runUpdate invokes it', () => {
+    const body = bodyOf('runUpdate');
+    expect(body).toMatch(/await stepStatePermissions\(\)/);
+  });
+});
+
+describe('#171 — update ends by verifying protection, like repair', () => {
+  it('a verify stage exists and runs the reconcile flow', () => {
+    const body = bodyOf('stepVerifyProtection');
+    expect(body).toMatch(/reconcileOpenClawPluginState\(/);
+    expect(body).toMatch(/formatReconcileReport\(/);
+  });
+
+  it('expected version is read fresh from disk, never the in-process pkg version', () => {
+    // After the npm step the on-disk package is the NEW build; the running
+    // process is the OLD one. Pinning expectations to the old version would
+    // certify the staleness this stage exists to end.
+    const body = bodyOf('stepVerifyProtection');
+    expect(body).toMatch(/expectedVersion:\s*readPackageVersion\(\)/);
+    expect(body).not.toMatch(/expectedVersion:\s*currentVersion/);
+  });
+
+  it('an applied-but-failed verify sets a non-zero exit code — no false all-clear', () => {
+    const body = bodyOf('stepVerifyProtection');
+    expect(body).toMatch(/result\.applied && !result\.ok.*exitCode = 1/s);
+  });
+
+  it('runUpdate invokes it', () => {
+    const body = bodyOf('runUpdate');
+    expect(body).toMatch(/await stepVerifyProtection\(home\)/);
+  });
+
+  it('skips cleanly when no plugin is registered — a Claude-Code-only box is not an error', () => {
+    const body = bodyOf('stepVerifyProtection');
+    expect(body).toMatch(/isRealtimePluginRegistered\(home\)/);
+  });
+});

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -438,6 +438,70 @@ function maybePrint411Notice(currentVersion: string, mainUpdated: boolean): void
   process.stdout.write(`     ${paint('gray', 'changelog: ')}${paint('cyan', 'https://github.com/Drakon-Systems-Ltd/ShieldCortex/blob/main/CHANGELOG.md')}\n\n`);
 }
 
+// ── #171: the two install-path fixes update was missing ─────
+
+/**
+ * Harden state permissions — the #163 fix, which `update` silently skipped.
+ *
+ * The audit hardening runs in `setupClaudeMd()` step 5, and `install` reaches
+ * it. `update` calls `setupHooks()` DIRECTLY, so every box that upgraded via
+ * `shieldcortex update` rather than the full install command kept its
+ * world-readable memories.db. The recurring codebase defect, again: a fix that
+ * lands on one of two call sites. Both surfaces now run the same helper.
+ */
+async function stepStatePermissions(): Promise<StepResult> {
+  return await step('State permissions', async () => {
+    const { secureStatePermissions } = await import('../setup/state-permissions.js');
+    const { getConfigDir } = await import('../cloud/config.js');
+    const findings = secureStatePermissions(getConfigDir());
+    const fixed = findings.filter((f) => f.fixed).length;
+    const failed = findings.length - fixed;
+    if (failed > 0) return { status: 'warn' as const, summary: `${failed} path(s) could not be tightened` };
+    return fixed > 0 ? `tightened ${fixed} path(s) to owner-only` : 'owner-only';
+  });
+}
+
+/**
+ * Finish by proving the update actually PROTECTS the box (#156/#171).
+ *
+ * Before this, `update` force-installed the plugin, printed the on-disk
+ * version transition, and left the gateway running the OLD build with one gray
+ * "restart …" hint in the footer. That gap — on-disk current, gateway stale —
+ * is the exact state three fleet boxes spent this week stuck in, and the state
+ * an operator explicitly cannot diagnose from our own output (doctor reads the
+ * disk; the gateway enforces from memory).
+ *
+ * So update now ends the same way repair does: reconcile → restart → wait for
+ * the gateway to prove it is the new process → self-check → one plain-English
+ * verdict line. Consent follows #156 exactly — an interactive terminal IS the
+ * consent (you typed `update`; a plugin update that leaves the old build
+ * enforcing is not an update), while headless runs still require the explicit
+ * envs and degrade to today's hint rather than restarting a gateway out from
+ * under an agent.
+ *
+ * The dynamic import is deliberate: npm has just replaced this package on
+ * disk, so importing here loads the FRESHLY INSTALLED reconcile/self-check —
+ * the new version verifies itself with its own logic, not last release's.
+ */
+async function stepVerifyProtection(home: string): Promise<void> {
+  if (!isRealtimePluginRegistered(home)) return;
+  process.stdout.write('\n');
+  try {
+    const { reconcileOpenClawPluginState, formatReconcileReport } = await import('../setup/openclaw-reconcile.js');
+    // Expected version read fresh from disk — after the npm step this is the
+    // NEW build, and pinning expectations to the in-process (old) version
+    // would certify the very staleness this step exists to end.
+    const result = await reconcileOpenClawPluginState({ home, expectedVersion: readPackageVersion() });
+    for (const line of formatReconcileReport(result)) {
+      process.stdout.write(`  ${line}\n`);
+    }
+    if (result.applied && !result.ok) process.exitCode = 1;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stdout.write(`  ${paint('gray', `protection check skipped — ${msg}`)}\n`);
+  }
+}
+
 // ── Public entry ────────────────────────────────────────────
 
 export async function runUpdate(): Promise<void> {
@@ -469,8 +533,13 @@ export async function runUpdate(): Promise<void> {
   await stepOpenClawPlugin(home);
   await stepOpenClawSkill(home);
   await stepClaudeHooks();
+  await stepStatePermissions();
 
   footer(Date.now() - flowStart, mainUpdated);
+
+  // The verdict comes AFTER the footer so the last thing on screen is the one
+  // line that answers "am I protected?" — not a spinner summary.
+  await stepVerifyProtection(home);
 
   // If the binding couldn't be auto-healed, print the exact copy-paste fix.
   if (engineResult.remediation) {


### PR DESCRIPTION
Answers "does `shieldcortex update` still work?" — it works, but it was a second copy of the install flow and two of this week's fixes never reached it. Details in the commit message and #171.

- `update` now runs the #163 permission hardening on the same directory `install` hardens.
- `update` now ends the way `repair` does: reconcile → restart → wait for readiness → self-check → one plain-English verdict line. #156 TTY consent applies; headless runs are unchanged.
- Expected version read fresh from disk after the npm step, so the freshly installed build verifies itself rather than the old in-process one.

7 wiring tests, delete-verified. Full suite 3,706 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)