### PR TITLE
feat(#179): one command installs the skill, and drift cannot hide

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2894,6 +2894,46 @@ export async function checkOpenClawRunningPluginVersion(
  * the operator invoked deliberately. Reporting a mode we quietly changed behind
  * their back would be its own dishonesty.
  */
+/**
+ * The installed OpenClaw SKILL must track the CLI version (#179).
+ *
+ * Found in the field, 1 Aug: a box whose every surface read green was carrying
+ * a skill copy 21 releases stale — nothing compared the skill to anything, so
+ * the drift was invisible by construction. The skill is the fleet's operating
+ * manual for this product; a stale one instructs agents in behaviour the
+ * shipped code no longer has.
+ *
+ * Absent skill is INFO, not a failure — Claude-Code-only installs never want
+ * it. Drift is a WARN with the one command that fixes it.
+ */
+export async function checkOpenClawSkillVersion(
+  home: string = os.homedir(),
+  cliVersion: string = pkg.version,
+): Promise<CheckResult> {
+  const label = 'OpenClaw skill version';
+  const { findInstalledSkillDirs, readInstalledSkillVersion } = await import('../setup/openclaw.js');
+  const dirs = findInstalledSkillDirs(home);
+  if (dirs.length === 0) {
+    return { label, status: 'info', message: 'skill not installed (optional) — `shieldcortex openclaw skill install` adds it' };
+  }
+  const v = readInstalledSkillVersion(dirs[0]);
+  if (!v) {
+    return {
+      label, status: 'warn',
+      message: `skill present at ${dirs[0]} but its SKILL.md version is unreadable`,
+      fix: 'Run shieldcortex openclaw skill install to reinstall a clean copy',
+    };
+  }
+  if (v === cliVersion) {
+    return { label, status: 'pass', message: `skill v${v} matches CLI v${cliVersion}` };
+  }
+  return {
+    label, status: 'warn',
+    message: `skill v${v} does not match CLI v${cliVersion} — agents are reading stale instructions`,
+    fix: 'Run shieldcortex openclaw skill install',
+  };
+}
+
 export async function checkStatePermissions(stateDir: string = getShieldCortexDir()): Promise<CheckResult> {
   const label = 'State permissions';
   let findings: Array<{ path: string; found: string; required: string }>;
@@ -3145,6 +3185,7 @@ export async function runDoctor(
     checkOpenClawResidue,
     checkOpenClawHookFreshness,
     checkOpenClawPluginVersion,
+    checkOpenClawSkillVersion,
     checkOpenClawPluginLoadState,
     checkOpenClawRunningPluginVersion,
     checkOpenClawPluginPackage,

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -336,24 +336,35 @@ async function stepOpenClawPlugin(home: string): Promise<StepResult> {
 }
 
 async function stepOpenClawSkill(home: string): Promise<StepResult> {
-  const skillDirs = [
-    path.join(home, '.openclaw', 'workspace', 'skills', 'shieldcortex'),
-    path.join(home, '.openclaw', 'skills', 'shieldcortex'),
-    path.join(home, 'clawd', 'skills', 'shieldcortex'),
-    path.join(home, 'friday', 'skills', 'shieldcortex'),
-  ];
-  if (!skillDirs.find((d) => fs.existsSync(d))) {
-    return await step('OpenClaw skill', async () => ({ status: 'skip' as const, summary: 'not installed' }));
+  // #179: this step used to be four stacked failures — it spawned a bare
+  // `openclaw` (invisible to non-interactive PATH on two of five fleet hosts),
+  // omitted the acknowledge flag ClawHub now requires (so even a resolvable
+  // binary cancelled), skipped silently when no copy existed, and reported
+  // "@latest installed" off the exit code without reading what landed. The
+  // measured result: a box carrying a skill 21 releases stale with every
+  // surface green. Now: resolved binary, acknowledge flag, verify-by-reading,
+  // and the skip names the command that installs.
+  const { resolveOpenClawBinary, findInstalledSkillDirs, readInstalledSkillVersion } =
+    await import('../setup/openclaw.js');
+  if (findInstalledSkillDirs(home).length === 0) {
+    return await step('OpenClaw skill', async () => ({
+      status: 'skip' as const,
+      summary: 'not installed — `shieldcortex openclaw skill install` adds it',
+    }));
   }
   return await step('OpenClaw skill', async () => {
+    const bin = resolveOpenClawBinary(home);
+    if (!bin) return { status: 'warn' as const, summary: 'openclaw binary not found — run `shieldcortex openclaw skill install`' };
     try {
-      await runQuiet('openclaw', ['skills', 'install', 'shieldcortex', '--force'], {
-        timeout: 60000,
+      await runQuiet(bin, ['skills', 'install', 'shieldcortex', '--force', '--acknowledge-clawhub-risk'], {
+        timeout: 120000,
         env: { ...process.env, HOME: home },
       });
-      return '@latest installed';
+      const dirs = findInstalledSkillDirs(home);
+      const v = dirs.length > 0 ? readInstalledSkillVersion(dirs[0]) : null;
+      return v ? `v${v} installed` : { status: 'warn' as const, summary: 'installed but version unreadable' };
     } catch {
-      return { status: 'warn' as const, summary: 'reinstall failed (run manually)' };
+      return { status: 'warn' as const, summary: 'reinstall failed — run `shieldcortex openclaw skill install`' };
     }
   });
 }

--- a/src/setup/__tests__/skill-install-179.test.ts
+++ b/src/setup/__tests__/skill-install-179.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #179 — the skill has one install path, and drift cannot hide.
+ *
+ * Field report, 1 Aug: an operator typed `shieldcortex openclaw skill install`
+ * — the obvious command — and got a usage screen. Behind it, four stacked
+ * failures had let the installed skill silently age 21 releases: the npm
+ * tarball does not ship the skill, the CLI offered no install path, `update`
+ * refreshed only an existing copy via a bare `openclaw` spawn (invisible to
+ * non-interactive PATH on two of five fleet hosts) without the acknowledge
+ * flag ClawHub now requires, and nothing anywhere compared the skill version
+ * to the CLI version.
+ */
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  resolveOpenClawBinary,
+  findInstalledSkillDirs,
+  readInstalledSkillVersion,
+} from '../openclaw.js';
+import { checkOpenClawSkillVersion } from '../../cli/doctor.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function fakeHome(skillVersion?: string): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-179-'));
+  if (skillVersion) {
+    const dir = path.join(home, '.openclaw', 'workspace', 'skills', 'shieldcortex');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      `---\nname: shieldcortex\nmetadata:\n  version: ${skillVersion}\n---\nbody\n`,
+    );
+  }
+  return home;
+}
+
+describe('#179 — binary resolution does not bet on PATH', () => {
+  it('falls back to well-known locations when `which` finds nothing', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-179bin-'));
+    try {
+      const binDir = path.join(home, '.npm-global', 'bin');
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.writeFileSync(path.join(binDir, 'openclaw'), '#!/bin/sh\n');
+      // `which` may or may not resolve on this host; the contract is that a
+      // known-location copy is found EVEN IF it does not.
+      const found = resolveOpenClawBinary(home);
+      expect(found).not.toBeNull();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('#179 — skill discovery and version parsing', () => {
+  it('finds the workspace copy and reads its frontmatter version', () => {
+    const home = fakeHome('4.47.6');
+    try {
+      const dirs = findInstalledSkillDirs(home);
+      expect(dirs).toHaveLength(1);
+      expect(readInstalledSkillVersion(dirs[0])).toBe('4.47.6');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null rather than throwing on a missing or mangled SKILL.md', () => {
+    const home = fakeHome();
+    try {
+      expect(findInstalledSkillDirs(home)).toHaveLength(0);
+      expect(readInstalledSkillVersion('/nonexistent')).toBeNull();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('#179 — doctor makes drift visible', () => {
+  it('the aiquant state: skill 21 releases behind → WARN naming the fix command', async () => {
+    const home = fakeHome('4.47.6');
+    try {
+      const r = await checkOpenClawSkillVersion(home, '4.47.27');
+      expect(r.status).toBe('warn');
+      expect(r.message).toContain('4.47.6');
+      expect(r.fix).toContain('shieldcortex openclaw skill install');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('matching versions → pass', async () => {
+    const home = fakeHome('4.47.27');
+    try {
+      const r = await checkOpenClawSkillVersion(home, '4.47.27');
+      expect(r.status).toBe('pass');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('absent skill → info, never a failure (Claude-Code-only boxes)', async () => {
+    const home = fakeHome();
+    try {
+      const r = await checkOpenClawSkillVersion(home, '4.47.27');
+      expect(r.status).toBe('info');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('#179 — the command the operator typed now exists', () => {
+  it('the openclaw subcommand router carries a skill case and the usage names it', () => {
+    const src = fs.readFileSync(path.join(repoRoot, 'src', 'setup', 'openclaw.ts'), 'utf-8');
+    expect(src).toMatch(/case 'skill':/);
+    expect(src).toMatch(/openclaw <install\|uninstall\|status\|repair\|skill install>/);
+  });
+
+  it('update wires the resolved binary + acknowledge flag, and its skip names the install command', () => {
+    const src = fs.readFileSync(path.join(repoRoot, 'src', 'cli', 'update.ts'), 'utf-8');
+    expect(src).toMatch(/resolveOpenClawBinary/);
+    expect(src).toMatch(/--acknowledge-clawhub-risk/);
+    expect(src).toMatch(/shieldcortex openclaw skill install/);
+  });
+});

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -1745,6 +1745,102 @@ export async function repairOpenClawPlugin(): Promise<void> {
   console.log('Repair complete. Restart the OpenClaw gateway to load the fresh plugin install.');
 }
 
+/**
+ * Resolve the `openclaw` binary robustly (#179).
+ *
+ * `which openclaw` alone fails on every box where user-level binaries are
+ * invisible to non-interactive shells — measured on two of five fleet hosts,
+ * and the same defect shape that left Claude Code hooks dead for weeks (#146:
+ * a bare command name is a bet about someone else's PATH). Fall back to the
+ * well-known install locations before giving up.
+ */
+export function resolveOpenClawBinary(home: string = os.homedir()): string | null {
+  try {
+    const found = execSync('which openclaw', { encoding: 'utf-8', timeout: 5000 }).trim();
+    if (found && fs.existsSync(found)) return found;
+  } catch { /* not on PATH — try known locations */ }
+  const candidates = [
+    path.join(home, '.npm-global', 'bin', 'openclaw'),
+    '/usr/local/bin/openclaw',
+    '/opt/homebrew/bin/openclaw',
+    path.join(home, '.local', 'bin', 'openclaw'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+/** The four places an installed skill copy can live, in preference order. */
+export function findInstalledSkillDirs(home: string = os.homedir()): string[] {
+  return [
+    path.join(home, '.openclaw', 'workspace', 'skills', 'shieldcortex'),
+    path.join(home, '.openclaw', 'skills', 'shieldcortex'),
+    path.join(home, 'clawd', 'skills', 'shieldcortex'),
+    path.join(home, 'friday', 'skills', 'shieldcortex'),
+  ].filter((d) => fs.existsSync(d));
+}
+
+/** Parse `version:` out of an installed SKILL.md frontmatter, or null. */
+export function readInstalledSkillVersion(skillDir: string): string | null {
+  try {
+    const text = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf-8').slice(0, 4000);
+    const m = text.match(/^\s*version:\s*([\w.\-]+)\s*$/m);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `shieldcortex openclaw skill install|update` (#179).
+ *
+ * Field report, 1 Aug: an operator on a fully-green box typed exactly this
+ * command and got the usage screen. Behind it, four stacked failures had let
+ * the installed skill silently age 21 releases: the npm tarball does not ship
+ * the skill (ClawHub is its distribution channel), the CLI offered no install
+ * path, `update` only refreshed a copy that already existed via a bare
+ * `openclaw` spawn that breaks on PATH-less hosts, and the ClawHub install now
+ * requires an acknowledge flag nothing passed. This command is the one path,
+ * and it VERIFIES: the installed SKILL.md version must match this CLI's
+ * version, or it says so plainly instead of printing a green line.
+ */
+export async function installOpenClawSkill(home: string = os.homedir()): Promise<boolean> {
+  const bin = resolveOpenClawBinary(home);
+  if (!bin) {
+    console.log('✗ Could not find the `openclaw` binary (PATH or known install locations).');
+    console.log('  Install OpenClaw first, or run: openclaw skills install shieldcortex --force --acknowledge-clawhub-risk');
+    return false;
+  }
+  const r = spawnSync(bin, ['skills', 'install', 'shieldcortex', '--force', '--acknowledge-clawhub-risk'], {
+    encoding: 'utf-8',
+    timeout: 120000,
+    env: { ...process.env, HOME: home },
+  });
+  const output = `${r.stdout ?? ''}${r.stderr ?? ''}`;
+  if (r.status !== 0) {
+    console.log('✗ ClawHub skill install failed:');
+    console.log(output.trim().split('\n').slice(-3).map((l) => `  ${l}`).join('\n'));
+    return false;
+  }
+  // Verify by reading what actually landed, never by trusting the exit code.
+  const dirs = findInstalledSkillDirs(home);
+  const version = dirs.length > 0 ? readInstalledSkillVersion(dirs[0]) : null;
+  const cliVersion = JSON.parse(
+    fs.readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'package.json'), 'utf-8'),
+  ).version as string;
+  if (!version) {
+    console.log('⚠ Install reported success but no SKILL.md version could be read — check `openclaw skills list`.');
+    return false;
+  }
+  if (version === cliVersion) {
+    console.log(`✓ ShieldCortex skill v${version} installed and matches this CLI.`);
+    return true;
+  }
+  console.log(`⚠ Skill installed at v${version}, but this CLI is v${cliVersion} — ClawHub may still be syncing the latest release. Re-run in a few minutes.`);
+  return false;
+}
+
 export async function handleOpenClawCommand(subcommand: string, extraArgs: string[] = []): Promise<void> {
   const noHooks = extraArgs.includes('--no-hooks');
   const noPlugins = extraArgs.includes('--no-plugins');
@@ -1763,8 +1859,22 @@ export async function handleOpenClawCommand(subcommand: string, extraArgs: strin
     case 'repair':
       await repairOpenClawPlugin();
       break;
+    case 'skill': {
+      // `install` and `update` are deliberately the same operation — ClawHub's
+      // force-install is idempotent, and the distinction was one more thing
+      // for an operator to guess wrong.
+      const verb = extraArgs[0] || '';
+      if (verb === 'install' || verb === 'update') {
+        const ok = await installOpenClawSkill();
+        if (!ok) process.exit(1);
+      } else {
+        console.log('Usage: shieldcortex openclaw skill <install|update>');
+        process.exit(1);
+      }
+      break;
+    }
     default:
-      console.log('Usage: shieldcortex openclaw <install|uninstall|status|repair>');
+      console.log('Usage: shieldcortex openclaw <install|uninstall|status|repair|skill install>');
       console.log('');
       console.log('Install options:');
       console.log('  --no-hooks              Skip hook installation (useful in Docker/CI)');


### PR DESCRIPTION
The command the operator typed now exists: `shieldcortex openclaw skill install` (and `update`, deliberately the same idempotent operation).

Closes all four stacked failures from #179: no CLI install path, bare-`openclaw` spawn breaking on PATH-less hosts, missing `--acknowledge-clawhub-risk`, and no surface anywhere comparing skill version to CLI version. New doctor check makes the 21-release drift class visible: pass/warn-with-fix/info.

Install verifies by **reading what landed** (SKILL.md version vs CLI version), never by trusting the exit code.

**Evidence:** 8 tests including the exact aiquant field state; full suite 3,724.

Closes #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)