### PR TITLE
fix(#197): uninstall removes everything install creates, or says why not

### DIFF
--- a/src/setup/__tests__/uninstall-parity-197.test.ts
+++ b/src/setup/__tests__/uninstall-parity-197.test.ts
@@ -1,0 +1,131 @@
+/**
+ * #197 — uninstall parity: every artifact install creates has a declared fate.
+ *
+ * Field origin, 3 Aug: the operator asked whether uninstall needed updating —
+ * the same instinct that caught `update` skipping install's hardening (#171).
+ * It did: install had grown the ClawHub skill (#179/#187) and uninstall never
+ * learned about it, so an "uninstalled" box kept a stale skill copy. Same
+ * disease as everything that week — a second call site the fix never reached.
+ *
+ * The manifest turns that from an audit finding into a failing test: an
+ * artifact must name its removal function (which must actually be CALLED from
+ * the uninstall path) or carry a written keep-reason that the operator sees.
+ */
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { UNINSTALL_MANIFEST, formatKeptSummary } from '../uninstall-manifest.js';
+import { uninstallOpenClawSkill, skillDirLooksShieldcortex } from '../openclaw.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const uninstallPathSource =
+  fs.readFileSync(path.join(repoRoot, 'src', 'setup', 'uninstall.ts'), 'utf-8') +
+  fs.readFileSync(path.join(repoRoot, 'src', 'setup', 'openclaw.ts'), 'utf-8');
+
+function skillHome(frontmatterName?: string): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-197-'));
+  const dir = path.join(home, '.openclaw', 'workspace', 'skills', 'shieldcortex');
+  fs.mkdirSync(dir, { recursive: true });
+  if (frontmatterName !== undefined) {
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      `---\nname: ${frontmatterName}\nmetadata:\n  version: 4.47.29\n---\nbody\n`,
+    );
+  }
+  return home;
+}
+
+describe('#197 — the manifest rule: exactly one fate per artifact', () => {
+  it('every artifact is removed XOR kept, never both, never neither', () => {
+    for (const a of UNINSTALL_MANIFEST) {
+      const fates = [a.removedBy, a.keepReason].filter(Boolean).length;
+      expect(`${a.id}: ${fates} fate(s)`).toBe(`${a.id}: 1 fate(s)`);
+    }
+  });
+
+  it('every removal function is actually called from the uninstall path', () => {
+    // A manifest entry naming a function nobody calls is the #171 disease
+    // with better paperwork. Definitions ("function foo(") do not count.
+    for (const a of UNINSTALL_MANIFEST) {
+      if (!a.removedBy) continue;
+      const callSite = new RegExp(`(?<!function )\\b${a.removedBy}\\(`);
+      expect(`${a.id} call-site: ${callSite.test(uninstallPathSource)}`).toBe(`${a.id} call-site: true`);
+    }
+  });
+
+  it('the skill artifact is in the manifest — the gap that opened #197 stays closed', () => {
+    const skill = UNINSTALL_MANIFEST.find((a) => a.id === 'clawhub-skill');
+    expect(skill?.removedBy).toBe('uninstallOpenClawSkill');
+  });
+
+  it('the full uninstall path itself removes the skill — the standalone verb alone is not parity', () => {
+    // A `skill uninstall` verb someone can type is not the same as
+    // `shieldcortex uninstall` leaving no skill behind. Pin the call inside
+    // uninstallOpenClawHook's own body.
+    const src = fs.readFileSync(path.join(repoRoot, 'src', 'setup', 'openclaw.ts'), 'utf-8');
+    const start = src.indexOf('export async function uninstallOpenClawHook');
+    const end = src.indexOf('export', start + 1);
+    expect(start).toBeGreaterThan(-1);
+    expect(src.slice(start, end)).toContain('uninstallOpenClawSkill();');
+  });
+});
+
+describe('#197 — skill removal is fail-closed on ownership', () => {
+  it('removes a ShieldCortex-owned skill copy', () => {
+    const home = skillHome('shieldcortex');
+    try {
+      const r = uninstallOpenClawSkill(home);
+      expect(r.removed).toHaveLength(1);
+      expect(r.skipped).toHaveLength(0);
+      expect(fs.existsSync(path.join(home, '.openclaw', 'workspace', 'skills', 'shieldcortex'))).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves a foreign directory that merely shares the name — a user's own 'shieldcortex' folder must survive our uninstall", () => {
+    const home = skillHome('someones-notes');
+    try {
+      const r = uninstallOpenClawSkill(home);
+      expect(r.removed).toHaveLength(0);
+      expect(r.skipped).toHaveLength(1);
+      expect(fs.existsSync(path.join(home, '.openclaw', 'workspace', 'skills', 'shieldcortex'))).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('an unreadable SKILL.md fails closed: kept, not deleted', () => {
+    const home = skillHome(undefined); // dir exists, no SKILL.md at all
+    try {
+      expect(skillDirLooksShieldcortex(path.join(home, '.openclaw', 'workspace', 'skills', 'shieldcortex'))).toBe(false);
+      const r = uninstallOpenClawSkill(home);
+      expect(r.removed).toHaveLength(0);
+      expect(r.skipped).toHaveLength(1);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('#197 — the operator sees what was kept, and why', () => {
+  it('the kept summary names every intentional keep with its reason', () => {
+    const summary = formatKeptSummary();
+    for (const a of UNINSTALL_MANIFEST) {
+      if (!a.keepReason) continue;
+      expect(summary).toContain(a.keepReason);
+      if (a.keptAt) expect(summary).toContain(a.keptAt);
+    }
+  });
+
+  it('uninstall actually prints it — the summary is wired, not decorative', () => {
+    const src = fs.readFileSync(path.join(repoRoot, 'src', 'setup', 'uninstall.ts'), 'utf-8');
+    expect(src).toMatch(/formatKeptSummary\(\)/);
+  });
+
+  it('the memory database keep still tells the operator how to delete it themselves', () => {
+    expect(formatKeptSummary()).toContain('~/.shieldcortex/memories.db');
+  });
+});

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -1173,6 +1173,11 @@ export async function uninstallOpenClawHook(): Promise<void> {
   // Clean up legacy plugin entry if present
   cleanupLegacyPlugin();
 
+  // Remove installed skill copies (#197) — before this, an "uninstalled" box
+  // kept a stale ClawHub skill that would silently age (the aiquant disease,
+  // in reverse: drift on a box that thinks it is clean).
+  uninstallOpenClawSkill();
+
   if (removed === 0) {
     console.log('cortex-memory hook is not installed.');
   }
@@ -1841,6 +1846,50 @@ export async function installOpenClawSkill(home: string = os.homedir()): Promise
   return false;
 }
 
+/**
+ * Ownership check before deleting a skill directory. Fail-closed: an
+ * unreadable or foreign SKILL.md means we do not touch the directory —
+ * `findInstalledSkillDirs` matches by directory name, and a user's unrelated
+ * "shieldcortex" folder must survive our uninstall.
+ */
+export function skillDirLooksShieldcortex(dir: string): boolean {
+  try {
+    const text = fs.readFileSync(path.join(dir, 'SKILL.md'), 'utf-8').slice(0, 4000);
+    return /^\s*name:\s*['"]?shieldcortex['"]?\s*$/mi.test(text);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Remove installed skill copies (#197). OpenClaw's CLI has install/update but
+ * no uninstall verb for skills, so direct removal of the known install
+ * locations is the only mechanism — gated on the ownership check above.
+ */
+export function uninstallOpenClawSkill(home: string = os.homedir()): { removed: string[]; skipped: string[] } {
+  const removed: string[] = [];
+  const skipped: string[] = [];
+  for (const dir of findInstalledSkillDirs(home)) {
+    if (!skillDirLooksShieldcortex(dir)) {
+      console.warn(`Skill: ${dir} does not look ShieldCortex-owned — leaving it alone.`);
+      skipped.push(dir);
+      continue;
+    }
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+      console.log(`Skill: removed ${dir}`);
+      removed.push(dir);
+    } catch (err: any) {
+      console.warn(`Skill: failed to remove ${dir}: ${err.message}`);
+      skipped.push(dir);
+    }
+  }
+  if (removed.length === 0 && skipped.length === 0) {
+    console.log('Skill: no installed copies found.');
+  }
+  return { removed, skipped };
+}
+
 export async function handleOpenClawCommand(subcommand: string, extraArgs: string[] = []): Promise<void> {
   const noHooks = extraArgs.includes('--no-hooks');
   const noPlugins = extraArgs.includes('--no-plugins');
@@ -1867,8 +1916,10 @@ export async function handleOpenClawCommand(subcommand: string, extraArgs: strin
       if (verb === 'install' || verb === 'update') {
         const ok = await installOpenClawSkill();
         if (!ok) process.exit(1);
+      } else if (verb === 'uninstall') {
+        uninstallOpenClawSkill();
       } else {
-        console.log('Usage: shieldcortex openclaw skill <install|update>');
+        console.log('Usage: shieldcortex openclaw skill <install|update|uninstall>');
         process.exit(1);
       }
       break;

--- a/src/setup/uninstall-manifest.ts
+++ b/src/setup/uninstall-manifest.ts
@@ -1,0 +1,123 @@
+/**
+ * Uninstall parity manifest (#197).
+ *
+ * Field origin, 3 Aug: the operator asked whether uninstall needed updating —
+ * the same instinct that caught `update` skipping install's permission
+ * hardening (#171). Audit confirmed the same disease: install had grown a new
+ * artifact (the ClawHub skill, #179/#187) and uninstall never learned about
+ * it, so an "uninstalled" box kept a stale skill copy that would age silently.
+ *
+ * This manifest is the fix for the CLASS, not just the instance: every
+ * artifact any install surface creates is listed here with exactly one fate —
+ * a named removal function, or a written reason it is deliberately kept. A
+ * parity test asserts both the exclusive-fate rule and that each removal
+ * function is actually called from the uninstall path, so the next new
+ * artifact cannot ship without declaring its uninstall story.
+ */
+
+export interface UninstallArtifact {
+  /** Stable identifier for the artifact. */
+  id: string;
+  /** What the artifact is, in operator English. */
+  description: string;
+  /** Which command creates it. */
+  createdBy: string;
+  /** Exported function that removes it — exclusive with `keepReason`. */
+  removedBy?: string;
+  /** Why uninstall deliberately leaves it — exclusive with `removedBy`. */
+  keepReason?: string;
+  /** Where the kept artifact lives, for the closing summary. */
+  keptAt?: string;
+}
+
+export const UNINSTALL_MANIFEST: UninstallArtifact[] = [
+  {
+    id: 'claude-settings-hooks',
+    description: 'ShieldCortex hooks in ~/.claude/settings.json',
+    createdBy: 'shieldcortex install',
+    removedBy: 'removeHooks',
+  },
+  {
+    id: 'claude-md-block',
+    description: 'Memory-system block in ~/.claude/CLAUDE.md',
+    createdBy: 'shieldcortex install',
+    removedBy: 'removeClaudeMdBlock',
+  },
+  {
+    id: 'mcp-entry',
+    description: 'MCP server entry in ~/.claude.json',
+    createdBy: 'shieldcortex install',
+    removedBy: 'removeMcpEntry',
+  },
+  {
+    id: 'background-service',
+    description: 'Brain-worker background service',
+    createdBy: 'shieldcortex install',
+    removedBy: 'uninstallService',
+  },
+  {
+    id: 'openclaw-hook',
+    description: 'cortex-memory hook in OpenClaw hooks directories',
+    createdBy: 'shieldcortex openclaw install',
+    removedBy: 'uninstallOpenClawHook',
+  },
+  {
+    id: 'openclaw-plugin',
+    description: 'shieldcortex-realtime OpenClaw plugin (files + config refs)',
+    createdBy: 'shieldcortex openclaw install',
+    removedBy: 'uninstallPlugin',
+  },
+  {
+    id: 'clawhub-skill',
+    description: 'ShieldCortex skill copies (ClawHub / workspace locations)',
+    createdBy: 'shieldcortex openclaw skill install',
+    removedBy: 'uninstallOpenClawSkill',
+  },
+  {
+    id: 'memories-db',
+    description: 'Memory database',
+    createdBy: 'shieldcortex install (first run)',
+    keepReason: 'your memories are your data, not ours to delete — remove ~/.shieldcortex yourself if you want them gone',
+    keptAt: '~/.shieldcortex/memories.db',
+  },
+  {
+    id: 'audit-trail',
+    description: 'Enforcement audit log',
+    createdBy: 'guard activity',
+    keepReason: 'the audit trail outlives the tool so past enforcement decisions stay reviewable',
+    keptAt: '~/.shieldcortex/audit/',
+  },
+  {
+    id: 'config-backups',
+    description: 'Backups taken before ShieldCortex ever mutated your config files',
+    createdBy: 'shieldcortex install / update / uninstall',
+    keepReason: 'they are your rollback if any removal above went wrong',
+    keptAt: '~/.shieldcortex/backups/',
+  },
+  {
+    id: 'state-permissions',
+    description: 'Owner-only permissions hardened onto ~/.shieldcortex',
+    createdBy: 'shieldcortex install / update',
+    keepReason: 'an attribute of the kept state above — tighter-than-default permissions are safe to leave',
+    keptAt: '~/.shieldcortex/',
+  },
+  {
+    id: 'npm-package',
+    description: 'The global npm package itself',
+    createdBy: 'npm i -g shieldcortex',
+    keepReason: 'npm owns it: npm uninstall -g shieldcortex',
+  },
+];
+
+/**
+ * The closing lines of every uninstall: what was deliberately kept, and why.
+ * Silence about a kept artifact reads as coverage — so it is never silent.
+ */
+export function formatKeptSummary(): string {
+  const kept = UNINSTALL_MANIFEST.filter((a) => a.keepReason);
+  const lines = ['Kept on purpose:'];
+  for (const a of kept) {
+    lines.push(`  - ${a.keptAt ? `${a.keptAt} — ` : ''}${a.description}: ${a.keepReason}`);
+  }
+  return lines.join('\n');
+}

--- a/src/setup/uninstall.ts
+++ b/src/setup/uninstall.ts
@@ -14,6 +14,7 @@ import readline from 'readline';
 import { uninstallService } from '../service/install.js';
 import { uninstallOpenClawHook } from './openclaw.js';
 import { looksLikeShieldcortex } from './json-config.js';
+import { formatKeptSummary } from './uninstall-manifest.js';
 
 /**
  * Check if the current process is running in an agent context.
@@ -326,10 +327,10 @@ export async function uninstallAll(options?: {
     }
   }
 
-  console.log('\nDatabase preserved at ~/.shieldcortex/memories.db — delete manually if desired.');
-  console.log('Uninstall complete.\n');
-  console.log('To also remove the npm package:');
-  console.log('  npm uninstall -g shieldcortex');
+  // The last thing on screen is what we deliberately did NOT remove, and why
+  // (#197). Silence about a kept artifact reads as coverage.
+  console.log('\nUninstall complete.\n');
+  console.log(formatKeptSummary());
   console.log('\nTo clear the npx cache:');
   console.log('  npx cache clean shieldcortex  (npm 9+)');
   console.log('  rm -rf ~/.npm/_npx             (older npm)\n');


### PR DESCRIPTION
Closes #197.

Field origin: Michael asked whether uninstall needed updating — the same instinct that caught `update` skipping install's hardening (#171). Audit confirmed it: install had grown the ClawHub skill (#179/#187) and uninstall never learned about it, so an "uninstalled" box kept a stale skill copy.

**What changed**

- `uninstallOpenClawSkill()` — removes the known skill install locations. Fail-closed ownership check first: a directory merely *named* shieldcortex whose SKILL.md doesn't declare `name: shieldcortex` (or has no SKILL.md) is left alone with a warning. Direct removal is the only mechanism — OpenClaw's `skills` CLI has install/update but no uninstall verb (verified against 2026.7.1-2). Wired into `uninstallOpenClawHook` (so both `shieldcortex uninstall` and `shieldcortex openclaw uninstall` get it) plus a `shieldcortex openclaw skill uninstall` verb.
- `uninstall-manifest.ts` — the fix for the **class**: every artifact any install surface creates is listed with exactly one fate — a removal function, or a written keep-reason. Tests enforce (a) exclusive fate, (b) every removal function has a real call site in the uninstall path, (c) the skill call is pinned inside `uninstallOpenClawHook`'s own body, so the standalone verb can't masquerade as parity.
- Uninstall output now ends with **"Kept on purpose:"** — memories.db (your data, not ours to delete), audit trail (outlives the tool), config backups (your rollback), the npm package (npm owns it) — each with its reason on screen.

**Proof**

- 10 new tests, all green; full suite **3,838 passed / 338 suites** (7 pre-existing skips).
- Delete-verified three ways: stripping the uninstall-path call, the kept-summary print, or the manifest skill entry each turns a distinct test red (first attempt used comment-out and two rails stayed green because the assertions still matched the commented text — redone with real deletion; that's why the body-pinned test exists).
- Behaviour tests run in a temp HOME: owned skill dir removed; foreign dir survives; missing SKILL.md fails closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)