### PR TITLE
fix(#201): approval hash is per command, not per attempt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Dependencies
-node_modules/
+node_modules
 
 # Build output
 dist/

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../projects/ShieldCortex/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../projects/ShieldCortex/node_modules

--- a/src/defence/iron-dome/__tests__/action-approvals.test.ts
+++ b/src/defence/iron-dome/__tests__/action-approvals.test.ts
@@ -59,6 +59,42 @@ describe('action approvals (#118)', () => {
     });
   });
 
+  describe('#201 — advisory fields do not move the hash of an exec call', () => {
+    // The live failure: every agent retry re-words `description` (and often
+    // `timeout`), so the approval id was minted per ATTEMPT and the operator
+    // chased a moving target. Neither field changes what executes.
+    const CMD = { command: 'sleep 10 && /opt/homebrew/bin/openclaw gateway restart' };
+
+    it('description and timeout are annotation, not action', () => {
+      expect(hashToolCall('Bash', { ...CMD, description: 'Restart the gateway after a delay', timeout: 120000 }))
+        .toBe(hashToolCall('Bash', { ...CMD, description: 'Restart OpenClaw gateway', timeout: 600000 }));
+      expect(hashToolCall('Bash', { ...CMD, description: 'x' })).toBe(hashToolCall('Bash', CMD));
+    });
+
+    it('load-bearing fields still move it', () => {
+      expect(hashToolCall('Bash', { ...CMD, dangerouslyDisableSandbox: true }))
+        .not.toBe(hashToolCall('Bash', CMD));
+      expect(hashToolCall('Bash', { ...CMD, run_in_background: true }))
+        .not.toBe(hashToolCall('Bash', CMD));
+    });
+
+    it('non-exec tools keep full-input hashing — description may be payload there', () => {
+      expect(hashToolCall('create_issue', { title: 't', description: 'a' }))
+        .not.toBe(hashToolCall('create_issue', { title: 't', description: 'b' }));
+    });
+
+    it('the live sequence: approve once, identical command with a re-worded description passes', () => {
+      const attempt1 = { ...CMD, description: 'Restart the gateway after a delay' };
+      const attempt2 = { ...CMD, description: 'Retry: restart OpenClaw gateway', timeout: 600000 };
+      const pending = recordPending(
+        { tool: 'Bash', input: attempt1, summary: `Bash: ${CMD.command}`, signals: ['service-restart'] },
+        { home, now: T0 },
+      );
+      expect(approveRequest(shortHash(pending.hash), { home, now: T0 + 1000 }).ok).toBe(true);
+      expect(consumeApproval('Bash', attempt2, { home, now: T0 + 2000 })).not.toBeNull();
+    });
+  });
+
   describe('the acceptance path', () => {
     it('refused → approved → passes ONCE → refused again', () => {
       const pending = request();

--- a/src/defence/iron-dome/action-approvals.ts
+++ b/src/defence/iron-dome/action-approvals.ts
@@ -34,6 +34,8 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from '
 import { homedir } from 'os';
 import { join } from 'path';
 
+import { classifyFamily } from './tool-action-guard.js';
+
 /** Default lifetime of an operator approval before it must be re-granted. */
 export const DEFAULT_APPROVAL_TTL_MS = 10 * 60 * 1000;
 
@@ -77,13 +79,41 @@ export function shortHash(hash: string): string {
 }
 
 /**
+ * Advisory fields on an EXEC tool call (#201). A Claude-harness Bash call
+ * carries `description` (a free-text label the model re-words on every
+ * attempt) and `timeout` — neither changes what executes, but hashing them
+ * minted a fresh approval id per ATTEMPT, so `shieldcortex approve` could
+ * never land: the operator approved hash A and the identical retry presented
+ * hash B. Stripped for exec-family tools only: on any other tool a
+ * `description` may be payload (an issue body, a PR description), where
+ * approving one text must not release another.
+ *
+ * Deliberately NOT stripped: `dangerouslyDisableSandbox`, `run_in_background`
+ * — they change confinement/supervision, so an approval for the sandboxed
+ * form must not release the unsandboxed one.
+ */
+const EXEC_ADVISORY_KEYS = new Set(['description', 'timeout']);
+
+function projectForHash(tool: string, input: unknown): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+  if (classifyFamily(tool) !== 'exec') return input;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(input as Record<string, unknown>)) {
+    if (!EXEC_ADVISORY_KEYS.has(key)) out[key] = (input as Record<string, unknown>)[key];
+  }
+  return out;
+}
+
+/**
  * Canonical hash of the exact call. Stable across processes: object keys are
  * sorted, whitespace in string values is collapsed, and everything else is
  * JSON with no formatting. Two textually different-but-equivalent commands
- * (extra spaces) hash the same; a different command never does.
+ * (extra spaces) hash the same; a different command never does. Exec-tool
+ * advisory fields are excluded (#201) so the hash is per COMMAND, not per
+ * attempt.
  */
 export function hashToolCall(tool: string, input: unknown): string {
-  const canonical = JSON.stringify([tool, canonicalise(input)]);
+  const canonical = JSON.stringify([tool, canonicalise(projectForHash(tool, input))]);
   return createHash('sha256').update(canonical).digest('hex');
 }
 


### PR DESCRIPTION
Closes #201.

**The failure (live, Friday-Mac, 5 Aug):** operator approves hash `480f54f95018` for a denied gateway restart → the agent re-issues the *identical command* → denied again under fresh hash `4aa7d80632a5`. `shieldcortex approve` could never unblock an agent-issued command because the model re-words the advisory `description` (and often `timeout`) on every attempt, and both were hashed.

**Fix:** `hashToolCall` projects `description` and `timeout` out of the input for exec-family tools (`classifyFamily === 'exec'`) before hashing.

**What deliberately still moves the hash:** `command` itself, `dangerouslyDisableSandbox`, `run_in_background` (confinement/supervision changes must not ride an existing approval), and the full input of every non-exec tool — a `description` on an issue-creation tool is payload, not annotation.

**Verified:** 4 new tests including the exact live sequence (approve attempt-1's hash, consume passes on attempt-2 with re-worded description + changed timeout); full suite 3842 passed / 338 suites; rebuilt dist re-checked by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)