### PR TITLE
fix(credential-leak): detect current provider key formats (VDP finding 1)

### DIFF
--- a/src/defence/__tests__/credential-key-formats.test.ts
+++ b/src/defence/__tests__/credential-key-formats.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Current provider key-format coverage.
+ *
+ * Origin: a VDP report on 2026-08-05 showed the OpenAI detector missed
+ * `sk-proj-*` — the default OpenAI key format since 2024 — because the regex
+ * disallowed dashes. Auditing the rest of the file found the same staleness in
+ * eight more providers, and a deeper root cause in the entropy net (below).
+ *
+ * This file is the standing rail: a detector that goes stale as a provider
+ * rotates its format fails HERE, rather than in a stranger's email.
+ *
+ * ALL key material below is fabricated. Bodies are typed out as obvious
+ * placeholder runs, never copied from a real credential.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { scanForCredentials } from '../credential-leak/index.js';
+import { shannonEntropy, ENTROPY_THRESHOLD } from '../credential-leak/entropy.js';
+
+/** Detected as a credential of any kind, by any detector. */
+function detects(content: string): boolean {
+  return scanForCredentials(content).findings.length > 0;
+}
+
+/** Detected specifically by a named provider pattern, not merely by entropy. */
+function detectsAsProvider(content: string, provider: string): boolean {
+  return scanForCredentials(content).findings.some((f) => f.provider === provider);
+}
+
+// Fabricated bodies. Long enough to clear each pattern's minimum length.
+const B62 = 'aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789AbCdEfGh';
+const HEX32 = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
+const HEX40 = `${HEX32}a1b2c3d4`;
+const HEX64 = `${HEX32}${HEX32}`;
+
+describe('current provider key formats', () => {
+  describe('OpenAI — the reported gap', () => {
+    it('detects the legacy sk- format (unchanged behaviour)', () => {
+      expect(detectsAsProvider(`sk-${B62}`, 'openai')).toBe(true);
+    });
+
+    // The reported bug. Every one of these was ALLOW before the fix.
+    it.each([
+      ['project key (default since 2024)', `sk-proj-${B62}`],
+      ['service account key', `sk-svcacct-${B62}`],
+      ['admin key (org billing/membership)', `sk-admin-${B62}`],
+    ])('detects the %s', (_label, key) => {
+      expect(detectsAsProvider(key, 'openai')).toBe(true);
+    });
+
+    // The researcher demonstrated the bypass in six separate contexts, not
+    // just as a bare token. All six are pinned.
+    it.each([
+      ['bare', `sk-proj-${B62}`],
+      ['in a sentence', `Please use my OpenAI key: sk-proj-${B62} for the calls`],
+      ['in JSON', `{"api_key": "sk-proj-${B62}"}`],
+      ['in a code block', '```\n' + `sk-proj-${B62}` + '\n```'],
+      ['behind a label', `OpenAI: sk-proj-${B62}`],
+      ['in single quotes', `key='sk-proj-${B62}'`],
+    ])('detects a project key %s', (_ctx, content) => {
+      expect(detects(content)).toBe(true);
+    });
+
+    it('does not double-report an Anthropic key as OpenAI', () => {
+      // Why the fix enumerates prefixes instead of allowing `-` after `sk-`:
+      // a free dash would make every sk-ant- key match the OpenAI pattern too.
+      const providers = scanForCredentials(`sk-ant-api03-${B62}`).findings.map((f) => f.provider);
+      expect(providers).toContain('anthropic');
+      expect(providers).not.toContain('openai');
+    });
+  });
+
+  describe('formats found stale while auditing the rest of the file', () => {
+    it.each([
+      ['GitHub App installation token (ghs_) — had no pattern at all', `ghs_${B62}`, 'github'],
+      ['GitHub user-to-server token (ghu_)', `ghu_${B62}`, 'github'],
+      ['GitHub refresh token (ghr_)', `ghr_${B62}`, 'github'],
+      ['AWS STS temporary key (ASIA)', 'ASIAIOSFODNN7EXAMPLE', 'aws'],
+      ['Stripe restricted key (rk_live_)', `rk_live_${B62}`, 'stripe'],
+      ['Stripe webhook signing secret', `whsec_${B62}`, 'stripe'],
+      ['Slack user token (xoxp-)', `xoxp-1234567890-1234567890123-${B62}`, 'slack'],
+      ['Slack rotating token (xoxe.)', `xoxe.xoxb-1-${B62}`, 'slack'],
+      ['Google OAuth client secret (GOCSPX-)', `GOCSPX-${B62}`, 'google'],
+      ['DigitalOcean OAuth token (doo_v1_)', `doo_v1_${HEX64}`, 'digitalocean'],
+      ['Twilio SID with uppercase hex', `SK${HEX32.toUpperCase()}`, 'twilio'],
+    ])('detects %s', (_label, key, provider) => {
+      expect(detectsAsProvider(key, provider)).toBe(true);
+    });
+
+    it('still detects the formats that were already covered', () => {
+      for (const [key, provider] of [
+        [`sk-ant-api03-${B62}`, 'anthropic'],
+        ['AKIAIOSFODNN7EXAMPLE', 'aws'],
+        [`ghp_${B62}`, 'github'],
+        [`sk_live_${B62}`, 'stripe'],
+        [`SG.${B62.slice(0, 22)}.${B62.slice(0, 43)}`, 'sendgrid'],
+        [`AIza${B62.slice(0, 35)}`, 'google'],
+        [`npm_${B62}`, 'npm'],
+        [`hf_${B62.slice(0, 34)}`, 'huggingface'],
+        [`dop_v1_${HEX64}`, 'digitalocean'],
+        [`hvs.${B62}`, 'hashicorp'],
+      ] as const) {
+        expect(detectsAsProvider(key, provider)).toBe(true);
+      }
+    });
+  });
+
+  describe('entropy net — the root cause beneath the reported bug', () => {
+    // The npm-package-specifier allowlist matched ANY token of
+    // [a-z0-9._-] starting with a letter, case-insensitively. That is the
+    // shape of most modern key material, so the entropy fallback — the net
+    // that should catch formats no regex knows yet — was switched off for the
+    // whole class. Fixing only the OpenAI regex would have left the net broken
+    // for the NEXT format a provider invents.
+    it('catches a novel dashed key shape that no pattern knows', () => {
+      expect(detects(`zz-newprovider-${B62}`)).toBe(true);
+    });
+
+    it('the novel shape is genuinely above the entropy threshold', () => {
+      expect(shannonEntropy(`zz-newprovider-${B62}`)).toBeGreaterThan(ENTROPY_THRESHOLD);
+    });
+
+    it('still ignores genuine npm package specifiers', () => {
+      for (const spec of ['@types/node-18.11.18', 'eslint-config-airbnb-typescript', '@babel/plugin-transform-runtime']) {
+        expect(detects(spec)).toBe(false);
+      }
+    });
+  });
+
+  describe('precision — realistic non-secrets must stay clean', () => {
+    // Recall changes are where false positives get introduced. This battery is
+    // the counterweight; the codebase has paid for FP regressions before.
+    it.each([
+      ['hyphenated prose starting sk-', 'I want to sk-etch out the sk-eleton of the plan'],
+      ['kubernetes resource name', 'sk-frontend-production-deployment-blue-green'],
+      ['git branch name', 'feature/add-user-authentication-flow-v2'],
+      ['file path', 'src/defence/credential-leak/patterns.ts'],
+      ['semver with prerelease', '4.47.30-beta.1'],
+      ['git SHA', HEX40],
+      ['sha256 digest', `sha256:${HEX64}`],
+      ['UUID', '550e8400-e29b-41d4-a716-446655440000'],
+      ['docker image ref', 'registry.fly.io/shieldcortex-api:deployment-01KZ0BEEQE85SGZC'],
+      ['CSS class list', 'btn-primary-large-rounded-shadow-hover-active'],
+      ['English sentence', 'The quick brown fox jumps over the lazy dog repeatedly today'],
+      ['env var name without a value', 'OPENAI_API_KEY'],
+      ['redacted key in a log line', 'using key sk-proj-****REDACTED****'],
+    ])('does not flag %s', (_label, content) => {
+      expect(detects(content)).toBe(false);
+    });
+
+    it('reports a Stripe publishable key, but only at medium severity', () => {
+      // Publishable keys are designed to be public, so this is deliberately
+      // not a critical finding — pinned because it is easy to "tidy" either
+      // into silence (losing a real signal) or up to critical (noise).
+      const findings = scanForCredentials('pk_test_TYooMQauvdEDq54NiTphI7jx').findings;
+      expect(findings.length).toBeGreaterThan(0);
+      expect(findings.every((f) => f.severity !== 'critical')).toBe(true);
+    });
+  });
+});

--- a/src/defence/credential-leak/entropy.ts
+++ b/src/defence/credential-leak/entropy.ts
@@ -136,8 +136,20 @@ function isLikelyFalsePositive(token: string): boolean {
   // Semver versions (possibly with pre-release tags)
   if (/^\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?$/.test(token)) return true;
 
-  // npm package specifiers (e.g., @types/node-18.11.18)
-  if (/^@?[a-z][a-z0-9._-]*(?:\/[a-z][a-z0-9._-]*)?$/i.test(token)) return true;
+  // npm package specifiers (e.g., @types/node-18.11.18).
+  //
+  // Entropy-gated on purpose. The shape [a-z0-9._-] starting with a letter is
+  // ALSO the shape of a large share of real key material — sk-proj-…,
+  // sk-svcacct-…, dop_v1_…, hvs.…, github_pat_… — so an ungated rule here
+  // silently switched the entropy net off for every one of them, which is how
+  // an OpenAI project key stayed invisible in all contexts (VDP 2026-08-05).
+  // A genuine package specifier is low-entropy; key material is not, so
+  // entropy is the discriminator that keeps the rule's intent without the hole.
+  if (
+    /^@?[a-z][a-z0-9._-]*(?:\/[a-z][a-z0-9._-]*)?$/i.test(token) &&
+    shannonEntropy(token) < ENTROPY_THRESHOLD
+  )
+    return true;
 
   // Pure lowercase with dashes — likely a slug or CSS class
   if (/^[a-z\-]+$/.test(token)) return true;

--- a/src/defence/credential-leak/patterns.ts
+++ b/src/defence/credential-leak/patterns.ts
@@ -30,7 +30,7 @@ export type CredentialSeverity = 'critical' | 'high' | 'medium' | 'low';
 // ── Known API Key Patterns ──
 
 export const API_KEY_PATTERNS: CredentialPattern[] = [
-  // OpenAI
+  // OpenAI — legacy `sk-` + body. No longer issued, but still valid in the wild.
   {
     name: 'OpenAI API Key',
     type: 'api_key',
@@ -39,6 +39,39 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     severity: 'critical',
     confidence: 0.95,
     minLength: 24,
+  },
+  // OpenAI — modern prefixed keys. `sk-proj-` has been the default since 2024,
+  // so the legacy pattern above misses essentially every key issued since.
+  //
+  // The prefixes are enumerated rather than allowing `-` freely after `sk-`
+  // (i.e. NOT /sk-[A-Za-z0-9\-_]{20,}/). A free dash would match ordinary
+  // hyphenated prose starting "sk-" and would also double-fire on every
+  // Anthropic `sk-ant-` key. Enumeration keeps recall without spending
+  // precision — the thing this codebase can least afford.
+  {
+    name: 'OpenAI Project API Key',
+    type: 'api_key',
+    provider: 'openai',
+    regex: /sk-proj-[A-Za-z0-9_-]{20,}/g,
+    severity: 'critical',
+    confidence: 0.97,
+  },
+  {
+    name: 'OpenAI Service Account Key',
+    type: 'api_key',
+    provider: 'openai',
+    regex: /sk-svcacct-[A-Za-z0-9_-]{20,}/g,
+    severity: 'critical',
+    confidence: 0.97,
+  },
+  {
+    // Org-level: billing, membership and project administration.
+    name: 'OpenAI Admin Key',
+    type: 'api_key',
+    provider: 'openai',
+    regex: /sk-admin-[A-Za-z0-9_-]{20,}/g,
+    severity: 'critical',
+    confidence: 0.97,
   },
   // Anthropic
   {
@@ -49,12 +82,13 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     severity: 'critical',
     confidence: 0.98,
   },
-  // AWS Access Key
+  // AWS Access Key. ASIA = STS temporary credentials; short-lived, but a live
+  // one plus its session token is full account access for its TTL.
   {
     name: 'AWS Access Key ID',
     type: 'api_key',
     provider: 'aws',
-    regex: /AKIA[0-9A-Z]{16}/g,
+    regex: /A[KS]IA[0-9A-Z]{16}/g,
     severity: 'critical',
     confidence: 0.97,
   },
@@ -85,6 +119,17 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     confidence: 0.98,
   },
   {
+    // ghu_ user-to-server, ghs_ App installation, ghr_ refresh.
+    // ghs_ in particular is what CI and agent runners carry, and it had no
+    // pattern at all before this — the widest of the confirmed gaps.
+    name: 'GitHub App Token',
+    type: 'api_key',
+    provider: 'github',
+    regex: /gh[usr]_[A-Za-z0-9]{36,}/g,
+    severity: 'critical',
+    confidence: 0.98,
+  },
+  {
     name: 'GitHub Fine-grained PAT',
     type: 'api_key',
     provider: 'github',
@@ -110,6 +155,16 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     confidence: 0.95,
   },
   {
+    // Restricted keys. Stripe's own guidance now steers users off sk_ onto
+    // rk_, so today's gap is tomorrow's default.
+    name: 'Stripe Restricted Key',
+    type: 'api_key',
+    provider: 'stripe',
+    regex: /rk_(?:live|test)_[A-Za-z0-9]{24,}/g,
+    severity: 'critical',
+    confidence: 0.97,
+  },
+  {
     name: 'Stripe Publishable Key',
     type: 'api_key',
     provider: 'stripe',
@@ -117,12 +172,22 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     severity: 'medium',
     confidence: 0.90,
   },
+  {
+    // Webhook signing secret — forges inbound events if leaked.
+    name: 'Stripe Webhook Signing Secret',
+    type: 'api_key',
+    provider: 'stripe',
+    regex: /whsec_[A-Za-z0-9]{24,}/g,
+    severity: 'critical',
+    confidence: 0.96,
+  },
   // Twilio
   {
     name: 'Twilio API Key',
     type: 'api_key',
     provider: 'twilio',
-    regex: /SK[a-f0-9]{32}/g,
+    // Twilio's spec permits uppercase hex; the old class missed those SIDs.
+    regex: /SK[a-fA-F0-9]{32}/g,
     severity: 'critical',
     confidence: 0.90,
   },
@@ -145,10 +210,39 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     confidence: 0.96,
   },
   {
+    // xoxp- user tokens carry a human's full workspace scope — arguably worse
+    // than the bot token above. xoxa-/xoxr- are the legacy app/refresh pair.
+    name: 'Slack User Token',
+    type: 'api_key',
+    provider: 'slack',
+    regex: /xox[par]-[0-9]{10,}-[0-9A-Za-z\-]{20,}/g,
+    severity: 'critical',
+    confidence: 0.96,
+  },
+  {
+    // App-level token (connections/socket mode).
+    name: 'Slack App-Level Token',
+    type: 'api_key',
+    provider: 'slack',
+    regex: /xapp-[0-9]-[A-Z0-9]{9,}-[0-9]{10,}-[a-f0-9]{40,}/g,
+    severity: 'critical',
+    confidence: 0.96,
+  },
+  {
+    // Rotation-era tokens: xoxe.xoxb-… / xoxe-… . The bot pattern above
+    // cannot match these — its `[0-9]{10,}` segment fails on the xoxe prefix.
+    name: 'Slack Rotating Token',
+    type: 'api_key',
+    provider: 'slack',
+    regex: /xoxe[.-][A-Za-z0-9.\-]{20,}/g,
+    severity: 'critical',
+    confidence: 0.95,
+  },
+  {
     name: 'Slack Webhook URL',
     type: 'api_key',
     provider: 'slack',
-    regex: /https:\/\/hooks\.slack\.com\/services\/T[A-Z0-9]{8,}\/B[A-Z0-9]{8,}\/[A-Za-z0-9]{20,}/g,
+    regex: /https:\/\/hooks\.slack\.com\/(?:services|triggers)\/T[A-Z0-9]{8,}\/B?[A-Z0-9]{8,}\/[A-Za-z0-9]{20,}/g,
     severity: 'high',
     confidence: 0.95,
   },
@@ -160,6 +254,14 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     regex: /AIza[A-Za-z0-9\-_]{35}/g,
     severity: 'critical',
     confidence: 0.95,
+  },
+  {
+    name: 'Google OAuth Client Secret',
+    type: 'api_key',
+    provider: 'google',
+    regex: /GOCSPX-[A-Za-z0-9_-]{20,}/g,
+    severity: 'critical',
+    confidence: 0.97,
   },
   // Mailgun
   {
@@ -212,7 +314,8 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     name: 'DigitalOcean Personal Access Token',
     type: 'api_key',
     provider: 'digitalocean',
-    regex: /dop_v1_[a-f0-9]{64}/g,
+    // dop_ personal access, doo_ OAuth access, dor_ refresh.
+    regex: /do[opr]_v1_[a-f0-9]{64}/g,
     severity: 'critical',
     confidence: 0.97,
   },


### PR DESCRIPTION
## The report

An external researcher reported through the VDP on 2026-08-05 that the OpenAI detector misses `sk-proj-*` — the **default OpenAI key format since 2024**. The regex was `/sk-[A-Za-z0-9]{20,}/` and the dash after `proj` breaks the match. In strict mode the key was ALLOW in every context: bare, in prose, in JSON, in a code block, quoted, labelled.

Confirmed before fixing. The Anthropic pattern two entries below already allowed dashes, so this was a straight oversight rather than a design choice.

## Root cause — bigger than the reported bug

Fixing the regex alone would have been treating the symptom.

`isLikelyFalsePositive()` in `entropy.ts` skipped any token matching an npm package specifier: `/^@?[a-z][a-z0-9._-]*(?:\/[a-z][a-z0-9._-]*)?$/i`. That is **also the shape of most modern key material** — `sk-proj-…`, `sk-svcacct-…`, `dop_v1_…`, `hvs.…`, `github_pat_…`. So the entropy fallback, the net that is supposed to catch formats no regex knows yet, was switched off for the whole class.

That is why the key was invisible in *all* contexts rather than merely unattributed, and why the next format a provider invents would have been invisible too. The rule is now entropy-gated: a genuine package specifier is low-entropy, key material is not.

## Formats fixed

Audited every pattern in the file against current provider documentation.

| Provider | Added |
|---|---|
| OpenAI | `sk-proj-`, `sk-svcacct-`, `sk-admin-` |
| GitHub | `ghs_` (App installation), `ghu_`, `ghr_` — **had no pattern at all** |
| AWS | `ASIA` (STS temporary credentials) |
| Stripe | `rk_live_`/`rk_test_` (restricted), `whsec_` (webhook signing) |
| Slack | `xoxp-`/`xoxa-`/`xoxr-`, `xapp-`, `xoxe.` rotation, `/triggers/` webhooks |
| Google | `GOCSPX-` (OAuth client secret) |
| DigitalOcean | `doo_v1_`, `dor_v1_` |
| Twilio | uppercase hex in the key SID |

`ghs_` is the one I would flag to a reviewer: those tokens flow through CI and agent runners constantly, carry repo write, and had zero coverage.

## Deliberately NOT taking the reported fix verbatim

The report suggests `/sk-[A-Za-z0-9\-_]{20,}/`. Rejected: a free dash matches ordinary hyphenated prose beginning `sk-`, and double-fires on every `sk-ant-` key alongside the Anthropic pattern. Prefixes are enumerated instead. Given this codebase's false-positive history, recall is not worth buying with precision — there is a test pinning the no-double-report behaviour.

## Proof

- **40 tests**: every current format, the six bypass contexts from the report, the already-covered formats as a negative control, and a precision battery of realistic non-secrets (hyphenated prose, k8s names, git branches, SHAs, digests, semver, CSS classes, redacted log lines).
- **Delete-verified independently** — reverting `patterns.ts` turns 14 red; reverting `entropy.ts` turns 1 red; with *only* the entropy fix in place `sk-proj-` is still caught generically. The two layers do different jobs and both are pinned.
- Full suite **3,878 green**, 339 suites. `build:ts` clean.
- One test of mine was wrong and the detector was right: a Stripe *publishable* test key is deliberately reported at medium. Corrected the test rather than weakening the detector, and pinned the intended severity.

## Deferred to a separate measured PR

Found while auditing; all are **precision** work that needs corpus measurement rather than being bundled into a recall fix:

- No pattern in the file uses word boundaries. The Azure 32-hex pattern fires **twice inside a single SHA-256 digest**. Likely a larger share of the historic FP rate than any missing provider.
- The Firebase `AAAA` pattern matches a run of base64-encoded zero bytes at 0.90 confidence, and the credential type was decommissioned mid-2024.
- ENV_SECRET patterns match documentation placeholders (`API_KEY=your-api-key-here`, `DB_PASSWORD=changeme_in_production`) at 0.82–0.85.

## Note

The SaaS API reports engine `4.32.1` against `4.47.30` on npm, so this fix does not reach `api.shieldcortex.ai` until that deploy is refreshed — tracked separately.