### PR TITLE
docs(security): fix dead reporting address in SECURITY.md, credit Sarvesh P

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,11 @@ Thanks for helping keep ShieldCortex — and the projects that depend on it — 
 
 ## Reporting a Vulnerability
 
-**Email: [security@drakonsystems.com](mailto:security@drakonsystems.com)**
+**Email: [support@drakonsystems.com](mailto:support@drakonsystems.com)**
+
+> `security@drakonsystems.com` is **not** a live mailbox and never was — mail to it
+> bounces. It was published here and on the website in error until 6 Aug 2026. If you
+> sent a report there, we did not receive it; please resend to the address above.
 
 Please do **not** open a public GitHub issue for security vulnerabilities. For non-security bugs, file an issue as normal.
 
@@ -53,6 +57,15 @@ We support the latest two major versions of the `shieldcortex` npm package. Olde
 ## Safe-Harbour
 
 If you act in good faith — staying within the scope above, avoiding privacy violations and service disruption, and giving us reasonable time to remediate before public disclosure — we will not initiate legal action against you. Testing is authorised only against your own machine, your own ShieldCortex Cloud account, or a designated test account you have created.
+
+## Acknowledgements
+
+We do not offer monetary rewards. We do credit every researcher whose report leads to a
+fix, by the name and link they ask for.
+
+| Researcher | Report | Shipped in |
+|---|---|---|
+| [Sarvesh P](https://www.sarvee.in) | Credential-leak detection bypasses (current provider key formats) and prompt-injection detection failures; also surfaced that the published security contact was a dead mailbox | [4.47.31](CHANGELOG.md) |
 
 ## Full Policy
 


### PR DESCRIPTION
`SECURITY.md` still told researchers to email `security@drakonsystems.com` — the mailbox that does not exist and bounces (`550 5.1.1 User does not exist`). The site, `security.txt`, /gdpr, the footer and the 4.47.31 changelog were repointed to `support@` earlier today; **this file was missed**, which made the changelog line "all now point at a live mailbox" untrue, and left the bad address in the first place a GitHub visitor looks.

Changes:
- Reporting address → `support@drakonsystems.com`, with an explicit note that `security@` bounces and that anyone who used it should resend.
- New **Acknowledgements** section crediting Sarvesh P (name + link as requested in his reply) for the VDP report behind 4.47.31.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)