### PR TITLE
docs(security): restore security@ as the reporting address (mailbox now live)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,12 @@ Thanks for helping keep ShieldCortex — and the projects that depend on it — 
 
 ## Reporting a Vulnerability
 
-**Email: [support@drakonsystems.com](mailto:support@drakonsystems.com)**
+**Email: [security@drakonsystems.com](mailto:security@drakonsystems.com)**
 
-> `security@drakonsystems.com` is **not** a live mailbox and never was — mail to it
-> bounces. It was published here and on the website in error until 6 Aug 2026. If you
-> sent a report there, we did not receive it; please resend to the address above.
+> `security@drakonsystems.com` went live on 7 Aug 2026; delivery is verified. Before
+> that date it bounced — if you sent a report there on or before 6 Aug 2026, we did
+> not receive it; please resend. Reports to
+> [support@drakonsystems.com](mailto:support@drakonsystems.com) also reach us.
 
 Please do **not** open a public GitHub issue for security vulnerabilities. For non-security bugs, file an issue as normal.
 


### PR DESCRIPTION
security@drakonsystems.com was provisioned today and delivery is verified end-to-end (test message accepted and received in the monitored inbox, 16:13Z). SECURITY.md points back at it, with the bounce note scoped to the pre-7-Aug window and support@ kept as fallback. Site counterparts (security.txt, /security, /gdpr) updated in shieldcortex-site 5ba9a1a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)