### PR TITLE
fix(extraction): dots inside IPs/versions/filenames no longer end the capture

### DIFF
--- a/scripts/lib/extract-memorable-segments.mjs
+++ b/scripts/lib/extract-memorable-segments.mjs
@@ -293,24 +293,38 @@ export function getExtractionThreshold(category, dynamicThreshold, categoryThres
 // the sentence ended. The new form stops at the first `.`, `!`, `?`, or
 // newline, capping at 200 chars for safety, and optionally consumes the
 // terminator so the captured group ends cleanly. v4.24.3.
+//
+// Issue #208: the naive class treated EVERY dot as a terminator, so dots
+// inside IP addresses ("172.16.0.10"), version strings ("v4.47.31"),
+// dotted host shorthand (".6") and filenames truncated the capture,
+// storing stumps like "Fix: (Ring camera squatting .". A dot/!/? is only
+// a sentence terminator when followed by whitespace or end-of-input;
+// otherwise it is content. `dotAware` rewrites each literal below into
+// that form at definition time, so the patterns stay readable while the
+// runtime class is context-sensitive. New patterns keep using `[^.!?\n]`
+// and inherit the rewrite automatically.
+
+const SEG_SRC = '(?:[^.!?\\n]|[.!?](?!\\s|$))';
+const dotAware = (re) => new RegExp(re.source.replaceAll('[^.!?\\n]', SEG_SRC), re.flags);
+const dotAwareAll = (patterns) => patterns.map(dotAware);
 
 export const FULL_EXTRACTORS = [
   {
     name: 'decision',
     titlePrefix: 'Decision: ',
-    patterns: [
+    patterns: dotAwareAll([
       /(?:we\s+)?decided\s+(?:to\s+)?([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:going|went)\s+with\s+([^.!?\n]{15,150}[.!?]?)/gi,
       /(?:chose|chosen|selected)\s+([^.!?\n]{15,150}[.!?]?)/gi,
       /the\s+(?:approach|solution|fix)\s+(?:is|was)\s+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:using|will\s+use)\s+([^.!?\n]{15,150}[.!?]?)/gi,
       /(?:opted\s+for|settled\s+on)\s+([^.!?\n]{15,150}[.!?]?)/gi,
-    ],
+    ]),
   },
   {
     name: 'error-fix',
     titlePrefix: 'Fix: ',
-    patterns: [
+    patterns: dotAwareAll([
       /(?:fixed|solved|resolved)\s+(?:by\s+)?([^.!?\n]{15,200}[.!?]?)/gi,
       /the\s+(?:fix|solution|workaround)\s+(?:is|was)\s+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:root\s+cause|issue)\s+(?:is|was)\s+([^.!?\n]{15,200}[.!?]?)/gi,
@@ -318,49 +332,49 @@ export const FULL_EXTRACTORS = [
       /(?:problem|issue)\s+was\s+([^.!?\n]{15,150}[.!?]?)/gi,
       /(?:the\s+)?bug\s+(?:is|was)\s+([^.!?\n]{15,150}[.!?]?)/gi,
       /(?:debugging|debugged)\s+([^.!?\n]{15,150}[.!?]?)/gi,
-    ],
+    ]),
   },
   {
     name: 'learning',
     titlePrefix: 'Learned: ',
-    patterns: [
+    patterns: dotAwareAll([
       /(?:learned|discovered|realized|found\s+out)\s+(?:that\s+)?([^.!?\n]{15,200}[.!?]?)/gi,
       /turns\s+out\s+(?:that\s+)?([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:TIL|today\s+I\s+learned)[:\s]+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:now\s+)?(?:understand|know)\s+(?:that\s+)?([^.!?\n]{15,150}[.!?]?)/gi,
       /(?:figured\s+out|worked\s+out)\s+([^.!?\n]{15,150}[.!?]?)/gi,
-    ],
+    ]),
   },
   {
     name: 'architecture',
     titlePrefix: 'Architecture: ',
-    patterns: [
+    patterns: dotAwareAll([
       /the\s+architecture\s+(?:is|uses|consists\s+of)\s+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:design|pattern)\s+(?:is|uses)\s+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:system|api|database)\s+(?:structure|design)\s+(?:is|uses)\s+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:created|added|implemented|built)\s+(?:a\s+)?([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:refactored|updated|changed)\s+(?:the\s+)?([^.!?\n]{15,150}[.!?]?)/gi,
-    ],
+    ]),
   },
   {
     name: 'preference',
     titlePrefix: 'Preference: ',
-    patterns: [
+    patterns: dotAwareAll([
       /(?:always|never)\s+([^.!?\n]{10,150}[.!?]?)/gi,
       /(?:prefer|want)\s+to\s+([^.!?\n]{10,150}[.!?]?)/gi,
       /(?:should|must)\s+(?:always\s+)?([^.!?\n]{10,150}[.!?]?)/gi,
-    ],
+    ]),
   },
   {
     name: 'important-note',
     titlePrefix: 'Note: ',
-    patterns: [
+    patterns: dotAwareAll([
       /important[:\s]+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:note|remember)[:\s]+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:key|critical)\s+(?:point|thing)[:\s]+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:this\s+is\s+)?(?:crucial|essential)[:\s]+([^.!?\n]{15,150}[.!?]?)/gi,
       /(?:don't\s+forget|keep\s+in\s+mind)[:\s]+([^.!?\n]{15,150}[.!?]?)/gi,
-    ],
+    ]),
   },
 ];
 
@@ -373,29 +387,29 @@ export const STOP_HOOK_EXTRACTORS = [
   {
     name: 'error-fix',
     titlePrefix: 'Fix: ',
-    patterns: [
+    patterns: dotAwareAll([
       /(?:fixed|solved|resolved)\s+(?:by\s+)?([^.!?\n]{15,200}[.!?]?)/gi,
       /the\s+(?:fix|solution|workaround)\s+(?:is|was)\s+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:root\s+cause|issue)\s+(?:is|was)\s+([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:error|bug)\s+(?:was\s+)?caused\s+by\s+([^.!?\n]{15,200}[.!?]?)/gi,
-    ],
+    ]),
   },
   {
     name: 'learning',
     titlePrefix: 'Learned: ',
-    patterns: [
+    patterns: dotAwareAll([
       /(?:learned|discovered|realized|found\s+out)\s+(?:that\s+)?([^.!?\n]{15,200}[.!?]?)/gi,
       /turns\s+out\s+(?:that\s+)?([^.!?\n]{15,200}[.!?]?)/gi,
       /(?:figured\s+out|worked\s+out)\s+([^.!?\n]{15,150}[.!?]?)/gi,
-    ],
+    ]),
   },
   {
     name: 'preference',
     titlePrefix: 'Preference: ',
-    patterns: [
+    patterns: dotAwareAll([
       /(?:always|never)\s+([^.!?\n]{10,150}[.!?]?)/gi,
       /(?:prefer|want)\s+to\s+([^.!?\n]{10,150}[.!?]?)/gi,
-    ],
+    ]),
   },
 ];
 
@@ -437,7 +451,7 @@ export function extractFirstSentence(text, maxLen = 120) {
   // version strings ("v4.24.3") don't fool it. A matched sentence is returned
   // WHOLE when it fits — the old `slice(0, maxLen)` chopped clean sentences
   // mid-word (every truncated title was exactly prefix+80 chars).
-  const match = trimmed.match(/^([^.!?\n]{15,160}[.!?])(?:\s|$)/);
+  const match = trimmed.match(dotAware(/^([^.!?\n]{15,160}[.!?])(?:\s|$)/));
   // A matched sentence is COMPLETE (regex-bounded ≤161 chars) — return it whole,
   // terminator intact. Re-truncating it to maxLen stripped the terminator and
   // appended a misleading ellipsis, just moving the truncation cliff 80→120

--- a/src/__tests__/extract-ip-version-dots.test.ts
+++ b/src/__tests__/extract-ip-version-dots.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from '@jest/globals';
+
+/**
+ * Issue #208: the sentence-bounded capture class `[^.!?\n]` treats EVERY
+ * dot as a sentence terminator, so any candidate containing an IP address,
+ * version string, dotted host shorthand or filename is truncated at the
+ * first internal dot. Field examples (Edith's install, 6-7 Aug 2026):
+ *
+ *   Fix: (Ring camera squatting .          ← cut inside "172.16.0.10"
+ *   Fix: this time by me releasing .       ← cut at host shorthand ".6"
+ *   Learned: the systemd unit's stop doesn't actually remove the address, so I removed .
+ *
+ * ~9 of the 12 most recent auto-extracted memories on that install were
+ * stumps of this kind — worst on exactly the infra/networking content
+ * where dotted tokens are densest.
+ *
+ * The fix: a dot/!/? only terminates a sentence when followed by
+ * whitespace or end-of-input. Dots followed by a non-space character
+ * (IPs, versions, domains, filenames, ".6" shorthand) are content.
+ *
+ * These tests pin that behaviour for the capture patterns AND the
+ * extractFirstSentence headline helper.
+ */
+
+const load = () => import('../../scripts/lib/extract-memorable-segments.mjs');
+
+describe('issue #208: dots inside IPs / versions / filenames are not sentence boundaries', () => {
+  it('captures a full sentence containing an IP address (the filed repro)', async () => {
+    const { extractMemorableSegments } = await load();
+    const text =
+      'The problem was the Ring camera squatting 172.16.0.10 which reset every tunnel connection. ' +
+      'Next we checked the switch.';
+    const segments = extractMemorableSegments(text);
+    const fixes = segments.filter((s) => s.extractorType === 'error-fix');
+    expect(fixes.length).toBeGreaterThan(0);
+    for (const f of fixes) {
+      expect(f.content).toContain('172.16.0.10');
+      expect(f.content).toContain('tunnel connection');
+      // still sentence-bounded: must not bleed into the next sentence
+      expect(f.content).not.toContain('checked the switch');
+    }
+  });
+
+  it('captures across version strings', async () => {
+    const { extractMemorableSegments } = await load();
+    const text =
+      'We decided to pin shieldcortex to v4.47.31 until the splitter fix ships. Other work continues.';
+    const segments = extractMemorableSegments(text);
+    const decisions = segments.filter((s) => s.extractorType === 'decision');
+    expect(decisions.length).toBeGreaterThan(0);
+    for (const d of decisions) {
+      expect(d.content).toContain('v4.47.31');
+      expect(d.content).toContain('splitter fix ships');
+      expect(d.content).not.toContain('Other work');
+    }
+  });
+
+  it('captures across dotted host shorthand and filenames', async () => {
+    const { extractMemorableSegments } = await load();
+    const text =
+      'Fixed by releasing .6 from the DHCP pool and renaming config.yaml.bak back into place. The reboot was clean.';
+    const segments = extractMemorableSegments(text);
+    const fixes = segments.filter((s) => s.extractorType === 'error-fix');
+    expect(fixes.length).toBeGreaterThan(0);
+    for (const f of fixes) {
+      expect(f.content).toContain('.6 from the DHCP pool');
+      expect(f.content).toContain('config.yaml.bak');
+      expect(f.content).not.toContain('reboot was clean');
+    }
+  });
+
+  it('never emits a candidate ending on a bare dangling dot', async () => {
+    const { extractMemorableSegments } = await load();
+    const text =
+      'Learned that the systemd unit stop does not remove the address 172.16.0.6 from eth0. ' +
+      'The fix was adding an ExecStopPost that releases 172.16.0.6 explicitly. ' +
+      'We decided to keep 10.0.0.0/8 for the lab.';
+    const segments = extractMemorableSegments(text);
+    expect(segments.length).toBeGreaterThan(0);
+    for (const s of segments) {
+      // the field failure mode: content/title truncated to "... releasing ."
+      expect(s.content).not.toMatch(/\s\.$/);
+      expect(s.title).not.toMatch(/\s\.$/);
+    }
+  });
+
+  it('extractFirstSentence returns the whole sentence when it contains dotted tokens', async () => {
+    const { extractFirstSentence } = await load();
+    const headline = extractFirstSentence(
+      'the Ring camera squatting 172.16.0.10 reset every tunnel connection. It took a day to find.',
+    );
+    expect(headline).toBe('the Ring camera squatting 172.16.0.10 reset every tunnel connection.');
+  });
+
+  it('still stops at genuine sentence boundaries (no greedy-capture regression)', async () => {
+    const { extractMemorableSegments } = await load();
+    const text =
+      'I decided to use Postgres for JSON support. The team agreed last week. Next we tune indexes.';
+    const segments = extractMemorableSegments(text);
+    const decisions = segments.filter((s) => s.extractorType === 'decision');
+    expect(decisions.length).toBeGreaterThan(0);
+    for (const d of decisions) {
+      expect(d.content).not.toContain('The team agreed');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #208.

## Root cause
Every auto-extraction capture pattern used the class `[^.!?\n]{N,M}` — the capture could never cross a dot, so any candidate containing an IP address, version string, dotted host shorthand (`.6`) or filename truncated at the first internal dot. The smarter whitespace-lookahead already present in `extractFirstSentence` never got a chance: the content was cut before it ran. Field impact on the reporting install: ~9 of the 12 most recent auto-extracted memories were stumps ("Fix: (Ring camera squatting .").

## Fix
A `.`/`!`/`?` only terminates a sentence when followed by whitespace or end-of-input:

```
(?:[^.!?\n]|[.!?](?!\s|$))
```

`dotAware()` rewrites each pattern literal at definition time (all 9 `patterns` arrays wrapped in `dotAwareAll`), so the 41 patterns stay readable as written and any new pattern using `[^.!?\n]` inherits the rule automatically. `extractFirstSentence`'s headline matcher gets the same treatment. The alternation's branches have disjoint first-character sets, so matching stays linear — no backtracking blowup.

## Tests
- New `src/__tests__/extract-ip-version-dots.test.ts`: 6 tests pinning the filed repro (IP mid-sentence), version strings, dotted-host shorthand + filenames, no dangling-dot candidates, headline behaviour, and the existing genuine-sentence-boundary behaviour (no greedy-capture regression).
- Full suite: **340/340 suites, 3884 passed, 7 skipped** (one unrelated suite was flaky on a first run, green on re-run twice).

Repro from the issue now extracts whole:
```
The Ring camera squatting 172.16.0.10 which reset every tunnel connection.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)