### PR TITLE
fix(config): Action Guard single source of truth — interceptor.actionGuard becomes a deprecated merging alias (#209)

### DIFF
--- a/plugins/openclaw/__tests__/action-guard-209-alias.test.ts
+++ b/plugins/openclaw/__tests__/action-guard-209-alias.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from '@jest/globals';
+import plugin from '../index.js';
+
+/**
+ * Issue #209 — single source of truth for Action Guard config, plugin side.
+ *
+ * Before this fix the plugin read ONLY `interceptor.actionGuard`, while the
+ * Claude Code hook read ONLY top-level `actionGuard` — two keys, one guard,
+ * silently divergent postures. The resolution: top-level `actionGuard` governs
+ * every surface; `interceptor.actionGuard` stays as a deprecated alias that
+ * fills per-key gaps. An explicit top-level value always wins.
+ *
+ * normaliseConfig folds the merged result into `interceptor.actionGuard`
+ * internally so initInterceptor and everything downstream is untouched — the
+ * alias dies at the parse boundary, not in the enforcement path.
+ *
+ * Hook-side contract: src/__tests__/pre-tool-hook-209-alias.test.ts.
+ * Doctor surfacing: src/cli/__tests__/doctor-action-guard.test.ts.
+ */
+
+const parse = (value: unknown) => plugin.configSchema.parse(value) as any;
+
+describe('plugin config — #209 top-level actionGuard single source of truth', () => {
+  it('accepts a top-level actionGuard block and folds it into the interceptor config', () => {
+    const parsed = parse({ actionGuard: { enforce: false } });
+    expect(parsed.interceptor?.actionGuard?.enforce).toBe(false);
+  });
+
+  it('top-level values win over conflicting alias values', () => {
+    const parsed = parse({
+      actionGuard: { enforce: false },
+      interceptor: { actionGuard: { enforce: true } },
+    });
+    expect(parsed.interceptor?.actionGuard?.enforce).toBe(false);
+  });
+
+  it('alias keys survive as gap-fill when the top-level block does not set them', () => {
+    const parsed = parse({
+      actionGuard: { enforce: false },
+      interceptor: { actionGuard: { enabled: true, autoApprove: ['git_force_push'] } },
+    });
+    expect(parsed.interceptor?.actionGuard).toEqual({
+      enforce: false,
+      enabled: true,
+      autoApprove: ['git_force_push'],
+    });
+  });
+
+  it('alias-only config still works unchanged (back-compat)', () => {
+    const parsed = parse({ interceptor: { actionGuard: { enforce: false } } });
+    expect(parsed.interceptor?.actionGuard?.enforce).toBe(false);
+  });
+
+  it('invalid top-level values are dropped individually, valid siblings survive', () => {
+    const parsed = parse({ actionGuard: { enabled: 'false', enforce: false } });
+    expect(parsed.interceptor?.actionGuard?.enforce).toBe(false);
+    expect(parsed.interceptor?.actionGuard?.enabled).toBeUndefined();
+  });
+
+  it('other interceptor keys are untouched by the fold', () => {
+    const parsed = parse({
+      actionGuard: { enforce: false },
+      interceptor: { enabled: true, severityActions: { high: 'warn' } },
+    });
+    expect(parsed.interceptor?.enabled).toBe(true);
+    expect(parsed.interceptor?.severityActions?.high).toBe('warn');
+    expect(parsed.interceptor?.actionGuard?.enforce).toBe(false);
+  });
+});

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -510,6 +510,26 @@ function normaliseConfig(raw: unknown, dropped?: string[]): SCConfig {
   const interceptor = normaliseInterceptorConfig(value.interceptor, dropped);
   if (interceptor) config.interceptor = interceptor;
 
+  // #209: single source of truth for the Action Guard. A top-level
+  // `actionGuard` block governs every surface; `interceptor.actionGuard` is a
+  // deprecated alias kept as per-key gap-fill so pre-#209 configs keep their
+  // posture. On a conflicting key the top-level value wins. The fold happens
+  // HERE, at the parse boundary, so initInterceptor and everything downstream
+  // still sees exactly one guard config at `interceptor.actionGuard` and the
+  // alias can never leak into the enforcement path. Conflicts are surfaced by
+  // `shieldcortex doctor` and the Claude Code hook's stderr note, not logged
+  // here — this parse also runs on the shield config file path, which has no
+  // logger. Mirrored in scripts/pre-tool-hook.mjs (loadActionGuardConfig) and
+  // src/cli/doctor.ts (checkActionGuard); the three build units cannot share
+  // an import, so keep them in step by hand.
+  const topGuard = normaliseActionGuardBlock(value.actionGuard, dropped, "actionGuard");
+  if (topGuard) {
+    config.interceptor = {
+      ...(config.interceptor ?? {}),
+      actionGuard: { ...(config.interceptor?.actionGuard ?? {}), ...topGuard },
+    };
+  }
+
   return config;
 }
 
@@ -538,6 +558,57 @@ function normaliseSeverityMap<A extends string>(
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+/**
+ * Validate one Action Guard block. Shared by the deprecated
+ * `interceptor.actionGuard` alias and the top-level `actionGuard` key (#209) —
+ * `pathPrefix` names which of the two a dropped key came from, so the #115
+ * warn log stays exact. Returns undefined (not {}) when nothing valid was
+ * found, matching normaliseInterceptorConfig's "empty means absent" contract.
+ */
+function normaliseActionGuardBlock(
+  raw: unknown,
+  dropped: string[] | undefined,
+  pathPrefix: string,
+): InterceptorUserConfig["actionGuard"] | undefined {
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    dropped?.push(pathPrefix);
+    return undefined;
+  }
+  const rawGuard = raw as Record<string, unknown>;
+  const guard: NonNullable<InterceptorUserConfig["actionGuard"]> = {};
+  if (rawGuard.enabled !== undefined) {
+    if (typeof rawGuard.enabled === "boolean") guard.enabled = rawGuard.enabled;
+    else dropped?.push(`${pathPrefix}.enabled`);
+  }
+  if (rawGuard.enforce !== undefined) {
+    if (typeof rawGuard.enforce === "boolean") guard.enforce = rawGuard.enforce;
+    else dropped?.push(`${pathPrefix}.enforce`);
+  }
+  if (rawGuard.auditAllows !== undefined) {
+    if (typeof rawGuard.auditAllows === "boolean") guard.auditAllows = rawGuard.auditAllows;
+    else dropped?.push(`${pathPrefix}.auditAllows`);
+  }
+  if (rawGuard.autoApprove !== undefined) {
+    if (Array.isArray(rawGuard.autoApprove) && rawGuard.autoApprove.every((entry) => typeof entry === "string")) {
+      // #115: defensive copy — downstream (initInterceptor's spread into
+      // InterceptorConfig) is read-only today, but aliasing the caller's
+      // array means a future in-place mutation of the host config object
+      // would silently corrupt the normalised config too.
+      guard.autoApprove = [...(rawGuard.autoApprove as string[])];
+    } else {
+      dropped?.push(`${pathPrefix}.autoApprove`);
+    }
+  }
+  // Carried through untouched — normaliseBrokerConfig is the boundary, and
+  // splitting that job across two files is how one of the halves ends up
+  // being the lenient one.
+  if (rawGuard.broker && typeof rawGuard.broker === "object" && !Array.isArray(rawGuard.broker)) {
+    guard.broker = rawGuard.broker as Record<string, unknown>;
+  }
+  return Object.keys(guard).length > 0 ? guard : undefined;
+}
+
 function normaliseInterceptorConfig(raw: unknown, dropped?: string[]): InterceptorUserConfig | undefined {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
   const value = raw as Record<string, unknown>;
@@ -554,44 +625,8 @@ function normaliseInterceptorConfig(raw: unknown, dropped?: string[]): Intercept
   const failurePolicy = normaliseSeverityMap(value.failurePolicy, FAILURE_ACTIONS, dropped, "interceptor.failurePolicy");
   if (failurePolicy) out.failurePolicy = failurePolicy;
 
-  if (value.actionGuard !== undefined) {
-    if (value.actionGuard && typeof value.actionGuard === "object" && !Array.isArray(value.actionGuard)) {
-      const rawGuard = value.actionGuard as Record<string, unknown>;
-      const guard: NonNullable<InterceptorUserConfig["actionGuard"]> = {};
-      if (rawGuard.enabled !== undefined) {
-        if (typeof rawGuard.enabled === "boolean") guard.enabled = rawGuard.enabled;
-        else dropped?.push("interceptor.actionGuard.enabled");
-      }
-      if (rawGuard.enforce !== undefined) {
-        if (typeof rawGuard.enforce === "boolean") guard.enforce = rawGuard.enforce;
-        else dropped?.push("interceptor.actionGuard.enforce");
-      }
-      if (rawGuard.auditAllows !== undefined) {
-        if (typeof rawGuard.auditAllows === "boolean") guard.auditAllows = rawGuard.auditAllows;
-        else dropped?.push("interceptor.actionGuard.auditAllows");
-      }
-      if (rawGuard.autoApprove !== undefined) {
-        if (Array.isArray(rawGuard.autoApprove) && rawGuard.autoApprove.every((entry) => typeof entry === "string")) {
-          // #115: defensive copy — downstream (initInterceptor's spread into
-          // InterceptorConfig) is read-only today, but aliasing the caller's
-          // array means a future in-place mutation of the host config object
-          // would silently corrupt the normalised config too.
-          guard.autoApprove = [...(rawGuard.autoApprove as string[])];
-        } else {
-          dropped?.push("interceptor.actionGuard.autoApprove");
-        }
-      }
-      // Carried through untouched — normaliseBrokerConfig is the boundary, and
-      // splitting that job across two files is how one of the halves ends up
-      // being the lenient one.
-      if (rawGuard.broker && typeof rawGuard.broker === "object" && !Array.isArray(rawGuard.broker)) {
-        guard.broker = rawGuard.broker as Record<string, unknown>;
-      }
-      if (Object.keys(guard).length > 0) out.actionGuard = guard;
-    } else {
-      dropped?.push("interceptor.actionGuard");
-    }
-  }
+  const actionGuard = normaliseActionGuardBlock(value.actionGuard, dropped, "interceptor.actionGuard");
+  if (actionGuard) out.actionGuard = actionGuard;
 
   // #115: empty/all-invalid normalises to undefined, not {} — {} is truthy
   // and made applyPluginConfigOverride treat a no-op interceptor block as a

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -64,8 +64,30 @@ function loadActionGuardConfig() {
     const configPath = join(homedir(), '.shieldcortex', 'config.json');
     if (!existsSync(configPath)) return { ...DEFAULT_ACTION_GUARD };
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
-    const raw = config?.actionGuard;
-    if (!raw || typeof raw !== 'object') return { ...DEFAULT_ACTION_GUARD };
+    // #209: single source of truth. Top-level `actionGuard` governs every
+    // surface; `interceptor.actionGuard` is a deprecated alias that fills
+    // per-key gaps so pre-#209 configs keep their posture. On a conflicting
+    // key the top-level value wins and the conflict is reported on stderr —
+    // honoured silently, a wrong alias would recreate the split-brain this
+    // fix exists to kill. Mirrored in plugins/openclaw/index.ts
+    // (normaliseConfig) and src/cli/doctor.ts (checkActionGuard); the three
+    // build units cannot share an import, so keep them in step by hand.
+    const isBlock = (v) => v && typeof v === 'object' && !Array.isArray(v);
+    const top = isBlock(config?.actionGuard) ? config.actionGuard : null;
+    const alias = isBlock(config?.interceptor?.actionGuard) ? config.interceptor.actionGuard : null;
+    if (top && alias) {
+      const conflicts = Object.keys(alias).filter(
+        (k) => k in top && JSON.stringify(top[k]) !== JSON.stringify(alias[k]),
+      );
+      if (conflicts.length > 0) {
+        process.stderr.write(
+          `[ShieldCortex] deprecated interceptor.actionGuard conflicts with actionGuard on: ${conflicts.join(', ')} — ` +
+          `top-level actionGuard wins; run \`shieldcortex doctor --fix-action-guard\` to migrate\n`,
+        );
+      }
+    }
+    const raw = top || alias ? { ...(alias ?? {}), ...(top ?? {}) } : null;
+    if (!raw) return { ...DEFAULT_ACTION_GUARD };
     return {
       enabled: raw.enabled !== false,
       enforce: raw.enforce !== false,

--- a/src/__tests__/pre-tool-hook-209-alias.test.ts
+++ b/src/__tests__/pre-tool-hook-209-alias.test.ts
@@ -1,0 +1,132 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Issue #209 — single source of truth for Action Guard config.
+ *
+ * Before this fix the Claude Code hook read ONLY top-level `actionGuard` and
+ * the OpenClaw plugin read ONLY `interceptor.actionGuard`, so the two surfaces
+ * could silently hold different enforcement postures. The resolution (#209):
+ * top-level `actionGuard` governs every surface; `interceptor.actionGuard` is
+ * a deprecated alias that fills gaps per key — an explicit top-level value
+ * always wins, and a conflicting alias value is reported, not honoured.
+ *
+ * These tests pin the HOOK side of that contract. The plugin side is pinned in
+ * plugins/openclaw/__tests__/action-guard-209-alias.test.ts and the doctor
+ * surfacing in src/cli/__tests__/doctor-action-guard.test.ts — the three merge
+ * implementations live in different build units and must stay in step.
+ */
+
+const HOOK_PATH = path.resolve(__dirname, '..', '..', 'scripts', 'pre-tool-hook.mjs');
+
+type HookResult = { stdout: string; stderr: string; code: number };
+
+function runHook(payload: unknown): Promise<HookResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [HOOK_PATH], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => { stdout += c.toString(); });
+    child.stderr.on('data', (c) => { stderr += c.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ stdout, stderr, code: code ?? 0 }));
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+function bashCall(command: string): Record<string, unknown> {
+  return {
+    session_id: 'test-session',
+    cwd: '/tmp',
+    permission_mode: 'default',
+    hook_event_name: 'PreToolUse',
+    tool_name: 'Bash',
+    tool_input: { command },
+  };
+}
+
+describe('pre-tool hook — #209 interceptor.actionGuard alias resolution', () => {
+  const originalHome = process.env.HOME;
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'shieldcortex-209-'));
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  function writeConfig(cfg: Record<string, unknown>): void {
+    const dir = path.join(tempHome, '.shieldcortex');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify(cfg));
+  }
+
+  it('honours the deprecated alias when no top-level block exists (back-compat)', async () => {
+    writeConfig({ interceptor: { actionGuard: { enforce: false } } });
+    const result = await runHook(bashCall('sudo systemctl stop nginx'));
+    expect(result.code).toBe(0);
+    // enforce:false via the alias → warn-mode: stderr warning, no decision.
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toMatch(/action guard/i);
+  });
+
+  it('top-level actionGuard wins over a conflicting alias value', async () => {
+    writeConfig({
+      actionGuard: { enforce: true },
+      interceptor: { actionGuard: { enforce: false } },
+    });
+    const result = await runHook(bashCall('sudo systemctl stop nginx'));
+    expect(result.code).toBe(0);
+    // Top-level enforce:true governs: the dangerous tier gates.
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('ask');
+  });
+
+  it('alias fills per-key gaps the top-level block does not set', async () => {
+    // Top-level sets only enforce; the alias's autoApprove must still apply.
+    writeConfig({
+      actionGuard: { enforce: true },
+      interceptor: { actionGuard: { autoApprove: ['sudo_command'] } },
+    });
+    const result = await runHook(bashCall('sudo systemctl stop nginx'));
+    expect(result.code).toBe(0);
+    // autoApprove match → no decision emitted (defers to Claude Code).
+    expect(result.stdout).toBe('');
+  });
+
+  it('reports a conflict on stderr and points at the doctor migration', async () => {
+    writeConfig({
+      actionGuard: { enforce: true },
+      interceptor: { actionGuard: { enforce: false } },
+    });
+    const result = await runHook(bashCall('sudo systemctl stop nginx'));
+    expect(result.code).toBe(0);
+    expect(result.stderr).toMatch(/interceptor\.actionGuard/);
+    expect(result.stderr).toMatch(/--fix-action-guard/);
+  });
+
+  it('catastrophic deny survives every alias combination', async () => {
+    writeConfig({
+      actionGuard: { enforce: false },
+      interceptor: { actionGuard: { enforce: false, enabled: true } },
+    });
+    const result = await runHook(bashCall('rm -rf /'));
+    expect(result.code).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+});

--- a/src/cli/__tests__/doctor-action-guard.test.ts
+++ b/src/cli/__tests__/doctor-action-guard.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
-import { checkActionGuard } from '../doctor.js';
+import { checkActionGuard, fixActionGuardConfig } from '../doctor.js';
 
 /**
  * Issue #94 — doctor had ZERO Action Guard check: its "Defence canary" probes
@@ -77,5 +77,86 @@ describe('doctor — Action Guard check (#94)', () => {
     const probe = results.find((r) => r.label === 'Action guard');
     expect(probe).toBeDefined();
     expect(probe!.status).toBe('pass');
+  });
+});
+
+/**
+ * Issue #209 — the split-key gotcha is resolved, not just warned about:
+ * top-level `actionGuard` now governs BOTH surfaces and
+ * `interceptor.actionGuard` is a deprecated gap-fill alias. Doctor's job
+ * changes accordingly: warn that the alias is in use (with the migration
+ * command), report conflicts as top-level-wins, and evaluate posture
+ * warnings against the EFFECTIVE merged config with per-key provenance.
+ */
+describe('doctor — Action Guard #209 alias resolution and migration', () => {
+  it('warns that the deprecated alias is in use, pointing at --fix-action-guard', async () => {
+    writeConfig({ interceptor: { actionGuard: { enforce: true } } });
+    const results = await checkActionGuard();
+    const warn = results.find((r) => r.status === 'warn' && /deprecated/i.test(r.message));
+    expect(warn).toBeDefined();
+    expect(warn!.fix ?? warn!.message).toMatch(/--fix-action-guard/);
+  });
+
+  it('conflict warning names the keys and states that top-level wins', async () => {
+    writeConfig({ actionGuard: { enforce: false }, interceptor: { actionGuard: { enforce: true } } });
+    const results = await checkActionGuard();
+    const warn = results.find((r) => r.status === 'warn' && /differ/i.test(r.message));
+    expect(warn).toBeDefined();
+    expect(warn!.message).toMatch(/enforce/);
+    expect(warn!.message).toMatch(/top-level|actionGuard.*wins/i);
+  });
+
+  it('posture warnings use the effective merged config with key provenance', async () => {
+    // enforce:false comes from the ALIAS (top-level does not set it) — the
+    // warn must fire and must name the alias key that caused it.
+    writeConfig({ actionGuard: { enabled: true }, interceptor: { actionGuard: { enforce: false } } });
+    const results = await checkActionGuard();
+    const warn = results.find((r) => r.status === 'warn' && /warn-mode/i.test(r.message));
+    expect(warn).toBeDefined();
+    expect(warn!.message).toMatch(/interceptor\.actionGuard\.enforce/);
+  });
+
+  it('does NOT warn warn-mode when top-level enforce:true overrides an alias enforce:false', async () => {
+    writeConfig({ actionGuard: { enforce: true }, interceptor: { actionGuard: { enforce: false } } });
+    const results = await checkActionGuard();
+    expect(results.find((r) => /warn-mode/i.test(r.message))).toBeUndefined();
+  });
+
+  it('fixActionGuardConfig migrates the alias into top-level, backs up, and clears the warning', async () => {
+    writeConfig({
+      actionGuard: { enforce: false },
+      interceptor: { enabled: true, actionGuard: { enforce: true, autoApprove: ['git_force_push'] } },
+    });
+    const fix = fixActionGuardConfig();
+    expect(fix.changed).toBe(true);
+    expect(fix.backupPath && fs.existsSync(fix.backupPath)).toBe(true);
+
+    const after = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    // Top-level wins on conflict (enforce stays false), alias gap-fills (autoApprove kept).
+    expect(after.actionGuard).toEqual({ enforce: false, autoApprove: ['git_force_push'] });
+    expect(after.interceptor.actionGuard).toBeUndefined();
+    // Sibling interceptor keys survive the migration.
+    expect(after.interceptor.enabled).toBe(true);
+
+    const results = await checkActionGuard();
+    expect(results.find((r) => /deprecated/i.test(r.message))).toBeUndefined();
+
+    if (fix.backupPath) fs.rmSync(fix.backupPath, { force: true });
+  });
+
+  it('fixActionGuardConfig removes an emptied interceptor block entirely', async () => {
+    writeConfig({ interceptor: { actionGuard: { enforce: false } } });
+    const fix = fixActionGuardConfig();
+    expect(fix.changed).toBe(true);
+    const after = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(after.actionGuard).toEqual({ enforce: false });
+    expect(after.interceptor).toBeUndefined();
+    if (fix.backupPath) fs.rmSync(fix.backupPath, { force: true });
+  });
+
+  it('fixActionGuardConfig is a no-op without the alias', async () => {
+    writeConfig({ actionGuard: { enforce: false } });
+    const fix = fixActionGuardConfig();
+    expect(fix.changed).toBe(false);
   });
 });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1707,11 +1707,12 @@ export async function checkDefenceCanary(): Promise<CheckResult> {
  *      probes: a catastrophic shape must block, a dangerous shape must gate,
  *      a benign shape must allow. A wrong verdict is a hard fail — the guard
  *      logic itself is broken on this box's build.
- *   2. Resolves the box's ACTUAL config for BOTH guard surfaces — the Claude
- *      Code hook reads top-level `actionGuard`, the OpenClaw plugin reads
- *      `interceptor.actionGuard` — and warns when either surface is opted
- *      down, or when the two resolve differently (the split-key gotcha: an
- *      operator setting one key may believe it governs both surfaces).
+ *   2. Resolves the box's EFFECTIVE guard config (#209): top-level
+ *      `actionGuard` governs both surfaces, `interceptor.actionGuard` is a
+ *      deprecated per-key gap-fill alias (top-level wins on conflict). Warns
+ *      when the effective posture is opted down (naming the exact key that
+ *      set it), when the alias is present at all, and when the alias holds
+ *      conflicting — and therefore ignored — values.
  *
  * Honest labelling: this is an in-process check of guard logic + config. It
  * does NOT prove the OpenClaw interceptor or the PreToolUse hook is actually
@@ -1771,52 +1772,106 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
     return results;
   }
 
-  // 2. Config-surface resolution (hook: `actionGuard`; plugin: `interceptor.actionGuard`).
+  // 2. Config resolution (#209). Both surfaces now resolve ONE effective
+  //    config: top-level `actionGuard` governs, `interceptor.actionGuard` is
+  //    a deprecated per-key gap-fill alias, top-level wins on conflict. This
+  //    check mirrors that merge (the hook, the plugin and this file are three
+  //    build units that cannot share an import — keep them in step by hand),
+  //    evaluates posture warnings against the EFFECTIVE config with per-key
+  //    provenance, and flags the alias itself so operators migrate off it.
   try {
     const configPath = path.join(getShieldCortexDir(), 'config.json');
     const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, 'utf-8')) : {};
-    const resolve = (r: unknown) => {
-      const o = r && typeof r === 'object' ? (r as Record<string, unknown>) : {};
-      return { enabled: o.enabled !== false, enforce: o.enforce !== false };
-    };
-    const hook = resolve(raw?.actionGuard);
-    const plugin = resolve(raw?.interceptor?.actionGuard);
+    const isBlock = (v: unknown): v is Record<string, unknown> =>
+      !!v && typeof v === 'object' && !Array.isArray(v);
+    const top = isBlock(raw?.actionGuard) ? (raw.actionGuard as Record<string, unknown>) : null;
+    const alias = isBlock(raw?.interceptor?.actionGuard)
+      ? (raw.interceptor.actionGuard as Record<string, unknown>)
+      : null;
+    const merged = { ...(alias ?? {}), ...(top ?? {}) };
+    const effective = { enabled: merged.enabled !== false, enforce: merged.enforce !== false };
+    // Which key set this value — top-level when it has the key, else the alias.
+    const provenance = (k: string) =>
+      top && k in top ? `actionGuard.${k}` : `interceptor.actionGuard.${k}`;
 
-    for (const [surface, cfg, key] of [
-      ['Claude Code hook', hook, 'actionGuard'],
-      ['OpenClaw plugin', plugin, 'interceptor.actionGuard'],
-    ] as const) {
-      if (!cfg.enabled) {
-        results.push({
-          label: `${label} config`,
-          status: 'warn',
-          message: `${surface} surface is disabled in config (\`${key}.enabled: false\`) — tool calls on that surface are not gated`,
-          fix: `Remove \`${key}.enabled: false\` from ~/.shieldcortex/config.json to restore gating.`,
-        });
-      } else if (!cfg.enforce) {
-        results.push({
-          label: `${label} config`,
-          status: 'warn',
-          message: `${surface} surface runs in warn-mode (\`${key}.enforce: false\`) — dangerous ops log but are not gated (catastrophic still blocks)`,
-        });
-      }
-    }
-    if (hook.enabled !== plugin.enabled || hook.enforce !== plugin.enforce) {
+    if (!effective.enabled) {
       results.push({
         label: `${label} config`,
         status: 'warn',
-        message:
-          `the two guard surfaces DIVERGE: Claude Code hook reads \`actionGuard\` ` +
-          `(enabled=${hook.enabled}, enforce=${hook.enforce}) while the OpenClaw plugin reads ` +
-          `\`interceptor.actionGuard\` (enabled=${plugin.enabled}, enforce=${plugin.enforce}) — ` +
-          `an operator setting one key may believe it governs both`,
+        message: `Action Guard is disabled in config (\`${provenance('enabled')}: false\`) — tool calls are not gated on either surface`,
+        fix: `Remove \`${provenance('enabled')}: false\` from ~/.shieldcortex/config.json to restore gating.`,
       });
+    } else if (!effective.enforce) {
+      results.push({
+        label: `${label} config`,
+        status: 'warn',
+        message: `Action Guard runs in warn-mode (\`${provenance('enforce')}: false\`) on both surfaces — dangerous ops log but are not gated (catastrophic still blocks)`,
+      });
+    }
+
+    if (alias) {
+      const conflicts = top
+        ? Object.keys(alias).filter(
+            (k) => k in top && JSON.stringify(top[k]) !== JSON.stringify(alias[k]),
+          )
+        : [];
+      if (conflicts.length > 0) {
+        results.push({
+          label: `${label} config`,
+          status: 'warn',
+          message:
+            `deprecated \`interceptor.actionGuard\` differs from \`actionGuard\` on: ${conflicts.join(', ')} — ` +
+            `the top-level value wins on both surfaces (#209), the alias values are ignored`,
+          fix: 'Run `shieldcortex doctor --fix-action-guard` to migrate the alias into the top-level block.',
+        });
+      } else {
+        results.push({
+          label: `${label} config`,
+          status: 'warn',
+          message:
+            `config uses the deprecated \`interceptor.actionGuard\` alias — it still works (both surfaces honour it), ` +
+            `but the single source of truth is the top-level \`actionGuard\` block (#209)`,
+          fix: 'Run `shieldcortex doctor --fix-action-guard` to migrate.',
+        });
+      }
     }
   } catch {
     // Unreadable config resolves to defaults on both runtime surfaces — nothing to warn about here.
   }
 
   return results;
+}
+
+/**
+ * `doctor --fix-action-guard` (#209): migrate the deprecated
+ * `interceptor.actionGuard` alias into the top-level `actionGuard` block —
+ * same merge the runtime surfaces apply (top-level wins per key, alias
+ * gap-fills), so the written config is exactly what was already in effect.
+ * Backs up config.json first and removes an emptied `interceptor` block.
+ */
+export function fixActionGuardConfig(): { changed: boolean; backupPath?: string; message: string } {
+  const configPath = path.join(getShieldCortexDir(), 'config.json');
+  if (!fs.existsSync(configPath)) return { changed: false, message: 'no config file — nothing to migrate' };
+  const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  const isBlock = (v: unknown): v is Record<string, unknown> =>
+    !!v && typeof v === 'object' && !Array.isArray(v);
+  const alias = isBlock(raw?.interceptor) && isBlock(raw.interceptor.actionGuard)
+    ? (raw.interceptor.actionGuard as Record<string, unknown>)
+    : null;
+  if (!alias) return { changed: false, message: 'no `interceptor.actionGuard` alias in config — nothing to migrate' };
+
+  const backupPath = `${configPath}.bak-fix-209-${new Date().toISOString().replace(/[:.]/g, '-')}`;
+  fs.copyFileSync(configPath, backupPath);
+
+  raw.actionGuard = { ...alias, ...(isBlock(raw.actionGuard) ? raw.actionGuard : {}) };
+  delete raw.interceptor.actionGuard;
+  if (Object.keys(raw.interceptor).length === 0) delete raw.interceptor;
+  fs.writeFileSync(configPath, JSON.stringify(raw, null, 2));
+  return {
+    changed: true,
+    backupPath,
+    message: `migrated interceptor.actionGuard into the top-level actionGuard block (backup: ${backupPath})`,
+  };
 }
 
 // ── Check 8b: Claude Code enforcement floor ───────────────
@@ -3235,6 +3290,34 @@ export async function runDoctor(
       }
     } else if (idx !== -1) {
       console.log(`  ${dim}--fix-project-keys: nothing to fix (no collision warning).${reset}\n`);
+    }
+  }
+
+  // --fix-action-guard (#209): migrate the deprecated interceptor.actionGuard
+  // alias into the top-level actionGuard block (backup + rewrite via
+  // fixActionGuardConfig), then re-run the check so the printed report
+  // reflects the post-fix state.
+  if (args.includes('--fix-action-guard')) {
+    try {
+      const fix = fixActionGuardConfig();
+      if (fix.changed) {
+        const refreshed = await checkActionGuard();
+        const start = results.findIndex((r) => r.label.startsWith('Action guard'));
+        if (start !== -1) {
+          const kept = results.filter((r) => !r.label.startsWith('Action guard'));
+          kept.splice(start, 0, ...refreshed);
+          results.length = 0;
+          results.push(...kept);
+        } else {
+          results.push(...refreshed);
+        }
+        console.log(`  ${dim}--fix-action-guard: ${fix.message}${reset}\n`);
+      } else {
+        console.log(`  ${dim}--fix-action-guard: ${fix.message}.${reset}\n`);
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(`  ${dim}--fix-action-guard failed: ${msg}${reset}\n`);
     }
   }
 


### PR DESCRIPTION
Closes #209.

## What
The two Action Guard surfaces read different config keys and could silently hold different enforcement postures (the split-brain Edith hit on her install: hook in warn-mode, plugin enforcing). This implements the triage-committed direction — **option 1, single source of truth**:

- Top-level `actionGuard` governs **every** surface.
- `interceptor.actionGuard` becomes a **deprecated alias**: per key it gap-fills where the top-level block is silent, and on a conflicting key the top-level value wins and the conflict is surfaced, not honoured.

## Where
- **Hook** (`scripts/pre-tool-hook.mjs`): merges alias under top-level; conflicting keys reported on stderr with the migration command.
- **Plugin** (`plugins/openclaw/index.ts`): `normaliseConfig` validates a top-level `actionGuard` block (same validation as the alias, via a shared `normaliseActionGuardBlock` helper) and folds it into `interceptor.actionGuard` at the parse boundary — `initInterceptor` and the enforcement path are untouched, so the alias can never leak downstream.
- **Doctor** (`src/cli/doctor.ts`): posture warnings now evaluate the **effective merged config** with per-key provenance (the warn names the exact key that set the posture). The alias presence warns as deprecated; conflicts warn as ignored-with-top-level-winning. New **`doctor --fix-action-guard`** migrates the alias into the top-level block: config.json backed up first, sibling `interceptor` keys preserved, an emptied `interceptor` block removed. The written config is exactly what was already in effect at runtime, so the migration can never change posture.

The three implementations live in build units that cannot share an import (the hook must run dist-free; the plugin builds across a package boundary). Each is pinned by tests asserting identical merge semantics, cross-referenced in comments.

## Behaviour note for existing split-brain installs
An install like Edith's (`actionGuard.enforce: false` + `interceptor.actionGuard.enforce: true`) now resolves to **warn-mode on both surfaces** — the top-level key is the operator-visible one and it wins, per the committed design. The change is loud: doctor warns twice (conflict + deprecation) and the hook notes the conflict on stderr. Catastrophic ops still hard-block regardless.

## Scope note
The issue's "surface divergence at write time via `shieldcortex config`" isn't implementable as described — `shieldcortex config` is the cloud-sync command; there is no general config-write CLI surface. Write-time coverage is the hook stderr note + runtime resolution + doctor.

## Tests
23 new/updated across the three surfaces; full suite 342/342 suites, 3902 passed / 7 skipped locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)