### PR TITLE
fix(install): verify on-disk plugin registration after install — restore when the native path wipes the stanza (#213)

### DIFF
--- a/src/setup/__tests__/verify-plugin-registration-213.test.ts
+++ b/src/setup/__tests__/verify-plugin-registration-213.test.ts
@@ -1,0 +1,115 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { verifyPluginRegistration } from '../openclaw.js';
+
+/**
+ * Issue #213 — the 4.47.32 installer left a box silently unprotected.
+ *
+ * Field origin (Case's aiquant box, 8 Aug 2026): `shieldcortex install` ran,
+ * the native `openclaw plugins install` path exited 0, and afterwards the
+ * `shieldcortex-realtime` stanza was GONE from openclaw.json (`plugins.allow`
+ * and `plugins.entries` both). Nothing verified the on-disk config after the
+ * native path — and the #74 honest-state self-check proves the RUNNING
+ * gateway's roster, which still held the pre-install plugin, so it passed.
+ * The wipe only bit at the next gateway restart: 7 plugins, no shieldcortex,
+ * while the CLI had reported installed.
+ *
+ * The invariant this file pins: an installer must never reduce the protection
+ * state it found. `verifyPluginRegistration` re-reads openclaw.json after any
+ * install path, restores the stanza when it is missing or disabled (via
+ * trustLocalPlugin — merge-preserving, never a whole-file clobber), and
+ * reports honestly when it cannot.
+ */
+
+let tempHome: string;
+
+beforeEach(() => {
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'shieldcortex-213-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+const configPath = () => path.join(tempHome, '.openclaw', 'openclaw.json');
+
+function writeConfig(cfg: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(configPath()), { recursive: true });
+  fs.writeFileSync(configPath(), JSON.stringify(cfg, null, 2) + '\n');
+}
+
+const FULL_STANZA = {
+  plugins: {
+    allow: ['codex', 'shieldcortex-realtime'],
+    entries: {
+      codex: { enabled: true, config: { appServer: { networkProxy: 'http://127.0.0.1:9' } } },
+      'shieldcortex-realtime': { enabled: true },
+    },
+  },
+};
+
+describe('verifyPluginRegistration (#213)', () => {
+  it('reports registered and leaves a correct config byte-for-byte untouched', () => {
+    writeConfig(FULL_STANZA);
+    const before = fs.readFileSync(configPath(), 'utf-8');
+    const result = verifyPluginRegistration(tempHome);
+    expect(result.registered).toBe(true);
+    expect(result.restored).toBe(false);
+    expect(fs.readFileSync(configPath(), 'utf-8')).toBe(before);
+  });
+
+  it('restores a wiped stanza (the Case shape: both allow and entries gone)', () => {
+    writeConfig({
+      plugins: {
+        allow: ['codex'],
+        entries: { codex: { enabled: true } },
+      },
+    });
+    const result = verifyPluginRegistration(tempHome);
+    expect(result.restored).toBe(true);
+    expect(result.registered).toBe(true);
+    const after = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(after.plugins.allow).toContain('shieldcortex-realtime');
+    expect(after.plugins.entries['shieldcortex-realtime']).toEqual({ enabled: true });
+    // Other plugins survive the restore untouched.
+    expect(after.plugins.allow).toContain('codex');
+    expect(after.plugins.entries.codex).toEqual({ enabled: true });
+  });
+
+  it('re-enables a disabled entry while preserving its other keys', () => {
+    writeConfig({
+      plugins: {
+        allow: ['shieldcortex-realtime'],
+        entries: {
+          'shieldcortex-realtime': { enabled: false, config: { cloudEnabled: true } },
+        },
+      },
+    });
+    const result = verifyPluginRegistration(tempHome);
+    expect(result.restored).toBe(true);
+    expect(result.registered).toBe(true);
+    const after = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(after.plugins.entries['shieldcortex-realtime']).toEqual({
+      enabled: true,
+      config: { cloudEnabled: true },
+    });
+  });
+
+  it('creates the registration when no config file exists at all', () => {
+    const result = verifyPluginRegistration(tempHome);
+    expect(result.registered).toBe(true);
+    expect(result.restored).toBe(true);
+    const after = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(after.plugins.allow).toContain('shieldcortex-realtime');
+  });
+
+  it('reports honestly when the restore itself is impossible', () => {
+    // `.openclaw` exists as a FILE, so the config path can never be written.
+    fs.writeFileSync(path.join(tempHome, '.openclaw'), 'not a directory');
+    const result = verifyPluginRegistration(tempHome);
+    expect(result.registered).toBe(false);
+    expect(result.detail).toMatch(/restore|write|fail/i);
+  });
+});

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -554,6 +554,63 @@ export function trustLocalPlugin(_installDir: string, _version: string, homeArg?
   }
 }
 
+/**
+ * Post-install registration verification + restore (#213).
+ *
+ * Field origin: on 8 Aug 2026 the 4.47.32 installer's native path
+ * (`openclaw plugins install`, exit 0) left openclaw.json WITHOUT the
+ * shieldcortex-realtime stanza — `plugins.allow` and `plugins.entries` both —
+ * and nothing checked. The #74 honest-state self-check proves the RUNNING
+ * gateway's roster, which still held the pre-install plugin, so it passed;
+ * the box booted unprotected at the next gateway restart while the CLI had
+ * reported installed.
+ *
+ * Invariant: an installer must never reduce the protection state it found.
+ * This re-reads the ON-DISK config after any install path — the artifact that
+ * decides what loads at the next restart, which no runtime roster can prove —
+ * and restores the stanza through trustLocalPlugin (merge-preserving, never a
+ * whole-file clobber) when it is missing or disabled. Callers fail LOUD when
+ * `registered` comes back false.
+ *
+ * `homeArg` is the same test seam as trustLocalPlugin's.
+ */
+export function verifyPluginRegistration(homeArg?: string): {
+  registered: boolean;
+  restored: boolean;
+  detail: string;
+} {
+  const configPath = homeArg
+    ? path.join(homeArg, '.openclaw', 'openclaw.json')
+    : openClawConfigPath();
+  const pluginId = PLUGIN_DIR_NAME;
+
+  const readState = (): { needsWrite: boolean; detail: string } => {
+    try {
+      if (!fs.existsSync(configPath)) return { needsWrite: true, detail: 'openclaw.json does not exist' };
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      return pluginInstallNeedsWrite(config, pluginId, '', '')
+        ? { needsWrite: true, detail: `${pluginId} missing or disabled in plugins.allow/entries` }
+        : { needsWrite: false, detail: 'registered' };
+    } catch (err) {
+      return { needsWrite: true, detail: `openclaw.json unreadable (${(err as Error).message})` };
+    }
+  };
+
+  const before = readState();
+  if (!before.needsWrite) return { registered: true, restored: false, detail: before.detail };
+
+  const wrote = trustLocalPlugin('', '', homeArg);
+  const after = readState();
+  if (!after.needsWrite) return { registered: true, restored: true, detail: `restored: ${before.detail}` };
+  return {
+    registered: false,
+    restored: false,
+    detail: wrote
+      ? `restore wrote but verification still failed: ${after.detail}`
+      : `restore write failed: ${after.detail}`,
+  };
+}
+
 function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
   if (process.env[OPENCLAW_SKIP_NATIVE_INSTALL_ENV] === '1') return null;
   if (!isOpenClawInstalled()) return null;
@@ -1042,6 +1099,27 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
 
   // Install the real-time plugin to the extensions directory
   const pluginInstallMode = installPlugin({ noPlugins: options.noPlugins });
+
+  // #213: verify the ON-DISK registration after whichever install path ran,
+  // BEFORE the gateway restart below — the restart boots from openclaw.json,
+  // and the native `openclaw plugins install` path has wiped the stanza in
+  // the field while exiting 0. The roster self-check further down cannot
+  // catch this: it proves the running gateway, which still holds the
+  // pre-install plugin until the restart.
+  if (pluginInstallMode !== 'skipped') {
+    const reg = verifyPluginRegistration();
+    if (reg.restored) {
+      console.warn('⚠  Install left shieldcortex-realtime unregistered in openclaw.json — stanza restored (#213).');
+      console.warn(`   (${reg.detail})`);
+    } else if (!reg.registered) {
+      console.error('✗ SECURITY: shieldcortex-realtime is NOT registered in openclaw.json and restore failed.');
+      console.error(`  ${reg.detail}`);
+      console.error('  The box will be UNPROTECTED after the next gateway restart even though files were installed.');
+      console.error('  Restore by hand: add "shieldcortex-realtime" to plugins.allow and');
+      console.error('  plugins.entries["shieldcortex-realtime"] = { "enabled": true } in ~/.openclaw/openclaw.json.');
+      process.exitCode = 1;
+    }
+  }
 
   console.log('');
   if (migratedLegacy > 0) {


### PR DESCRIPTION
Closes #213 (Case's aiquant repro, 8 Aug).

## Root cause chain
1. `installPlugin` tries the **native** path first (`openclaw plugins install …`) and on exit 0 returns immediately — **nothing re-reads openclaw.json**. On aiquant that path removed the `shieldcortex-realtime` stanza (`plugins.allow` + `plugins.entries`) while exiting 0.
2. The #74 honest-state self-check verifies the **running gateway's roster** — which still held the pre-install plugin — so it passed against stale runtime state. The wiped artifact was the on-disk config, the thing that decides what loads at the next restart, and no check read it. The box booted unprotected at 14:01.

## Fix
- **`verifyPluginRegistration()`** (exported, `homeArg` test seam): re-reads openclaw.json after whichever install path ran, using the existing `pluginInstallNeedsWrite` as the "correctly registered" predicate, and restores via `trustLocalPlugin` — merge-preserving, other plugins' entries byte-for-byte untouched (pinned by the existing #112 test plus five new tests including the exact Case wipe shape and the disabled-entry shape).
- Wired into the install flow **before the gateway-restart step**, so a restore lands in the config the restart boots from. Restored → loud ⚠ naming #213. Restore impossible → `✗ SECURITY` block with the manual stanza fix and exit code 1.

## Deliberately out of scope (noted, not snuck in)
- Characterising exactly which OpenClaw write drops the stanza (their `plugins install` internals) — the verify-and-restore holds regardless of mechanism.
- Case's doctor suggestion (PID-attributing hot-reload registrations) — filing separately.
- Hardening the #74 self-check for the repair path — the install path is covered by this ordering.

## Tests
5 new + existing preservation suite; full suite locally **343/343 suites, 3907 passed / 7 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)