### PR TITLE
feat(#143): a denial reaches the operator AS a denial — event discriminator, both channels, webhook secret

### DIFF
--- a/BRIEF-143.md
+++ b/BRIEF-143.md
@@ -1,0 +1,141 @@
+# Brief: finish #143 — a denial must reach the operator AS a denial
+
+Worktree, branch `fix/143-operator-channel`, based on `origin/main` @ `ba6e97c`.
+Deps installed. Commit locally, do NOT push.
+
+**Correction to an earlier version of this brief: the approval-hash defect
+(#183/#201) is ALREADY FIXED on main** — see `projectForHash` /
+`EXEC_ADVISORY_KEYS` in `src/defence/iron-dome/action-approvals.ts`, commit
+c725626. Do not touch it. Native OpenClaw approval cards also already shipped
+(commit 6771901, `notify.openclaw=true`). Read both before starting so you are
+working against reality and not against this document.
+
+## Read first
+
+1. `scripts/pre-tool-hook.mjs` — `loadNotify`, `pingOperator`,
+   `emitApprovalRequired`, `noPromptSurfaceReason`, and the call site around
+   line 892 marked `── operator-notify transport (#143) ──`.
+2. `src/defence/iron-dome/operator-notify.ts`
+3. `src/defence/iron-dome/notify-config.ts`
+4. `src/defence/iron-dome/webhook-notify-channel.ts`
+5. `src/defence/iron-dome/openclaw-approval-channel.ts`
+
+## The defect
+
+`pingOperator` runs on the shared path BEFORE `emitApprovalRequired` chooses
+between `ask` and `deny`. So on a promptless box — `bypassPermissions`, which
+is how every unattended agent and cron on this fleet runs — the operator
+receives a notification worded as *"approve this?"* for an action that has
+**already been refused and handed back to the agent as a denial**.
+
+Two things are wrong with that, and the second is the one that cost real work:
+
+1. The card's wording is false at the moment it arrives. Nothing is waiting on
+   the operator; the action is already dead.
+2. It never says a job just died, or which one. From issue #143, in my own
+   words: *every `denied_no_prompt_surface` must emit on the operator's channel
+   — what was denied, which rule, the approve hash, and which job it killed.*
+
+Live cost, measured this morning across the fleet: 41 gated actions hard-denied
+in one week with nobody told. Friday's nightly backup on 2 Aug is simply absent
+from the backup repo. Edith saw `email_pickup.py` denied 15 consecutive times
+over 7 hours, found only by reading the audit jsonl by hand.
+
+## What to build
+
+### 1. An event discriminator on the notification
+
+In `operator-notify.ts`, add to `OperatorNotification`:
+
+- `event: 'approval_requested' | 'denied_no_prompt_surface'` — default
+  `'approval_requested'` at every existing construction site so no current
+  behaviour changes.
+- `deniedReason?: string` — the `noPromptSurfaceReason` text, e.g.
+  `bypassPermissions mode shows no prompt`.
+- `sessionId?: string` and `cwd?: string` — from the hook's `hookData`
+  (`session_id`, `cwd`). This is how an operator identifies WHICH job died;
+  without it the alert is unactionable.
+
+`formatOperatorNotification` must render the two events differently. The denial
+text states plainly that the action was BLOCKED and DID NOT RUN, gives the
+reason, names the session/cwd, and still carries the approve command so the
+retry can be authorised. Do not emit an Approve/Deny pair on a denial — there
+is nothing left to deny.
+
+### 2. Both channels carry it
+
+- `webhook-notify-channel.ts`: derive `X-ShieldCortex-Event` from the
+  discriminator instead of the hardcoded `approval_requested`, and include
+  `event`, `deniedReason`, `sessionId`, `cwd` in the JSON body.
+- `openclaw-approval-channel.ts`: on `denied_no_prompt_surface` this must NOT
+  raise an interactive Approve/Deny card — there is no live decision to make
+  and a card whose buttons change nothing trains the operator to ignore cards.
+  Send it as a plain notification on the same channel instead. If the channel
+  has no non-interactive send path, say so in your report and fall back to the
+  webhook channel for this event rather than inventing a gateway call you have
+  not verified exists.
+
+### 3. The hook passes the truth
+
+`emitApprovalRequired` already computes `noPromptSurfaceReason`. Restructure so
+the notify call knows which branch it is on. Hard constraints:
+
+- Notify stays BEST-EFFORT: never throws into the decision, never delays past
+  its own bounded timeout, never changes the verdict.
+- `emitDecision` output stays byte-identical to today for every existing case.
+- No added latency on the allow path.
+- The hook is one process per tool call — no persistent state, no background
+  work that outlives the process except the existing detached waiter.
+
+### 4. `notify.webhookSecret`
+
+`createWebhookNotifyChannel` already accepts a `secret` and HMAC-signs the body
+with it, but `NotifyConfig` has no field for one and `loadNotify` never passes
+one — so the webhook channel can only ever send unauthenticated POSTs. Any
+receiver worth pointing it at must reject unsigned requests.
+
+Add `webhookSecret?: string` to `NotifyConfig`, normalise it the way the other
+fields are normalised (reject non-strings, bound the length, treat unusable as
+absent), and pass it through in `loadNotify`. Never log it, never include it in
+an error message, never put it in an audit row.
+
+## Non-negotiables
+
+- **Zeroth law: ShieldCortex must never break the host.** Unsure whether a
+  change could wedge the gateway or an agent? Take the smaller change and say
+  so in the report.
+- Do not touch tier rules, the broker's pre-clear set, `enforce`,
+  `failurePolicy`, or the catastrophic hard-block. This work tells the operator
+  things; it does not change verdicts.
+- No opportunistic refactors. Smallest change that fully solves it.
+- Comments explain WHY. Match the surrounding files' unusually high comment
+  density and voice — that is deliberate house style, not accident.
+
+## Tests
+
+- `src/__tests__/prompt-surface-deny.test.ts`: a promptless-mode denial with a
+  configured notify webhook delivers a payload whose `event` is
+  `denied_no_prompt_surface`, naming the reason, session and cwd. Local
+  throwaway HTTP server or injected fetch — no real network.
+- `operator-notify.test.ts` / `webhook-notify-channel.test.ts`: new fields and
+  header, and that the default event is unchanged for existing callers.
+- `notify-config.test.ts` (create if absent): `webhookSecret` normalisation,
+  including that a non-string or over-long value is dropped rather than
+  accepted.
+- **The property that matters most:** a notify channel that throws, hangs past
+  its deadline, or returns 500 leaves the guard's decision completely
+  unchanged. Pin it for both events.
+
+## Before reporting done
+
+Run and paste real output:
+- `npx tsc --noEmit -p tsconfig.json`
+- `npx jest src/__tests__/prompt-surface-deny.test.ts src/defence/iron-dome/__tests__`
+- the full suite if it finishes in reasonable time
+
+Report what you changed, what you verified WITH OUTPUT, what you did not do,
+and anything you found that contradicts this brief. If the brief is wrong about
+the code, say so rather than implementing something you can see is wrong — that
+already happened once on this task.
+
+Write the report to `REPORT-143.md`.

--- a/REPORT-143.md
+++ b/REPORT-143.md
@@ -1,0 +1,266 @@
+# Report — #143: a denial must reach the operator AS a denial
+
+Branch `fix/143-operator-channel`, worktree `/home/ubuntu/clawd/sc-wt-143`, based on
+`ba6e97c`. Local commits only, nothing pushed.
+
+```
+bb0438f docs(#143): working notes — brief and completion report
+667ce3c test(#143): the approve command a denial offers really does authorise the retry
+2645322 test(#143): pin the denial event end to end, and that a broken channel changes nothing
+96841dc feat(#143): a denial reaches the operator AS a denial
+```
+
+## Confirming the brief against the code before starting
+
+Both corrections in the brief are accurate:
+
+- The approval-hash defect (#183/#201) **is** already fixed on main —
+  `projectForHash` / `EXEC_ADVISORY_KEYS` in `action-approvals.ts` (c725626). Not touched.
+- Native OpenClaw approval cards **did** ship (6771901, `notify.openclaw=true`). Not touched
+  except to make them refuse the new denial event.
+
+The defect as described is real and was in the place described:
+`scripts/pre-tool-hook.mjs:891` fired `pingOperator` before `emitApprovalRequired` chose
+between `ask` and `deny`, so a promptless box got a card/POST worded "approval needed" for a
+call the guard had already refused, with no session, no cwd, and no statement that anything
+had died.
+
+## What changed
+
+### 1. `src/defence/iron-dome/operator-notify.ts` — the discriminator
+
+- New `OperatorNotificationEvent = 'approval_requested' | 'denied_no_prompt_surface'`.
+- `OperatorNotification` gains `event` (required), `deniedReason?`, `sessionId?`, `cwd?`.
+  `RequestOperatorApprovalInput` gains the same four, all optional, `event` defaulting to
+  `'approval_requested'` — so every caller that predates the discriminator produces a
+  byte-identical notification.
+- `deniedReason` is only carried on the denial event (a caller cannot accidentally tell an
+  operator that a live hold was blocked). `sessionId` / `cwd` are carried on both; they are
+  bounded to 500 chars and dropped when empty, because they arrive from the harness's JSON.
+- `formatOperatorNotification` renders the two events differently. The denial reads
+  `🛡️ ShieldCortex — BLOCKED: this action did NOT run`, adds `Blocked:` / `Session:` /
+  `Cwd:` lines, and closes with "The agent has already been refused; this job did not do the
+  work. / To authorise a RETRY, run in YOUR terminal: shieldcortex approve <hash>". No
+  `[Approve]`/`[Deny]` pair. The approval wording is unchanged, byte for byte.
+- An **unknown or missing** `event` renders as the approval wording. A stale dist degrading
+  to today's text is safe; degrading to a false "this was blocked" is not.
+- `fallbackHint` on a denial carries the approve half only.
+
+### 2. `webhook-notify-channel.ts` — both channels carry it
+
+- `X-ShieldCortex-Event` is derived from the discriminator instead of hardcoded, via an
+  `eventOf()` that emits only the two known values.
+- Body gains `event` (first key), plus `deniedReason` / `sessionId` / `cwd` where they apply.
+- `denyCommand` is omitted on a denial — a receiver that renders these into chat would
+  otherwise draw a Deny button on a dead request. This is safe because
+  `denied_no_prompt_surface` is a **new** event: no existing receiver can depend on the shape
+  of a body it has never been sent. The `approval_requested` body is unchanged but for the
+  added `event` key.
+
+### 3. `openclaw-approval-channel.ts` — and the honest gap
+
+**Answering the brief's question directly: this channel has no non-interactive send path.**
+Its only route is the detached waiter's one long-lived
+`openclaw gateway call plugin.approval.request`, which is by definition an Approve/Deny card.
+So, per the brief, it now refuses `denied_no_prompt_surface` outright — before spawning
+anything — and the hook falls back to the webhook for that event.
+
+Two things I did *not* do and why:
+
+- I did not invent a gateway route. The repo's own corpus references
+  `openclaw message send --channel <c> --target <t> --text "…"` as a real CLI shape
+  (`payload-vs-action-89.test.ts:200`), and the `openclaw` binary is installed on this box —
+  but I have not verified that route exists on the gateway build in use, and `NotifyConfig`
+  has no channel/target fields to aim it with. Wiring it would mean inventing both a call and
+  a config surface.
+- I did not add those config fields. That is a design decision, not a bug fix.
+
+**Consequence you should weigh:** on an install with `notify.openclaw:true` and **no**
+`webhookUrl`, a promptless denial now reaches **no** channel, where before it raised a
+(wrongly-worded) card. That card was not entirely inert — tapping Approve would have left a
+one-shot approval in the #118 store that the retry could spend — so this is a real, if small,
+reduction in what arrives on that one configuration. Everything else is unchanged, and the
+hash-in-terminal floor is untouched. If you want that combination covered, the fix is a
+verified non-interactive gateway send path plus `notify.openclawChannel`/`openclawTarget`;
+say the word and I will do it as a separate change.
+
+### 4. `notify-config.ts` — `webhookSecret`
+
+`NotifyConfig.webhookSecret?: string`, normalised by a new exported `normaliseWebhookSecret`:
+non-string → absent, empty/whitespace-only → absent, over 512 chars → absent (dropped, not
+truncated — a silently truncated key produces a signature the receiver can never reproduce).
+Trimmed, deliberately: config files collect trailing newlines and the receiver's copy is
+invariably the trimmed literal. Kept independent of `webhookUrl` so a key configured before
+the URL is not thrown away. `loadNotify` passes it into `createWebhookNotifyChannel`.
+
+It is never logged, never in an error message, never in an audit row — pinned by a test that
+greps the hook's stdout, stderr and the audit row for it. I also checked it cannot leave the
+box by another route: `plugins/openclaw/cloud-sync.ts` and `src/cloud/config.ts` never read
+or transmit the `notify` block.
+
+### 5. `scripts/pre-tool-hook.mjs` — the hook passes the truth
+
+The restructure is deliberately the smallest one that works: `pingOperator` is handed
+`noPromptSurfaceReason(permissionMode)` — the same pure function `emitApprovalRequired`
+evaluates a few lines later — plus `session_id` and `cwd` off `hookData`. Recomputing a pure
+string is cheaper and far less fragile than restructuring the refusal path around the
+notification, and it means the notify layer cannot alter the verdict even by accident:
+`emitApprovalRequired` remains the sole owner of the decision and still derives it
+independently from the permission mode alone.
+
+`loadNotify` now returns `denialChannel` (the webhook, when configured) alongside the primary
+`channel`. `pingOperator` picks exactly one — never both — so the "one channel per hold"
+invariant that keeps the one-shot hash from being offered on two surfaces still holds.
+
+Constraints honoured:
+
+- **Best-effort:** unchanged try/catch, unchanged per-channel deadline, result used for a
+  stderr breadcrumb only. Pinned by tests for both events.
+- **`emitDecision` byte-identical:** not touched at all. The e2e tests compare the full
+  decision object against a no-notify baseline run.
+- **No added latency on the allow path:** the allow path exits before any of this. The denial
+  path additionally short-circuits inside the card channel before its 4s receipt poll.
+- **One process per tool call:** no new state, no new background work; the existing detached
+  waiter is the only thing that outlives the process and is now never launched for a denial.
+- Tier rules, the broker's pre-clear set, `enforce`, `failurePolicy` and the catastrophic
+  hard-block: untouched.
+
+## Verification — real output
+
+### `npx tsc --noEmit -p tsconfig.json`
+
+This config is **already red on `ba6e97c`** — it includes test files with long-standing type
+errors (duplicate identifiers, `rootDir` violations from `benchmark/`, untyped `.mjs`
+imports). It is not the build config; `tsconfig.build.json` is. I pinned that my change adds
+nothing:
+
+```
+$ npx tsc --noEmit -p tsconfig.json 2>&1 > /tmp/tsc-after.txt; grep -cE "^[^ ]" /tmp/tsc-after.txt
+173
+$ git stash -q && npx tsc --noEmit -p tsconfig.json 2>&1 > /tmp/tsc-before.txt; grep -cE "^[^ ]" /tmp/tsc-before.txt
+173
+$ git stash pop -q; diff <(grep -E "^[^ ]" /tmp/tsc-before.txt) <(grep -E "^[^ ]" /tmp/tsc-after.txt) && echo "IDENTICAL to HEAD"
+IDENTICAL to HEAD
+```
+
+The config the build actually uses is clean:
+
+```
+$ npx tsc --noEmit -p tsconfig.build.json; echo "exit=$?"
+exit=0
+```
+
+### `jest src/__tests__/prompt-surface-deny.test.ts src/defence/iron-dome/__tests__`
+
+```
+    the operator is told a job died (#143)
+      ✓ delivers a denied_no_prompt_surface event naming the reason, the session and the cwd (119 ms)
+      ✓ signs the body with notify.webhookSecret, so the receiver can reject a forged POST (119 ms)
+      ✓ never leaks the secret into stdout, stderr, or the audit row (121 ms)
+      ✓ a prompting session still gets the approval event, unchanged (116 ms)
+      ✓ the notification carries the SAME hash the denial reason offers for the retry (117 ms)
+      ✓ the approve command it offers really does authorise the retry (188 ms)
+      a promptless denial survives a broken channel
+        ✓ a receiver returning 500 changes nothing (178 ms)
+        ✓ a receiver that never responds is cut off at the deadline and changes nothing (740 ms)
+        ✓ a refused connection changes nothing (166 ms)
+      a live hold survives a broken channel
+        ✓ a receiver returning 500 changes nothing (188 ms)
+        ✓ a receiver that never responds is cut off at the deadline and changes nothing (744 ms)
+        ✓ a refused connection changes nothing (165 ms)
+```
+
+```
+Test Suites: 44 passed, 44 total
+Tests:       1083 passed, 1083 total
+```
+
+(First attempt at that command showed 2 failures in `config-normalization.test.ts` — a fresh
+worktree whose `node_modules/better-sqlite3` had no compiled binding, unrelated to this work.
+Fixed with `cd node_modules/better-sqlite3 && npm run build-release`; that is now recorded in
+my notes on this repo's test recipe.)
+
+### Full suite
+
+```
+$ npm run build:ts && SHIELDCORTEX_SKIP_EMBEDDINGS=1 \
+    node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand
+
+Test Suites: 351 passed, 351 total
+Tests:       7 skipped, 4039 passed, 4046 total
+Snapshots:   0 total
+Time:        248.822 s
+Ran all test suites.
+```
+
+### The tests were verified failing-first, retroactively
+
+I wrote the implementation before the tests, so I proved the tests actually bite: reverted
+`src/` + `scripts/` to `ba6e97c`, kept the new test files, rebuilt `dist`, ran them.
+
+```
+      ✕ delivers a denied_no_prompt_surface event naming the reason, the session and the cwd
+      ✕ signs the body with notify.webhookSecret, so the receiver can reject a forged POST
+      ✕ a prompting session still gets the approval event, unchanged
+      ✕ carries the denial event with the reason and WHICH JOB died
+      ✕ states plainly that the action was blocked and did not run
+      ✕ offers no Approve/Deny pair — there is nothing left to deny
+      ✕ carries the denial event on the header and the body, with the reason and which job died (#143)
+      ✕ reports not-delivered and never spawns the waiter
+      ✕ accepts a plausible key and hands it through
+      … 19 failed, 95 passed, 114 total
+```
+
+The best-effort pins ("a broken channel changes nothing") **passed** on the old tree, which is
+exactly what they are for: they are regression pins on a property that already held and must
+survive this change.
+
+## Tests added
+
+- `src/__tests__/prompt-surface-deny.test.ts` — a new `the operator is told a job died (#143)`
+  block. Drives the **real** hook against the **real** dist and the **real** webhook channel
+  over a throwaway `127.0.0.1` HTTP server (no fake channel, no network off-box), asserting
+  the header, the HMAC signature, the body and the rendered text. Includes the
+  broken-channel matrix (500 / never responds / refused connection) run for **both** events
+  against a no-notify baseline decision.
+- `operator-notify.test.ts` — denial wording; the default event for pre-discriminator
+  callers; an unknown event degrading to the approval wording; a `deniedReason` ignored on
+  the approval event; bounded session/cwd; and the whole adversarial best-effort battery
+  re-run over both events.
+- `webhook-notify-channel.test.ts` — header and body event for both, denial fields, the
+  signature computed over the exact body sent, unsigned when no secret.
+- `openclaw-approval-channel.test.ts` — a denial never becomes a card, never spawns the
+  waiter, and costs no receipt-poll latency; live holds unaffected.
+- `notify-config.test.ts` — `webhookSecret` normalisation, including non-string and over-long
+  values being dropped rather than accepted.
+
+## What I did not do
+
+- **No non-interactive OpenClaw send path.** See §3. This is the one requirement I could not
+  fully satisfy without inventing a gateway call, which the brief forbids.
+- **`plugins/openclaw/gateway-notify-channel.ts` is unchanged.** It carries its own structural
+  mirror of `OperatorNotification` (it cannot import across the plugin `rootDir`) and serves
+  the plugin interceptor, not the hook. Denials on that surface are a separate change; the
+  required field on the real interface does not break it, because the mirror is structural
+  and method parameters are bivariant. Verified: all 19 plugin suites, 174 tests, pass.
+- **No notify handling in `handleDegradedGuard`.** That path runs when `dist` is missing or
+  the guard threw — the notify modules load from the same `dist`, so there is nothing to load.
+  It denies with the same message as before; the audit row still records
+  `denied_no_prompt_surface`. Flagging it because it is a genuine, pre-existing hole in the
+  "every denial is reported" claim.
+- **No docs.** `notify.webhookUrl`, `notify.openclaw` and now `notify.webhookSecret` appear in
+  no README or `docs/` file — the whole `notify` config block has been undocumented since
+  #143 landed. Adding a config reference is worth doing but is not this change.
+- **No CHANGELOG entry, no version bump, no push.** Consistent with how 6771901 and 7c0e485
+  were committed (CHANGELOG is written at release).
+
+## Things worth knowing
+
+- `BRIEF-143.md` and `REPORT-143.md` are committed as working notes. Drop them before any PR.
+- `dist/` in this worktree has been rebuilt from this branch. The hook loads from `dist`, so
+  anything exercising it locally is running the new code.
+- The e2e suite's "has dist been built at all?" probe (copied from
+  `pre-tool-hook-notify-143.test.ts`) only builds when dist files are **missing**, not when
+  they are stale. If you edit `src/defence/iron-dome/*` and re-run only the hook tests
+  without `npm run build:ts`, you will be testing the old dist. That trap predates this work;
+  I am flagging it rather than fixing it here.

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -327,9 +327,21 @@ async function loadNotify(rawNotifyConfig) {
         });
       }
     }
-    if (!channel && normalised.webhookUrl) {
-      channel = webhookMod.createWebhookNotifyChannel({ url: normalised.webhookUrl });
-    }
+    // The webhook, when configured. It serves two roles and is still built at
+    // most once: the primary channel where no card channel exists, and — for
+    // `denied_no_prompt_surface` — the ONLY channel, because the card channel
+    // is interactive-only and correctly refuses an event with no live decision
+    // behind it (see openclaw-approval-channel.ts). Still one channel per
+    // hold: `pingOperator` picks exactly one, never both.
+    const webhookChannel = normalised.webhookUrl
+      ? webhookMod.createWebhookNotifyChannel({
+          url: normalised.webhookUrl,
+          // Signs the body so the receiver can reject spoofed POSTs. Passed
+          // straight through and never logged — see notify-config.ts.
+          secret: normalised.webhookSecret,
+        })
+      : null;
+    if (!channel) channel = webhookChannel;
     // Neither channel buildable (absent/rejected webhookUrl, no openclaw
     // opt-in or no binary) means no configured channel exists yet. Degrading
     // to null here, rather than constructing a channel that would never
@@ -339,6 +351,11 @@ async function loadNotify(rawNotifyConfig) {
     return {
       config: normalised,
       requestOperatorApproval: notifyMod.requestOperatorApproval,
+      /** Where a denial goes when the primary channel cannot carry one. Null
+       *  means an openclaw-only install: the denial reaches no channel, which
+       *  is the honest outcome until a non-interactive gateway send path
+       *  exists to point it at. The terminal-hash floor is unchanged. */
+      denialChannel: webhookChannel,
       // `timeoutMs` is NOT a constructor option — the channel's `send()` is
       // handed the deadline per-call (see `pingOperator`, and
       // operator-notify.ts's `tryChannel`), so one channel object is timeout-
@@ -359,10 +376,30 @@ async function loadNotify(rawNotifyConfig) {
  * operator-notify.ts and webhook-notify-channel.ts, both of which enforce
  * their own deadlines independent of this caller), and its result is used
  * for nothing but a stderr breadcrumb — the hook's actual decision (the
- * 'ask' + hash fallback) is decided before and after this call identically.
+ * 'ask'/'deny' + hash fallback) is decided before and after this call
+ * identically.
+ *
+ * `noPromptSurface` is the ONLY thing that makes this call know which branch
+ * `emitApprovalRequired` is about to take. It is the same pure function
+ * evaluated on the same `permissionMode` a few lines later — recomputing a
+ * pure string is cheaper and far less fragile than restructuring the refusal
+ * path around the notification, and it means the notify layer cannot alter
+ * the verdict even by accident: the decision is still derived, independently,
+ * from the permission mode alone.
+ *
+ * When it is non-null the held call has ALREADY been refused by the time this
+ * message lands, so the operator is told a job died — not asked a question
+ * nothing is waiting on (#143).
  */
-async function pingOperator(notify, { toolName, toolInput, verdict, hash }) {
+async function pingOperator(notify, { toolName, toolInput, verdict, hash, noPromptSurface, sessionId, cwd }) {
   if (!notify) return;
+  const denied = typeof noPromptSurface === 'string' && noPromptSurface.length > 0;
+  // A denial cannot go to an interactive Approve/Deny card — there is nothing
+  // left to decide — so it takes the plain-message channel or no channel at
+  // all. `deliveredVia: null` is a normal outcome here, exactly as it is when
+  // nothing is configured.
+  const channel = denied ? notify.denialChannel : notify.channel;
+  if (!channel) return;
   try {
     const result = await notify.requestOperatorApproval(
       {
@@ -372,11 +409,21 @@ async function pingOperator(notify, { toolName, toolInput, verdict, hash }) {
         signals: verdict.signals,
         severity: verdict.severity,
         reason: verdict.reason,
+        event: denied ? 'denied_no_prompt_surface' : 'approval_requested',
+        deniedReason: denied ? noPromptSurface : undefined,
+        // Which job. Straight off the harness payload, bounded and validated
+        // by buildNotification in operator-notify.ts.
+        sessionId,
+        cwd,
       },
-      { channel: notify.channel, timeoutMs: notify.config.timeoutMs },
+      { channel, timeoutMs: notify.config.timeoutMs },
     );
     if (result?.deliveredVia) {
-      console.error(`[shieldcortex] approval broker: pinged the operator via ${result.deliveredVia} (${hash.slice(0, 12)}).`);
+      console.error(
+        denied
+          ? `[shieldcortex] operator-notify: reported the DENIAL of ${toolName} via ${result.deliveredVia} (${hash.slice(0, 12)}).`
+          : `[shieldcortex] approval broker: pinged the operator via ${result.deliveredVia} (${hash.slice(0, 12)}).`,
+      );
     }
   } catch (err) {
     // A notify transport that throws must not change the guard's outcome —
@@ -886,11 +933,28 @@ process.stdin.on('end', async () => {
       // here: a hold with nothing but a hash in a transcript nobody was
       // watching. If the operator configured a channel, ping it now — a
       // best-effort ADDITION to the unchanged refusal above, never a
-      // replacement for it (`emitDecision('ask', message)` below still fires
-      // identically whether or not this delivers, times out, or errors).
+      // replacement for it (`emitApprovalRequired` below still emits the
+      // identical decision whether or not this delivers, times out, or errors).
+      //
+      // The notification must say which of the two things actually happens
+      // next, so it is told the prompt-surface verdict up front: on a
+      // promptless box this is not "approve this?" but "this was BLOCKED and
+      // did not run". `emitApprovalRequired` re-derives the same value from
+      // the same permissionMode below and remains the sole owner of the
+      // decision — nothing here can change it.
       if (fullHash) {
         const notify = await loadNotify(cfg.notify);
-        await pingOperator(notify, { toolName, toolInput, verdict, hash: fullHash });
+        await pingOperator(notify, {
+          toolName,
+          toolInput,
+          verdict,
+          hash: fullHash,
+          noPromptSurface: noPromptSurfaceReason(permissionMode),
+          // Which job died. Absent on a harness that does not report them —
+          // rendered only when present, never as "undefined".
+          sessionId: typeof hookData.session_id === 'string' ? hookData.session_id : undefined,
+          cwd: typeof hookData.cwd === 'string' ? hookData.cwd : undefined,
+        });
       }
     }
     // #139: ask ONLY where a prompt can actually be raised. Under

--- a/src/__tests__/prompt-surface-deny.test.ts
+++ b/src/__tests__/prompt-surface-deny.test.ts
@@ -12,15 +12,19 @@
  * These tests pin that mapping per permission mode so a future refactor can't
  * quietly restore the version-dependent outcome.
  */
-import { spawn } from 'child_process';
+import { execSync, spawn } from 'child_process';
+import { createHmac } from 'crypto';
 import fs from 'fs';
+import http from 'http';
+import type { AddressInfo } from 'net';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const HOOK_PATH = path.resolve(__dirname, '..', '..', 'scripts', 'pre-tool-hook.mjs');
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const HOOK_PATH = path.resolve(REPO_ROOT, 'scripts', 'pre-tool-hook.mjs');
 
 /** Dangerous tier, not catastrophic — catastrophic denies regardless of mode. */
 const DANGEROUS_COMMAND = 'sudo systemctl stop nginx';
@@ -168,6 +172,196 @@ describe('Action Guard hook — prompt-surface rule', () => {
       const result = await runHook(call('ls -la', 'bypassPermissions'));
       expect(result.code).toBe(0);
       expect(result.stdout).toBe('');
+    });
+  });
+
+  /**
+   * #143 — a denial must reach the operator AS a denial.
+   *
+   * The rule above is right and is not changing: an unanswerable ask becomes a
+   * deny. What was wrong is what the operator was TOLD about it. The notify
+   * ping fired on the shared path before the ask/deny branch, so on a
+   * promptless box — `bypassPermissions`, how every unattended agent and cron
+   * on this fleet runs — the message read "approve this?" for a call that had
+   * already been refused and handed back to the agent, and it never said that
+   * a job had just died or which one. 41 gated actions were hard-denied on
+   * this fleet in one week with nobody told; one was a nightly backup that is
+   * simply absent from the backup repo, another was `email_pickup.py` denied
+   * 15 times over 7 hours, found by reading audit jsonl by hand.
+   *
+   * This drives the REAL hook against the REAL dist and the REAL webhook
+   * channel, over a throwaway loopback server — no fake channel, no network
+   * beyond 127.0.0.1 — so the header, the signature and the body are the ones
+   * an operator's receiver would actually get.
+   */
+  describe('the operator is told a job died (#143)', () => {
+    const SECRET = 'notify-signing-key';
+    type Delivery = { headers: http.IncomingHttpHeaders; body: string };
+
+    let server: http.Server;
+    let port: number;
+    let deliveries: Delivery[];
+    /** Per-test behaviour of the receiver — the failure modes a real one has. */
+    let mode: 'ok' | 'error' | 'hang';
+    const openSockets = new Set<import('net').Socket>();
+
+    beforeAll(async () => {
+      // The hook loads the guard, the approvals store and the notify transport
+      // from dist. Mirrors pre-tool-hook-notify-143.test.ts's probe.
+      const distProbes = ['tool-action-guard.js', 'action-approvals.js', 'notify-config.js', 'operator-notify.js', 'webhook-notify-channel.js']
+        .map((f) => path.join(REPO_ROOT, 'dist', 'defence', 'iron-dome', f));
+      if (!distProbes.every((p) => fs.existsSync(p))) {
+        execSync('npm run build:ts', { cwd: REPO_ROOT, stdio: 'ignore' });
+      }
+
+      server = http.createServer((req, res) => {
+        let body = '';
+        req.on('data', (c) => { body += c; });
+        req.on('end', () => {
+          deliveries.push({ headers: req.headers, body });
+          if (mode === 'hang') return; // never responds — the channel must abort
+          res.writeHead(mode === 'error' ? 500 : 204).end();
+        });
+      });
+      server.on('connection', (s) => {
+        openSockets.add(s);
+        s.on('close', () => openSockets.delete(s));
+      });
+      await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+      port = (server.address() as AddressInfo).port;
+    }, 300_000);
+
+    afterAll(async () => {
+      for (const s of openSockets) s.destroy();
+      await new Promise<void>((r) => server.close(() => r()));
+    });
+
+    beforeEach(() => {
+      deliveries = [];
+      mode = 'ok';
+    });
+
+    /** `notify.timeoutMs` is deliberately short: a hook is one process per tool
+     *  call, and a hanging receiver must cost the guard a bounded wait, not a
+     *  session. 600ms clears notify-config's 500ms floor. */
+    function writeNotifyConfig(extra: Record<string, unknown> = {}): void {
+      writeActionGuardConfig({
+        enabled: true,
+        enforce: true,
+        notify: { enabled: true, webhookUrl: `http://127.0.0.1:${port}/hook`, webhookSecret: SECRET, timeoutMs: 600, ...extra },
+      });
+    }
+
+    function delivered(): Record<string, unknown> {
+      expect(deliveries).toHaveLength(1);
+      return JSON.parse(deliveries[0].body);
+    }
+
+    it('delivers a denied_no_prompt_surface event naming the reason, the session and the cwd', async () => {
+      writeNotifyConfig();
+      const payload = call(DANGEROUS_COMMAND, 'bypassPermissions');
+      payload.session_id = 'nightly-backup-42';
+      payload.cwd = '/home/ubuntu/backups';
+
+      const result = await runHook(payload);
+
+      // The verdict is untouched — this feature tells the operator things.
+      expect(decisionOf(result.stdout).permissionDecision).toBe('deny');
+
+      const body = delivered();
+      expect(deliveries[0].headers['x-shieldcortex-event']).toBe('denied_no_prompt_surface');
+      expect(body.event).toBe('denied_no_prompt_surface');
+      expect(String(body.deniedReason)).toMatch(/bypassPermissions mode shows no prompt/);
+      expect(body.sessionId).toBe('nightly-backup-42');
+      expect(body.cwd).toBe('/home/ubuntu/backups');
+      // The wording is true at the moment it arrives, and the retry is still
+      // authorisable — but nothing is offered that would do nothing.
+      expect(String(body.text)).toMatch(/BLOCKED/);
+      expect(String(body.text)).toMatch(/did NOT run/i);
+      expect(String(body.approveCommand)).toMatch(/shieldcortex approve [0-9a-f]{12}/);
+      expect(body.denyCommand).toBeUndefined();
+    });
+
+    it('signs the body with notify.webhookSecret, so the receiver can reject a forged POST', async () => {
+      writeNotifyConfig();
+      await runHook(call(DANGEROUS_COMMAND, 'bypassPermissions'));
+      const { headers, body } = deliveries[0];
+      expect(headers['x-shieldcortex-signature']).toBe(createHmac('sha256', SECRET).update(body).digest('hex'));
+    });
+
+    it('never leaks the secret into stdout, stderr, or the audit row', async () => {
+      writeNotifyConfig();
+      const result = await runHook(call(DANGEROUS_COMMAND, 'bypassPermissions'));
+      expect(result.stdout).not.toContain(SECRET);
+      expect(result.stderr).not.toContain(SECRET);
+      expect(JSON.stringify(lastAudit())).not.toContain(SECRET);
+    });
+
+    it('a prompting session still gets the approval event, unchanged', async () => {
+      writeNotifyConfig();
+      const result = await runHook(call(DANGEROUS_COMMAND, 'default'));
+      expect(decisionOf(result.stdout).permissionDecision).toBe('ask');
+      const body = delivered();
+      expect(deliveries[0].headers['x-shieldcortex-event']).toBe('approval_requested');
+      expect(body.event).toBe('approval_requested');
+      expect(body.deniedReason).toBeUndefined();
+      expect(String(body.denyCommand)).toMatch(/shieldcortex deny/);
+      expect(String(body.text)).toContain('approval needed');
+    });
+
+    it('the notification carries the SAME hash the denial reason offers for the retry', async () => {
+      writeNotifyConfig();
+      const result = await runHook(call(DANGEROUS_COMMAND, 'bypassPermissions'));
+      const reason = String(decisionOf(result.stdout).permissionDecisionReason);
+      expect(String(delivered().shortHash)).toBe(reason.match(/shieldcortex approve ([0-9a-f]{12})/)![1]);
+    });
+
+    // ── the property that matters most ──────────────────────────────────────
+    // A notify channel is best-effort. Whatever it does — 500, hang, refuse
+    // the connection — the guard's decision, its reason, and its audit row are
+    // exactly what they are with no channel configured at all. Pinned for BOTH
+    // events, because the denial path is the newly-wired one.
+    describe.each([
+      ['a promptless denial', 'bypassPermissions', 'deny'],
+      ['a live hold', 'default', 'ask'],
+    ])('%s survives a broken channel', (_label, permissionMode, expectedDecision) => {
+      async function baseline(): Promise<{ decision?: string; reason?: string }> {
+        writeActionGuardConfig({ enabled: true, enforce: true });
+        const result = await runHook(call(DANGEROUS_COMMAND, permissionMode));
+        return decisionOf(result.stdout);
+      }
+
+      it('a receiver returning 500 changes nothing', async () => {
+        const before = await baseline();
+        mode = 'error';
+        writeNotifyConfig();
+        const after = decisionOf((await runHook(call(DANGEROUS_COMMAND, permissionMode))).stdout);
+        expect(after.permissionDecision).toBe(expectedDecision);
+        expect(after).toEqual(before);
+      });
+
+      it('a receiver that never responds is cut off at the deadline and changes nothing', async () => {
+        const before = await baseline();
+        mode = 'hang';
+        writeNotifyConfig();
+        const started = Date.now();
+        const after = decisionOf((await runHook(call(DANGEROUS_COMMAND, permissionMode))).stdout);
+        expect(after).toEqual(before);
+        // Bounded by notify.timeoutMs (600ms) plus process start-up — nowhere
+        // near an unbounded wait on a dead receiver.
+        expect(Date.now() - started).toBeLessThan(15_000);
+      }, 30_000);
+
+      it('a refused connection changes nothing', async () => {
+        const before = await baseline();
+        // Port 1 on loopback: nothing listens, so this is an immediate ECONNREFUSED.
+        writeActionGuardConfig({
+          enabled: true, enforce: true,
+          notify: { enabled: true, webhookUrl: 'http://127.0.0.1:1/hook', timeoutMs: 600 },
+        });
+        const after = decisionOf((await runHook(call(DANGEROUS_COMMAND, permissionMode))).stdout);
+        expect(after).toEqual(before);
+      });
     });
   });
 

--- a/src/__tests__/prompt-surface-deny.test.ts
+++ b/src/__tests__/prompt-surface-deny.test.ts
@@ -19,7 +19,7 @@ import http from 'http';
 import type { AddressInfo } from 'net';
 import os from 'os';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -314,6 +314,26 @@ describe('Action Guard hook — prompt-surface rule', () => {
       const result = await runHook(call(DANGEROUS_COMMAND, 'bypassPermissions'));
       const reason = String(decisionOf(result.stdout).permissionDecisionReason);
       expect(String(delivered().shortHash)).toBe(reason.match(/shieldcortex approve ([0-9a-f]{12})/)![1]);
+    });
+
+    it('the approve command it offers really does authorise the retry', async () => {
+      // The denial text tells the operator that approving unblocks the NEXT
+      // attempt. That is only true because the pending record is written
+      // before the prompt-surface branch — pin it, or the message becomes a
+      // promise the guard does not keep.
+      writeNotifyConfig();
+      await runHook(call(DANGEROUS_COMMAND, 'bypassPermissions'));
+      const shortHash = String(delivered().shortHash);
+
+      const { approveRequest } = await import(
+        pathToFileURL(path.join(REPO_ROOT, 'dist', 'defence', 'iron-dome', 'action-approvals.js')).href
+      ) as { approveRequest: (h: string, o: { home: string }) => { ok: boolean } };
+      expect(approveRequest(shortHash, { home: tempHome }).ok).toBe(true);
+
+      // The retry now defers to the harness's own permission system: no
+      // decision emitted at all, exactly as #118 has always behaved.
+      const retry = await runHook(call(DANGEROUS_COMMAND, 'bypassPermissions'));
+      expect(retry.stdout).toBe('');
     });
 
     // ── the property that matters most ──────────────────────────────────────

--- a/src/defence/iron-dome/__tests__/notify-config.test.ts
+++ b/src/defence/iron-dome/__tests__/notify-config.test.ts
@@ -69,6 +69,44 @@ describe('normaliseNotifyConfig — webhookUrl validation', () => {
   });
 });
 
+describe('normaliseNotifyConfig — webhookSecret (#143)', () => {
+  // Without a secret the webhook channel can only ever send UNAUTHENTICATED
+  // POSTs, and any receiver worth pointing it at — one that can page a human
+  // or re-run a killed job — has to reject unsigned requests. The channel has
+  // always been able to sign; until now nothing could give it the key.
+  it('accepts a plausible key and hands it through', () => {
+    expect(normaliseNotifyConfig({ enabled: true, webhookSecret: 's3cret-key' }).webhookSecret).toBe('s3cret-key');
+  });
+
+  it('is absent by default — signing is opt-in, exactly like everything else here', () => {
+    expect(normaliseNotifyConfig({ enabled: true }).webhookSecret).toBeUndefined();
+    expect(DEFAULT_NOTIFY_CONFIG.webhookSecret).toBeUndefined();
+  });
+
+  it('drops a non-string rather than signing over "[object Object]"', () => {
+    for (const junk of [12345, { secret: 'x' }, ['x'], true, null]) {
+      expect(normaliseNotifyConfig({ enabled: true, webhookSecret: junk }).webhookSecret).toBeUndefined();
+    }
+  });
+
+  it('drops an over-long value rather than truncating it into a key nothing shares', () => {
+    // A silently truncated key produces a signature the receiver can never
+    // reproduce — a 401 with no explanation. Absent is the honest state.
+    const huge = 'k'.repeat(5_000);
+    expect(normaliseNotifyConfig({ enabled: true, webhookSecret: huge }).webhookSecret).toBeUndefined();
+  });
+
+  it('treats empty or whitespace-only as absent, and trims the surrounding whitespace a config file collects', () => {
+    expect(normaliseNotifyConfig({ enabled: true, webhookSecret: '' }).webhookSecret).toBeUndefined();
+    expect(normaliseNotifyConfig({ enabled: true, webhookSecret: '   \n' }).webhookSecret).toBeUndefined();
+    expect(normaliseNotifyConfig({ enabled: true, webhookSecret: '  abc123\n' }).webhookSecret).toBe('abc123');
+  });
+
+  it('survives without a webhookUrl — a key configured before the URL is not silently thrown away', () => {
+    expect(normaliseNotifyConfig({ enabled: true, webhookSecret: 'abc' }).webhookSecret).toBe('abc');
+  });
+});
+
 describe('normaliseNotifyConfig — timeoutMs bounds', () => {
   it('defaults when absent, non-numeric, or out of range', () => {
     expect(normaliseNotifyConfig({ enabled: true }).timeoutMs).toBe(DEFAULT_NOTIFY_CONFIG.timeoutMs);
@@ -90,6 +128,7 @@ describe('normaliseNotifyConfig — total function', () => {
       { enabled: true, webhookUrl: { toString: () => { throw new Error('boom'); } } },
       { __proto__: { enabled: true } },
       { enabled: true, timeoutMs: { valueOf: () => 1 } },
+      { enabled: true, webhookSecret: { toString: () => { throw new Error('boom'); } } },
       JSON.parse('{"enabled":true,"webhookUrl":"https://x.com","extra":{"a":[1,2,{"b":3}]}}'),
     ];
     for (const h of hostiles) {

--- a/src/defence/iron-dome/__tests__/openclaw-approval-channel.test.ts
+++ b/src/defence/iron-dome/__tests__/openclaw-approval-channel.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../openclaw-approval-channel.js';
 
 const NOTIFICATION: OperatorNotification = {
+  event: 'approval_requested',
   hash: 'f'.repeat(64),
   shortHash: 'f'.repeat(12),
   tool: 'Bash',

--- a/src/defence/iron-dome/__tests__/openclaw-approval-channel.test.ts
+++ b/src/defence/iron-dome/__tests__/openclaw-approval-channel.test.ts
@@ -128,6 +128,55 @@ describe('openclaw-approval-channel — delivery is not consent', () => {
   });
 });
 
+describe('a denial never becomes a card (#143)', () => {
+  // The card is the only send path this channel has, and its buttons decide a
+  // LIVE hold. A `denied_no_prompt_surface` notification has no live decision
+  // behind it — the guard already refused the call and told the agent so. A
+  // card whose Approve/Deny changes nothing teaches the operator that these
+  // taps are optional, which is a worse outcome than the message not arriving
+  // on this channel at all. The caller falls through to the plain-message
+  // channel (the webhook) instead.
+  const DENIED = { ...NOTIFICATION, event: 'denied_no_prompt_surface' as const, deniedReason: 'bypassPermissions mode shows no prompt' };
+
+  test('reports not-delivered and never spawns the waiter', async () => {
+    const spawn = fakeSpawn();
+    const ch = createOpenClawApprovalChannel({
+      ...CHANNEL_OPTS,
+      spawnImpl: spawn.impl,
+      readReceipt: receiptSequence([{ phase: 'requesting' }]),
+    });
+
+    const result = await ch.send(DENIED, { timeoutMs: 5_000 });
+
+    expect(result.delivered).toBe(false);
+    if (!result.delivered) expect(result.reason).toMatch(/interactive/i);
+    expect(spawn.calls).toHaveLength(0);
+  });
+
+  test('refuses immediately — no receipt poll, so a denial adds no latency to the hook', async () => {
+    let polls = 0;
+    const ch = createOpenClawApprovalChannel({
+      ...CHANNEL_OPTS,
+      spawnImpl: fakeSpawn().impl,
+      readReceipt: () => { polls += 1; return { phase: 'requesting' }; },
+    });
+    await ch.send(DENIED, { timeoutMs: 5_000 });
+    expect(polls).toBe(0);
+  });
+
+  test('the approval event is unaffected — cards still go up for live holds', async () => {
+    const spawn = fakeSpawn();
+    const ch = createOpenClawApprovalChannel({
+      ...CHANNEL_OPTS,
+      spawnImpl: spawn.impl,
+      readReceipt: receiptSequence([{ phase: 'requesting' }]),
+    });
+    const result = await ch.send(NOTIFICATION, { timeoutMs: 5_000 });
+    expect(result).toEqual({ delivered: true });
+    expect(spawn.calls).toHaveLength(1);
+  });
+});
+
 describe('buildCardFields / buildCardRequestParams — what the operator sees', () => {
   test('caps: title ≤ 80, description ≤ 256, even for a pathological command', () => {
     const { title, description } = buildCardFields({

--- a/src/defence/iron-dome/__tests__/operator-notify.test.ts
+++ b/src/defence/iron-dome/__tests__/operator-notify.test.ts
@@ -168,6 +168,7 @@ describe('requestOperatorApproval — a broken or hostile channel never releases
 describe('the notification content', () => {
   it('carries the exact command, the tripped signals, the tier, and both affordances bound to the SAME hash', () => {
     const text = formatOperatorNotification({
+      event: 'approval_requested',
       hash: BASE_INPUT.hash,
       shortHash: BASE_INPUT.hash.slice(0, 12),
       tool: BASE_INPUT.tool,
@@ -189,6 +190,7 @@ describe('the notification content', () => {
 
   it('surfaces the judge verdict when present', () => {
     const text = formatOperatorNotification({
+      event: 'approval_requested',
       hash: BASE_INPUT.hash,
       shortHash: BASE_INPUT.hash.slice(0, 12),
       tool: BASE_INPUT.tool,
@@ -206,6 +208,7 @@ describe('the notification content', () => {
 
   it('says plainly when no judge ran, rather than omitting the field silently', () => {
     const text = formatOperatorNotification({
+      event: 'approval_requested',
       hash: BASE_INPUT.hash,
       shortHash: BASE_INPUT.hash.slice(0, 12),
       tool: BASE_INPUT.tool,
@@ -233,6 +236,7 @@ describe('the notification content', () => {
   it('truncates a pathologically long command rather than sending it unbounded', () => {
     const huge = 'echo ' + 'A'.repeat(50_000);
     const text = formatOperatorNotification({
+      event: 'approval_requested',
       hash: BASE_INPUT.hash,
       shortHash: BASE_INPUT.hash.slice(0, 12),
       tool: 'Bash',

--- a/src/defence/iron-dome/__tests__/operator-notify.test.ts
+++ b/src/defence/iron-dome/__tests__/operator-notify.test.ts
@@ -233,6 +233,57 @@ describe('the notification content', () => {
     await requestOperatorApproval(BASE_INPUT, { channel });
   });
 
+  it('defaults to the approval event for a caller that predates the discriminator', async () => {
+    // Every construction site that existed before #143's denial event meant
+    // "a human must decide this" — so an input with no `event` must still
+    // produce exactly that, or an upgrade would start telling operators that
+    // held calls were blocked.
+    let seen: unknown;
+    const channel = fakeChannel('configured', (n) => { seen = n; return { delivered: true }; });
+    await requestOperatorApproval(BASE_INPUT, { channel });
+    expect((seen as { event: string }).event).toBe('approval_requested');
+    expect((seen as { deniedReason?: string }).deniedReason).toBeUndefined();
+  });
+
+  it('carries the denial event with the reason and WHICH JOB died', async () => {
+    let seen: unknown;
+    const channel = fakeChannel('configured', (n) => { seen = n; return { delivered: true }; });
+    await requestOperatorApproval(
+      {
+        ...BASE_INPUT,
+        event: 'denied_no_prompt_surface',
+        deniedReason: 'bypassPermissions mode shows no prompt',
+        sessionId: 'sess-42',
+        cwd: '/home/ubuntu/nightly-backup',
+      },
+      { channel },
+    );
+    const n = seen as { event: string; deniedReason: string; sessionId: string; cwd: string };
+    expect(n.event).toBe('denied_no_prompt_surface');
+    expect(n.deniedReason).toBe('bypassPermissions mode shows no prompt');
+    expect(n.sessionId).toBe('sess-42');
+    expect(n.cwd).toBe('/home/ubuntu/nightly-backup');
+  });
+
+  it('ignores a deniedReason on the approval event rather than claiming a live hold was blocked', () => {
+    const text = formatOperatorNotification({
+      event: 'approval_requested',
+      hash: BASE_INPUT.hash,
+      shortHash: BASE_INPUT.hash.slice(0, 12),
+      tool: BASE_INPUT.tool,
+      command: BASE_INPUT.command,
+      signals: BASE_INPUT.signals,
+      severity: BASE_INPUT.severity,
+      reason: BASE_INPUT.reason,
+      deniedReason: 'this should never be rendered',
+      judge: null,
+      fallbackHint: `shieldcortex approve ${BASE_INPUT.hash.slice(0, 12)}`,
+    });
+    expect(text).toContain('approval needed');
+    expect(text).not.toContain('this should never be rendered');
+    expect(text).not.toMatch(/BLOCKED/);
+  });
+
   it('truncates a pathologically long command rather than sending it unbounded', () => {
     const huge = 'echo ' + 'A'.repeat(50_000);
     const text = formatOperatorNotification({
@@ -248,6 +299,150 @@ describe('the notification content', () => {
       fallbackHint: 'shieldcortex approve abc123',
     });
     expect(text.length).toBeLessThan(10_000);
+  });
+});
+
+/**
+ * The denial event (#143). On a promptless box — `bypassPermissions`, which is
+ * how every unattended agent and cron on this fleet runs — an "ask" has nowhere
+ * to go, so the guard DENIES (#139). The operator used to be told "approve
+ * this?" about a call that had already been refused and handed back to the
+ * agent. Two things were wrong: the wording was false the moment it arrived,
+ * and it never said a job had just died or which one. 41 gated actions were
+ * hard-denied on this fleet in one week with nobody told; one of them was a
+ * nightly backup that is simply absent from the backup repo.
+ */
+describe('the denial notification — what it must say', () => {
+  const DENIED = {
+    event: 'denied_no_prompt_surface' as const,
+    hash: BASE_INPUT.hash,
+    shortHash: BASE_INPUT.hash.slice(0, 12),
+    tool: BASE_INPUT.tool,
+    command: BASE_INPUT.command,
+    signals: BASE_INPUT.signals,
+    severity: BASE_INPUT.severity,
+    reason: BASE_INPUT.reason,
+    deniedReason: 'bypassPermissions mode shows no prompt',
+    sessionId: 'sess-42',
+    cwd: '/home/ubuntu/nightly-backup',
+    judge: null,
+    fallbackHint: `shieldcortex approve ${BASE_INPUT.hash.slice(0, 12)}`,
+  };
+
+  it('states plainly that the action was blocked and did not run', () => {
+    const text = formatOperatorNotification(DENIED);
+    expect(text).toMatch(/BLOCKED/);
+    expect(text).toMatch(/did NOT run/i);
+    // Never the question. Nothing is waiting on the operator.
+    expect(text).not.toContain('approval needed');
+  });
+
+  it('gives the reason and names the job — session and cwd — so the alert is actionable', () => {
+    const text = formatOperatorNotification(DENIED);
+    expect(text).toContain('bypassPermissions mode shows no prompt');
+    expect(text).toContain('sess-42');
+    expect(text).toContain('/home/ubuntu/nightly-backup');
+  });
+
+  it('still carries the approve command, because authorising the RETRY is the only way forward', () => {
+    const text = formatOperatorNotification(DENIED);
+    expect(text).toContain(`shieldcortex approve ${DENIED.shortHash}`);
+    expect(text).toMatch(/retry/i);
+  });
+
+  it('offers no Approve/Deny pair — there is nothing left to deny', () => {
+    // A pair of affordances where one does nothing is how an operator learns
+    // that these messages can be ignored.
+    const text = formatOperatorNotification(DENIED);
+    expect(text).not.toContain('[Approve]');
+    expect(text).not.toContain('[Deny]');
+    expect(text).not.toContain(`shieldcortex deny ${DENIED.shortHash}`);
+  });
+
+  it('renders without a session, cwd, or reason rather than printing "undefined"', () => {
+    const text = formatOperatorNotification({
+      ...DENIED,
+      deniedReason: undefined,
+      sessionId: undefined,
+      cwd: undefined,
+    });
+    expect(text).toMatch(/BLOCKED/);
+    expect(text).not.toMatch(/undefined/);
+  });
+
+  it('an unknown or missing event reads as the approval wording, never as a false "blocked"', () => {
+    // A stale dist or an older plugin can hand over an object without the
+    // discriminator. Degrading to today's text is safe; degrading to "this was
+    // blocked" would be a lie about a call that is still live.
+    const stale = { ...DENIED, event: undefined as unknown as 'approval_requested' };
+    expect(formatOperatorNotification(stale)).toContain('approval needed');
+    const bogus = { ...DENIED, event: 'something_else' as unknown as 'approval_requested' };
+    expect(formatOperatorNotification(bogus)).toContain('approval needed');
+  });
+
+  it('bounds a pathological session id and cwd — they arrive from the harness payload, not from us', async () => {
+    let seen: unknown;
+    const channel = fakeChannel('configured', (n) => { seen = n; return { delivered: true }; });
+    await requestOperatorApproval(
+      {
+        ...BASE_INPUT,
+        event: 'denied_no_prompt_surface',
+        deniedReason: 'x'.repeat(10_000),
+        sessionId: 's'.repeat(10_000),
+        cwd: '/' + 'c'.repeat(10_000),
+      },
+      { channel },
+    );
+    const n = seen as { deniedReason: string; sessionId: string; cwd: string };
+    expect(n.sessionId.length).toBeLessThan(1_000);
+    expect(n.cwd.length).toBeLessThan(1_000);
+    expect(n.deniedReason.length).toBeLessThan(1_000);
+  });
+});
+
+/**
+ * THE property, pinned for BOTH events: the transport is best-effort and the
+ * guard's decision is not its business. A channel that throws, hangs past its
+ * deadline, or reports a 500 leaves the caller with exactly `deliveredVia:
+ * null` — which is the same thing "no channel configured" produces, and is
+ * what the hook's unchanged hash-in-terminal floor is there for.
+ */
+describe('best-effort for both events — a broken channel changes nothing', () => {
+  const EVENTS = ['approval_requested', 'denied_no_prompt_surface'] as const;
+
+  it.each(EVENTS)('%s: a channel that throws yields deliveredVia:null, not a rejection', async (event) => {
+    const channel: NotifyChannel = { name: 'boom', send: async () => { throw new Error('ECONNRESET'); } };
+    const result = await requestOperatorApproval({ ...BASE_INPUT, event }, { channel });
+    expect(result.deliveredVia).toBeNull();
+    expect(result.attempts[0].result.delivered).toBe(false);
+  });
+
+  it.each(EVENTS)('%s: a channel that hangs is cut off at the deadline', async (event) => {
+    const channel: NotifyChannel = { name: 'hangs', send: () => new Promise(() => {}) };
+    const started = Date.now();
+    const result = await requestOperatorApproval({ ...BASE_INPUT, event }, { channel, timeoutMs: 30 });
+    expect(result.deliveredVia).toBeNull();
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  it.each(EVENTS)('%s: a channel reporting a server error is just a failed attempt', async (event) => {
+    const channel: NotifyChannel = {
+      name: 'five-hundred',
+      send: async () => ({ delivered: false, reason: 'webhook responded 500' }),
+    };
+    const result = await requestOperatorApproval({ ...BASE_INPUT, event }, { channel });
+    expect(result.deliveredVia).toBeNull();
+    // Still nothing on the result that could be read as a decision.
+    expect(Object.keys(result).sort()).toEqual(['attempts', 'deliveredVia']);
+  });
+
+  it.each(EVENTS)('%s: a channel that claims an approval confers none', async (event) => {
+    const hostile: NotifyChannel = {
+      name: 'hostile',
+      send: async () => ({ delivered: true, approved: true } as unknown as ChannelSendResult),
+    };
+    const result = await requestOperatorApproval({ ...BASE_INPUT, event }, { channel: hostile });
+    expect(result.attempts).toEqual([{ channel: 'hostile', result: { delivered: true } }]);
   });
 });
 

--- a/src/defence/iron-dome/__tests__/webhook-notify-channel.test.ts
+++ b/src/defence/iron-dome/__tests__/webhook-notify-channel.test.ts
@@ -16,6 +16,7 @@
  * replies `{"approved":true}` gets nothing from this channel for it.
  */
 import { describe, it, expect, jest } from '@jest/globals';
+import { createHmac } from 'node:crypto';
 import { createWebhookNotifyChannel } from '../webhook-notify-channel.js';
 import type { OperatorNotification } from '../operator-notify.js';
 
@@ -109,6 +110,61 @@ describe('createWebhookNotifyChannel', () => {
     expect(result).toEqual({ delivered: true });
   });
 
+  it('sends the approval event by default, on the header and in the body', async () => {
+    const calls: Array<{ init: RequestInit }> = [];
+    const fetchImpl = jest.fn(async (_url: string, init: RequestInit) => { calls.push({ init }); return fakeResponse(true); });
+    const channel = createWebhookNotifyChannel({ url: 'https://ops.example.com/hook', fetchImpl: fetchImpl as unknown as typeof fetch });
+    await channel.send(NOTIFICATION, { timeoutMs: 5_000 });
+
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers['X-ShieldCortex-Event']).toBe('approval_requested');
+    const body = JSON.parse(String(calls[0].init.body));
+    expect(body.event).toBe('approval_requested');
+    // Unchanged for every existing receiver: a live hold still offers both.
+    expect(body.approveCommand).toContain('shieldcortex approve');
+    expect(body.denyCommand).toContain('shieldcortex deny');
+  });
+
+  it('carries the denial event on the header and the body, with the reason and which job died (#143)', async () => {
+    // A receiver has to be able to ROUTE on this — page a human for a dead
+    // cron, queue a live approval — before it renders anything.
+    const calls: Array<{ init: RequestInit }> = [];
+    const fetchImpl = jest.fn(async (_url: string, init: RequestInit) => { calls.push({ init }); return fakeResponse(true); });
+    const channel = createWebhookNotifyChannel({ url: 'https://ops.example.com/hook', fetchImpl: fetchImpl as unknown as typeof fetch });
+    await channel.send(
+      {
+        ...NOTIFICATION,
+        event: 'denied_no_prompt_surface',
+        deniedReason: 'bypassPermissions mode shows no prompt',
+        sessionId: 'sess-42',
+        cwd: '/home/ubuntu/nightly-backup',
+      },
+      { timeoutMs: 5_000 },
+    );
+
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers['X-ShieldCortex-Event']).toBe('denied_no_prompt_surface');
+    const body = JSON.parse(String(calls[0].init.body));
+    expect(body.event).toBe('denied_no_prompt_surface');
+    expect(body.deniedReason).toBe('bypassPermissions mode shows no prompt');
+    expect(body.sessionId).toBe('sess-42');
+    expect(body.cwd).toBe('/home/ubuntu/nightly-backup');
+    expect(body.text).toMatch(/BLOCKED/);
+    // The retry can still be authorised; there is nothing left to deny.
+    expect(body.approveCommand).toContain('shieldcortex approve');
+    expect(body.denyCommand).toBeUndefined();
+  });
+
+  it('never invents an event value a receiver could not have been told about', async () => {
+    const calls: Array<{ init: RequestInit }> = [];
+    const fetchImpl = jest.fn(async (_url: string, init: RequestInit) => { calls.push({ init }); return fakeResponse(true); });
+    const channel = createWebhookNotifyChannel({ url: 'https://ops.example.com/hook', fetchImpl: fetchImpl as unknown as typeof fetch });
+    // A stale caller (older dist, older plugin) with no discriminator at all.
+    await channel.send({ ...NOTIFICATION, event: undefined as unknown as 'approval_requested' }, { timeoutMs: 5_000 });
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers['X-ShieldCortex-Event']).toBe('approval_requested');
+  });
+
   it('signs the payload with HMAC when a secret is configured, so a spoofed POST to a shared endpoint is detectable', async () => {
     const calls: Array<{ init: RequestInit }> = [];
     const fetchImpl = jest.fn(async (_url: string, init: RequestInit) => {
@@ -124,5 +180,34 @@ describe('createWebhookNotifyChannel', () => {
     const headers = calls[0].init.headers as Record<string, string>;
     expect(headers['X-ShieldCortex-Signature']).toBeDefined();
     expect(headers['X-ShieldCortex-Signature']).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('the signature is over the EXACT body sent, denial event included — a receiver can verify it', async () => {
+    // The point of notify.webhookSecret (#143): a receiver that can page a
+    // human or re-run a killed job must be able to reject unsigned or forged
+    // POSTs, and to do that the signature has to cover the body it actually
+    // got — including the `event` it routes on.
+    const calls: Array<{ init: RequestInit }> = [];
+    const fetchImpl = jest.fn(async (_url: string, init: RequestInit) => { calls.push({ init }); return fakeResponse(true); });
+    const channel = createWebhookNotifyChannel({
+      url: 'https://ops.example.com/hook',
+      secret: 'top-secret',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await channel.send({ ...NOTIFICATION, event: 'denied_no_prompt_surface' }, { timeoutMs: 5_000 });
+
+    const { init } = calls[0];
+    const body = String(init.body);
+    const expected = createHmac('sha256', 'top-secret').update(body).digest('hex');
+    expect((init.headers as Record<string, string>)['X-ShieldCortex-Signature']).toBe(expected);
+    expect(JSON.parse(body).event).toBe('denied_no_prompt_surface');
+  });
+
+  it('sends unsigned — never a placeholder signature — when no secret is configured', async () => {
+    const calls: Array<{ init: RequestInit }> = [];
+    const fetchImpl = jest.fn(async (_url: string, init: RequestInit) => { calls.push({ init }); return fakeResponse(true); });
+    const channel = createWebhookNotifyChannel({ url: 'https://ops.example.com/hook', fetchImpl: fetchImpl as unknown as typeof fetch });
+    await channel.send(NOTIFICATION, { timeoutMs: 5_000 });
+    expect((calls[0].init.headers as Record<string, string>)['X-ShieldCortex-Signature']).toBeUndefined();
   });
 });

--- a/src/defence/iron-dome/__tests__/webhook-notify-channel.test.ts
+++ b/src/defence/iron-dome/__tests__/webhook-notify-channel.test.ts
@@ -20,6 +20,7 @@ import { createWebhookNotifyChannel } from '../webhook-notify-channel.js';
 import type { OperatorNotification } from '../operator-notify.js';
 
 const NOTIFICATION: OperatorNotification = {
+  event: 'approval_requested',
   hash: 'b'.repeat(64),
   shortHash: 'bbbbbbbbbbbb',
   tool: 'Bash',

--- a/src/defence/iron-dome/notify-config.ts
+++ b/src/defence/iron-dome/notify-config.ts
@@ -28,6 +28,15 @@ export interface NotifyConfig {
    *  Absent = no configured channel (the TUI tier and the hash fallback are
    *  the only things left). See webhook-notify-channel.ts. */
   webhookUrl?: string;
+  /** HMAC-SHA256 signing key for the webhook body (`X-ShieldCortex-Signature`,
+   *  see webhook-notify-channel.ts). Without it this install can only ever
+   *  send UNAUTHENTICATED POSTs, and any receiver worth pointing at — one that
+   *  can page a human or re-run a job — has to reject unsigned requests.
+   *
+   *  This is the one field in this file that is a credential: it is never
+   *  logged, never put in an error message, and never written to an audit row.
+   *  Nothing here formats it, and nothing downstream may either. */
+  webhookSecret?: string;
   /** Deliver via a native OpenClaw plugin-approval card — Approve/Deny
    *  buttons on whatever channel the operator's gateway already reaches
    *  (Telegram, WhatsApp, Discord…). Strict `true` only, same as `enabled`:
@@ -40,6 +49,11 @@ export interface NotifyConfig {
 const TIMEOUT_MIN_MS = 500;
 const TIMEOUT_MAX_MS = 60_000;
 const WEBHOOK_URL_MAX_LENGTH = 2_048;
+/** An HMAC key is a key, not a document. Generous enough for any real
+ *  generator (a 512-bit hex key is 128 chars), small enough that a config file
+ *  that has accidentally swallowed a file's contents is rejected rather than
+ *  hashed. */
+const WEBHOOK_SECRET_MAX_LENGTH = 512;
 
 export const DEFAULT_NOTIFY_CONFIG: NotifyConfig = {
   enabled: false,
@@ -84,6 +98,29 @@ export function normaliseWebhookUrl(v: unknown): string | undefined {
 }
 
 /**
+ * The webhook signing key, or undefined. Same "unusable reads as absent"
+ * discipline as every other field here — a non-string, an empty string, or
+ * something too long to be a key is dropped, which degrades to today's
+ * unsigned POST rather than to a crash or to a signature computed over
+ * `[object Object]`.
+ *
+ * Trimmed deliberately: config files acquire trailing newlines, and the
+ * receiver's copy of the secret is invariably the trimmed literal, so trimming
+ * turns an invisible whitespace mismatch into a working signature rather than
+ * a 401 nobody can explain.
+ *
+ * NOTE for anyone editing this: no branch of this function may put the value
+ * into a thrown error, a log line, or a return value other than the secret
+ * itself. It is the only credential in this config.
+ */
+export function normaliseWebhookSecret(v: unknown): string | undefined {
+  if (typeof v !== 'string') return undefined;
+  const trimmed = v.trim();
+  if (!trimmed || trimmed.length > WEBHOOK_SECRET_MAX_LENGTH) return undefined;
+  return trimmed;
+}
+
+/**
  * Turn whatever was on disk into a config the notify transport can be
  * trusted with. Total: every input, including junk, yields a valid
  * NotifyConfig — never throws, never passes an unrecognised key through.
@@ -103,6 +140,12 @@ export function normaliseNotifyConfig(raw: unknown): NotifyConfig {
 
   const webhookUrl = normaliseWebhookUrl(raw.webhookUrl);
   if (webhookUrl !== undefined) cfg.webhookUrl = webhookUrl;
+
+  // Kept independent of `webhookUrl`: a secret configured without a URL is
+  // harmless (nothing signs anything), and dropping it here would make a
+  // later URL fix silently produce unsigned POSTs.
+  const webhookSecret = normaliseWebhookSecret(raw.webhookSecret);
+  if (webhookSecret !== undefined) cfg.webhookSecret = webhookSecret;
 
   return cfg;
 }

--- a/src/defence/iron-dome/openclaw-approval-channel.ts
+++ b/src/defence/iron-dome/openclaw-approval-channel.ts
@@ -175,6 +175,24 @@ export function createOpenClawApprovalChannel(opts: OpenClawApprovalChannelOptio
   return {
     name: 'openclaw-approval',
     async send(notification, { timeoutMs }) {
+      // This channel has exactly ONE send path — `plugin.approval.request`,
+      // an interactive Approve/Deny card — and a `denied_no_prompt_surface`
+      // notification has no live decision behind it: the guard already refused
+      // the call and handed the agent a denial. A card whose buttons change
+      // nothing is worse than no card, because it teaches the operator that
+      // these taps are optional. So this event is refused here, cheaply and
+      // before spawning anything, and the caller falls through to a channel
+      // that can carry a plain message (the webhook — see `loadNotify` in
+      // scripts/pre-tool-hook.mjs). Sending it as a non-interactive gateway
+      // message instead would need a gateway route this codebase has not
+      // verified exists, plus channel/target config NotifyConfig does not
+      // have; inventing either would be a worse trade than falling back.
+      if (notification.event === 'denied_no_prompt_surface') {
+        return {
+          delivered: false,
+          reason: 'openclaw approval cards are interactive-only — a denial has no decision left to offer',
+        };
+      }
       const params = buildCardRequestParams(notification);
       const receiptDir = opts.receiptDir ?? join(tmpdir(), 'shieldcortex-approval-receipts');
       const receiptPath = join(receiptDir, `${randomUUID()}.json`);

--- a/src/defence/iron-dome/operator-notify.ts
+++ b/src/defence/iron-dome/operator-notify.ts
@@ -44,6 +44,25 @@
  *     not a rung of it.
  */
 
+/**
+ * What actually happened to the held call, from the operator's point of view.
+ *
+ * The distinction is not cosmetic. On a promptless box — `bypassPermissions`,
+ * which is how every unattended agent and cron on this fleet runs — the hook
+ * cannot raise a prompt, so the guard DENIES rather than leaving an
+ * unanswerable ask (#139). Before this discriminator existed, both outcomes
+ * were notified with the same "approval needed" wording, so the operator was
+ * asked to approve something that had already been refused and handed back to
+ * the agent seconds earlier. Measured cost of that on this fleet: 41 gated
+ * actions hard-denied in one week with nobody told a job had died.
+ *
+ *   'approval_requested'      — the call is HELD, a human answer still decides it.
+ *   'denied_no_prompt_surface' — the call is DEAD. Nothing is waiting on the
+ *                                operator; this is an incident report, and the
+ *                                only forward path is authorising a RETRY.
+ */
+export type OperatorNotificationEvent = 'approval_requested' | 'denied_no_prompt_surface';
+
 /** What the judge (approval-judge.ts) found, carried for display only. This
  *  module never re-derives a decision from it — see the module doc above. */
 export interface NotificationJudgeSummary {
@@ -62,6 +81,12 @@ export interface NotificationJudgeSummary {
  * be tricked into tapping yes on something you didn't initiate").
  */
 export interface OperatorNotification {
+  /** Which of the two outcomes this is. Required, because a notification whose
+   *  wording does not match what happened is worse than none: the operator
+   *  learns that these messages are approximately true and stops reading them.
+   *  Every pre-existing construction site supplies 'approval_requested', which
+   *  is exactly what they all meant before the discriminator existed. */
+  event: OperatorNotificationEvent;
   /** Full sha256 from action-approvals.ts's hashToolCall. The one thing every
    *  reply — tap, webhook, or terminal — must be bound to. */
   hash: string;
@@ -79,9 +104,23 @@ export interface OperatorNotification {
    *  judge ran — rendered explicitly, never silently omitted, so "no AI
    *  looked at this" is as visible as a verdict would be. */
   judge: NotificationJudgeSummary | null;
+  /** WHY no prompt could be raised, verbatim from the hook's
+   *  `noPromptSurfaceReason` (e.g. `bypassPermissions mode shows no prompt`).
+   *  Only set on 'denied_no_prompt_surface' — on the approval path there is
+   *  nothing to explain, the ask went out. */
+  deniedReason?: string;
+  /** Which job this was. An alert that says "something was blocked somewhere"
+   *  is unactionable: the operator's next move is always to go look at the job
+   *  that died, and these two fields are the only handle on it this hook has
+   *  (`session_id` / `cwd` off the harness payload). Carried on both events —
+   *  useful on an ask, load-bearing on a denial. */
+  sessionId?: string;
+  cwd?: string;
   /** The `shieldcortex approve <hash>` / `shieldcortex deny <hash>` text.
    *  ALWAYS present — this is the floor (#118) and is never conditional on
-   *  whether a channel is configured or expected to succeed. */
+   *  whether a channel is configured or expected to succeed. On a denial it
+   *  carries the approve half only: the call is already refused, so "deny" is
+   *  an affordance with nothing behind it. */
   fallbackHint: string;
 }
 
@@ -114,6 +153,15 @@ export interface RequestOperatorApprovalInput {
   severity: string;
   reason: string;
   judge?: NotificationJudgeSummary | null;
+  /** Defaults to 'approval_requested' — so a caller written before the
+   *  discriminator existed keeps producing byte-identical notifications. */
+  event?: OperatorNotificationEvent;
+  /** Only meaningful with event: 'denied_no_prompt_surface'; ignored otherwise
+   *  rather than rendered, so a caller cannot accidentally tell the operator an
+   *  action was blocked when it is merely held. */
+  deniedReason?: string;
+  sessionId?: string;
+  cwd?: string;
 }
 
 export interface RequestOperatorApprovalDeps {
@@ -150,10 +198,24 @@ const DEFAULT_TIMEOUT_MS = 10_000;
  *  command keeps a single pathological tool call from producing a
  *  multi-megabyte push notification or webhook payload. */
 const MAX_COMMAND_CHARS = 2_000;
+/** Session id, cwd and the denial reason all arrive from the harness's own
+ *  JSON payload, which this module does not control. Same instinct as
+ *  MAX_COMMAND_CHARS: bound anything that crosses in from outside before it
+ *  becomes a push notification. */
+const MAX_CONTEXT_CHARS = 500;
 
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
   return `${text.slice(0, max)}… [truncated ${text.length - max} chars]`;
+}
+
+/** A bounded, non-empty string, or undefined — a field we cannot render
+ *  honestly is omitted rather than shown as "undefined". */
+function optionalText(v: unknown): string | undefined {
+  if (typeof v !== 'string') return undefined;
+  const trimmed = v.trim();
+  if (!trimmed) return undefined;
+  return truncate(trimmed, MAX_CONTEXT_CHARS);
 }
 
 /** Build the notification content once, so every channel in the resolution
@@ -161,7 +223,9 @@ function truncate(text: string, max: number): string {
  *  differently-scoped version of what tripped. */
 function buildNotification(input: RequestOperatorApprovalInput): OperatorNotification {
   const shortHash = input.hash.slice(0, 12);
-  return {
+  const denied = input.event === 'denied_no_prompt_surface';
+  const notification: OperatorNotification = {
+    event: denied ? 'denied_no_prompt_surface' : 'approval_requested',
     hash: input.hash,
     shortHash,
     tool: input.tool,
@@ -170,8 +234,24 @@ function buildNotification(input: RequestOperatorApprovalInput): OperatorNotific
     severity: input.severity,
     reason: input.reason,
     judge: input.judge ?? null,
-    fallbackHint: `shieldcortex approve ${shortHash}   |   shieldcortex deny ${shortHash}`,
+    // On a denial the deny half is dropped: the guard already said no, and an
+    // affordance that does nothing is how an operator learns to ignore the
+    // ones that do.
+    fallbackHint: denied
+      ? `shieldcortex approve ${shortHash}   (authorises a RETRY — the blocked call is already gone)`
+      : `shieldcortex approve ${shortHash}   |   shieldcortex deny ${shortHash}`,
   };
+  // Only set on the event they belong to, so an absent field is unambiguous
+  // rather than "maybe the caller forgot".
+  if (denied) {
+    const deniedReason = optionalText(input.deniedReason);
+    if (deniedReason) notification.deniedReason = deniedReason;
+  }
+  const sessionId = optionalText(input.sessionId);
+  if (sessionId) notification.sessionId = sessionId;
+  const cwd = optionalText(input.cwd);
+  if (cwd) notification.cwd = cwd;
+  return notification;
 }
 
 /** Human-readable rendering, used by channels that send plain text (webhook
@@ -179,16 +259,32 @@ function buildNotification(input: RequestOperatorApprovalInput): OperatorNotific
  *  richer presentation (inline buttons, etc.) from the structured
  *  `OperatorNotification` instead — this is the lowest common denominator. */
 export function formatOperatorNotification(n: OperatorNotification): string {
-  const lines = [
-    '🛡️ ShieldCortex — approval needed',
-    '',
+  // A stale caller (an older dist, a plugin built before the discriminator)
+  // can hand over an object with no `event` at all. Anything that is not
+  // EXACTLY the denial reads as the approval wording — the same value every
+  // pre-#143-denial caller meant — so an unknown value degrades to today's
+  // text rather than to a false "this was blocked".
+  const denied = n.event === 'denied_no_prompt_surface';
+  const lines = denied
+    ? ['🛡️ ShieldCortex — BLOCKED: this action did NOT run', '']
+    : ['🛡️ ShieldCortex — approval needed', ''];
+  lines.push(
     `Tool:      ${n.tool}`,
     `Command:   ${n.command}`,
     `Tripped:   ${n.signals.join(', ') || 'none'}`,
     `Tier:      ${n.severity}`,
     `Reason:    ${n.reason}`,
-    '',
-  ];
+  );
+  if (denied) {
+    // WHICH JOB DIED. Without this the alert is a fact about the fleet rather
+    // than something an operator can act on — the incident this fixes was
+    // found by reading audit jsonl by hand precisely because the alert (when
+    // it arrived at all) never named the session or the working directory.
+    lines.push(`Blocked:   ${n.deniedReason ?? 'no prompt surface in this session'}`);
+    if (n.sessionId) lines.push(`Session:   ${n.sessionId}`);
+    if (n.cwd) lines.push(`Cwd:       ${n.cwd}`);
+  }
+  lines.push('');
   if (n.judge) {
     lines.push(
       `AI judge:  ${n.judge.assessment} (confidence ${n.judge.confidence})` +
@@ -200,8 +296,17 @@ export function formatOperatorNotification(n: OperatorNotification): string {
     lines.push('AI judge:  no judge ran — this verdict is rules-only');
   }
   lines.push('');
-  lines.push(`[Approve]  shieldcortex approve ${n.shortHash}`);
-  lines.push(`[Deny]     shieldcortex deny ${n.shortHash}`);
+  if (denied) {
+    // No Approve/Deny pair: there is nothing left to deny, and the approve
+    // command means something different here — it authorises the NEXT attempt,
+    // which is the only thing that can still happen.
+    lines.push('The agent has already been refused; this job did not do the work.');
+    lines.push('To authorise a RETRY, run in YOUR terminal:');
+    lines.push(`  shieldcortex approve ${n.shortHash}`);
+  } else {
+    lines.push(`[Approve]  shieldcortex approve ${n.shortHash}`);
+    lines.push(`[Deny]     shieldcortex deny ${n.shortHash}`);
+  }
   return truncate(lines.join('\n'), 4_000);
 }
 
@@ -245,6 +350,13 @@ async function tryChannel(
 /**
  * Try to reach the operator: TUI first (only if `attended`), then the
  * configured channel. Returns which one delivered, or null.
+ *
+ * Despite the name, this also carries the `denied_no_prompt_surface` event
+ * (see `OperatorNotificationEvent`) — the transport, the resolution order and
+ * the deadline are identical whether the news is "a human must decide this" or
+ * "a job just died and nobody was told", and duplicating all of that to change
+ * one string would be the more dangerous change. The name is kept because
+ * every caller, every channel and the #118 store already speak it.
  *
  * This function does not record a pending approval, does not consume one,
  * and does not decide approve/deny — see the module doc. Callers keep doing

--- a/src/defence/iron-dome/webhook-notify-channel.ts
+++ b/src/defence/iron-dome/webhook-notify-channel.ts
@@ -36,8 +36,23 @@ export interface WebhookNotifyChannelOptions {
   fetchImpl?: typeof fetch;
 }
 
+/** The event as a header/body value. Anything that is not exactly the denial
+ *  reads as `approval_requested` — a receiver routing on this header must
+ *  never see a value this module invented, and an older caller with no `event`
+ *  at all keeps getting the header it has always got. */
+function eventOf(n: OperatorNotification): string {
+  return n.event === 'denied_no_prompt_surface' ? 'denied_no_prompt_surface' : 'approval_requested';
+}
+
 function buildPayload(n: OperatorNotification): Record<string, unknown> {
-  return {
+  const event = eventOf(n);
+  const denied = event === 'denied_no_prompt_surface';
+  const payload: Record<string, unknown> = {
+    // First field on purpose: a receiver that renders these into a chat has to
+    // know whether it is drawing a question or an incident report BEFORE it
+    // draws anything, and drawing Approve/Deny buttons on a dead request is
+    // how an operator is trained to ignore the live ones.
+    event,
     hash: n.hash,
     shortHash: n.shortHash,
     tool: n.tool,
@@ -48,9 +63,18 @@ function buildPayload(n: OperatorNotification): Record<string, unknown> {
     judge: n.judge,
     text: formatOperatorNotification(n),
     approveCommand: `shieldcortex approve ${n.shortHash}`,
-    denyCommand: `shieldcortex deny ${n.shortHash}`,
     ts: new Date().toISOString(),
   };
+  // Present only where they mean something: `denyCommand` on a live hold (on a
+  // denial there is nothing left to deny), the denial context on a denial.
+  // `denied_no_prompt_surface` is a NEW event, so no existing receiver can be
+  // relying on the shape of its body — the `approval_requested` body is
+  // unchanged but for the added `event` key.
+  if (!denied) payload.denyCommand = `shieldcortex deny ${n.shortHash}`;
+  if (denied && n.deniedReason) payload.deniedReason = n.deniedReason;
+  if (n.sessionId) payload.sessionId = n.sessionId;
+  if (n.cwd) payload.cwd = n.cwd;
+  return payload;
 }
 
 /**
@@ -73,7 +97,10 @@ export function createWebhookNotifyChannel(opts: WebhookNotifyChannelOptions): N
 
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
-        'X-ShieldCortex-Event': 'approval_requested',
+        // Derived, not hardcoded: a receiver that filters or routes on this
+        // header (page me for a denial, queue an approval) is the whole point
+        // of having a header at all.
+        'X-ShieldCortex-Event': eventOf(notification),
       };
       if (opts.secret) {
         headers['X-ShieldCortex-Signature'] = createHmac('sha256', opts.secret).update(body).digest('hex');


### PR DESCRIPTION
Closes part of #143.

## The defect

`scripts/pre-tool-hook.mjs` fired `pingOperator` **before** `emitApprovalRequired` chose
between `ask` and `deny`. On a box with no prompt surface (`bypassPermissions`), the operator
therefore received a card worded *"approval needed"* for a call the guard had **already
refused** — no session, no cwd, and no statement that a job had just died. Answering it did
nothing, because there was nothing left to answer.

## What changes

- **A discriminator.** `OperatorNotificationEvent = 'approval_requested' | 'denied_no_prompt_surface'`.
  A denial renders as `🛡️ ShieldCortex — BLOCKED: this action did NOT run`, carries
  `Blocked:` / `Session:` / `Cwd:`, and offers the retry-authorising `shieldcortex approve <hash>`
  only — no Approve/Deny pair on a dead request.
- **Both channels carry it** — OpenClaw cards and the webhook (`X-ShieldCortex-Event`,
  `event` as the first body key). `denyCommand` is omitted on a denial.
- **A webhook secret field**, so a fallback receiver can reject unsigned posts.
- **Back-compatible by construction.** `event` defaults to `'approval_requested'`; every
  pre-existing caller produces a byte-identical notification. An unknown/missing event renders
  as the approval wording — a stale dist degrading to today's text is safe, degrading to a
  false "this was blocked" is not.

## Why the unattended lane is the one that matters

`denied_no_prompt_surface` **is** the cron lane. Every piece of verified damage this week came
from it: Friday's 2 Aug nightly backup (missing from the backup repo entirely), the
security-sentry runs, three gateway restarts, the 9 Aug Ekho plugin install. Veronica
independently reproduced 8 more on an **enforcing** box with `notify.openclaw` **enabled** on
**4.47.35** — so this is not warn mode, not missing config, and not a stale version.

Accurate internal statement: **#143 is closed for interactive turns and open for unattended ones.**
This PR closes the *notification* half of the unattended lane. It does **not** deliver durable
pending approvals or action resumption — a denial still kills the job, the operator now simply
learns it happened and can authorise the retry. That remainder stays open on #143.

## Tests

`115 passed, 5 suites` — `prompt-surface-deny`, `operator-notify`, `notify-config`,
`openclaw-approval-channel`, `webhook-notify-channel`.

Pinned explicitly: a broken notifier can never become a broken guard — a receiver returning
500, one that never responds (cut off at the deadline), and a refused connection each change
the guard's decision by nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
