### PR TITLE
fix(#222): a wiped plugin stanza is a FAIL, and repair actually restores it

### DIFF
--- a/src/__tests__/doctor-wiped-stanza-222.test.ts
+++ b/src/__tests__/doctor-wiped-stanza-222.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from '@jest/globals';
+import { reconcilePluginState, planReconcileActions, type PluginLoadState, type ReconcileInput } from '../integrations/openclaw-plugin-index.js';
+import { renderPluginLoadVerdict } from '../cli/doctor.js';
+
+/**
+ * Issue #222 — doctor reported HEALTHY on a host whose plugin stanza had been
+ * wiped by the #214 installer bug. Every unprotected verdict in
+ * `reconcilePluginState` was gated behind `enabledInConfig`, and a wipe sets
+ * that false, so the fault silenced the alarm built to catch it: three fail
+ * rules skipped, fall through to `healthy`, doctor prints
+ * "realtime plugin loaded (roster-confirmed)".
+ *
+ * Field evidence (EDITH, 2026-08-10): unattended 4.47.33 → 4.47.35 install
+ * removed the entry and dropped it from plugins.allow; gateway restarted
+ * without the plugin; ~1 hour with no memory firewall and no action guard,
+ * green ticks throughout.
+ *
+ * Three things have to hold, and the third is the one that makes this a class
+ * fix rather than another patch:
+ *
+ *   1. installed + stanza absent  ⇒ FAIL (unprotected, and nobody asked for it)
+ *   2. installed + enabled:false  ⇒ NOT a fail (a deliberate opt-out is not damage)
+ *      and an UNREADABLE config ⇒ NOT a confident fail (unknown ≠ unprotected)
+ *   3. doctor's renderer cannot green-tick a state it does not recognise —
+ *      the `default: status:'pass'` arm is exactly how a new reconciler state
+ *      (including this one) silently reads as healthy.
+ */
+
+const PLUGIN_ID = 'shieldcortex-realtime';
+
+function input(overrides: Partial<ReconcileInput> = {}): ReconcileInput {
+  return {
+    pluginId: PLUGIN_ID,
+    expectedVersion: '4.47.36',
+    // The wipe: entry deleted (enabled null) AND removed from plugins.allow.
+    config: { enabled: null, inAllow: false, readable: true },
+    installsJson: { version: '4.47.36', installPath: '/home/u/.openclaw/npm/projects/p/node_modules/x' },
+    index: { installRecords: {}, plugins: [], warning: null },
+    // The package is still on disk — the updater just installed it.
+    onDiskVersion: '4.47.36',
+    projectDirs: ['p'],
+    liveRoster: null,
+    ...overrides,
+  } as ReconcileInput;
+}
+
+describe('#222 — a wiped stanza is a failure, not health', () => {
+  it('FAILS when the package is installed but the stanza is gone', () => {
+    const v = reconcilePluginState(input());
+    expect(v.severity).toBe('fail');
+    expect(v.state).toBe('installed-not-enabled');
+  });
+
+  it('says the host is unprotected, and does not claim it is enabled', () => {
+    const v = reconcilePluginState(input());
+    const reasons = v.reasons.join(' ').toLowerCase();
+    expect(reasons).toMatch(/unprotected|not registered|not enabled/);
+    // The old healthy verdict asserted "enabled, present on the running gateway
+    // boot roster" — the one thing that is provably untrue after a wipe.
+    expect(reasons).not.toMatch(/\benabled, present\b/);
+  });
+
+  it('recommends re-registering, not reinstalling a package that is already on disk', () => {
+    expect(reconcilePluginState(input()).recommendedAction).toBe('re-register');
+  });
+
+  it('still FAILS when only the allow-list entry survives being dropped', () => {
+    // entry present but disabled-by-absence is covered above; here the entry is
+    // gone and allow is gone — the exact #214 shape — with the index still
+    // listing it, which is what made every index-derived check read healthy.
+    const v = reconcilePluginState(
+      input({ index: { installRecords: {}, plugins: [{ pluginId: PLUGIN_ID, enabled: true }], warning: null } }),
+    );
+    expect(v.severity).toBe('fail');
+  });
+});
+
+describe('#222 — but an intentional state is not damage', () => {
+  it('does NOT fail when the operator explicitly set enabled:false', () => {
+    const v = reconcilePluginState(input({ config: { enabled: false, inAllow: false, readable: true } }));
+    expect(v.severity).not.toBe('fail');
+    expect(v.state).toBe('disabled-by-operator');
+  });
+
+  it('does not recommend a reinstall for a deliberate opt-out', () => {
+    const v = reconcilePluginState(input({ config: { enabled: false, inAllow: false, readable: true } }));
+    expect(v.recommendedAction).toBe('none');
+  });
+
+  it('does NOT claim unprotected when openclaw.json could not be read', () => {
+    // An unreadable config yields the same {enabled:null, inAllow:false} shape as
+    // a wipe. Convicting on it would be a confident answer from a failed read —
+    // the fail-open/fail-loud confusion #74 already warns about.
+    const v = reconcilePluginState(input({ config: { enabled: null, inAllow: false, readable: false } }));
+    expect(v.severity).toBe('warn');
+    expect(v.state).toBe('config-unreadable');
+  });
+});
+
+describe('#222 — doctor cannot green-tick an unrecognised state', () => {
+  const ALL_STATES: PluginLoadState[] = [
+    'healthy',
+    'not-installed',
+    'enabled-not-loaded',
+    'installed-not-enabled',
+    'disabled-by-operator',
+    'config-unreadable',
+    'index-unreadable',
+    'load-unproven',
+    'version-regressed',
+    'conflicted-metadata',
+    'duplicate-install',
+  ];
+
+  function verdictFor(state: PluginLoadState) {
+    return {
+      state,
+      severity: 'fail' as const,
+      recommendedAction: 'none' as const,
+      enabledInConfig: false,
+      loadedInIndex: false,
+      loadedInLiveRoster: null,
+      indexReadable: true,
+      openClawTracked: false,
+      indexWarnsConflict: false,
+      metadataConflict: false,
+      indexVersion: null,
+      installsJsonVersion: null,
+      onDiskVersion: '4.47.36',
+      expectedVersion: '4.47.36',
+      reasons: ['because'],
+    };
+  }
+
+  it('renders the wiped state as a FAIL, not a pass', () => {
+    const r = renderPluginLoadVerdict(verdictFor('installed-not-enabled'));
+    expect(r.status).toBe('fail');
+    expect(r.message.toLowerCase()).toMatch(/unprotected/);
+    expect(r.fix).toBeTruthy();
+  });
+
+  it('only ever renders pass for the genuinely healthy state', () => {
+    // The regression that let #222 through: a `default:` arm returning pass, so
+    // ANY state the renderer does not know about reads as green.
+    for (const state of ALL_STATES) {
+      const r = renderPluginLoadVerdict(verdictFor(state));
+      if (state !== 'healthy') {
+        expect([state, r.status]).not.toEqual([state, 'pass']);
+      }
+    }
+  });
+
+  it('treats a completely unknown state as a warning rather than health', () => {
+    const r = renderPluginLoadVerdict(verdictFor('some-future-state' as PluginLoadState));
+    expect(r.status).not.toBe('pass');
+  });
+
+  it('does not fail a deliberate opt-out', () => {
+    const r = renderPluginLoadVerdict(verdictFor('disabled-by-operator'));
+    expect(r.status).toBe('info');
+  });
+});
+
+describe('#222 — repair actually remediates the wiped state', () => {
+  const planOpts = {
+    pluginId: PLUGIN_ID,
+    packageName: '@drakon-systems/shieldcortex-realtime',
+    expectedVersion: '4.47.36',
+  };
+
+  it('plans a real restore, not an empty no-op', () => {
+    // The other half of the bug: doctor can name `shieldcortex repair` as the
+    // fix, but if repair has no route for the action it "succeeds" by doing
+    // nothing and the host stays unprotected.
+    const plan = planReconcileActions(reconcilePluginState(input()), planOpts);
+    expect(plan.map((s) => s.kind)).toContain('restore-registration');
+  });
+
+  it('restores rather than reinstalling a package that is already correct', () => {
+    const kinds = planReconcileActions(reconcilePluginState(input()), planOpts).map((s) => s.kind);
+    expect(kinds).not.toContain('openclaw-install');
+    expect(kinds).not.toContain('openclaw-install-pinned');
+  });
+
+  it('reloads the gateway and re-verifies after restoring', () => {
+    // A restored stanza does nothing until the gateway reloads, and a repair
+    // that does not re-verify is just a claim.
+    const kinds = planReconcileActions(reconcilePluginState(input()), planOpts).map((s) => s.kind);
+    expect(kinds).toContain('gateway-reload');
+    expect(kinds).toContain('self-check');
+    expect(kinds.indexOf('restore-registration')).toBeLessThan(kinds.indexOf('gateway-reload'));
+  });
+
+  it('never plans an install for a deliberate opt-out', () => {
+    const v = reconcilePluginState(input({ config: { enabled: false, inAllow: false, readable: true } }));
+    const kinds = planReconcileActions(v, planOpts).map((s) => s.kind);
+    expect(kinds).toEqual(['self-check']);
+  });
+
+  it('an unrouted action still plans an honest verification rather than nothing', () => {
+    const plan = planReconcileActions(
+      { ...reconcilePluginState(input()), recommendedAction: 'some-future-action' as never },
+      planOpts,
+    );
+    expect(plan.length).toBeGreaterThan(0);
+    expect(plan.map((s) => s.kind)).toContain('self-check');
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -19,7 +19,7 @@ import {
   findEoverrideRiskPins,
   isRealtimePluginDisabledInConfig,
 } from '../integrations/openclaw-plugin-state.js';
-import { gatherReconcileInput, reconcilePluginState } from '../integrations/openclaw-plugin-index.js';
+import { gatherReconcileInput, reconcilePluginState, type ReconcileVerdict } from '../integrations/openclaw-plugin-index.js';
 import { parseRegistrationsSince } from '../integrations/openclaw-gateway-roster.js';
 import { readRunningGatewayProcess } from '../integrations/openclaw-gateway-process.js';
 import { resolveSelfInstallDir } from '../setup/native-binding.js';
@@ -2642,7 +2642,20 @@ export async function checkOpenClawPluginLoadState(
     return { label, status: 'info', message: 'skipped (OpenClaw not detected)' };
   }
 
-  const verdict = reconcilePluginState(gatherReconcileInput(home, { expectedVersion }));
+  return renderPluginLoadVerdict(reconcilePluginState(gatherReconcileInput(home, { expectedVersion })));
+}
+
+/**
+ * Verdict → operator-facing check result. Split out of
+ * `checkOpenClawPluginLoadState` so every state can be asserted directly
+ * (#222): the bug there was not the classification but the RENDERING — a
+ * `default:` arm that returned `pass`, so any state this function did not
+ * explicitly recognise (including a newly added unprotected one) green-ticked.
+ * There is no catch-all pass here now; `healthy` is spelled out, and anything
+ * unrecognised warns.
+ */
+export function renderPluginLoadVerdict(verdict: ReconcileVerdict): CheckResult {
+  const label = 'OpenClaw plugin loaded';
   const fix = 'Run `shieldcortex repair` to reconcile the plugin install metadata and verify it actually loads.';
 
   switch (verdict.state) {
@@ -2704,7 +2717,43 @@ export async function checkOpenClawPluginLoadState(
         message: `${(verdict.onDiskVersion && 'realtime plugin has ') || ''}multiple install dirs on disk — prune the stale duplicate before a toggle re-resolves to it`,
         fix,
       };
-    default:
+    case 'installed-not-enabled':
+      // #222: the #214 installer wipe. The package is on disk and correct; the
+      // openclaw.json registration is gone, so the gateway will not load it.
+      // 'warn' only in the narrow case where the RUNNING gateway still has it
+      // from a pre-wipe boot — protected now, unprotected at the next restart.
+      return verdict.severity === 'warn'
+        ? {
+            label,
+            status: 'warn',
+            message:
+              'realtime plugin is loaded in the RUNNING gateway but is NO LONGER REGISTERED in openclaw.json — protection ends at the next gateway restart',
+            fix: 'Run `shieldcortex repair` to restore the plugin registration before the next restart.',
+          }
+        : {
+            label,
+            status: 'fail',
+            message:
+              'realtime plugin is installed on disk but NOT REGISTERED in openclaw.json (no entry, absent from plugins.allow) — the host is UNPROTECTED: no memory firewall, no action guard',
+            fix: 'Run `shieldcortex repair` to restore the plugin registration. The package itself is fine — it does not need reinstalling.',
+          };
+    case 'disabled-by-operator':
+      // Deliberate opt-out. Reporting damage here would train operators to
+      // ignore the check that catches a real wipe.
+      return {
+        label,
+        status: 'info',
+        message: 'realtime plugin is explicitly disabled in openclaw.json (enabled:false) — not loaded, by choice',
+      };
+    case 'config-unreadable':
+      return {
+        label,
+        status: 'warn',
+        message:
+          'cannot read ~/.openclaw/openclaw.json — cannot tell whether the realtime plugin is still registered; NOT necessarily unprotected',
+        fix: 'Check that ~/.openclaw/openclaw.json exists and is valid JSON, then re-run `shieldcortex doctor`.',
+      };
+    case 'healthy':
       // Roster-confirmed loaded, but doctor does NOT run the live enforcement
       // canary (that needs gateway consent) — so it must not claim "enforcing"
       // from roster presence alone (#74 attempt #3 was roster-present-but-not-
@@ -2713,6 +2762,15 @@ export async function checkOpenClawPluginLoadState(
         label,
         status: 'pass',
         message: `realtime plugin loaded (roster-confirmed, v${verdict.onDiskVersion ?? verdict.expectedVersion}); enforcement not probed here — prove it live with: ${LIVE_CANARY_COMMAND}`,
+      };
+    default:
+      // NOT a pass. A state this renderer does not recognise is an unknown, and
+      // #222 is precisely what happens when an unknown renders as health.
+      return {
+        label,
+        status: 'warn',
+        message: `unrecognised plugin state '${String(verdict.state)}' — cannot confirm the realtime plugin is loaded`,
+        fix,
       };
   }
 }

--- a/src/integrations/openclaw-plugin-index.ts
+++ b/src/integrations/openclaw-plugin-index.ts
@@ -66,8 +66,16 @@ export interface ReconcileInput {
   pluginId: string;
   /** The version the package expects to be enforcing (pkg.version). */
   expectedVersion: string;
-  /** `~/.openclaw/openclaw.json` → plugins.entries[id].enabled + plugins.allow. */
-  config: { enabled: boolean | null; inAllow: boolean };
+  /**
+   * `~/.openclaw/openclaw.json` → plugins.entries[id].enabled + plugins.allow.
+   *
+   * `readable` distinguishes "the file says this plugin is not registered" from
+   * "the file could not be read" — both previously collapsed to
+   * `{enabled:null, inAllow:false}`, which would let a corrupt config convict a
+   * host as UNPROTECTED (#222). Defaults to true so existing callers and
+   * fixtures keep their meaning.
+   */
+  config: { enabled: boolean | null; inAllow: boolean; readable?: boolean };
   /** Legacy installs.json record, or null when absent. */
   installsJson: InstallsJsonRecord | null;
   /** Parsed latest SQLite index row, or null when the index is unreadable. */
@@ -96,6 +104,14 @@ export type PluginLoadState =
   | 'healthy'
   | 'not-installed'
   | 'enabled-not-loaded'
+  /** #222: installed on disk, but no longer registered in openclaw.json —
+   *  the #214 installer wipe. Unprotected, and nobody asked for it. */
+  | 'installed-not-enabled'
+  /** #222: the operator explicitly set enabled:false. Intentional, not damage. */
+  | 'disabled-by-operator'
+  /** #222: openclaw.json could not be read, so "not registered" cannot be
+   *  distinguished from "cannot tell". Unknown is never a confident verdict. */
+  | 'config-unreadable'
   | 'index-unreadable'
   | 'load-unproven'
   | 'version-regressed'
@@ -109,7 +125,10 @@ export type RecommendedAction =
   | 'install'
   | 'update-openclaw-tracked'
   | 'reinstall-pinned'
-  | 'dedupe-and-reload';
+  | 'dedupe-and-reload'
+  /** #222: the package is present and correct; only the openclaw.json
+   *  registration is missing. Re-register it — do NOT reinstall. */
+  | 're-register';
 
 export interface ReconcileVerdict {
   state: PluginLoadState;
@@ -165,6 +184,9 @@ export function reconcilePluginState(input: ReconcileInput): ReconcileVerdict {
 
   const enabledInConfig =
     config.enabled === true || (config.enabled == null && config.inAllow === true);
+
+  // Absent ⇒ true: callers predating #222 pass a config they successfully read.
+  const configReadable = config.readable !== false;
 
   const loadedInIndex = Boolean(
     index?.plugins?.some((p) => p.pluginId === pluginId && p.enabled === true),
@@ -226,6 +248,43 @@ export function reconcilePluginState(input: ReconcileInput): ReconcileVerdict {
   if (!installed) {
     reasons.push('plugin not installed on this host (no config, installs.json, index record, or on-disk build)');
     return { ...base, state: 'not-installed', severity: 'ok', recommendedAction: 'install', reasons };
+  }
+
+  // 1b. #222 THE SILENCED ALARM: installed on disk but NOT registered in
+  //     openclaw.json. Every rule below is gated on `enabledInConfig`, so a
+  //     wipe (#214 — entry deleted AND dropped from plugins.allow) skipped all
+  //     of them and fell through to `healthy`: the fault disabled the check
+  //     built to catch it, and doctor green-ticked an unprotected host for an
+  //     hour (EDITH, 2026-08-10).
+  //
+  //     Three distinct causes must NOT be collapsed:
+  //       - config unreadable  → we cannot tell. Warn; never convict on a failed read.
+  //       - enabled:false      → the operator meant it. Not damage.
+  //       - stanza absent      → nobody chose this. FAIL.
+  if (!enabledInConfig) {
+    if (!configReadable) {
+      reasons.push('cannot read ~/.openclaw/openclaw.json — unable to tell whether the plugin is still registered; NOT necessarily unprotected');
+      return { ...base, state: 'config-unreadable', severity: 'warn', recommendedAction: 'none', reasons };
+    }
+
+    if (config.enabled === false) {
+      reasons.push('explicitly disabled in openclaw.json (enabled:false) — intentional operator choice, not a fault');
+      return { ...base, state: 'disabled-by-operator', severity: 'ok', recommendedAction: 'none', reasons };
+    }
+
+    // Installed, readable config, no entry and not allow-listed.
+    if (loadedInLiveRoster === true) {
+      // Still live in the RUNNING gateway (it booted from the pre-wipe config),
+      // so the host is protected right now but will lose the plugin on the next
+      // restart. Saying "unprotected" here would be false; saying "healthy"
+      // would be the #222 bug. It is a warning with a deadline.
+      reasons.push('loaded in the RUNNING gateway but no longer registered in openclaw.json — protection ends at the next gateway restart');
+      return { ...base, state: 'installed-not-enabled', severity: 'warn', recommendedAction: 're-register', reasons };
+    }
+
+    reasons.push('installed on disk but NOT registered in openclaw.json (no plugins.entries entry and absent from plugins.allow) — the host is UNPROTECTED: no memory firewall, no action guard');
+    reasons.push('this is the #214 installer wipe shape; the package is present and correct, so re-register it rather than reinstalling');
+    return { ...base, state: 'installed-not-enabled', severity: 'fail', recommendedAction: 're-register', reasons };
   }
 
   // 2a. #142 guard on rule 2: the boot line is a snapshot and registration
@@ -323,6 +382,9 @@ export type ReconcileStepKind =
   | 'openclaw-install-pinned'
   | 'openclaw-install'
   | 'prune-duplicate-dirs'
+  /** #222: restore a wiped openclaw.json registration WITHOUT reinstalling —
+   *  the package on disk is already correct, only the stanza is missing. */
+  | 'restore-registration'
   | 'gateway-reload'
   | 'self-check';
 
@@ -416,10 +478,30 @@ export function planReconcileActions(verdict: ReconcileVerdict, opts: PlanOption
       reloadThenVerify();
       break;
 
+    // #222: the #214 wipe. The package on disk is present and correct — a
+    // reinstall would be churn (and on an OpenClaw-tracked plugin can fail
+    // outright). Restore the registration, then prove it actually loads.
+    case 're-register':
+      steps.push({
+        kind: 'restore-registration',
+        description: 'restore the plugin registration in openclaw.json (entry + plugins.allow), preserving every other plugin\'s config',
+      });
+      reloadThenVerify();
+      break;
+
     case 'none':
-    default:
       // Healthy: never churn the install — just verify honestly.
       steps.push({ kind: 'self-check', description: 'verify the healthy state with the honest-state self-check' });
+      break;
+
+    default:
+      // An unrouted action must not silently plan a no-op and report success —
+      // that is the #222 shape one layer down (repair "succeeds" by doing
+      // nothing). Verify honestly and let the self-check speak.
+      steps.push({
+        kind: 'self-check',
+        description: `unrouted remediation '${String(verdict.recommendedAction)}' — no automatic fix available; verifying state honestly instead`,
+      });
       break;
   }
 
@@ -505,7 +587,7 @@ export interface GatherOptions {
   readLiveRoster?: () => string[] | null;
 }
 
-function readConfigEnable(home: string, pluginId: string): { enabled: boolean | null; inAllow: boolean } {
+function readConfigEnable(home: string, pluginId: string): { enabled: boolean | null; inAllow: boolean; readable: boolean } {
   try {
     const cfg = JSON.parse(fs.readFileSync(path.join(home, '.openclaw', 'openclaw.json'), 'utf-8')) as {
       plugins?: { entries?: Record<string, { enabled?: unknown }>; allow?: unknown };
@@ -516,9 +598,12 @@ function readConfigEnable(home: string, pluginId: string): { enabled: boolean | 
     const inAllow = allow.some(
       (e) => typeof e === 'string' && (e === pluginId || e.endsWith(`/${pluginId}`) || e.includes(`/${pluginId}/`)),
     );
-    return { enabled, inAllow };
+    return { enabled, inAllow, readable: true };
   } catch {
-    return { enabled: null, inAllow: false };
+    // #222: missing/corrupt/unparseable openclaw.json. This used to return the
+    // same shape as "registered nowhere", so an unreadable config would have
+    // been convicted as UNPROTECTED once that became a fail.
+    return { enabled: null, inAllow: false, readable: false };
   }
 }
 

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -224,6 +224,29 @@ export async function reconcileOpenClawPluginState(options: ReconcileOptions): P
       stepResults.push({ kind: step.kind, ok: r.restarted, detail });
       continue;
     }
+    // #222: restore a wiped openclaw.json registration. Imported lazily — a
+    // static import would drag setup/openclaw.ts in at module load, which is
+    // exactly why this orchestrator lives in its own file (see header), and
+    // openclaw.ts already imports THIS module dynamically in the other
+    // direction.
+    if (step.kind === 'restore-registration') {
+      let ok = false;
+      let detail = '';
+      try {
+        const { trustLocalPlugin } = await import('./openclaw.js');
+        // installDir/version are accepted but no longer persisted; the write is
+        // merge-preserving and idempotent, so a partially-wiped stanza is safe.
+        ok = trustLocalPlugin('', options.expectedVersion, home);
+        detail = ok
+          ? 'registration restored in openclaw.json (entry + plugins.allow)'
+          : 'could not restore the registration — openclaw.json may be read-only or malformed';
+      } catch (err) {
+        detail = `restore failed: ${err instanceof Error ? err.message : String(err)}`;
+      }
+      stepResults.push({ kind: step.kind, ok, detail });
+      if (!ok) messages.push(`SECURITY: ${detail} — the host stays UNPROTECTED until the plugin is registered again`);
+      continue;
+    }
     if (step.kind === 'prune-duplicate-dirs') {
       let ok = true;
       for (const d of step.dirs ?? []) {


### PR DESCRIPTION
Closes #222.

## The bug

`reconcilePluginState` gated **every** unprotected verdict behind `enabledInConfig`. The #214 installer wipe deletes the `plugins.entries` entry *and* drops the plugin from `plugins.allow`, which sets that false — so all three fail rules were skipped and control fell through to `state: 'healthy'`.

The fault disabled the alarm built to catch it. On EDITH's box (2026-08-10) that was ~1 hour with no memory firewall and no action guard, green ticks throughout.

## Three causes that were one shape

An unreadable `openclaw.json` returned the **same** `{enabled:null, inAllow:false}` as a wipe, so simply making that a fail would convict a host with a corrupt config as UNPROTECTED. `readConfigEnable` now reports `readable`, and the three cases are separated because they need opposite responses:

| Cause | Verdict | Why |
|---|---|---|
| config unreadable | `config-unreadable` — **warn** | Unknown is not a confident verdict |
| `enabled:false` | `disabled-by-operator` — **info** | A deliberate opt-out is not damage |
| stanza absent | `installed-not-enabled` — **fail** | Nobody chose this |

One narrower case is preserved: when the **running** gateway still holds the plugin from a pre-wipe boot, the host is protected *now* and loses it at the next restart. That is a warning with a deadline — neither "unprotected" nor "healthy".

## The class fix (why this is more than one more state)

Adding a state is not sufficient, and that is the trap:

- **doctor's renderer ended in `default: status:'pass'`.** Any state it did not explicitly recognise green-ticked — so a newly added *unprotected* state reads as health. `healthy` is now spelled out, the catch-all warns, and the renderer is extracted as `renderPluginLoadVerdict()` so every state can be asserted directly.
- **`planReconcileActions` had the identical shape one layer down** (`case 'none': default:` → self-check only), so a new action lets `repair` "succeed" by doing nothing. An unrouted action now plans an honest verification and says so.

## Remediation is real, not named

doctor pointing at `shieldcortex repair` is worthless if repair has no route. The new `re-register` action plans a `restore-registration` step, executed via `trustLocalPlugin` (merge-preserving and idempotent — other plugins' entries untouched), then reloads the gateway and re-verifies.

It deliberately does **not** reinstall: the package on disk is already present and correct, and reinstalling an OpenClaw-tracked plugin can fail outright.

## Tests

16 new, in `src/__tests__/doctor-wiped-stanza-222.test.ts`, including the regression that let this through — **no state other than `healthy` may ever render as `pass`**, asserted across every state in the union plus an unknown one.

Full serial suite: **352 suites, 4055 passed, 0 failures** (main baseline: 351/4039 — delta is exactly this PR's additions). Typecheck clean.

> Note for reviewers: the local `--runInBand` full run exits 1 despite an all-green summary. I verified this is **pre-existing on unmodified main** (`MAIN-BASELINE-EXIT=1`, zero failures) and not introduced here; CI's parallel `npm test` is unaffected. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
