### PR TITLE
fix(#200): the ClawHub release gate can fail, and says which failure it is

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -249,51 +249,28 @@ jobs:
         if: env.HAS_CLAWHUB_TOKEN == 'true'
         run: npm install -g clawhub
 
-      - name: Check ClawHub version
-        id: clawhub_version_check
+      # Publish + verify in one place (scripts/clawhub-sync.mjs), so the release
+      # gate is the same code path a human runs locally and is unit-tested
+      # (src/__tests__/clawhub-sync-state.test.ts).
+      #
+      # This step CAN FAIL, and that is the point (#200). It previously emitted
+      # `::warning` on a mismatch and exited 0, so the job went green while
+      # ClawHub served stale code — three times (4.47.29, 4.47.30, 4.47.36).
+      #
+      # It polls because ClawHub promotes through a moderation queue: 4.47.36
+      # took ~26 minutes from upload to promotion, so a 10-minute bound would
+      # false-fail a perfectly healthy release. 30 minutes sits above the
+      # observed norm, and the script exits the moment the version promotes.
+      #
+      # Exit codes: 0 synced · 2 uploaded-but-unpromoted · 1 never landed.
+      # Both failures are red, but they say which one happened — republishing a
+      # 'pending' version just burns a version number on an "already exists".
+      - name: Sync + verify ClawHub
         if: env.HAS_CLAWHUB_TOKEN == 'true'
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
           RELEASE_VERSION: ${{ steps.tag.outputs.version }}
-        run: |
-          clawhub login --token "$CLAWHUB_TOKEN" --no-browser
-          clawhub whoami
-          CLAWHUB_LATEST=$(clawhub inspect shieldcortex 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
-          echo "ClawHub latest: '${CLAWHUB_LATEST}'  releasing: '${RELEASE_VERSION}'"
-          if [ "$CLAWHUB_LATEST" = "$RELEASE_VERSION" ]; then
-            echo "clawhub_has_version=true" >> $GITHUB_OUTPUT
-          else
-            echo "clawhub_has_version=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Publish ShieldCortex skill to ClawHub
-        if: env.HAS_CLAWHUB_TOKEN == 'true' && steps.clawhub_version_check.outputs.clawhub_has_version == 'false'
-        continue-on-error: true
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
-          RELEASE_VERSION: ${{ steps.tag.outputs.version }}
-        run: |
-          clawhub publish "$GITHUB_WORKSPACE/skills/shieldcortex" \
-            --slug shieldcortex \
-            --name "ShieldCortex" \
-            --version "$RELEASE_VERSION" \
-            --changelog "Auto-sync from npm publish ${RELEASE_TAG}"
-
-      # Make the ClawHub outcome VISIBLE. Warns (does not fail the release) if the
-      # version didn't land — e.g. the interactive MIT-0 web gate — pointing to the
-      # manual web fallback, so this can never silently rot again.
-      - name: Verify ClawHub sync
-        if: env.HAS_CLAWHUB_TOKEN == 'true'
-        env:
-          RELEASE_VERSION: ${{ steps.tag.outputs.version }}
-        run: |
-          CLAWHUB_LATEST=$(clawhub inspect shieldcortex 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
-          if [ "$CLAWHUB_LATEST" = "$RELEASE_VERSION" ]; then
-            echo "✅ ClawHub synced at ${RELEASE_VERSION}"
-          else
-            echo "::warning title=ClawHub not synced::ClawHub is at '${CLAWHUB_LATEST}', expected '${RELEASE_VERSION}'. If blocked by the MIT-0 web gate, publish manually at https://clawhub.ai/skills/publish — drop skills/shieldcortex, tick the MIT-0 box, set version ${RELEASE_VERSION}."
-          fi
+        run: node scripts/clawhub-sync.mjs --wait 30
 
       - name: Skip ClawHub sync (missing token)
         if: env.HAS_CLAWHUB_TOKEN != 'true'

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "audit:security": "npm audit --audit-level=moderate",
     "prepack": "node scripts/ensure-bin-executable.mjs",
     "release:clawhub": "node scripts/clawhub-sync.mjs",
+    "release:clawhub:check": "node scripts/clawhub-sync.mjs --check",
     "version": "node scripts/sync-plugin-version.mjs && git add plugins/openclaw/package.json plugins/openclaw/openclaw.plugin.json skills/shieldcortex/SKILL.md",
     "prepublishOnly": "node scripts/sync-plugin-version.mjs --check && npm run build && npm run test:dist"
   },

--- a/scripts/clawhub-sync.mjs
+++ b/scripts/clawhub-sync.mjs
@@ -1,27 +1,42 @@
 #!/usr/bin/env node
 // scripts/clawhub-sync.mjs
 //
-// Publish the ShieldCortex skill to ClawHub at the current package.json version.
+// Publish the ShieldCortex skill to ClawHub at the current package.json version,
+// and/or verify that ClawHub actually serves it.
 //
-// Why this exists: ClawHub sync lived ONLY in .github/workflows/publish.yml, which
-// fires on tag push in CI. But 4.x releases are published MANUALLY from a dev
-// machine (npm tokens rotate, so CI auto-publish isn't used) — so that CI step
-// never runs, and the documented "ClawHub auto-sync" silently doesn't happen for
-// the actual release path. This script makes the manual flow self-sufficient:
-// after `npm publish`, run `npm run release:clawhub`.
+//   node scripts/clawhub-sync.mjs                    publish if needed, then verify
+//   node scripts/clawhub-sync.mjs --check            READ-ONLY verify, never publishes
+//   node scripts/clawhub-sync.mjs --check --wait 30  poll up to 30 min for promotion
 //
-// Idempotent: no-ops if ClawHub is already at this version. Auth: if CLAWHUB_TOKEN
-// is set it logs in (headless/CI); otherwise it assumes `clawhub login` was already
-// run locally. Mirrors the publish.yml clawhub publish command exactly.
+// Exit codes (issue #200 — a check that cannot fail is a decoration):
+//   0  ClawHub serves this version
+//   2  version uploaded but not promoted (moderation queue) — no republish needed
+//   1  version absent from ClawHub — the publish did not land
+//
+// Why --check is read-only: the old script published whenever it found drift, so
+// any "verify" loop could republish. A verification path must not mutate the
+// thing it verifies.
+//
+// Auth: if CLAWHUB_TOKEN is set it logs in (headless/CI); otherwise it assumes
+// `clawhub login` was already run locally.
 
 import { readFileSync, existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { readLatestVersion, readVersionList, diagnose, describeState, exitCodeFor } from './lib/clawhub-state.mjs';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const version = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
 const skillDir = join(root, 'skills', 'shieldcortex');
+
+const argv = process.argv.slice(2);
+const CHECK_ONLY = argv.includes('--check');
+const waitIdx = argv.indexOf('--wait');
+// Measured: 4.47.36 promoted ~26 min after upload, so a 10-minute bound would
+// false-fail a healthy release. Default generously; override for a fast check.
+const WAIT_MINUTES = waitIdx >= 0 ? Number(argv[waitIdx + 1] ?? 30) : 0;
+const POLL_INTERVAL_MS = 30_000;
 
 // Resolve the clawhub binary. `npm i -g clawhub` installs to npm's global prefix
 // (e.g. ~/.npm-global/bin), which is NOT always first on PATH: a stale root-owned
@@ -51,13 +66,23 @@ function clawhubCliVersion() {
   }
 }
 
-function clawhubVersion() {
+/** One structured read of ClawHub state. Never mutates. */
+function fetchState() {
   try {
-    const out = clawhub(['inspect', 'shieldcortex'], { capture: true });
-    return (out.match(/[0-9]+\.[0-9]+\.[0-9]+/) || [''])[0];
-  } catch {
-    return '';
+    const out = clawhub(['inspect', 'shieldcortex', '--versions', '--limit', '50', '--json'], { capture: true });
+    const json = JSON.parse(out);
+    return { latest: readLatestVersion(json), versions: readVersionList(json) };
+  } catch (err) {
+    // A read failure is NOT evidence of a good state — report it as such rather
+    // than letting an empty read look like "absent" for the wrong reason.
+    console.warn(`[clawhub-sync] ⚠️ could not read ClawHub state: ${err?.message ?? err}`);
+    return { latest: '', versions: [], readFailed: true };
   }
+}
+
+function sleep(ms) {
+  // Synchronous sleep keeps this script dependency-free and linear.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 if (process.env.CLAWHUB_TOKEN) {
@@ -73,33 +98,51 @@ if (/^0\.(?:[0-9]|1[0-9]|2[0-2])\./.test(cliVersion)) {
   );
 }
 
-const current = clawhubVersion();
-console.log(`[clawhub-sync] ClawHub: '${current || 'none'}'  package: '${version}'`);
+let { latest, versions } = fetchState();
+console.log(`[clawhub-sync] ClawHub: '${latest || 'none'}'  package: '${version}'${CHECK_ONLY ? '  (read-only check)' : ''}`);
 
-if (current === version) {
-  console.log(`[clawhub-sync] ✅ Already synced at ${version} — nothing to do.`);
-  process.exit(0);
+// Publish only when asked to AND only when the version is genuinely missing.
+// A 'pending' version already exists server-side; republishing it just burns a
+// version number for an "already exists" error.
+if (!CHECK_ONLY) {
+  const state = diagnose({ latest, versions, target: version });
+  if (state === 'synced') {
+    console.log(`[clawhub-sync] ✅ Already synced at ${version} — nothing to do.`);
+    process.exit(0);
+  }
+  if (state === 'pending') {
+    console.log(`[clawhub-sync] ${version} is already uploaded and awaiting promotion — not republishing.`);
+  } else {
+    console.log(`[clawhub-sync] Publishing skill to ClawHub @ ${version}…`);
+    clawhub([
+      'publish', skillDir,
+      '--slug', 'shieldcortex',
+      '--name', 'ShieldCortex',
+      '--version', version,
+      '--changelog', `Sync from npm publish v${version}`,
+    ]);
+  }
 }
 
-console.log(`[clawhub-sync] Publishing skill to ClawHub @ ${version}…`);
-clawhub([
-  'publish', skillDir,
-  '--slug', 'shieldcortex',
-  '--name', 'ShieldCortex',
-  '--version', version,
-  '--changelog', `Sync from manual npm publish v${version}`,
-]);
+// Verify — polling if asked. Exits as soon as ClawHub serves the version.
+const deadline = Date.now() + WAIT_MINUTES * 60_000;
+const startedAt = Date.now();
+let state = diagnose({ latest, versions, target: version });
 
-// Loud, non-fatal verification — a ClawHub hiccup (e.g. the MIT-0 web gate) should
-// be visible, not silently masked.
-const after = clawhubVersion();
-if (after === version) {
-  console.log(`[clawhub-sync] ✅ ClawHub synced at ${version}`);
+while (state !== 'synced' && Date.now() < deadline) {
+  sleep(POLL_INTERVAL_MS);
+  ({ latest, versions } = fetchState());
+  state = diagnose({ latest, versions, target: version });
+  if (state !== 'synced') {
+    const waitedMin = Math.round((Date.now() - startedAt) / 60_000);
+    console.log(`[clawhub-sync] …still '${latest || 'none'}' (${state}) after ${waitedMin}m`);
+  }
+}
+
+const message = describeState({ state, latest, target: version, waitedMs: Date.now() - startedAt });
+if (state === 'synced') {
+  console.log(`[clawhub-sync] ${message}`);
 } else {
-  console.warn(
-    `[clawhub-sync] ⚠️ ClawHub is at '${after}', expected '${version}'. If blocked by the ` +
-    `MIT-0 web gate, publish manually at https://clawhub.ai/skills/publish (drop skills/shieldcortex, ` +
-    `tick MIT-0, set version ${version}).`,
-  );
-  process.exitCode = 1;
+  console.error(`[clawhub-sync] ${message}`);
 }
+process.exit(exitCodeFor(state));

--- a/scripts/lib/clawhub-state.mjs
+++ b/scripts/lib/clawhub-state.mjs
@@ -1,0 +1,87 @@
+// scripts/lib/clawhub-state.mjs
+//
+// Pure ClawHub-state logic, split out of clawhub-sync.mjs so the release gate
+// can be unit-tested without a network or a CLI (issue #200).
+//
+// The bug this exists to kill: the publish workflow's "Verify ClawHub sync"
+// step could only ever emit `::warning` on a mismatch, so the job went green
+// while ClawHub served a stale version — three times (4.47.29, 4.47.30,
+// 4.47.36). A check that cannot fail is a decoration, not a check.
+//
+// The other half of the bug is that a mismatch has TWO very different causes
+// and the old code could not tell them apart:
+//
+//   pending — the version uploaded fine and is sitting behind ClawHub's
+//             moderation queue. It promotes itself. Measured at ~26 minutes
+//             on 4.47.36 (version createdAt → moderation updatedAt), which is
+//             why a 10-minute bound would false-fail a perfectly good release.
+//   absent  — the publish never landed. This is the one that needs a human.
+//
+// `versions[]` is what separates them: it lists uploaded versions regardless of
+// which one is promoted to `latest`.
+
+/** Read the promoted version out of `clawhub inspect --json`. */
+export function readLatestVersion(inspectJson) {
+  if (!inspectJson || typeof inspectJson !== 'object') return '';
+  return (
+    inspectJson.latestVersion?.version ??
+    inspectJson.skill?.tags?.latest ??
+    ''
+  );
+}
+
+/** Read the uploaded-version history out of `clawhub inspect --versions --json`. */
+export function readVersionList(inspectJson) {
+  if (!inspectJson || !Array.isArray(inspectJson.versions)) return [];
+  return inspectJson.versions
+    .map((v) => (typeof v === 'string' ? v : v?.version))
+    .filter((v) => typeof v === 'string' && v.length > 0);
+}
+
+/**
+ * Classify the sync state for `target`.
+ *
+ * Returns one of:
+ *   'synced'  — ClawHub serves the target version. The only success.
+ *   'pending' — target is uploaded but not promoted (moderation queue).
+ *   'absent'  — target was never uploaded. The publish genuinely failed.
+ */
+export function diagnose({ latest, versions, target }) {
+  if (!target) throw new Error('diagnose requires a target version');
+  if (latest === target) return 'synced';
+  if (Array.isArray(versions) && versions.includes(target)) return 'pending';
+  return 'absent';
+}
+
+/**
+ * The operator-facing line for a state. Deliberately says what to DO — a red
+ * step that does not say which of the two failures happened just moves the
+ * guesswork rather than removing it.
+ */
+export function describeState({ state, latest, target, waitedMs = 0 }) {
+  const waited = waitedMs > 0 ? ` after ${Math.round(waitedMs / 60_000)}m` : '';
+  switch (state) {
+    case 'synced':
+      return `✅ ClawHub synced at ${target}`;
+    case 'pending':
+      return (
+        `⏳ ClawHub PUBLISHED ${target} but is still serving '${latest || 'none'}'${waited}. ` +
+        `The upload landed — this is the moderation queue, which typically promotes within ~30m. ` +
+        `Check https://clawhub.ai/skills/shieldcortex; no republish is needed (the version already exists).`
+      );
+    case 'absent':
+    default:
+      return (
+        `❌ ClawHub does NOT have ${target}; it is serving '${latest || 'none'}'${waited}. ` +
+        `The publish did not land. Re-run \`npm run release:clawhub\`, or publish manually at ` +
+        `https://clawhub.ai/skills/publish (drop skills/shieldcortex, tick MIT-0, set version ${target}).`
+      );
+  }
+}
+
+/** Process exit code per state. Only a true sync is success — see #200. */
+export function exitCodeFor(state) {
+  if (state === 'synced') return 0;
+  if (state === 'pending') return 2;
+  return 1;
+}

--- a/src/__tests__/clawhub-sync-state.test.ts
+++ b/src/__tests__/clawhub-sync-state.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from '@jest/globals';
+// @ts-expect-error -- importing a .mjs release-script utility (no type decls)
+import { readLatestVersion, readVersionList, diagnose, describeState, exitCodeFor } from '../../scripts/lib/clawhub-state.mjs';
+
+/**
+ * Issue #200 — the publish workflow's ClawHub step false-greened three times
+ * (4.47.29, 4.47.30, 4.47.36): it emitted `::warning` on a version mismatch and
+ * the job went green while ClawHub served stale code.
+ *
+ * These tests pin the two things that make the gate real:
+ *
+ *   1. A mismatch can NEVER map to a success exit code.
+ *   2. `pending` (uploaded, behind moderation) is distinguishable from `absent`
+ *      (publish never landed) — because those need opposite human responses,
+ *      and conflating them is why "just republish" was the standing advice for
+ *      a version that already existed.
+ */
+
+// Shapes taken from real `clawhub inspect shieldcortex --json` output.
+const inspectJson = {
+  skill: { slug: 'shieldcortex', tags: { latest: '4.47.36' } },
+  latestVersion: { version: '4.47.36', license: 'MIT-0' },
+  moderation: { verdict: 'clean' },
+};
+
+const versionsJson = {
+  versions: [
+    { version: '4.47.36', changelog: 'Auto-sync from npm publish v4.47.36' },
+    { version: '4.47.35', changelog: 'Auto-sync from npm publish v4.47.35' },
+    { version: '4.47.34', changelog: 'Auto-sync from npm publish v4.47.34' },
+  ],
+};
+
+describe('#200 — reading ClawHub state structurally', () => {
+  it('reads the promoted version from latestVersion', () => {
+    expect(readLatestVersion(inspectJson)).toBe('4.47.36');
+  });
+
+  it('falls back to skill.tags.latest when latestVersion is absent', () => {
+    expect(readLatestVersion({ skill: { tags: { latest: '4.47.30' } } })).toBe('4.47.30');
+  });
+
+  it('returns empty rather than throwing on junk', () => {
+    expect(readLatestVersion(null)).toBe('');
+    expect(readLatestVersion({})).toBe('');
+    expect(readVersionList(null)).toEqual([]);
+    expect(readVersionList({ versions: 'nope' })).toEqual([]);
+  });
+
+  it('reads the uploaded-version history', () => {
+    expect(readVersionList(versionsJson)).toEqual(['4.47.36', '4.47.35', '4.47.34']);
+  });
+
+  it('does not mistake a version-shaped string elsewhere in the payload for the promoted version', () => {
+    // The old implementation grepped the first /\d+\.\d+\.\d+/ out of human-readable
+    // CLI output, so an engine version or a version inside the summary could win.
+    const decoy = {
+      skill: { summary: 'Requires engine v2.4.26 and node 20.0.0', tags: { latest: '4.47.36' } },
+      latestVersion: { version: '4.47.36' },
+    };
+    expect(readLatestVersion(decoy)).toBe('4.47.36');
+  });
+});
+
+describe('#200 — diagnosing a mismatch', () => {
+  it('calls it synced only when the promoted version IS the target', () => {
+    expect(diagnose({ latest: '4.47.36', versions: ['4.47.36'], target: '4.47.36' })).toBe('synced');
+  });
+
+  it('calls it pending when the target is uploaded but not promoted', () => {
+    // The real 4.47.36 case: `clawhub publish` returned "already exists" while
+    // `latest` still read 4.47.35 for ~26 minutes.
+    expect(diagnose({ latest: '4.47.35', versions: ['4.47.36', '4.47.35'], target: '4.47.36' })).toBe('pending');
+  });
+
+  it('calls it absent when the target was never uploaded', () => {
+    expect(diagnose({ latest: '4.47.35', versions: ['4.47.35', '4.47.34'], target: '4.47.36' })).toBe('absent');
+  });
+
+  it('treats a missing version list as absent rather than assuming pending', () => {
+    // Fail-closed: if we cannot prove the upload landed, do not claim it did.
+    expect(diagnose({ latest: '4.47.35', versions: [], target: '4.47.36' })).toBe('absent');
+    expect(diagnose({ latest: '4.47.35', versions: undefined, target: '4.47.36' })).toBe('absent');
+  });
+
+  it('refuses to diagnose without a target', () => {
+    expect(() => diagnose({ latest: '4.47.36', versions: [], target: '' })).toThrow();
+  });
+});
+
+describe('#200 — a mismatch can never exit zero', () => {
+  it('maps synced to 0', () => {
+    expect(exitCodeFor('synced')).toBe(0);
+  });
+
+  it('maps BOTH failure states to non-zero', () => {
+    // This is the whole issue: the old step warned and exited 0.
+    expect(exitCodeFor('pending')).not.toBe(0);
+    expect(exitCodeFor('absent')).not.toBe(0);
+  });
+
+  it('gives pending and absent DIFFERENT codes so CI can tell them apart', () => {
+    expect(exitCodeFor('pending')).not.toBe(exitCodeFor('absent'));
+  });
+
+  it('treats an unknown state as a failure, not a pass', () => {
+    expect(exitCodeFor('who-knows')).not.toBe(0);
+  });
+});
+
+describe('#200 — the message tells the operator which failure this is', () => {
+  it('pending says the upload landed and no republish is needed', () => {
+    const msg = describeState({ state: 'pending', latest: '4.47.35', target: '4.47.36', waitedMs: 1_800_000 });
+    expect(msg).toContain('4.47.36');
+    expect(msg).toMatch(/moderation/i);
+    expect(msg).toMatch(/no republish/i);
+    expect(msg).toContain('30m');
+  });
+
+  it('absent says the publish did not land and names the fallback', () => {
+    const msg = describeState({ state: 'absent', latest: '4.47.35', target: '4.47.36' });
+    expect(msg).toMatch(/did not land/i);
+    expect(msg).toContain('clawhub.ai/skills/publish');
+  });
+
+  it('does not tell an operator to republish a version that already exists', () => {
+    // Republishing a pending version returns "Version X already exists" and
+    // wastes a version number — the exact wrong move, and what the old
+    // single warning message advised in both cases.
+    const pending = describeState({ state: 'pending', latest: '4.47.35', target: '4.47.36' });
+    expect(pending).not.toContain('clawhub.ai/skills/publish');
+  });
+
+  it('synced states the version plainly', () => {
+    expect(describeState({ state: 'synced', latest: '4.47.36', target: '4.47.36' })).toContain('4.47.36');
+  });
+});


### PR DESCRIPTION
Closes #200.

## The bug

The publish workflow's "Verify ClawHub sync" step could only ever emit `::warning` and exit 0, so the job went green while ClawHub served stale code. That has now happened **three times** — 4.47.29, 4.47.30, and 4.47.36 today, where the step reported `success` while annotating `ClawHub is at '4.47.35', expected '4.47.36'`.

A check that cannot fail is a decoration.

## The half of the bug the issue did not name

A mismatch has two causes needing **opposite** responses, and nothing could tell them apart:

- **pending** — uploaded, sitting behind ClawHub's moderation queue. It promotes itself.
- **absent** — the publish never landed. This one needs a human.

`versions[]` separates them: it lists uploaded versions regardless of which is promoted. This matters because republishing a *pending* version returns `Version X already exists` and burns a version number — and the old single warning message advised exactly that in **both** cases.

## On the timeout

The issue suggests a ~10-minute bound. Measured on 4.47.36 today (version `createdAt` → moderation `updatedAt`): promotion took **~26 minutes**. A 10-minute bound would have false-failed a perfectly healthy release, so the default is 30 — above the observed norm, and the script exits the moment the version promotes.

## Changes

- **`scripts/lib/clawhub-state.mjs`** — pure state logic (read, diagnose, describe, exit code), unit-testable with no network and no CLI.
- **Structural reads** via `--json` (`latestVersion.version`, `versions[]`) instead of grepping the first `/\d+\.\d+\.\d+/` out of human-readable CLI output, where an engine version or a summary string could win.
- **Read-only `--check`** (issue item 3) — the old script published whenever it found drift, so any verification loop could republish. A verification path must not mutate what it verifies. Exposed as `npm run release:clawhub:check`.
- **`--wait <minutes>`** bounded polling.
- **Never republishes** a version that is already uploaded.
- **`publish.yml`** runs the same code path a human runs, with no `continue-on-error`.

Exit codes: **0** synced · **2** uploaded-but-unpromoted · **1** never landed. Both failures are red, but they say which one happened.

## Tests

18 new, in `src/__tests__/clawhub-sync-state.test.ts`, pinning that a mismatch can never map to exit 0, that the two failures stay distinguishable, and that a `pending` message never tells an operator to republish.

Verified against live ClawHub end-to-end: synced → exit 0; a version ClawHub has never seen → exit 1 with the `absent` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
