### PR TITLE
fix(#225) phase 1: stop claiming conversation hooks OpenClaw dropped

### DIFF
--- a/plugins/openclaw/conversation-access.ts
+++ b/plugins/openclaw/conversation-access.ts
@@ -1,0 +1,83 @@
+/**
+ * #225 phase 1 — the plugin-side copy of the conversation-access grant reader.
+ *
+ * Duplicated from `src/integrations/openclaw-conversation-access.ts` because
+ * the plugin is a separate build with no `src/` imports (same boundary as the
+ * reviewed-script allowlist and the fallback guard patterns). The two copies
+ * are held together by a parity test — see
+ * `src/__tests__/conversation-access-honesty-225.test.ts`.
+ *
+ * Why the plugin needs it at all: the startup line announced
+ * `registered (llm_input + llm_output + …)` unconditionally, on hosts where
+ * OpenClaw had just dropped both for want of the grant. The plugin cannot
+ * observe that rejection (the host emits it as its own diagnostic and `api.on`
+ * returns void), so it must read the same config the host reads and describe
+ * only what will actually be live.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export interface ConversationAccessState {
+  granted: boolean;
+  readable: boolean;
+  entryPresent: boolean;
+}
+
+/** Pure: evaluate a parsed openclaw.json object. */
+export function evaluateConversationAccess(config: unknown, pluginId: string): ConversationAccessState {
+  if (!config || typeof config !== 'object') {
+    return { granted: false, readable: false, entryPresent: false };
+  }
+  const plugins = (config as { plugins?: unknown }).plugins;
+  const entries = plugins && typeof plugins === 'object'
+    ? (plugins as { entries?: unknown }).entries
+    : undefined;
+  const entry = entries && typeof entries === 'object'
+    ? (entries as Record<string, unknown>)[pluginId]
+    : undefined;
+
+  if (!entry || typeof entry !== 'object') {
+    return { granted: false, readable: true, entryPresent: false };
+  }
+
+  const hooks = (entry as { hooks?: unknown }).hooks;
+  const raw = hooks && typeof hooks === 'object'
+    ? (hooks as { allowConversationAccess?: unknown }).allowConversationAccess
+    : undefined;
+
+  // Strict `true`, matching OpenClaw's own `!== true` comparison exactly.
+  return { granted: raw === true, readable: true, entryPresent: true };
+}
+
+/** Read `~/.openclaw/openclaw.json` and evaluate the grant. Never throws. */
+export function readConversationAccess(home: string, pluginId: string): ConversationAccessState {
+  try {
+    const raw = readFileSync(path.join(home, '.openclaw', 'openclaw.json'), 'utf-8');
+    return evaluateConversationAccess(JSON.parse(raw), pluginId);
+  } catch {
+    return { granted: false, readable: false, entryPresent: false };
+  }
+}
+
+/**
+ * The hooks this plugin can honestly claim at startup. Conversation hooks are
+ * only listed when the host will actually keep them.
+ */
+export function describeRegisteredHooks(opts: {
+  access: ConversationAccessState;
+  beforeToolCallRegistered: boolean;
+}): string {
+  const live: string[] = [];
+  if (opts.access.granted) live.push('llm_input', 'llm_output');
+  if (opts.beforeToolCallRegistered) live.push('before_tool_call');
+  live.push('/shieldcortex-status');
+
+  let line = live.join(' + ');
+  if (!opts.access.granted) {
+    line += opts.access.readable
+      ? ' — conversation scanning INACTIVE (llm_input/llm_output dropped by OpenClaw: set plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess=true to enable)'
+      : ' — conversation scanning state UNKNOWN (could not read openclaw.json)';
+  }
+  return line;
+}

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { readConversationAccess, describeRegisteredHooks } from './conversation-access.js';
 import { createInterceptor, DEFAULT_CONFIG as DEFAULT_INTERCEPTOR_CONFIG } from './interceptor.js';
 import type { InterceptorConfig, BrokerRuntime } from './interceptor.js';
 import { syncInterceptEvent } from './intercept-ingest.js';
@@ -1418,10 +1419,28 @@ export default {
       api.logger?.info?.('[shieldcortex] interceptor.enabled:false in plugin config — before_tool_call hook not registered');
     }
 
+    // These two are CONVERSATION hooks: OpenClaw drops them at registration
+    // for a non-bundled plugin unless the host grants
+    // plugins.entries.<id>.hooks.allowConversationAccess = true. We still
+    // attempt registration (the host decides, and the grant can be added
+    // without a code change), but we must not CLAIM them afterwards — see the
+    // honesty note on the log line below (#225).
     api.on("llm_input", handleLlmInput, { timeoutMs: 30_000 });
     api.on("llm_output", handleLlmOutput, { timeoutMs: 30_000 });
 
-    api.logger.info(`[shieldcortex] v${_version} registered (llm_input + llm_output${_beforeToolCallRegistered ? " + before_tool_call" : ""} + /shieldcortex-status)`);
+    // #225: this line used to announce `llm_input + llm_output` unconditionally.
+    // On any host without the conversation-access grant the gateway logged, on
+    // the very next two lines, that it had dropped both — so ShieldCortex was
+    // claiming conversation protection it did not have, in the one place an
+    // operator looks to confirm startup. Report only what is actually live, and
+    // name the missing grant when it is the reason.
+    const conversationAccess = readConversationAccess(homedir(), PLUGIN_ID);
+    api.logger.info(
+      `[shieldcortex] v${_version} registered (${describeRegisteredHooks({
+        access: conversationAccess,
+        beforeToolCallRegistered: _beforeToolCallRegistered,
+      })})`,
+    );
     } catch (err) {
       // Plugin must never block channel startup — warn and bail gracefully.
       // #134 §2: this used to be a bare console.warn, which bypasses the

--- a/src/__tests__/conversation-access-honesty-225.test.ts
+++ b/src/__tests__/conversation-access-honesty-225.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  evaluateConversationAccess,
+  describeConversationAccess,
+  conversationAccessFix,
+} from '../integrations/openclaw-conversation-access.js';
+import {
+  evaluateConversationAccess as pluginEvaluate,
+  describeRegisteredHooks,
+} from '../../plugins/openclaw/conversation-access.js';
+
+/**
+ * #225 phase 1 — report conversation-scanning state honestly.
+ *
+ * Verified live on this fleet (gateway log, 2026-08-10, six occurrences):
+ *
+ *   [shieldcortex] v4.47.35 registered (llm_input + llm_output + before_tool_call + …)
+ *   [plugins] typed hook "llm_input" blocked because non-bundled plugins must set
+ *             plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess=true
+ *   [plugins] typed hook "llm_output" blocked …
+ *
+ * We announced two hooks the host had just dropped. These tests pin the three
+ * things that keep the report honest:
+ *
+ *   1. The grant is read exactly as OpenClaw reads it (strict `true`), so we
+ *      can never report "granted" for a value the host rejects.
+ *   2. An ungranted host is reported as INACTIVE — not silently, and not as
+ *      damage (withholding conversation access is a legitimate choice).
+ *   3. A GRANT IS NOT PROTECTION. `llm_input` is observation-only; the granted
+ *      message must never read as "blocked"/"protected", or phase 1 just moves
+ *      the false green rather than removing it.
+ */
+
+const PLUGIN_ID = 'shieldcortex-realtime';
+
+const granted = { plugins: { entries: { [PLUGIN_ID]: { enabled: true, hooks: { allowConversationAccess: true } } } } };
+// The exact shape on this box today.
+const ungranted = { plugins: { entries: { [PLUGIN_ID]: { enabled: true } } } };
+
+describe('#225 — reading the grant exactly as OpenClaw does', () => {
+  it('grants only on a strict boolean true', () => {
+    expect(evaluateConversationAccess(granted, PLUGIN_ID).granted).toBe(true);
+  });
+
+  it('does NOT grant on truthy-but-not-true values', () => {
+    // OpenClaw compares `explicitConversationAccess !== true`, so these are all
+    // rejected by the host. Reporting them as granted would recreate the bug
+    // one layer up.
+    for (const v of ['true', 1, 'yes', {}, []]) {
+      const cfg = { plugins: { entries: { [PLUGIN_ID]: { hooks: { allowConversationAccess: v } } } } };
+      expect(evaluateConversationAccess(cfg, PLUGIN_ID).granted).toBe(false);
+    }
+  });
+
+  it('reports ungranted when the entry exists without the hooks block', () => {
+    const s = evaluateConversationAccess(ungranted, PLUGIN_ID);
+    expect(s.granted).toBe(false);
+    expect(s.entryPresent).toBe(true);
+    expect(s.readable).toBe(true);
+  });
+
+  it('reports ungranted when the plugin has no entry at all', () => {
+    const s = evaluateConversationAccess({ plugins: { entries: {} } }, PLUGIN_ID);
+    expect(s.granted).toBe(false);
+    expect(s.entryPresent).toBe(false);
+  });
+
+  it('distinguishes unreadable config from a denied grant', () => {
+    // Unknown must never be reported as a confident answer — the same
+    // distinction #222 needed.
+    const s = evaluateConversationAccess(null, PLUGIN_ID);
+    expect(s.readable).toBe(false);
+    expect(s.granted).toBe(false);
+  });
+
+  it('never throws on hostile shapes', () => {
+    for (const junk of [undefined, 42, 'nope', [], { plugins: 'no' }, { plugins: { entries: 7 } }]) {
+      expect(() => evaluateConversationAccess(junk, PLUGIN_ID)).not.toThrow();
+    }
+  });
+
+  it('does not read another plugin\'s grant as ours', () => {
+    const other = { plugins: { entries: { 'someone-else': { hooks: { allowConversationAccess: true } } } } };
+    expect(evaluateConversationAccess(other, PLUGIN_ID).granted).toBe(false);
+  });
+});
+
+describe('#225 — the message tells the truth in both directions', () => {
+  it('an ungranted host is told scanning is INACTIVE', () => {
+    const msg = describeConversationAccess(evaluateConversationAccess(ungranted, PLUGIN_ID), PLUGIN_ID);
+    expect(msg).toMatch(/INACTIVE/);
+    expect(msg).toMatch(/allowConversationAccess/);
+  });
+
+  it('a GRANTED host is NOT told it is protected — observation only', () => {
+    // The trap: `llm_input` has no blocking contract, so "granted" means
+    // "we can see it", never "we can stop it".
+    const msg = describeConversationAccess(evaluateConversationAccess(granted, PLUGIN_ID), PLUGIN_ID);
+    expect(msg.toLowerCase()).toMatch(/observation only/);
+    expect(msg.toLowerCase()).not.toMatch(/\bprotected\b/);
+    // Any mention of blocking must be a DENIAL of it, never a claim.
+    expect(msg.toLowerCase()).toMatch(/never blocked/);
+  });
+
+  it('an unreadable config says unknown, not inactive', () => {
+    const msg = describeConversationAccess({ granted: false, readable: false, entryPresent: false }, PLUGIN_ID);
+    expect(msg.toLowerCase()).toMatch(/unknown|cannot read/);
+  });
+
+  it('the fix names the exact key and frames withholding as legitimate', () => {
+    const fix = conversationAccessFix(PLUGIN_ID);
+    expect(fix).toContain('allowConversationAccess');
+    expect(fix).toContain(PLUGIN_ID);
+    expect(fix.toLowerCase()).toMatch(/restart/);
+    expect(fix.toLowerCase()).toMatch(/valid choice|your call/);
+  });
+});
+
+describe('#225 — the startup line claims only what is live', () => {
+  it('does NOT name llm_input/llm_output when the grant is missing', () => {
+    // The exact bug: the gateway logged "registered (llm_input + llm_output …)"
+    // and then, on the next two lines, that it had dropped both.
+    const line = describeRegisteredHooks({
+      access: pluginEvaluate(ungranted, PLUGIN_ID),
+      beforeToolCallRegistered: true,
+    });
+    expect(line).not.toMatch(/llm_input \+/);
+    expect(line).toMatch(/INACTIVE/);
+    expect(line).toContain('allowConversationAccess');
+    // What IS live must still be reported.
+    expect(line).toContain('before_tool_call');
+  });
+
+  it('names them when the grant IS present', () => {
+    const line = describeRegisteredHooks({
+      access: pluginEvaluate(granted, PLUGIN_ID),
+      beforeToolCallRegistered: true,
+    });
+    expect(line).toContain('llm_input');
+    expect(line).toContain('llm_output');
+    expect(line).not.toMatch(/INACTIVE/);
+  });
+
+  it('says UNKNOWN rather than INACTIVE when openclaw.json is unreadable', () => {
+    const line = describeRegisteredHooks({
+      access: { granted: false, readable: false, entryPresent: false },
+      beforeToolCallRegistered: true,
+    });
+    expect(line).toMatch(/UNKNOWN/);
+  });
+
+  it('never claims before_tool_call when it was not registered', () => {
+    const line = describeRegisteredHooks({
+      access: pluginEvaluate(granted, PLUGIN_ID),
+      beforeToolCallRegistered: false,
+    });
+    expect(line).not.toContain('before_tool_call');
+  });
+});
+
+describe('#225 — the two build-boundary copies agree (drift guard)', () => {
+  // src/ and plugins/ are separate builds and cannot import each other, so the
+  // grant reader is duplicated. If one copy learns a rule the other does not,
+  // doctor and the plugin would report different states for the same host.
+  const CASES: unknown[] = [
+    granted,
+    ungranted,
+    { plugins: { entries: {} } },
+    { plugins: { entries: { [PLUGIN_ID]: { hooks: { allowConversationAccess: 'true' } } } } },
+    { plugins: { entries: { [PLUGIN_ID]: { hooks: { allowConversationAccess: 1 } } } } },
+    { plugins: { entries: { [PLUGIN_ID]: { hooks: {} } } } },
+    { plugins: 'nope' },
+    null,
+    undefined,
+    42,
+  ];
+
+  it('produces identical verdicts for every fixture', () => {
+    for (const cfg of CASES) {
+      expect(pluginEvaluate(cfg, PLUGIN_ID)).toEqual(evaluateConversationAccess(cfg, PLUGIN_ID));
+    }
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -19,7 +19,12 @@ import {
   findEoverrideRiskPins,
   isRealtimePluginDisabledInConfig,
 } from '../integrations/openclaw-plugin-state.js';
-import { gatherReconcileInput, reconcilePluginState, type ReconcileVerdict } from '../integrations/openclaw-plugin-index.js';
+import { gatherReconcileInput, reconcilePluginState, REALTIME_PLUGIN_ID, type ReconcileVerdict } from '../integrations/openclaw-plugin-index.js';
+import {
+  readConversationAccess,
+  describeConversationAccess,
+  conversationAccessFix,
+} from '../integrations/openclaw-conversation-access.js';
 import { parseRegistrationsSince } from '../integrations/openclaw-gateway-roster.js';
 import { readRunningGatewayProcess } from '../integrations/openclaw-gateway-process.js';
 import { resolveSelfInstallDir } from '../setup/native-binding.js';
@@ -2633,6 +2638,49 @@ export async function checkOpenClawPluginVersion(
  * reads OpenClaw's own loaded roster, so a silent drop cannot hide. `home` /
  * `expectedVersion` are injectable for tests.
  */
+/**
+ * #225 phase 1: report whether conversation scanning is actually happening.
+ *
+ * OpenClaw drops the conversation hooks (`llm_input`/`llm_output`) at
+ * registration unless a non-bundled plugin is granted
+ * `plugins.entries.<id>.hooks.allowConversationAccess = true`. On this fleet
+ * the gateway logged that drop six times in one day while ShieldCortex's own
+ * startup line announced both hooks as registered — protection claimed, not
+ * held.
+ *
+ * Two honest outcomes, and neither is a green tick for "protected":
+ *  - ungranted → WARN. Nothing is being scanned. Not a `fail`: withholding
+ *    conversation access is a legitimate operator choice on a sensitive
+ *    surface, and crying damage over a deliberate decision is how a check
+ *    earns the right to be ignored.
+ *  - granted → INFO, explicitly OBSERVATION ONLY. `llm_input` has no blocking
+ *    contract, so a pass tick here would be a fresh false green.
+ */
+export async function checkOpenClawConversationScanning(
+  home: string = os.homedir(),
+): Promise<CheckResult> {
+  const label = 'Conversation scanning';
+  if (!fs.existsSync(path.join(home, '.openclaw'))) {
+    return { label, status: 'info', message: 'skipped (OpenClaw not detected)' };
+  }
+
+  const state = readConversationAccess(home, REALTIME_PLUGIN_ID);
+  const message = describeConversationAccess(state, REALTIME_PLUGIN_ID);
+
+  if (!state.readable) {
+    return {
+      label,
+      status: 'warn',
+      message,
+      fix: 'Check that ~/.openclaw/openclaw.json exists and is valid JSON, then re-run `shieldcortex doctor`.',
+    };
+  }
+  if (!state.granted) {
+    return { label, status: 'warn', message, fix: conversationAccessFix(REALTIME_PLUGIN_ID) };
+  }
+  return { label, status: 'info', message };
+}
+
 export async function checkOpenClawPluginLoadState(
   home: string = os.homedir(),
   expectedVersion: string = pkg.version,
@@ -3304,6 +3352,7 @@ export async function runDoctor(
     checkOpenClawPluginVersion,
     checkOpenClawSkillVersion,
     checkOpenClawPluginLoadState,
+    checkOpenClawConversationScanning,
     checkOpenClawRunningPluginVersion,
     checkOpenClawPluginPackage,
     checkOpenClawDuplicateInstalls,

--- a/src/integrations/openclaw-conversation-access.ts
+++ b/src/integrations/openclaw-conversation-access.ts
@@ -1,0 +1,101 @@
+/**
+ * #225 phase 1 — honest state for OpenClaw conversation-hook access.
+ *
+ * OpenClaw gates the conversation hooks (`llm_input`, `llm_output`,
+ * `before_agent_run`, …) behind an explicit per-plugin consent grant: a
+ * non-bundled plugin only receives them when
+ * `plugins.entries.<id>.hooks.allowConversationAccess` is exactly `true`.
+ * Without it the host DROPS the registration and emits a warn diagnostic:
+ *
+ *   [plugins] typed hook "llm_input" blocked because non-bundled plugins must
+ *   set plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess=true
+ *
+ * ShieldCortex has been logging `registered (llm_input + llm_output + …)` on
+ * exactly the hosts where those two were then dropped — claiming conversation
+ * protection it does not have. That is the same false-green class as #222
+ * (doctor healthy over a wiped stanza) and #200 (a verify step that could only
+ * pass), and this module exists to make the state reportable rather than
+ * assumed.
+ *
+ * IMPORTANT: a grant is NOT protection. Even when granted, `llm_input` is an
+ * observation hook with no blocking contract — detections are logged, never
+ * stopped. Enforcement is a separate piece of work; do not let "granted" be
+ * rendered as "protected".
+ *
+ * Withholding the grant is a legitimate operator choice — conversation content
+ * is sensitive — so an ungranted host is reported as a WARNING with the exact
+ * config to add, never as damage.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export interface ConversationAccessState {
+  /** `plugins.entries.<id>.hooks.allowConversationAccess === true`. */
+  granted: boolean;
+  /** openclaw.json parsed. False ⇒ we cannot tell; never claim either way. */
+  readable: boolean;
+  /** The plugin has an entry in openclaw.json at all. */
+  entryPresent: boolean;
+}
+
+/** Pure: evaluate a parsed openclaw.json object. */
+export function evaluateConversationAccess(config: unknown, pluginId: string): ConversationAccessState {
+  if (!config || typeof config !== 'object') {
+    return { granted: false, readable: false, entryPresent: false };
+  }
+  const plugins = (config as { plugins?: unknown }).plugins;
+  const entries = plugins && typeof plugins === 'object'
+    ? (plugins as { entries?: unknown }).entries
+    : undefined;
+  const entry = entries && typeof entries === 'object'
+    ? (entries as Record<string, unknown>)[pluginId]
+    : undefined;
+
+  if (!entry || typeof entry !== 'object') {
+    return { granted: false, readable: true, entryPresent: false };
+  }
+
+  const hooks = (entry as { hooks?: unknown }).hooks;
+  const raw = hooks && typeof hooks === 'object'
+    ? (hooks as { allowConversationAccess?: unknown }).allowConversationAccess
+    : undefined;
+
+  // Strict `true` only — OpenClaw itself compares `!== true`, so a truthy
+  // string or 1 does NOT grant access. Matching that exactly is the whole
+  // point: reporting "granted" for a value the host rejects would recreate the
+  // bug in the reporting layer.
+  return { granted: raw === true, readable: true, entryPresent: true };
+}
+
+/** Read `~/.openclaw/openclaw.json` and evaluate the grant. Never throws. */
+export function readConversationAccess(home: string, pluginId: string): ConversationAccessState {
+  try {
+    const raw = fs.readFileSync(path.join(home, '.openclaw', 'openclaw.json'), 'utf-8');
+    return evaluateConversationAccess(JSON.parse(raw), pluginId);
+  } catch {
+    return { granted: false, readable: false, entryPresent: false };
+  }
+}
+
+/**
+ * The exact config an operator must add. Kept here so the doctor message, the
+ * plugin's startup line and the tests cannot drift apart.
+ */
+export function conversationAccessFix(pluginId: string): string {
+  return `Add "hooks": { "allowConversationAccess": true } to plugins.entries["${pluginId}"] in ~/.openclaw/openclaw.json, then restart the gateway. Conversation content is sensitive — this is your call, and leaving it ungranted is a valid choice.`;
+}
+
+/**
+ * The honest one-line description of conversation-scanning state.
+ * `granted` deliberately does NOT read as "protected" (see module doc).
+ */
+export function describeConversationAccess(state: ConversationAccessState, pluginId: string): string {
+  if (!state.readable) {
+    return 'cannot read ~/.openclaw/openclaw.json — conversation-scanning state unknown';
+  }
+  if (!state.granted) {
+    return `conversation scanning INACTIVE — OpenClaw drops llm_input/llm_output at registration because plugins.entries.${pluginId}.hooks.allowConversationAccess is not true; no conversation content is being scanned on this host`;
+  }
+  return 'conversation scanning active — OBSERVATION ONLY: detections are logged and audited, never blocked';
+}


### PR DESCRIPTION
Phase 1 of #225 — **honest state only. No enforcement change.**

## The bug, from this fleet's gateway log

```
[shieldcortex] v4.47.35 registered (llm_input + llm_output + before_tool_call + …)
[plugins] typed hook "llm_input" blocked because non-bundled plugins must set
          plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess=true
[plugins] typed hook "llm_output" blocked …
```

Six occurrences on 10 Aug, four on 9 Aug. **We announce two hooks the host has just refused**, in the one place an operator looks to confirm startup. Conversation scanning has been inert on this host while the product reported it live — the same false-green class as #222 (doctor healthy over a wiped stanza) and #200 (a verify step that could only pass).

OpenClaw gates the conversation hooks behind a per-plugin consent grant: a non-bundled plugin receives `llm_input`/`llm_output`/`before_agent_run` only when `plugins.entries.<id>.hooks.allowConversationAccess` is exactly `true` (`registry:4224-4235`). There is no CLI to grant it — it is a hand-edited per-host config change requiring a gateway restart.

## What this PR does

- The startup line names **only hooks that will actually be live**, and names the missing grant when that is the reason.
- `doctor` gains a **Conversation scanning** check reporting the real state.

Verified against this box:

| | |
|---|---|
| **Before** | `registered (llm_input + llm_output + before_tool_call + /shieldcortex-status)` |
| **After** | `registered (before_tool_call + /shieldcortex-status — conversation scanning INACTIVE (llm_input/llm_output dropped by OpenClaw: set plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess=true to enable))` |

`doctor` returns `warn` with the exact config to add.

## What this PR explicitly does NOT do

It adds no enforcement. Even when granted, `llm_input` cannot block — verified against the installed runtime, not just the docs: it is typed `(event, ctx) => Promise<void> | void`, dispatched through `runVoidHook` which **discards the return value** and catches throws (`hook-runner-global:464-474`), from a call site that is **not awaited** (`selection:14102`). Mutating history is inert too — `cloneHookMessages` is `structuredClone` per message.

Enforcement requires `before_agent_run`, plus an engine-floor bump to `>=2026.5.12` (the first release containing it — our declared floor is `>=2026.3.22`, two months earlier, and unknown hooks are *warned and ignored, not thrown*), plus a decision about its fail-closed blast radius. Phases 2 and 3.

## Three calls that keep this from re-creating the bug one layer up

1. **A grant is not protection.** Granted reports `info` + "OBSERVATION ONLY: detections are logged and audited, never blocked" — deliberately not a `pass` tick. A green here would be a fresh false green, pinned by a test asserting the granted message never claims protection.
2. **Ungranted is `warn`, not `fail`.** Conversation content is sensitive and withholding access is a legitimate operator choice; the fix text says so explicitly. A check that reports damage over a deliberate decision earns the right to be ignored.
3. **Strict `true` only**, matching OpenClaw's own `!== true`. `"true"` and `1` are rejected by the host, and a test pins that we reject them identically — reporting "granted" for a value the host refuses would be this exact bug in the reporting layer.

## Drift guard

`src/` and `plugins/` are separate builds that cannot import each other, so the grant reader is duplicated. A test asserts both copies return **identical verdicts across 10 fixtures** — otherwise `doctor` and the plugin could report different states for the same host.

## Tests

16 new in `src/__tests__/conversation-access-honesty-225.test.ts`. Both tsconfigs typecheck.

> Full serial suite: 353/354 suites, 4089 passed. The one failure was an `ENOTEMPTY` in `claude-md-refresh`'s `afterEach` `fs.rmSync` teardown (a deep nested `node_modules` tree); assertions passed, and it passes on re-run. That suite takes ~110 s doing real filesystem installs and is independently flaky — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
