### PR TITLE
fix(#225) phase 2: detect whether a host can enforce at all

### DIFF
--- a/src/__tests__/conversation-capability-225.test.ts
+++ b/src/__tests__/conversation-capability-225.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  evaluateEnforcementSupport,
+  describeEnforcementSupport,
+  CONVERSATION_ENFORCEMENT_MIN_OPENCLAW,
+} from '../integrations/openclaw-conversation-capability.js';
+
+/**
+ * #225 phase 2 — capability detection.
+ *
+ * `before_agent_run` is the only conversation hook that can block, and it first
+ * shipped in OpenClaw 2026.5.12 (dist-verified: 0 occurrences in 2026.4.23 /
+ * 5.5 / 5.6 / 5.7, 54 in 5.12). Our manifest still declares `>= 2026.3.22`.
+ *
+ * The trap: OpenClaw does not reject an unknown typed hook — it warns and
+ * returns. So registering it on an older host looks successful and enforces
+ * nothing. These tests pin that we can tell the difference BEFORE claiming
+ * enforcement, and that an unreadable version is never reported as either.
+ */
+
+describe('#225 phase 2 — which hosts can enforce at all', () => {
+  it('the floor is the release that actually contains the hook', () => {
+    expect(CONVERSATION_ENFORCEMENT_MIN_OPENCLAW).toBe('2026.5.12');
+  });
+
+  it('rejects every version in the silently-ignoring range', () => {
+    // Each of these declares support in our manifest today and would register
+    // the hook to no effect.
+    for (const v of ['2026.3.22', '2026.4.23', '2026.5.5', '2026.5.6', '2026.5.7']) {
+      expect(evaluateEnforcementSupport(v).support).toBe('unsupported');
+    }
+  });
+
+  it('accepts the first release containing it, and later ones', () => {
+    for (const v of ['2026.5.12', '2026.5.19', '2026.6.1', '2026.7.1']) {
+      expect(evaluateEnforcementSupport(v).support).toBe('supported');
+    }
+  });
+
+  it('treats a prerelease of a supported version as supported', () => {
+    // 2026.7.2-beta.7 and 2026.8.1-beta.1 are already published upstream. A raw
+    // semver compare ranks a prerelease BELOW its release, which would report
+    // a newer host as incapable.
+    expect(evaluateEnforcementSupport('2026.7.2-beta.7').support).toBe('supported');
+    expect(evaluateEnforcementSupport('2026.8.1-beta.1').support).toBe('supported');
+  });
+
+  it('reports UNKNOWN rather than guessing when the version cannot be read', () => {
+    // Unknown must never collapse into either answer — claiming "unsupported"
+    // would hide a capable host, claiming "supported" would promise
+    // enforcement we cannot deliver.
+    for (const v of [null, '', 'not-a-version', 'latest']) {
+      expect(evaluateEnforcementSupport(v as string | null).support).toBe('unknown');
+    }
+  });
+
+  it('carries the host and minimum versions for the operator', () => {
+    const cap = evaluateEnforcementSupport('2026.4.23');
+    expect(cap.hostVersion).toBe('2026.4.23');
+    expect(cap.minVersion).toBe('2026.5.12');
+  });
+});
+
+describe('#225 phase 2 — the message never over-promises', () => {
+  it('an unsupported host is told detections can only ever be advisory', () => {
+    const msg = describeEnforcementSupport(evaluateEnforcementSupport('2026.4.23'));
+    expect(msg).toMatch(/UNAVAILABLE/);
+    expect(msg).toContain('2026.5.12');
+    expect(msg.toLowerCase()).toMatch(/advisory/);
+  });
+
+  it('a SUPPORTED host is not told it is enforcing', () => {
+    // Capability is not activation. Phase 2 detects; nothing enforces yet.
+    const msg = describeEnforcementSupport(evaluateEnforcementSupport('2026.7.1'));
+    expect(msg).toMatch(/AVAILABLE/);
+    expect(msg.toLowerCase()).toMatch(/not yet enabled|observation-only/);
+  });
+
+  it('an unknown host says unknown', () => {
+    expect(describeEnforcementSupport(evaluateEnforcementSupport(null)).toLowerCase()).toMatch(/unknown/);
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -25,6 +25,11 @@ import {
   describeConversationAccess,
   conversationAccessFix,
 } from '../integrations/openclaw-conversation-access.js';
+import {
+  readOpenClawHostVersion,
+  evaluateEnforcementSupport,
+  describeEnforcementSupport,
+} from '../integrations/openclaw-conversation-capability.js';
 import { parseRegistrationsSince } from '../integrations/openclaw-gateway-roster.js';
 import { readRunningGatewayProcess } from '../integrations/openclaw-gateway-process.js';
 import { resolveSelfInstallDir } from '../setup/native-binding.js';
@@ -2665,7 +2670,12 @@ export async function checkOpenClawConversationScanning(
   }
 
   const state = readConversationAccess(home, REALTIME_PLUGIN_ID);
-  const message = describeConversationAccess(state, REALTIME_PLUGIN_ID);
+  // #225 phase 2: the grant and the host's CAPABILITY are independent facts,
+  // and an operator needs both. Granting access on a host whose OpenClaw
+  // predates before_agent_run buys observation and nothing more — saying so up
+  // front is cheaper than discovering it after enabling enforcement.
+  const capability = evaluateEnforcementSupport(readOpenClawHostVersion(home));
+  const message = `${describeConversationAccess(state, REALTIME_PLUGIN_ID)}; ${describeEnforcementSupport(capability)}`;
 
   if (!state.readable) {
     return {
@@ -2677,6 +2687,17 @@ export async function checkOpenClawConversationScanning(
   }
   if (!state.granted) {
     return { label, status: 'warn', message, fix: conversationAccessFix(REALTIME_PLUGIN_ID) };
+  }
+  if (capability.support === 'unsupported') {
+    // Granted but incapable: scanning happens, enforcement never can. That is a
+    // real ceiling on this host, not a misconfiguration — warn, and name the
+    // version that lifts it.
+    return {
+      label,
+      status: 'warn',
+      message,
+      fix: `Upgrade OpenClaw to ${capability.minVersion} or later if you want conversation enforcement to become possible. Scanning and auditing work as-is.`,
+    };
   }
   return { label, status: 'info', message };
 }

--- a/src/integrations/openclaw-conversation-capability.ts
+++ b/src/integrations/openclaw-conversation-capability.ts
@@ -1,0 +1,104 @@
+/**
+ * #225 phase 2 — can this host enforce on the conversation path at all?
+ *
+ * `before_agent_run` is the only conversation hook that can block a run, and it
+ * did not exist until OpenClaw **2026.5.12**. Verified by sweeping the
+ * published dists: 0 occurrences in 2026.4.23, 2026.5.5, 2026.5.6 and 2026.5.7;
+ * 54 in 2026.5.12. Our plugin manifest declares `openclaw >= 2026.3.22`.
+ *
+ * The trap this module closes: OpenClaw does NOT reject an unknown typed hook.
+ * It emits `unknown typed hook "…" ignored` as a warn diagnostic and returns.
+ * So on every host in the 2026.3.22–2026.5.7 range, registering the hook would
+ * appear to succeed and enforce nothing — a silent no-op, which is the same
+ * false-green family as #200, #222 and phase 1 of this issue.
+ *
+ * DELIBERATELY NOT a hard engine-floor bump. Raising `engines.openclaw` to
+ * 2026.5.12 would block installation for every operator on an older host —
+ * including from the Action Guard (`before_tool_call`), which is not a
+ * conversation hook, works fine on 2026.3.22, and is the plugin's primary
+ * defence. Punishing users of a working feature to gate one they may never
+ * enable is the wrong trade. The floor stays; the CAPABILITY is detected and
+ * reported per host.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import semver from 'semver';
+
+/** First OpenClaw release containing `before_agent_run` (dist-verified). */
+export const CONVERSATION_ENFORCEMENT_MIN_OPENCLAW = '2026.5.12';
+
+export type EnforcementSupport = 'supported' | 'unsupported' | 'unknown';
+
+export interface ConversationCapability {
+  support: EnforcementSupport;
+  /** The detected OpenClaw version, or null when it could not be read. */
+  hostVersion: string | null;
+  minVersion: string;
+}
+
+/**
+ * OpenClaw versions are CalVer (`2026.5.12`) which is semver-shaped, so semver
+ * comparison is correct — but a build/tag suffix (`2026.7.2-beta.7`) must not
+ * make a prerelease compare LOW against a plain version. `semver.coerce` drops
+ * the prerelease, which is what we want: 2026.7.2-beta.7 supports the hook.
+ */
+export function evaluateEnforcementSupport(hostVersion: string | null): ConversationCapability {
+  const base = { hostVersion, minVersion: CONVERSATION_ENFORCEMENT_MIN_OPENCLAW };
+  if (!hostVersion) return { ...base, support: 'unknown' };
+
+  const coerced = semver.valid(semver.coerce(hostVersion) ?? '');
+  if (!coerced) return { ...base, support: 'unknown' };
+
+  return {
+    ...base,
+    support: semver.gte(coerced, CONVERSATION_ENFORCEMENT_MIN_OPENCLAW) ? 'supported' : 'unsupported',
+  };
+}
+
+/**
+ * Read the installed OpenClaw version. The managed install lives under a
+ * node-version-specific directory (`tools/node-v24.15.0/lib/node_modules`),
+ * so the path is discovered rather than assumed. Never throws — an unreadable
+ * install yields `unknown`, never a confident answer.
+ */
+export function readOpenClawHostVersion(home: string): string | null {
+  const toolsDir = path.join(home, '.openclaw', 'tools');
+  let candidates: string[] = [];
+  try {
+    candidates = fs
+      .readdirSync(toolsDir)
+      .map((d) => path.join(toolsDir, d, 'lib', 'node_modules', 'openclaw', 'package.json'));
+  } catch {
+    return null;
+  }
+
+  // Prefer the highest version found: a box can carry more than one managed
+  // node runtime, and a stale one must not decide the verdict.
+  let best: string | null = null;
+  for (const file of candidates) {
+    try {
+      const v = (JSON.parse(fs.readFileSync(file, 'utf-8')) as { version?: unknown }).version;
+      if (typeof v !== 'string') continue;
+      const coerced = semver.valid(semver.coerce(v) ?? '');
+      if (!coerced) continue;
+      if (!best || semver.gt(coerced, semver.valid(semver.coerce(best) ?? '') ?? '0.0.0')) best = v;
+    } catch {
+      continue;
+    }
+  }
+  return best;
+}
+
+/** The honest one-liner for a capability verdict. */
+export function describeEnforcementSupport(cap: ConversationCapability): string {
+  switch (cap.support) {
+    case 'supported':
+      return `conversation enforcement AVAILABLE on OpenClaw ${cap.hostVersion} (>= ${cap.minVersion}) — not yet enabled; scanning remains observation-only`;
+    case 'unsupported':
+      return `conversation enforcement UNAVAILABLE — OpenClaw ${cap.hostVersion} predates ${cap.minVersion}, which first shipped the only conversation hook that can block (before_agent_run). Detections here can never be more than advisory`;
+    case 'unknown':
+    default:
+      return 'conversation enforcement support UNKNOWN — could not read the installed OpenClaw version';
+  }
+}


### PR DESCRIPTION
Phase 2 of #225 — **capability detection. Still no enforcement.**

## The trap

`before_agent_run` is the only conversation hook that can block a run, and it first shipped in OpenClaw **2026.5.12**. Dist-verified by sweeping published tarballs for the string:

| version | occurrences |
|---|---|
| 2026.4.23 | **0** |
| 2026.5.5 / 5.6 / 5.7 | 0 / 0 / 0 |
| **2026.5.12** | **54** |
| 2026.6.1 … 2026.7.1 | present |

Our manifest declares `openclaw >= 2026.3.22`. And OpenClaw does **not reject** an unknown typed hook — it emits `unknown typed hook "…" ignored` as a warn diagnostic and returns. So on every host in the 2026.3.22–2026.5.7 range, registering the hook would look successful and enforce nothing: the same false-green family as #200, #222, and phase 1 of this issue.

## Deliberately NOT an engine-floor bump

The original plan (and my own earlier recommendation) said bump `engines.openclaw` to `>=2026.5.12`. **I did not do that, and think it would be a mistake.**

It would block installation for every operator on an older host — including for the **Action Guard**, which is not a conversation hook, works fine on 2026.3.22, and is the plugin's primary defence. Punishing users of a working feature to gate one they may never enable is the wrong trade.

The floor stays. The *capability* is detected and reported per host.

## What's here

- `readOpenClawHostVersion()` discovers the managed install — the path is node-version-specific (`tools/node-v24.15.0/lib/node_modules/…`), so it is globbed rather than assumed, and the highest version wins when a box carries several node runtimes.
- **Prereleases coerce.** `2026.7.2-beta.7` and `2026.8.1-beta.1` are already published upstream; a raw semver compare ranks a prerelease *below* its release and would report a newer host as incapable.
- **Unreadable ⇒ `unknown`**, never collapsed into either answer. "Unsupported" would hide a capable host; "supported" would promise enforcement we cannot deliver.
- `doctor`'s **Conversation scanning** check now reports the grant and the capability together — granting access on a pre-5.12 host buys observation and nothing more, and saying so up front is cheaper than discovering it after enabling enforcement.
- A granted-but-incapable host **warns** and names the version that lifts the ceiling; scanning and auditing still work as-is.

**Capability is not activation.** A supported host is told enforcement is `AVAILABLE` and "not yet enabled" — never that it is enforcing. There is a test for that.

## Verified on this box (OpenClaw 2026.7.1)

```
conversation scanning INACTIVE — OpenClaw drops llm_input/llm_output at registration
because plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess is not true;
conversation enforcement AVAILABLE on OpenClaw 2026.7.1 (>= 2026.5.12) — not yet enabled;
scanning remains observation-only
```

## Tests

9 new in `src/__tests__/conversation-capability-225.test.ts`, including every version in the silently-ignoring range, the prerelease cases, and that the messages never over-promise. Typecheck clean.

> Full serial suite: 354/355 suites, 4098 passed. The one failure is the known `claude-md-refresh` teardown flake — `ENOTEMPTY` in its `afterEach` `fs.rmSync`, which has now hit two different subdirectories (`.npm/_cacache/index-v5` here, `dashboard/.next/standalone` on the previous run). That test performs a real npm install into a temp home and then recursively deletes it; assertions pass and it passes on re-run. Unrelated to this change, filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
