### PR TITLE
fix(#236): cap eviction can no longer eat the memory it was just handed

### DIFF
--- a/src/__tests__/memory-cap-eviction-236.test.ts
+++ b/src/__tests__/memory-cap-eviction-236.test.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { initDatabase, closeDatabase, getDatabase } from '../database/init.js';
+import { addMemory, getMemoryById } from '../memory/store.js';
+import { enforceMemoryLimits } from '../memory/consolidate.js';
+import { DEFAULT_CONFIG } from '../memory/types.js';
+
+/**
+ * Issue #236 — once `long_term` reaches its cap, `enforceMemoryLimits()`
+ * deleted the memory that was JUST INSERTED, milliseconds after `remember`
+ * returned success with its ID.
+ *
+ * Mechanism: eviction ordered by raw `salience ASC`, but long-term salience is
+ * a forward-only ratchet — the decay pass is fed short-term rows only — so a
+ * mature store sits at a solid wall of 1.0 (field data: 1000 of 1000 rows).
+ * A new write lands below the wall (importance:"high" → 0.8), making it the
+ * unique global minimum: always the victim. Field numbers over 16 days:
+ * 169 of 171 sub-1.0 new writes deleted within 2s of insert; every write at
+ * exactly 1.0 survived. The memories most worth keeping were exactly the ones
+ * being dropped, with a success response for every one.
+ *
+ * The fix has two independent legs, both pinned here:
+ *   1. GRACE WINDOW (state-independent): a row created within the last hour is
+ *      never an eviction victim, whatever the salience distribution says. A
+ *      cap breach during the window is temporary overshoot, not data loss.
+ *   2. EFFECTIVE-SALIENCE RANKING: past the window, victims are chosen by the
+ *      shared computeEffectiveSalience (recency × access × pin × downvotes) —
+ *      the same signal recall ranks by — instead of a saturated raw salience.
+ *      Eviction and recall now agree about what is valuable.
+ * Plus pin parity with prune.ts: pinned rows are never cap-evicted.
+ */
+
+// Small cap so the wall is cheap to build; enforceMemoryLimits takes a config.
+const CAP = 10;
+const cfg = { ...DEFAULT_CONFIG, maxLongTermMemories: CAP, maxShortTermMemories: CAP };
+
+/** SQLite CURRENT_TIMESTAMP format ('YYYY-MM-DD HH:MM:SS'), offset into the past. */
+function sqliteTs(agoMs: number): string {
+  return new Date(Date.now() - agoMs).toISOString().slice(0, 19).replace('T', ' ');
+}
+const DAYS = 86_400_000;
+
+interface SeedRow {
+  salience?: number;
+  createdAgoMs?: number;
+  accessedAgoMs?: number;
+  accessCount?: number;
+  pinned?: boolean;
+  type?: 'short_term' | 'long_term';
+  title?: string;
+}
+
+/** Direct seed (defaults satisfy the WS3 provenance trigger). Returns row id. */
+function seed(row: SeedRow): number {
+  const db = getDatabase();
+  const r = db.prepare(`
+    INSERT INTO memories (uuid, type, category, title, content, salience, access_count, last_accessed, created_at)
+    VALUES (?, ?, 'note', ?, ?, ?, ?, ?, ?)
+  `).run(
+    randomUUID(),
+    row.type ?? 'long_term',
+    row.title ?? 'wall row',
+    'seeded content for cap-eviction tests',
+    row.salience ?? 1.0,
+    row.accessCount ?? 0,
+    sqliteTs(row.accessedAgoMs ?? 30 * DAYS),
+    sqliteTs(row.createdAgoMs ?? 60 * DAYS),
+  );
+  return Number(r.lastInsertRowid);
+}
+
+/** The field state: a full store whose every row sits at salience 1.0. */
+function buildWall(n: number = CAP): number[] {
+  return Array.from({ length: n }, (_, i) =>
+    seed({ salience: 1.0, createdAgoMs: (60 + i) * DAYS, accessedAgoMs: (20 + i) * DAYS, accessCount: 3 })
+  );
+}
+
+describe('#236 — a brand-new memory must survive cap enforcement', () => {
+  beforeEach(() => {
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  it('the reported repro: at cap, a fresh high-importance write is NOT the victim', () => {
+    buildWall();
+    // The real path: remember → addMemory. importance:"high" ⇒ salience 0.8 —
+    // below the wall, i.e. the exact shape that was 100% fatal in the field.
+    const fresh = addMemory({
+      title: 'probe',
+      content: 'the memory most worth keeping, per the field data',
+      category: 'note',
+      type: 'long_term',
+      salience: 0.8,
+    } as never, cfg);
+
+    const deleted = enforceMemoryLimits(cfg);
+
+    expect(deleted).toBe(1); // cap is still enforced…
+    expect(getMemoryById(fresh.id)).not.toBeNull(); // …but never against the newborn
+  });
+
+  it('remember success stays true: the returned ID resolves after enforcement', () => {
+    buildWall();
+    const fresh = addMemory({
+      title: 'durable', content: 'an ID handed back must keep meaning something',
+      category: 'note', type: 'long_term', salience: 0.6,
+    } as never, cfg);
+    enforceMemoryLimits(cfg);
+    // The field failure: ✓ Remembered → get_memory: "not found" ~5ms later.
+    expect(getMemoryById(fresh.id)?.title).toBe('durable');
+  });
+
+  it('grace window is state-independent: even a global-minimum newborn survives', () => {
+    // Adversarial wall: every row accessed JUST NOW with real access counts, so
+    // effective-salience ranking alone would still sort the newborn (0.3) last.
+    // Only the grace window saves it — this is the leg that must not regress.
+    for (let i = 0; i < CAP; i++) {
+      seed({ salience: 1.0, createdAgoMs: 60 * DAYS, accessedAgoMs: 0, accessCount: 10 });
+    }
+    const fresh = seed({ salience: 0.3, createdAgoMs: 0, accessedAgoMs: 0, title: 'newborn minimum' });
+
+    const deleted = enforceMemoryLimits(cfg);
+
+    expect(deleted).toBe(1);
+    expect(getMemoryById(fresh)).not.toBeNull();
+  });
+
+  it('past the window, the stalest row loses — not the most recently useful', () => {
+    // Same raw salience everywhere; only recency/access differ. Eviction must
+    // agree with recall about value: the 90-days-stale row dies first.
+    const stale = seed({ salience: 1.0, createdAgoMs: 100 * DAYS, accessedAgoMs: 90 * DAYS, accessCount: 0, title: 'stale' });
+    for (let i = 0; i < CAP; i++) {
+      seed({ salience: 1.0, createdAgoMs: 100 * DAYS, accessedAgoMs: 1 * DAYS, accessCount: 5 });
+    }
+    const deleted = enforceMemoryLimits(cfg);
+
+    expect(deleted).toBe(1);
+    expect(getMemoryById(stale)).toBeNull();
+  });
+
+  it('never evicts a pinned row (parity with prune.ts)', () => {
+    // The pinned row is deliberately the WORST candidate by every other signal.
+    const pinned = seed({ salience: 1.0, createdAgoMs: 200 * DAYS, accessedAgoMs: 180 * DAYS, accessCount: 0, pinned: true, title: 'pinned keepsake' });
+    getDatabase().prepare('UPDATE memories SET pinned = 1 WHERE id = ?').run(pinned);
+    const expendable = seed({ salience: 1.0, createdAgoMs: 150 * DAYS, accessedAgoMs: 100 * DAYS, accessCount: 0, title: 'expendable' });
+    for (let i = 0; i < CAP; i++) {
+      seed({ salience: 1.0, createdAgoMs: 100 * DAYS, accessedAgoMs: 1 * DAYS, accessCount: 5 });
+    }
+
+    enforceMemoryLimits(cfg);
+
+    expect(getMemoryById(pinned)).not.toBeNull();
+    expect(getMemoryById(expendable)).toBeNull();
+  });
+
+  it('short_term eviction gets the same newborn protection', () => {
+    for (let i = 0; i < CAP; i++) {
+      seed({ type: 'short_term', salience: 0.9, createdAgoMs: 10 * DAYS, accessedAgoMs: 5 * DAYS });
+    }
+    const fresh = seed({ type: 'short_term', salience: 0.25, createdAgoMs: 0, accessedAgoMs: 0, title: 'st newborn' });
+
+    const deleted = enforceMemoryLimits(cfg);
+
+    expect(deleted).toBe(1);
+    expect(getMemoryById(fresh)).not.toBeNull();
+  });
+
+  it('an all-newborn overflow overshoots the cap instead of eating itself', () => {
+    // Pathological burst: cap+3 rows all inside the grace window. Nothing is
+    // evictable yet — the store must overshoot temporarily rather than destroy
+    // writes it just accepted. (The wall ages out of the window within the
+    // hour and the next enforcement pass reclaims the overshoot.)
+    for (let i = 0; i < CAP + 3; i++) {
+      seed({ salience: 0.5, createdAgoMs: 0, accessedAgoMs: 0 });
+    }
+    const deleted = enforceMemoryLimits(cfg);
+    expect(deleted).toBe(0);
+    const count = (getDatabase().prepare("SELECT COUNT(*) AS n FROM memories WHERE type='long_term'").get() as { n: number }).n;
+    expect(count).toBe(CAP + 3);
+  });
+});

--- a/src/memory/consolidate.ts
+++ b/src/memory/consolidate.ts
@@ -547,8 +547,72 @@ export function clusterAndSummarise(options?: { minClusterSize?: number }): {
 }
 
 /**
- * Enforce maximum memory limits
- * Removes lowest-priority memories when limits are exceeded
+ * #236: a row created within this window is NEVER an eviction victim.
+ *
+ * Why this is load-bearing and not just polish: eviction used to order by raw
+ * `salience ASC`, and long-term salience is a forward-only ratchet (the decay
+ * pass is fed short-term rows only) — so a mature store is a solid wall of
+ * 1.0 and the newest sub-1.0 write is the unique global minimum. Field data
+ * over 16 days: 169 of 171 new sub-1.0 long-term writes were deleted within
+ * ~2s of insert, while `remember` had already returned success with their ID.
+ * `importance:"high"` maps to 0.8, so the memories most worth keeping were
+ * exactly the ones being dropped.
+ *
+ * Ranking smarter (below) is not sufficient on its own — a newborn has
+ * access_count 0, so against a wall of recently-touched rows it can still sort
+ * first. The grace window is state-independent: whatever the salience
+ * distribution says, a memory the store just accepted is not destroyed. A cap
+ * breach during the window becomes a temporary overshoot, reclaimed by the
+ * next enforcement pass once rows age past the hour.
+ */
+const EVICTION_GRACE_WINDOW = "-1 hour";
+
+/**
+ * Choose cap-eviction victims for one memory type.
+ *
+ * Victims are ranked by the shared `computeEffectiveSalience` (recency ×
+ * access × pin × downvote penalty) — the same signal recall ranks by — because
+ * raw `salience` is saturated at 1.0 across mature long-term stores and
+ * carries no information (#236). Eviction and recall now agree about what is
+ * valuable: the stalest, least-consulted, most-downvoted rows go first.
+ *
+ * Exclusions, both state-independent:
+ *  - rows inside EVICTION_GRACE_WINDOW (see above — never eat a newborn);
+ *  - pinned rows, matching prune.ts ("pinned memories are never pruned").
+ *    If an operator pins more rows than the cap, the store stays over cap
+ *    rather than overriding an explicit keep.
+ *
+ * Ties (e.g. equal effective salience) break toward evicting the stalest row,
+ * then the least-accessed, then the oldest id — deterministic, and the exact
+ * opposite of the old `access_count ASC` tiebreak that anti-selected newborns.
+ */
+function pickEvictionVictims(
+  db: Database.Database,
+  type: 'short_term' | 'long_term',
+  toRemove: number
+): number[] {
+  const candidates = db.prepare(`
+    SELECT id, salience, last_accessed, access_count, pinned, downvote_count
+    FROM memories
+    WHERE type = ?
+      AND COALESCE(pinned, 0) = 0
+      AND created_at < datetime('now', ?)
+  `).all(type, EVICTION_GRACE_WINDOW) as Array<Record<string, unknown>>;
+
+  candidates.sort((a, b) =>
+    (effectiveSalienceOfRow(a) - effectiveSalienceOfRow(b)) ||
+    ((Date.parse(String(a.last_accessed ?? '')) || 0) - (Date.parse(String(b.last_accessed ?? '')) || 0)) ||
+    ((a.access_count as number ?? 0) - (b.access_count as number ?? 0)) ||
+    ((a.id as number) - (b.id as number))
+  );
+
+  return candidates.slice(0, toRemove).map((r) => r.id as number);
+}
+
+/**
+ * Enforce maximum memory limits.
+ * Removes the lowest-effective-salience eligible memories when limits are
+ * exceeded — never newborns, never pinned rows (see pickEvictionVictims/#236).
  */
 export function enforceMemoryLimits(config: MemoryConfig = DEFAULT_CONFIG): number {
   // Note: If called within consolidate(), this is already in a transaction
@@ -563,14 +627,7 @@ export function enforceMemoryLimits(config: MemoryConfig = DEFAULT_CONFIG): numb
 
   if (shortTermCount > config.maxShortTermMemories) {
     const toRemove = shortTermCount - config.maxShortTermMemories;
-    const lowPriority = db.prepare(`
-      SELECT id FROM memories
-      WHERE type = 'short_term'
-      ORDER BY salience ASC, last_accessed ASC
-      LIMIT ?
-    `).all(toRemove) as { id: number }[];
-
-    for (const { id } of lowPriority) {
+    for (const id of pickEvictionVictims(db, 'short_term', toRemove)) {
       deleteMemory(id);
       deleted++;
     }
@@ -583,14 +640,7 @@ export function enforceMemoryLimits(config: MemoryConfig = DEFAULT_CONFIG): numb
 
   if (longTermCount > config.maxLongTermMemories) {
     const toRemove = longTermCount - config.maxLongTermMemories;
-    const lowPriority = db.prepare(`
-      SELECT id FROM memories
-      WHERE type = 'long_term'
-      ORDER BY salience ASC, access_count ASC, last_accessed ASC
-      LIMIT ?
-    `).all(toRemove) as { id: number }[];
-
-    for (const { id } of lowPriority) {
+    for (const id of pickEvictionVictims(db, 'long_term', toRemove)) {
       deleteMemory(id);
       deleted++;
     }
@@ -690,12 +740,15 @@ const DOWNVOTE_SQL = `
  *   - combined ≥ 0.85  → DELETE (near-identical; content already in the kept row)
  *   - combined < 0.85  → DOWNVOTE (reversible; sinks via effective salience)
  *
- * Why the split exists at all: NO reaping path (decay.ts shouldDelete,
- * prune.ts, expiry.ts, enforceMemoryLimits) reads `downvote_count` or effective
- * salience — they all order by raw `salience`. So downvote-ONLY would leave the
- * store unbounded (the dups sink in recall but never get pruned). Deleting the
- * near-identical losers keeps the store bounded with zero information loss; the
- * moderate near-dups are preserved and merely demoted.
+ * Why the split exists at all: most reaping paths (decay.ts shouldDelete,
+ * prune.ts, expiry.ts) read raw `salience`, not `downvote_count`/effective
+ * salience — so downvote-ONLY would leave the store effectively unbounded
+ * there (the dups sink in recall but never get pruned). Deleting the
+ * near-identical losers keeps the store bounded with zero information loss;
+ * the moderate near-dups are preserved and merely demoted. (Since #236,
+ * enforceMemoryLimits is the exception: cap eviction ranks by effective
+ * salience, so downvoted dups are now also the PREFERRED cap victims — which
+ * strengthens this boundedness argument rather than relying on it.)
  *
  * Tags are unioned onto the kept row and access counts summed (metadata only,
  * non-lossy). STM→LTM promotion is handled separately by processDecay/


### PR DESCRIPTION
Closes #236.

## The bug, confirmed against current main

Once `long_term` reaches its cap, `enforceMemoryLimits()` deleted the row that was **just inserted** — milliseconds after `remember` returned success with its ID. Reproduced first, TDD-style: the new test file failed **6 of 7** against the pre-fix code, exactly along the reported fault line, including the headline repro (`remember` at cap → the returned ID must still resolve; it didn't).

The reporter's mechanism analysis was correct on every point and made this fix straightforward — eviction ordered by raw `salience ASC`, long-term salience ratchets to a wall of 1.0 (the decay pass is fed short-term rows only), so a new write at 0.8 is the unique global minimum and always the victim, with `access_count ASC` anti-selecting newborns on ties.

## The fix — two independent legs, both required

**1. Grace window (state-independent).** A row created within the last hour is never an eviction victim, whatever the salience distribution says. This is the load-bearing leg, and there is a test that proves ranking alone cannot replace it: an adversarial wall where every row was accessed *just now* still out-ranks a newborn (access floor × recency), and only the window saves it. A cap breach inside the window becomes a temporary overshoot, reclaimed on the next pass once rows age past the hour — the trade the issue proposed, taken deliberately: **overshoot is recoverable, deletion is not.**

**2. Effective-salience ranking.** Past the window, victims are ranked by the shared `computeEffectiveSalience` (recency × access × pin × downvote penalty) — the exact signal recall ranks by — via the existing `effectiveSalienceOfRow` adapter, instead of a saturated raw `salience`. Eviction and recall now agree about what is valuable: the stalest, least-consulted, most-downvoted rows go first. Tiebreaks evict the stalest, then least-accessed, then oldest id — deterministic, and the opposite of the old newborn-killing order.

**Plus pin parity with `prune.ts`** ("pinned memories are never pruned"): cap eviction now excludes pinned rows too. An operator who pins more rows than the cap keeps them all — the store stays over cap rather than overriding an explicit keep.

Both legs applied to the `short_term` query as well — identical shape, identical fix.

## A comment that would have become a lie

The B11 dedup design's boundedness argument rested on "*NO reaping path … reads effective salience — they all order by raw salience*". That is no longer true of `enforceMemoryLimits`, and the change actually **strengthens** the argument: downvoted near-dup losers now sink in effective salience and become the *preferred* cap victims. Comment updated to say so rather than leaving stale reasoning in place.

## Deliberately out of scope (noted, not forgotten)

- **Configurable caps** (suggestion 4) — real, but it is config plumbing (`MemoryConfig` has no user-config merge path at all), not the data loss. Worth its own small issue.
- **Time decay for long-term salience** (suggestion 3) — the wider salience-wall thread (v4.34.0 lineage). Effective-salience ranking sidesteps the saturated signal for eviction without changing any stored values.

## Tests

7 in `src/__tests__/memory-cap-eviction-236.test.ts` — the reported repro through the real `addMemory`, the returned-ID durability contract, the ranking-defeating adversarial wall, stalest-loses ordering, pin exemption, the short-term twin, and the all-newborn overshoot.

Full serial suite: **360/360 suites, 4149 passed, 0 failures.** 31 adjacent memory suites checked separately first. Typecheck clean.

Credit to @markthebest12 — the report's field data (169/171 sub-1.0 writes lost, the 1.0-survival split, the `sqlite_sequence` insert-then-delete proof) is what let this go from filed to fixed in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
