### PR TITLE
feat(memory): operator-configurable memory caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,10 @@ All config lives in `~/.shieldcortex/config.json`:
       "enabled": true
     }
   ],
+  "memory": {
+    "maxLongTermMemories": 5000,
+    "maxShortTermMemories": 250
+  },
   "expiryRules": [
     { "category": "todo", "maxAgeDays": 30 },
     { "category": "architecture", "protect": true }
@@ -873,7 +877,12 @@ All config lives in `~/.shieldcortex/config.json`:
 }
 ```
 
-Full reference: [docs/configuration.md](docs/configuration.md)
+**`memory`** — the caps at which ShieldCortex starts evicting. Once a store
+reaches its cap, every new memory that is kept permanently evicts an older one,
+so this is the point at which the product begins forgetting on your behalf.
+Defaults are `1000` long-term / `100` short-term. Values below `10` are refused
+(a cap of `0` would evict the whole store) and any invalid value falls back to
+the default with a warning on stderr — it is never silently ignored.
 
 </details>
 

--- a/src/__tests__/configurable-caps-wiring.test.ts
+++ b/src/__tests__/configurable-caps-wiring.test.ts
@@ -1,0 +1,125 @@
+import { createHmac, randomUUID } from 'node:crypto';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { initDatabase, closeDatabase, getDatabase } from '../database/init.js';
+import { enforceMemoryLimits } from '../memory/consolidate.js';
+import { __resetCapWarningsForTest } from '../memory/config.js';
+
+/**
+ * Configurable caps — the WIRING half.
+ *
+ * `resolveMemoryConfig` is unit-tested separately; that proves nothing about
+ * whether anything CONSULTS it. A correct policy function with no working call
+ * site is the exact defect this repo shipped in #222, #226 and #233 — and the
+ * failure would be silent here too: the operator raises their cap, the store
+ * keeps evicting at 1000, and nothing says otherwise.
+ *
+ * These drive the REAL `enforceMemoryLimits()` with NO config argument, so the
+ * default parameter — and therefore the resolver — is what decides.
+ */
+
+const originalConfigDir = process.env.SHIELDCORTEX_CONFIG_DIR;
+let tempDir: string;
+let configDir: string;
+
+function writeConfig(obj: unknown): void {
+  const key = 'a'.repeat(64);
+  writeFileSync(join(configDir, '.integrity-key'), key, { mode: 0o600 });
+  const body = JSON.stringify(obj, null, 2) + '\n';
+  writeFileSync(join(configDir, 'config.json'), body);
+  const sig = createHmac('sha256', key).update(body, 'utf-8').digest('hex');
+  writeFileSync(join(configDir, '.config-sig'), sig, { mode: 0o600 });
+}
+
+const DAYS = 86_400_000;
+function sqliteTs(agoMs: number): string {
+  return new Date(Date.now() - agoMs).toISOString().slice(0, 19).replace('T', ' ');
+}
+
+/** Seed an evictable long-term row: old enough to clear #236's grace window. */
+function seedEvictable(n: number): void {
+  const db = getDatabase();
+  const stmt = db.prepare(`
+    INSERT INTO memories (uuid, type, category, title, content, salience, access_count, last_accessed, created_at)
+    VALUES (?, 'long_term', 'note', ?, 'seeded', 1.0, 0, ?, ?)
+  `);
+  for (let i = 0; i < n; i++) {
+    stmt.run(randomUUID(), `row ${i}`, sqliteTs((10 + i) * DAYS), sqliteTs((30 + i) * DAYS));
+  }
+}
+
+function longTermCount(): number {
+  return (getDatabase().prepare("SELECT COUNT(*) AS n FROM memories WHERE type='long_term'").get() as { n: number }).n;
+}
+
+describe('configurable caps — the resolver is actually consulted', () => {
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sc-caps-wiring-'));
+    configDir = join(tempDir, '.shieldcortex');
+    mkdirSync(configDir, { recursive: true });
+    process.env.SHIELDCORTEX_CONFIG_DIR = configDir;
+    __resetCapWarningsForTest();
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalConfigDir === undefined) delete process.env.SHIELDCORTEX_CONFIG_DIR;
+    else process.env.SHIELDCORTEX_CONFIG_DIR = originalConfigDir;
+  });
+
+  it('a RAISED cap actually stops eviction — called with no config argument', () => {
+    // 120 rows: over the built-in 100 short-term default's sibling long-term
+    // default? No — well under 1000, so nothing should be evicted anyway.
+    // The real test is a LOWERED cap below the row count (next case). Here we
+    // prove a raised cap is honoured by lowering the row count under it.
+    writeConfig({ memory: { maxLongTermMemories: 20 } });
+    seedEvictable(25);
+    expect(longTermCount()).toBe(25);
+
+    const deleted = enforceMemoryLimits(); // ← no argument: default param decides
+
+    expect(deleted).toBe(5);
+    expect(longTermCount()).toBe(20);
+  });
+
+  it('WITHOUT the override the built-in default applies (25 rows ≪ 1000 ⇒ no eviction)', () => {
+    // Same 25 rows, no memory block: the 1000 default means nothing is evicted.
+    // Contrast with the case above — this is what proves the config, and not
+    // some incidental change, moved the behaviour.
+    writeConfig({ cloudEnabled: false });
+    seedEvictable(25);
+
+    const deleted = enforceMemoryLimits();
+
+    expect(deleted).toBe(0);
+    expect(longTermCount()).toBe(25);
+  });
+
+  it('a REFUSED cap (0) falls back to the default rather than wiping the store', () => {
+    // End-to-end proof of the safety property: the operator writes a zero, and
+    // the store survives intact.
+    writeConfig({ memory: { maxLongTermMemories: 0 } });
+    seedEvictable(25);
+
+    const deleted = enforceMemoryLimits();
+
+    expect(deleted).toBe(0);
+    expect(longTermCount()).toBe(25);
+  });
+
+  it('an explicit config argument still wins over the file', () => {
+    // Callers that pass a config (tests, the MCP server's own resolved config)
+    // must not be silently overridden by the file.
+    writeConfig({ memory: { maxLongTermMemories: 20 } });
+    seedEvictable(25);
+
+    const deleted = enforceMemoryLimits({ maxLongTermMemories: 24, maxShortTermMemories: 100 } as never);
+
+    expect(deleted).toBe(1);
+    expect(longTermCount()).toBe(24);
+  });
+});

--- a/src/__tests__/configurable-memory-caps.test.ts
+++ b/src/__tests__/configurable-memory-caps.test.ts
@@ -1,0 +1,224 @@
+import { createHmac } from 'node:crypto';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { resolveMemoryConfig, validateCap, MIN_MEMORY_CAP, __resetCapWarningsForTest } from '../memory/config.js';
+import { DEFAULT_CONFIG } from '../memory/types.js';
+
+/**
+ * Operator-configurable memory caps — follow-up to #236 (suggestion 4).
+ *
+ * `maxShortTermMemories`/`maxLongTermMemories` were hardcoded in
+ * `DEFAULT_CONFIG` with no user-config path, so raising the ceiling meant
+ * editing `dist/`. That ceiling is not cosmetic: once a store reaches it, every
+ * surviving write permanently evicts an older memory, so it is the point at
+ * which the product starts forgetting on the operator's behalf.
+ *
+ * The properties pinned here, in order of how much damage getting them wrong
+ * would do:
+ *   1. A cap of 0/negative is REFUSED, not honoured. Honouring it would make
+ *      the next enforcement pass a store-wipe — an operator fat-fingering a
+ *      zero must not lose their memory.
+ *   2. Invalid values fall back to the default and are refused LOUDLY. A
+ *      silently-ignored config key is the #225 defect class: the operator
+ *      believes they configured something and nothing says otherwise.
+ *   3. No config, unreadable config, or a malformed block ⇒ exactly today's
+ *      defaults. This sits on the write path; it must never throw.
+ *
+ * Harness follows expiry-rules.test.ts: a fresh SHIELDCORTEX_CONFIG_DIR per
+ * test (so readRawConfig's mtime cache cannot serve a stale read between
+ * cases) with an integrity-signed body (so the reader does not fall back to
+ * tamper mode instead of parsing what we wrote).
+ */
+
+const originalConfigDir = process.env.SHIELDCORTEX_CONFIG_DIR;
+let tempDir: string;
+let configDir: string;
+
+/** Write an integrity-signed config.json the reader will actually trust. */
+function writeConfig(obj: unknown): void {
+  const key = 'a'.repeat(64);
+  writeFileSync(join(configDir, '.integrity-key'), key, { mode: 0o600 });
+  const body = JSON.stringify(obj, null, 2) + '\n';
+  writeFileSync(join(configDir, 'config.json'), body);
+  const sig = createHmac('sha256', key).update(body, 'utf-8').digest('hex');
+  writeFileSync(join(configDir, '.config-sig'), sig, { mode: 0o600 });
+}
+
+/** Write a body that is not valid JSON at all (still signed, so the failure
+ *  under test is the PARSE, not the integrity check). */
+function writeRawConfigBody(body: string): void {
+  const key = 'a'.repeat(64);
+  writeFileSync(join(configDir, '.integrity-key'), key, { mode: 0o600 });
+  writeFileSync(join(configDir, 'config.json'), body);
+  const sig = createHmac('sha256', key).update(body, 'utf-8').digest('hex');
+  writeFileSync(join(configDir, '.config-sig'), sig, { mode: 0o600 });
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'sc-mem-caps-'));
+  configDir = join(tempDir, '.shieldcortex');
+  mkdirSync(configDir, { recursive: true });
+  process.env.SHIELDCORTEX_CONFIG_DIR = configDir;
+  __resetCapWarningsForTest();
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  if (originalConfigDir === undefined) delete process.env.SHIELDCORTEX_CONFIG_DIR;
+  else process.env.SHIELDCORTEX_CONFIG_DIR = originalConfigDir;
+});
+
+describe('configurable caps — the happy path', () => {
+  it('honours a raised long-term cap from the memory block', () => {
+    writeConfig({ memory: { maxLongTermMemories: 5000 } });
+    expect(resolveMemoryConfig().maxLongTermMemories).toBe(5000);
+  });
+
+  it('honours a raised short-term cap', () => {
+    writeConfig({ memory: { maxShortTermMemories: 250 } });
+    expect(resolveMemoryConfig().maxShortTermMemories).toBe(250);
+  });
+
+  it('leaves every other MemoryConfig field untouched', () => {
+    writeConfig({ memory: { maxLongTermMemories: 5000 } });
+    const resolved = resolveMemoryConfig();
+    expect(resolved.decayRate).toBe(DEFAULT_CONFIG.decayRate);
+    expect(resolved.consolidationThreshold).toBe(DEFAULT_CONFIG.consolidationThreshold);
+    expect(resolved.ranker).toEqual(DEFAULT_CONFIG.ranker);
+    expect(resolved.maxShortTermMemories).toBe(DEFAULT_CONFIG.maxShortTermMemories);
+  });
+
+  it('does not mutate DEFAULT_CONFIG', () => {
+    // A shared module-level object edited in place would leak the override into
+    // every other consumer in the process.
+    writeConfig({ memory: { maxLongTermMemories: 9999 } });
+    resolveMemoryConfig();
+    expect(DEFAULT_CONFIG.maxLongTermMemories).toBe(1000);
+  });
+});
+
+describe('configurable caps — a bad value must never wipe the store', () => {
+  it('REFUSES a cap of 0 — honouring it would evict everything', () => {
+    // The whole reason validation exists: enforceMemoryLimits with cap 0 would
+    // delete every eligible row on the next pass.
+    writeConfig({ memory: { maxLongTermMemories: 0 } });
+    expect(resolveMemoryConfig().maxLongTermMemories).toBe(DEFAULT_CONFIG.maxLongTermMemories);
+  });
+
+  it('REFUSES a negative cap', () => {
+    writeConfig({ memory: { maxLongTermMemories: -50 } });
+    expect(resolveMemoryConfig().maxLongTermMemories).toBe(DEFAULT_CONFIG.maxLongTermMemories);
+  });
+
+  it('REFUSES anything below the documented minimum', () => {
+    writeConfig({ memory: { maxLongTermMemories: MIN_MEMORY_CAP - 1 } });
+    expect(resolveMemoryConfig().maxLongTermMemories).toBe(DEFAULT_CONFIG.maxLongTermMemories);
+  });
+
+  it('accepts exactly the minimum', () => {
+    writeConfig({ memory: { maxLongTermMemories: MIN_MEMORY_CAP } });
+    expect(resolveMemoryConfig().maxLongTermMemories).toBe(MIN_MEMORY_CAP);
+  });
+
+  it('refuses a numeric STRING rather than coercing it', () => {
+    // Matches the `=== true` discipline used for config booleans: a value the
+    // loader silently reinterprets is one the operator cannot reason about.
+    writeConfig({ memory: { maxLongTermMemories: '5000' } });
+    expect(resolveMemoryConfig().maxLongTermMemories).toBe(DEFAULT_CONFIG.maxLongTermMemories);
+  });
+
+  it('refuses fractional, NaN and Infinity', () => {
+    for (const bad of [10.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      __resetCapWarningsForTest();
+      writeConfig({ memory: { maxLongTermMemories: bad } });
+      expect(resolveMemoryConfig().maxLongTermMemories).toBe(DEFAULT_CONFIG.maxLongTermMemories);
+    }
+  });
+
+  it('rejects a bad value LOUDLY — a silently-ignored key is the #225 defect class', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      writeConfig({ memory: { maxLongTermMemories: 0 } });
+      resolveMemoryConfig();
+      const said = warn.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(said).toMatch(/maxLongTermMemories/);
+      expect(said.toLowerCase()).toMatch(/ignoring|default/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('warns once per key, not once per write', () => {
+    // This sits on the write path; a warning per insert would be a log flood.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      writeConfig({ memory: { maxLongTermMemories: -1 } });
+      resolveMemoryConfig();
+      resolveMemoryConfig();
+      resolveMemoryConfig();
+      const hits = warn.mock.calls.filter((c) => String(c[0]).includes('maxLongTermMemories'));
+      expect(hits).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('a bad value for one cap does not discard a good value for the other', () => {
+    writeConfig({ memory: { maxLongTermMemories: 4000, maxShortTermMemories: -5 } });
+    const resolved = resolveMemoryConfig();
+    expect(resolved.maxLongTermMemories).toBe(4000);
+    expect(resolved.maxShortTermMemories).toBe(DEFAULT_CONFIG.maxShortTermMemories);
+  });
+});
+
+describe('configurable caps — absent or broken config yields today\'s behaviour', () => {
+  it('no config file at all ⇒ defaults', () => {
+    // Fresh temp config dir, nothing written.
+    expect(resolveMemoryConfig()).toEqual(DEFAULT_CONFIG);
+  });
+
+  it('config without a memory block ⇒ defaults', () => {
+    writeConfig({ cloudEnabled: false });
+    expect(resolveMemoryConfig().maxLongTermMemories).toBe(DEFAULT_CONFIG.maxLongTermMemories);
+  });
+
+  it('a memory block of the wrong shape ⇒ defaults, no throw', () => {
+    for (const junk of ['nope', 42, [], null]) {
+      expect(() => resolveMemoryConfig()).not.toThrow();
+      writeConfig({ memory: junk });
+      expect(resolveMemoryConfig().maxLongTermMemories).toBe(DEFAULT_CONFIG.maxLongTermMemories);
+    }
+  });
+
+  it('unparseable JSON ⇒ defaults, no throw (never block a write on config)', () => {
+    writeRawConfigBody('{ this is not json');
+    expect(() => resolveMemoryConfig()).not.toThrow();
+    expect(resolveMemoryConfig().maxLongTermMemories).toBe(DEFAULT_CONFIG.maxLongTermMemories);
+  });
+});
+
+describe('validateCap — the unit contract', () => {
+  it('passes through a valid whole number at or above the minimum', () => {
+    expect(validateCap(5000)).toBe(5000);
+    expect(validateCap(MIN_MEMORY_CAP)).toBe(MIN_MEMORY_CAP);
+  });
+
+  it('returns undefined (keep the default) for every invalid shape', () => {
+    for (const bad of [0, -1, 1.5, '100', null, {}, [], true, Number.NaN, Number.POSITIVE_INFINITY]) {
+      __resetCapWarningsForTest();
+      expect(validateCap(bad)).toBeUndefined();
+    }
+  });
+
+  it('treats undefined as "not configured", silently', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(validateCap(undefined)).toBeUndefined();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/src/memory/config.ts
+++ b/src/memory/config.ts
@@ -1,0 +1,114 @@
+/**
+ * Operator-configurable memory caps (#236 follow-up).
+ *
+ * `MemoryConfig` had no user-config path at all: `maxShortTermMemories` and
+ * `maxLongTermMemories` were hardcoded in `DEFAULT_CONFIG` and every call site
+ * defaulted straight to it, so raising the ceiling meant editing `dist/`. On a
+ * store that has reached the cap, every surviving write permanently evicts an
+ * older memory — so the cap is not a soft preference, it is the point at which
+ * the product starts forgetting on the operator's behalf. That number should
+ * be theirs.
+ *
+ * Config lives in `~/.shieldcortex/config.json` under a `memory` block,
+ * matching the existing namespaced-block convention (`actionGuard`,
+ * `interceptor`):
+ *
+ *   { "memory": { "maxLongTermMemories": 5000, "maxShortTermMemories": 250 } }
+ *
+ * Validation fails toward the DEFAULT, never toward destruction. A cap of 0 or
+ * a negative would make `enforceMemoryLimits` evict the entire store on the
+ * next pass, so anything below MIN_MEMORY_CAP is refused rather than honoured —
+ * an operator fat-fingering a zero must not lose their memory.
+ *
+ * Invalid values are refused LOUDLY (once per process). A config key that is
+ * silently ignored is the same class of defect as #225: the operator believes
+ * they have configured something, and nothing tells them otherwise.
+ */
+
+import { readRawConfig } from '../cloud/config.js';
+import { DEFAULT_CONFIG, type MemoryConfig } from './types.js';
+
+/**
+ * Lowest cap an operator may set. Below this, `enforceMemoryLimits` would be a
+ * store-wipe rather than a bound.
+ */
+export const MIN_MEMORY_CAP = 10;
+
+/** Keys accepted inside the `memory` block. */
+const CAP_KEYS = ['maxShortTermMemories', 'maxLongTermMemories'] as const;
+type CapKey = (typeof CAP_KEYS)[number];
+
+/** Warn at most once per key per process — this is read on every write path. */
+const warned = new Set<string>();
+
+function warnOnce(key: string, message: string): void {
+  if (warned.has(key)) return;
+  warned.add(key);
+  console.warn(`[shieldcortex] ${message}`);
+}
+
+/** Reset the once-per-process warning state. Tests only. */
+export function __resetCapWarningsForTest(): void {
+  warned.clear();
+}
+
+/** The `memory` block from raw config, or an empty object. Mirrors actionGuardBlock. */
+function memoryBlock(raw: Record<string, unknown>): Record<string, unknown> {
+  return raw.memory && typeof raw.memory === 'object' && !Array.isArray(raw.memory)
+    ? (raw.memory as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Validate one cap override. Returns undefined (keep the default) for anything
+ * that is not a finite, whole number at or above MIN_MEMORY_CAP.
+ *
+ * Deliberately strict about type: a JSON string `"5000"` is refused rather than
+ * coerced, matching the `=== true` discipline used for the config booleans. A
+ * config value the loader silently reinterprets is a config value the operator
+ * cannot reason about.
+ */
+export function validateCap(value: unknown, key: string = 'cap'): number | undefined {
+  if (value === undefined) return undefined;
+
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    warnOnce(key, `memory.${key} must be a number — ignoring ${JSON.stringify(value)} and using the default.`);
+    return undefined;
+  }
+  if (!Number.isInteger(value)) {
+    warnOnce(key, `memory.${key} must be a whole number — ignoring ${value} and using the default.`);
+    return undefined;
+  }
+  if (value < MIN_MEMORY_CAP) {
+    warnOnce(
+      key,
+      `memory.${key}=${value} is below the minimum of ${MIN_MEMORY_CAP} and would evict the whole store — ignoring it and using the default.`,
+    );
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * `DEFAULT_CONFIG` with any valid operator overrides from the `memory` block
+ * applied. Never throws: an unreadable or malformed config yields the defaults,
+ * because failing to parse config must not stop memories being stored.
+ *
+ * `readRawConfig()` is mtime-cached, so this is cheap enough to sit on the
+ * write path as a default parameter.
+ */
+export function resolveMemoryConfig(base: MemoryConfig = DEFAULT_CONFIG): MemoryConfig {
+  let block: Record<string, unknown>;
+  try {
+    block = memoryBlock(readRawConfig());
+  } catch {
+    return base;
+  }
+
+  const resolved: MemoryConfig = { ...base };
+  for (const key of CAP_KEYS) {
+    const override = validateCap(block[key], key);
+    if (override !== undefined) resolved[key satisfies CapKey] = override;
+  }
+  return resolved;
+}

--- a/src/memory/consolidate.ts
+++ b/src/memory/consolidate.ts
@@ -10,6 +10,7 @@
 
 import type Database from 'better-sqlite3';
 import { getDatabase, withTransaction } from '../database/init.js';
+import { resolveMemoryConfig } from './config.js';
 import { expireQuarantineItems } from '../defence/quarantine/auto-expire.js';
 import { guardReadRows } from '../defence/trust/read-guard.js';
 import type { DefenceSource } from '../defence/types.js';
@@ -62,7 +63,7 @@ import { computeEffectiveSalience } from '../../scripts/lib/salience.mjs';
  * This is like the brain's sleep consolidation - should be run periodically
  */
 export function consolidate(
-  config: MemoryConfig = DEFAULT_CONFIG
+  config: MemoryConfig = resolveMemoryConfig()
 ): ConsolidationResult {
   // Wrap entire consolidation in a transaction for atomicity
   return withTransaction(() => {
@@ -614,7 +615,7 @@ function pickEvictionVictims(
  * Removes the lowest-effective-salience eligible memories when limits are
  * exceeded — never newborns, never pinned rows (see pickEvictionVictims/#236).
  */
-export function enforceMemoryLimits(config: MemoryConfig = DEFAULT_CONFIG): number {
+export function enforceMemoryLimits(config: MemoryConfig = resolveMemoryConfig()): number {
   // Note: If called within consolidate(), this is already in a transaction
   // If called standalone, we wrap it for safety
   const db = getDatabase();

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -28,6 +28,7 @@ import {
   extractTags,
   analyzeSalienceFactors,
 } from './salience.js';
+import { resolveMemoryConfig } from './config.js';
 import { calculateDecayedScore } from './decay.js';
 import {
   emitMemoryCreated,
@@ -443,7 +444,7 @@ function quarantineMemory(input: MemoryInput, source: DefenceSource, result: Def
  */
 export function addMemory(
   input: MemoryInput,
-  config: MemoryConfig = DEFAULT_CONFIG,
+  config: MemoryConfig = resolveMemoryConfig(),
   source?: DefenceSource
 ): Memory {
   // Check if memory creation is paused
@@ -1234,7 +1235,7 @@ export function deleteMemory(
  */
 export function getProjectMemories(
   project: string,
-  config: MemoryConfig = DEFAULT_CONFIG
+  config: MemoryConfig = resolveMemoryConfig()
 ): Memory[] {
   const db = getDatabase();
   const rows = db.prepare(`

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { initDatabase } from './database/init.js';
-import { DEFAULT_CONFIG } from './memory/types.js';
+import { resolveMemoryConfig } from './memory/config.js';
 import { getCurrentVersion } from './api/version.js';
 import {
   initProjectContext,
@@ -203,8 +203,10 @@ export function checkAndTriggerKillSwitch(text: string, source: string): boolean
  * Create and configure the MCP server
  */
 export function createServer(dbPath?: string): McpServer {
-  // Initialize database
-  const config = { ...DEFAULT_CONFIG };
+  // Initialize database. Caps come from the operator's `memory` block when set
+  // (see memory/config.ts) — the ceiling at which the product starts forgetting
+  // on their behalf should be theirs to choose.
+  const config = resolveMemoryConfig();
   if (dbPath) {
     config.dbPath = dbPath;
   }


### PR DESCRIPTION
Follow-up to #236 (suggestion 4).

## Why

`maxShortTermMemories`/`maxLongTermMemories` were hardcoded in `DEFAULT_CONFIG` with no user-config path — every call site defaulted straight to it — so raising the ceiling meant **editing `dist/`**.

That ceiling is not cosmetic. Once a store reaches the cap, every write that survives **permanently evicts an older memory**, so it is the point at which the product starts forgetting on the operator's behalf. That number should be theirs.

## Config

`~/.shieldcortex/config.json`, under a `memory` block matching the existing namespaced-block convention (`actionGuard`, `interceptor`):

```json
{ "memory": { "maxLongTermMemories": 5000, "maxShortTermMemories": 250 } }
```

## Validation fails toward the DEFAULT, never toward destruction

| Input | Result |
|---|---|
| `0` / negative / below `MIN_MEMORY_CAP` (10) | **refused** — would make the next `enforceMemoryLimits` pass a store-WIPE |
| `"5000"` (numeric string) | refused, not coerced |
| fractional / NaN / Infinity | refused |
| wrong-typed `memory` block, unparseable JSON, missing file | today's defaults, no throw |

An operator fat-fingering a zero must not lose their memory — and that is proven **end-to-end** (write `0` → run real eviction → store intact), not merely at the unit level.

Numeric strings are refused rather than coerced, matching the `=== true` discipline used for the config booleans: a value the loader silently reinterprets is one the operator cannot reason about.

**Invalid values are refused LOUDLY** (once per key per process, since this is per-write). A silently-ignored config key is the #225 defect class — the operator believes they configured something and nothing says otherwise.

Never throws: this sits on the write path, so a broken config must not block a memory being stored.

## Wiring

The resolver replaces the `DEFAULT_CONFIG` default parameter on the cap-relevant chain — `addMemory`, `consolidate()`, `enforceMemoryLimits` — plus `createServer()`.

`consolidate()` had to change too: it passes its own config down to `enforceMemoryLimits`, so leaving its default as `DEFAULT_CONFIG` would have bypassed the resolver on the scheduled path. An explicit argument still wins over the file.

## Tests

**24 total — 20 policy, 4 wiring.** The wiring tests call `enforceMemoryLimits()` **with no argument**, so the default parameter (and therefore the resolver) is what decides. A correct resolver with no call site is the exact defect shipped in #222, #226 and #233 — and it would be silent here too: the operator raises their cap, the store keeps evicting at 1000, and nothing says otherwise.

Harness follows `expiry-rules.test.ts` — a fresh `SHIELDCORTEX_CONFIG_DIR` per test with an integrity-signed body, so neither the mtime cache nor tamper-mode fallback can mask a result.

Full serial suite: **362/362 suites, 4173 passed, 0 failures.** Typecheck clean.

## Incidental

README linked to `docs/configuration.md`, **which does not exist**. Replaced the dead link with the actual documentation inline, rather than leaving a broken pointer or stubbing a file to satisfy it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)