### PR TITLE
fix(#218): create state-tree paths owner-only, at creation

### DIFF
--- a/scripts/lib/precompact-log.mjs
+++ b/scripts/lib/precompact-log.mjs
@@ -19,6 +19,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
+import { mkdirSecure } from './state-perms.mjs';
 import { homedir } from 'os';
 import { join } from 'path';
 
@@ -39,7 +40,7 @@ function logPath(index) {
 function ensureDir() {
   const dir = logDir();
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+    mkdirSecure(dir);
   }
 }
 

--- a/scripts/lib/recall-log.mjs
+++ b/scripts/lib/recall-log.mjs
@@ -30,6 +30,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
+import { mkdirSecure } from './state-perms.mjs';
 import { homedir } from 'os';
 import { join } from 'path';
 
@@ -50,7 +51,7 @@ function logPath(index) {
 function ensureDir() {
   const dir = logDir();
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+    mkdirSecure(dir);
   }
 }
 

--- a/scripts/lib/state-perms.mjs
+++ b/scripts/lib/state-perms.mjs
@@ -1,0 +1,28 @@
+// scripts/lib/state-perms.mjs
+//
+// #218 — the .mjs half of "create state-tree paths already owner-only".
+//
+// The TS source has src/setup/state-permissions.ts (SECURE_DIR_MODE 0o700,
+// SECURE_OPEN_MODE 0o600, mkdirSecure). The hooks and the installer are a
+// separate build that cannot import from src/, so the same two modes live here
+// as the ONE source of truth for the script side — no bare 0o700 literal
+// scattered across six hooks.
+//
+// Why it matters: mkdir's mode binds only at CREATION and is ignored for a dir
+// that already exists, and open(2)/writeFile without a mode use 0666 & ~umask
+// (644, or 664 under umask 002). Every path a hook or the installer recreates
+// after the install-time hardening pass would otherwise land loose again, and
+// doctor fails on it after the next gateway restart.
+
+import { mkdirSync } from 'node:fs';
+
+/** Owner-only directory mode. Mirrors SECURE_DIR_MODE. */
+export const STATE_DIR_MODE = 0o700;
+
+/** Owner-only file mode for openSync/writeFileSync. Mirrors SECURE_FILE_MODE. */
+export const STATE_FILE_MODE = 0o600;
+
+/** Create a directory (and parents) inside the state tree already owner-only. */
+export function mkdirSecure(dir) {
+  mkdirSync(dir, { recursive: true, mode: STATE_DIR_MODE });
+}

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -10,6 +10,7 @@
  *   - Running as a local/dev install (npm_config_global !== 'true')
  */
 import { existsSync, copyFileSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirSecure, STATE_FILE_MODE } from './lib/state-perms.mjs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { spawnSync } from 'child_process';
@@ -40,12 +41,12 @@ function writeFreshInstallDefaults() {
   if (existsSync(configFile)) return false;
 
   try {
-    mkdirSync(configDir, { recursive: true });
+    mkdirSecure(configDir);
     const defaults = {
       openclawAutoMemory: true,
       proactiveRecall: true,
     };
-    writeFileSync(configFile, JSON.stringify(defaults, null, 2) + '\n');
+    writeFileSync(configFile, JSON.stringify(defaults, null, 2) + '\n', { mode: STATE_FILE_MODE });
     return true;
   } catch {
     return false;

--- a/scripts/pre-compact-hook.mjs
+++ b/scripts/pre-compact-hook.mjs
@@ -12,6 +12,7 @@
  */
 
 import Database from 'better-sqlite3';
+import { mkdirSecure } from './lib/state-perms.mjs';
 import { existsSync, mkdirSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -141,7 +142,7 @@ process.stdin.on('end', async () => {
 
     // Ensure database directory exists
     if (!existsSync(DB_DIR)) {
-      mkdirSync(DB_DIR, { recursive: true });
+      mkdirSecure(DB_DIR);
     }
 
     // Check if database exists

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -49,6 +49,7 @@
  */
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
+import { mkdirSecure } from './lib/state-perms.mjs';
 import { dirname, join, resolve } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -635,7 +636,7 @@ function summariseToolArgs(args) {
 function writeAuditEntry(toolName, verdict, args, action, outcome, extra = {}) {
   try {
     const auditDir = join(homedir(), '.shieldcortex', 'audit');
-    mkdirSync(auditDir, { recursive: true });
+    mkdirSecure(auditDir);
     const date = new Date().toISOString().slice(0, 10);
     const entry = {
       type: 'intercept',

--- a/scripts/prompt-recall-hook.mjs
+++ b/scripts/prompt-recall-hook.mjs
@@ -10,6 +10,7 @@
  */
 
 import Database from 'better-sqlite3';
+import { mkdirSecure } from './lib/state-perms.mjs';
 import { createHash } from 'crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
@@ -255,7 +256,7 @@ function loadDedupState() {
 
 function saveDedupState(state) {
   try {
-    mkdirSync(join(homedir(), '.shieldcortex'), { recursive: true });
+    mkdirSecure(join(homedir(), '.shieldcortex'));
     writeFileSync(RECALL_DEDUP_PATH, JSON.stringify(state), { mode: 0o600 });
   } catch {
     // Best-effort.

--- a/scripts/session-end-hook.mjs
+++ b/scripts/session-end-hook.mjs
@@ -22,6 +22,7 @@
  */
 
 import Database from 'better-sqlite3';
+import { mkdirSecure } from './lib/state-perms.mjs';
 import { existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -183,7 +184,7 @@ process.stdin.on('end', async () => {
       if (conversationText && conversationText.length >= 100) {
         // Ensure database directory exists
         if (!existsSync(DB_DIR)) {
-          mkdirSync(DB_DIR, { recursive: true });
+          mkdirSecure(DB_DIR);
         }
 
         if (!existsSync(DB_PATH)) {

--- a/scripts/stop-hook.mjs
+++ b/scripts/stop-hook.mjs
@@ -17,6 +17,7 @@
  */
 
 import Database from 'better-sqlite3';
+import { mkdirSecure } from './lib/state-perms.mjs';
 import { existsSync, mkdirSync, openSync, readSync, closeSync, statSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -55,7 +56,7 @@ function logDisabledOnceForSession(sessionId, reason) {
     return;
   }
   try {
-    mkdirSync(STOP_DISABLED_SENTINEL_DIR, { recursive: true });
+    mkdirSecure(STOP_DISABLED_SENTINEL_DIR);
     const sentinel = join(STOP_DISABLED_SENTINEL_DIR, sessionId.replace(/[^a-zA-Z0-9_.-]/g, '_'));
     if (existsSync(sentinel)) return;
     writeFileSync(sentinel, new Date().toISOString(), { mode: 0o600 });

--- a/src/__tests__/state-permissions-at-create-218.test.ts
+++ b/src/__tests__/state-permissions-at-create-218.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, rmSync, mkdirSync, statSync, openSync, closeSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  mkdirSecure,
+  SECURE_OPEN_MODE,
+  SECURE_DIR_MODE,
+  secureStatePermissions,
+} from '../setup/state-permissions.js';
+
+/**
+ * #218 — create state-tree paths owner-only at CREATION, so a runtime that
+ * recreates a lock file or a log dir after the install-time hardening pass no
+ * longer lands loose and fails doctor after every gateway restart.
+ *
+ * The reported loop: closeDatabase() unlinks memories.db.lock on every clean
+ * shutdown; initDatabase() recreates it via openSync('wx'). With no mode that
+ * is 0666 & ~umask (644/664), which auditStatePermissions flags and doctor
+ * turns into a hard fail — green, one restart, red, forever.
+ *
+ * These assert the two create primitives, and that secureStatePermissions
+ * still retro-tightens an already-loose path (the create-mode cannot, so the
+ * install/update/repair pass is still load-bearing).
+ *
+ * mode & 0o777 masks the file-type bits; skipped on Windows where POSIX modes
+ * are not meaningful.
+ */
+const isWindows = process.platform === 'win32';
+const d = isWindows ? describe.skip : describe;
+
+function modeOf(p: string): number {
+  return statSync(p).mode & 0o777;
+}
+
+d('#218 — owner-only at creation', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'sc-perms-218-')); });
+  afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+  it('mkdirSecure creates a directory at 0700', () => {
+    const dir = join(root, 'audit');
+    mkdirSecure(dir);
+    expect(modeOf(dir)).toBe(SECURE_DIR_MODE);
+    expect(modeOf(dir)).toBe(0o700);
+  });
+
+  it('mkdirSecure applies the mode to every parent it creates', () => {
+    // recursive mkdir sets the mode on each level it makes — the whole new
+    // subtree is owner-only, not just the leaf.
+    const nested = join(root, 'a', 'b', 'c');
+    mkdirSecure(nested);
+    expect(modeOf(join(root, 'a'))).toBe(0o700);
+    expect(modeOf(join(root, 'a', 'b'))).toBe(0o700);
+    expect(modeOf(nested)).toBe(0o700);
+  });
+
+  it('a file opened with SECURE_OPEN_MODE lands at 0600 — the lock-file fix', () => {
+    // Mirrors init.ts acquireStartupLock: openSync(path, 'wx', SECURE_OPEN_MODE).
+    const lock = join(root, 'memories.db.lock');
+    const fd = openSync(lock, 'wx', SECURE_OPEN_MODE);
+    closeSync(fd);
+    expect(modeOf(lock)).toBe(0o600);
+  });
+
+  it('reproduces the reported regression: a mode-LESS open lands loose', () => {
+    // The bug, pinned so a future edit that drops the mode arg is caught here.
+    const lock = join(root, 'loose.lock');
+    const fd = openSync(lock, 'wx');   // no mode — 0666 & ~umask
+    closeSync(fd);
+    expect(modeOf(lock) & 0o077).not.toBe(0);   // group/other bits present
+  });
+});
+
+d('#218 — the create-mode does NOT retro-tighten, so the pass is still needed', () => {
+  let root: string;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'sc-perms-218b-')); });
+  afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+  it('mkdirSecure is a no-op on a directory that already exists loose', () => {
+    // This is WHY secureStatePermissions must keep running on install/update/
+    // repair: a box hardened loose once cannot self-correct via create-mode.
+    const dir = join(root, 'audit');
+    mkdirSync(dir, { mode: 0o777 });
+    const before = modeOf(dir);
+    mkdirSecure(dir);
+    expect(modeOf(dir)).toBe(before);   // unchanged — mkdir mode ignored for existing
+    expect(modeOf(dir) & 0o077).not.toBe(0);
+  });
+
+  it('secureStatePermissions retro-tightens the loose dir', () => {
+    // The repair/install/update leg: given the loose dir above, the pass fixes it.
+    mkdirSync(join(root, 'audit'), { mode: 0o777 });
+    const findings = secureStatePermissions(root);
+    expect(findings.some(f => f.path.endsWith('audit') && f.fixed)).toBe(true);
+    expect(modeOf(join(root, 'audit')) & 0o077).toBe(0);
+  });
+});

--- a/src/api/session-token.ts
+++ b/src/api/session-token.ts
@@ -7,6 +7,7 @@
  */
 
 import { randomBytes, timingSafeEqual } from 'crypto';
+import { mkdirSecure } from '../setup/state-permissions.js';
 import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -23,7 +24,7 @@ let cachedToken: string | null = null;
  */
 export function generateSessionToken(): string {
   const token = randomBytes(32).toString('hex');
-  mkdirSync(CONFIG_DIR, { recursive: true });
+  mkdirSecure(CONFIG_DIR);
   writeFileSync(TOKEN_FILE, token, { mode: 0o600 });
   try {
     chmodSync(TOKEN_FILE, 0o600);

--- a/src/audit/dependency-scanner.ts
+++ b/src/audit/dependency-scanner.ts
@@ -20,6 +20,7 @@
  */
 
 import { readdirSync, readFileSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSecure } from '../setup/state-permissions.js';
 import { join, resolve } from 'path';
 import { execSync } from 'child_process';
 import { homedir } from 'os';
@@ -306,7 +307,7 @@ export function quarantinePackage(
   const destDir = join(quarantineBase, `${safeName}-${timestamp}`);
   const pkgDestDir = join(destDir, 'pkg');
 
-  mkdirSync(destDir, { recursive: true });
+  mkdirSecure(destDir);
 
   // Move the package directory
   renameSync(srcPath, pkgDestDir);

--- a/src/cli/__tests__/repair-hardens-permissions-218.test.ts
+++ b/src/cli/__tests__/repair-hardens-permissions-218.test.ts
@@ -1,0 +1,69 @@
+/**
+ * #218 wiring — `shieldcortex repair` must re-harden the state tree.
+ *
+ * doctor's permission check fails after a gateway restart (a recreated lock
+ * file / log dir under default umask), and doctor's own fix text points the
+ * operator at `repair`. Before this, `repair` ran only the native-binding and
+ * plugin-reconcile passes — so the command doctor recommended did not correct
+ * what doctor failed on: the exact one-call-site gap of #222/#103, one layer
+ * over.
+ *
+ * Source-level, in the #171 tradition (update-install-parity-171.test.ts): the
+ * helper `secureStatePermissions` is tested directly in
+ * state-permissions-at-create-218.test.ts; what would rot silently is whether
+ * THIS caller invokes it. A runtime test of `runRepair()` would chmod the real
+ * ~/.shieldcortex.
+ */
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const repairSrc = fs.readFileSync(path.join(repoRoot, 'src', 'cli', 'repair.ts'), 'utf-8');
+
+describe('#218 — repair re-hardens the state tree', () => {
+  it('a state-permission pass exists and calls the shared helper on getConfigDir()', () => {
+    const at = repairSrc.indexOf('function runStatePermissionPass');
+    expect(at).toBeGreaterThanOrEqual(0);
+    const body = repairSrc.slice(at, repairSrc.indexOf('\n}', at));
+    expect(body).toMatch(/secureStatePermissions\(/);
+    // The SAME resolver install/update pass — honours SHIELDCORTEX_CONFIG_DIR,
+    // not a hardcoded homedir subset.
+    expect(body).toMatch(/getConfigDir\(\)/);
+  });
+
+  it('runRepair actually invokes it', () => {
+    const at = repairSrc.indexOf('export async function runRepair');
+    expect(at).toBeGreaterThanOrEqual(0);
+    const body = repairSrc.slice(at, repairSrc.indexOf('\nexport ', at + 1) >= 0 ? repairSrc.indexOf('\nexport ', at + 1) : repairSrc.length);
+    expect(body).toMatch(/runStatePermissionPass\(\)/);
+  });
+
+  it('a permission it could not fix is a hard error, never a false all-clear', () => {
+    const at = repairSrc.indexOf('function runStatePermissionPass');
+    const body = repairSrc.slice(at, repairSrc.indexOf('\n}', at));
+    expect(body).toMatch(/process\.exitCode = 1/);
+  });
+});
+
+describe('#218 — doctor points at repair, and its manual advice is guard-safe', () => {
+  const doctorSrc = fs.readFileSync(path.join(repoRoot, 'src', 'cli', 'doctor.ts'), 'utf-8');
+
+  it('the permission fix recommends `shieldcortex repair`, not a full install', () => {
+    // Find the permission-hardening fix line specifically.
+    const idx = doctorSrc.indexOf("(it re-hardens the state tree)");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    const line = doctorSrc.slice(doctorSrc.lastIndexOf('\n', idx) + 1, doctorSrc.indexOf('\n', idx));
+    expect(line).toMatch(/shieldcortex repair/);
+  });
+
+  it('the manual one-liner does NOT use a `{…}` brace expansion the guard gates', () => {
+    // The touch-approval-store rule fires on the expanded `.shieldcortex/approvals`
+    // path — a brace list would make our own printed advice require approval.
+    const idx = doctorSrc.indexOf("(it re-hardens the state tree)");
+    const line = doctorSrc.slice(doctorSrc.lastIndexOf('\n', idx) + 1, doctorSrc.indexOf('\n', idx));
+    expect(line).not.toMatch(/\{audit|approvals,logs\}/);
+    expect(line).toMatch(/chmod 700 ~\/\.shieldcortex\/audit/);
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3256,7 +3256,13 @@ export async function checkStatePermissions(stateDir: string = getShieldCortexDi
     message:
       `${findings.length} path(s) readable or writable beyond the owner (${worst}${findings.length > 4 ? ', …' : ''}) — ` +
       `the memory database and the audit trail must be owner-only`,
-    fix: 'Run `shieldcortex install` (it hardens on every run), or by hand: chmod 700 ~/.shieldcortex ~/.shieldcortex/{audit,approvals,logs} && chmod 600 ~/.shieldcortex/memories.db* ~/.shieldcortex/config.json*',
+    // #218: point at `repair` — it now re-hardens the state tree directly
+    // (runStatePermissionPass) without rewriting CLAUDE.md/hooks the way a full
+    // `install` does. The manual one-liner uses an explicit `audit approvals
+    // logs` list rather than a `{…}` brace expansion, because the guard's
+    // touch-approval-store rule gates the expanded form (approving our own
+    // printed advice would be its own paper cut).
+    fix: 'Run `shieldcortex repair` (it re-hardens the state tree), or by hand: chmod 700 ~/.shieldcortex && chmod 700 ~/.shieldcortex/audit ~/.shieldcortex/approvals ~/.shieldcortex/logs && chmod 600 ~/.shieldcortex/memories.db* ~/.shieldcortex/config.json*',
   };
 }
 

--- a/src/cli/migrate-legacy.ts
+++ b/src/cli/migrate-legacy.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { mkdirSecure } from '../setup/state-permissions.js';
 import path from 'path';
 import os from 'os';
 import { randomUUID } from 'crypto';
@@ -960,7 +961,7 @@ export async function repairProjectKeys(opts: RepairOptions = {}): Promise<Repai
 
     // 5. Per-rewrite JSON log under ~/.shieldcortex/logs/.
     const logsDir = path.join(os.homedir(), '.shieldcortex', 'logs');
-    fs.mkdirSync(logsDir, { recursive: true });
+    mkdirSecure(logsDir);
     const logPath = path.join(
       logsDir,
       `project-key-repair-${new Date().toISOString().replace(/[:.]/g, '-')}.json`

--- a/src/cli/repair.ts
+++ b/src/cli/repair.ts
@@ -14,6 +14,8 @@
  */
 
 import { ensureNativeBinding } from '../setup/native-binding.js';
+import { secureStatePermissions } from '../setup/state-permissions.js';
+import { getConfigDir } from '../cloud/config.js';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
@@ -58,6 +60,46 @@ export async function runRepair(_args: string[] = []): Promise<void> {
   }
 
   await runPluginReconcilePass();
+  runStatePermissionPass();
+}
+
+/**
+ * Third repair pass: re-harden the state-tree permissions (#218).
+ *
+ * doctor's permission check fails after a gateway restart when a runtime
+ * recreates a lock file or a log dir under the default umask. The create-time
+ * modes (state-permissions.mkdirSecure / SECURE_OPEN_MODE) stop new paths
+ * landing loose, but a create-mode cannot retro-tighten a path that ALREADY
+ * exists — so a fleet box that was recreated loose once needs an explicit
+ * correction. `install`/`update` already run this; `repair` did not, which is
+ * exactly the gap doctor's own "run repair to reconcile" advice fell into.
+ * Now it does, so the fix doctor points at actually corrects what doctor fails.
+ */
+function runStatePermissionPass(): void {
+  process.stdout.write(`\n  ${c('90', 'Checking state-tree permissions…')}\n`);
+  try {
+    // getConfigDir() (honours SHIELDCORTEX_CONFIG_DIR) — the SAME resolver
+    // install/update pass to secureStatePermissions, so repair hardens exactly
+    // the tree they do rather than a hardcoded-homedir subset.
+    const findings = secureStatePermissions(getConfigDir());
+    const corrected = findings.filter(f => f.fixed);
+    const failed = findings.filter(f => !f.fixed);
+    if (findings.length === 0) {
+      process.stdout.write(`  ${c('32', '✓')}  Permissions: already owner-only\n`);
+    } else {
+      for (const f of corrected) {
+        process.stdout.write(`  ${c('32', '✓')}  Tightened ${f.path} (${f.found} → ${f.required})\n`);
+      }
+      for (const f of failed) {
+        process.stdout.write(`  ${c('31', '✗')}  Could not tighten ${f.path} (${f.found} → ${f.required})${f.error ? `: ${f.error}` : ''}\n`);
+      }
+      if (failed.length > 0) process.exitCode = 1;   // never report a false all-clear
+    }
+    process.stdout.write('\n');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stdout.write(`  ${c('90', `State-permission check skipped — ${msg}`)}\n\n`);
+  }
 }
 
 /**

--- a/src/cli/upsell-state.ts
+++ b/src/cli/upsell-state.ts
@@ -9,6 +9,7 @@
  */
 
 import fs from 'fs';
+import { mkdirSecure } from '../setup/state-permissions.js';
 import path from 'path';
 import os from 'os';
 
@@ -59,7 +60,7 @@ export function setUpsellState(updates: Partial<UpsellState>): void {
   try {
     const dir = path.dirname(statePath());
     if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
+      mkdirSecure(dir);
     }
     const current = getUpsellState();
     const next: UpsellState = { ...current, ...updates };

--- a/src/cloud/config.ts
+++ b/src/cloud/config.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { homedir, hostname } from 'os';
 import { randomUUID, randomBytes, createHmac, timingSafeEqual } from 'crypto';
 import type { RankerConfig, RankerEngine, RankerWeights } from '../memory/types.js';
+import { mkdirSecure } from '../setup/state-permissions.js';
 
 export interface CloudConfig {
   cloudApiKey: string | null;
@@ -100,7 +101,7 @@ function getIntegrityKey(): string {
   } catch { /* ignore */ }
   // Generate new key on first run
   const key = randomBytes(32).toString('hex');
-  mkdirSync(configDir, { recursive: true });
+  mkdirSecure(configDir);
   writeFileSync(integrityKeyFile, key, { mode: 0o600 });
   try { chmodSync(integrityKeyFile, 0o600); } catch { /* best-effort */ }
   cachedIntegrityKey = key;
@@ -463,7 +464,7 @@ function invalidateRawConfigCache(): void {
 function writeRawConfig(raw: Record<string, unknown>): void {
   const configDir = getConfigDir();
   const configFile = getConfigFile();
-  mkdirSync(configDir, { recursive: true });
+  mkdirSecure(configDir);
 
   // Never carry an inbound `_sig` through; we always recompute it.
   const { _sig: _ignored, ...rest } = raw;

--- a/src/database/init.ts
+++ b/src/database/init.ts
@@ -14,6 +14,7 @@ import { getInlineSchema } from './inline-schema.js';
 import { seedDefaultFirewallRules } from './seed-firewall-rules.js';
 import { debugLog } from '../debug-log.js';
 import { MAX_DB_FILE_BYTES, WARN_DB_FILE_BYTES } from '../limits.js';
+import { mkdirSecure, SECURE_OPEN_MODE } from '../setup/state-permissions.js';
 
 const _currentFile = fileURLToPath(import.meta.url);
 const _currentDir = dirname(_currentFile);
@@ -226,7 +227,7 @@ function acquireStartupLock(dbPath: string): void {
   }, null, 2);
 
   const tryOpen = () => {
-    lockFileFd = openSync(lockFilePath as string, 'wx');
+    lockFileFd = openSync(lockFilePath as string, 'wx', SECURE_OPEN_MODE);
     writeFileSync(lockFileFd, payload, 'utf-8');
   };
 
@@ -514,9 +515,9 @@ export function initDatabase(dbPath?: string): Database.Database {
   enforceSafeRuntimePath(expandedPath, explicitDbPath);
   const dir = dirname(expandedPath);
 
-  // Create directory if it doesn't exist
+  // Create directory if it doesn't exist — owner-only from the first mkdir (#218).
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+    mkdirSecure(dir);
   }
 
   // Store path for size monitoring

--- a/src/defence/iron-dome/action-approvals.ts
+++ b/src/defence/iron-dome/action-approvals.ts
@@ -30,6 +30,7 @@
  */
 
 import { createHash } from 'crypto';
+import { mkdirSecure } from '../../setup/state-permissions.js';
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -179,7 +180,7 @@ function readFile(home?: string): ApprovalFile {
 
 function writeFileAtomic(file: ApprovalFile, home?: string): void {
   const dir = approvalsDir(home);
-  mkdirSync(dir, { recursive: true });
+  mkdirSecure(dir);
   const target = approvalsPath(home);
   const tmp = `${target}.tmp`;
   writeFileSync(tmp, JSON.stringify(file, null, 2), { mode: 0o600 });

--- a/src/defence/skill-scanner/verdict-store.ts
+++ b/src/defence/skill-scanner/verdict-store.ts
@@ -14,6 +14,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { mkdirSecure } from '../../setup/state-permissions.js';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -43,7 +44,7 @@ const STORE_VERSION = 1;
 
 function getDataDir(): string {
   const dir = process.env.SHIELDCORTEX_CONFIG_DIR || join(homedir(), '.shieldcortex');
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  if (!existsSync(dir)) mkdirSecure(dir);
   return dir;
 }
 

--- a/src/license/store.ts
+++ b/src/license/store.ts
@@ -11,6 +11,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync, statSync } from 'fs';
+import { mkdirSecure } from '../setup/state-permissions.js';
 import { join } from 'path';
 import { homedir } from 'os';
 import { verifyLicenseKey } from './verify.js';
@@ -176,7 +177,7 @@ export function activateLicense(key: string): LicenseInfo {
 
   const configDir = getConfigDir();
   const licenseFile = getLicenseFilePath();
-  mkdirSync(configDir, { recursive: true });
+  mkdirSecure(configDir);
   writeFileSync(licenseFile, JSON.stringify(file, null, 2) + '\n', { mode: 0o600 });
 
   // Refresh cache + mtime so the next getLicense() call in this process

--- a/src/service/install.ts
+++ b/src/service/install.ts
@@ -8,6 +8,7 @@
  */
 
 import fs from 'fs';
+import { mkdirSecure } from '../setup/state-permissions.js';
 import path from 'path';
 import os from 'os';
 import { execSync } from 'child_process';
@@ -40,7 +41,7 @@ function detectDefaultServiceMode(platform: Platform): ServiceMode {
 
 function getServiceConfig(mode: ServiceMode): ServiceConfig {
   const logsDir = path.join(os.homedir(), '.shieldcortex', 'logs');
-  fs.mkdirSync(logsDir, { recursive: true });
+  mkdirSecure(logsDir);
 
   return {
     nodePath: process.execPath,

--- a/src/setup/mcp-self-heal.ts
+++ b/src/setup/mcp-self-heal.ts
@@ -21,6 +21,7 @@
  */
 
 import fs from 'fs';
+import { mkdirSecure } from './state-permissions.js';
 import path from 'path';
 import os from 'os';
 import {
@@ -114,7 +115,7 @@ export async function selfHealMcpNativeBinding(
   let breadcrumbPath: string | undefined;
   try {
     const target = logsDir();
-    fs.mkdirSync(target, { recursive: true });
+    mkdirSecure(target);
     breadcrumbPath = path.join(target, MCP_SPAWN_ERROR_LOG);
     const body = [
       `[${now()}] ShieldCortex MCP server spawn failed (better-sqlite3 native-module load).`,

--- a/src/setup/migrate.ts
+++ b/src/setup/migrate.ts
@@ -6,6 +6,7 @@
  */
 
 import fs from 'fs';
+import { mkdirSecure } from './state-permissions.js';
 import path from 'path';
 import os from 'os';
 import { execSync } from 'child_process';
@@ -232,7 +233,7 @@ export function migrateDatabase(): { copied: boolean; merged: boolean; mergedCou
 
   // Fresh install — just copy
   if (!fs.existsSync(targetPath)) {
-    fs.mkdirSync(targetDir, { recursive: true });
+    mkdirSecure(targetDir);
     fs.copyFileSync(legacyPath, targetPath);
     console.log(`  Database: copied ${legacyPath} → ${targetPath}`);
     console.log(`  (Original preserved at ${legacyPath} for rollback)`);

--- a/src/setup/state-permissions.ts
+++ b/src/setup/state-permissions.ts
@@ -46,6 +46,31 @@ export const SECURE_SUBDIRS = ['audit', 'approvals', 'logs', 'quarantine', 'reca
 /** Files that must be owner-only, by exact name or by prefix. */
 const SECURE_FILE_PREFIXES = ['memories.db', 'config.json', 'worker.json', 'integrity'];
 
+/**
+ * #218 — create state-tree paths already owner-only, at CREATION.
+ *
+ * The audited set (this dir + SECURE_SUBDIRS + SECURE_FILE_PREFIXES) is
+ * hardened at install/update by `secureStatePermissions`. But `mkdir`'s mode
+ * binds only when the directory is CREATED and is IGNORED for one that already
+ * exists, and `open(2)` without a mode uses `0666 & ~umask` (644, or 664 under
+ * umask 002) — so ANY path a runtime recreates after the install-time pass
+ * (the lock file every gateway bounce, the log/audit dirs every hook run) lands
+ * loose again, and doctor fails on it after every restart.
+ *
+ * The fix is to stop relying on a later pass: create it secure the first time.
+ * `secureStatePermissions` still runs on install/update to retro-tighten the
+ * fleet's already-loose paths, because a create-mode cannot do that.
+ *
+ * These are the single source of truth for the two create modes; no state-tree
+ * creator should pass a bare `{ recursive: true }` or a mode-less `open`.
+ */
+export function mkdirSecure(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true, mode: SECURE_DIR_MODE });
+}
+
+/** Mode for openSync/writeFileSync of any file inside the state tree. */
+export const SECURE_OPEN_MODE = SECURE_FILE_MODE;   // 0o600
+
 export interface PermissionFinding {
   path: string;
   /** The mode we found, as an octal string (e.g. "644"). */

--- a/src/xray/activity.ts
+++ b/src/xray/activity.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { mkdirSecure } from '../setup/state-permissions.js';
 import os from 'os';
 import path from 'path';
 
@@ -73,7 +74,7 @@ export interface XRayWatchSessionEntry {
 
 function ensureXRayDir(): void {
   if (!fs.existsSync(XRAY_DIR)) {
-    fs.mkdirSync(XRAY_DIR, { recursive: true });
+    mkdirSecure(XRAY_DIR);
   }
 }
 

--- a/src/xray/findings-store.ts
+++ b/src/xray/findings-store.ts
@@ -6,6 +6,7 @@
  */
 
 import fs from 'fs';
+import { mkdirSecure } from '../setup/state-permissions.js';
 import path from 'path';
 import os from 'os';
 import crypto from 'crypto';
@@ -19,7 +20,7 @@ function defaultBasePath(): string {
 }
 
 function ensureDir(dir: string): void {
-  fs.mkdirSync(dir, { recursive: true });
+  mkdirSecure(dir);
 }
 
 function findingDedupeKey(target: string, f: XRayFinding): string {

--- a/src/xray/index.ts
+++ b/src/xray/index.ts
@@ -10,6 +10,7 @@
  */
 
 import fs from 'fs';
+import { mkdirSecure } from '../setup/state-permissions.js';
 import path from 'path';
 import os from 'os';
 
@@ -72,7 +73,7 @@ function incrementUsage(): void {
 
   const dir = path.dirname(USAGE_FILE);
   if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
+    mkdirSecure(dir);
   }
   fs.writeFileSync(USAGE_FILE, JSON.stringify(usage));
 }


### PR DESCRIPTION
Closes #218.

## The loop

doctor's permission check fails after **every gateway restart**: a runtime recreates `memories.db.lock` (and log/audit dirs) under the default umask, *after* the install-time hardening pass already ran. `openSync('wx')` with no mode is `0666 & ~umask` (644, or 664 under umask 002); `mkdirSync` with no mode is 755/775. Both land in the set doctor audits — green doctor, one bounce, red doctor, forever. aiquant re-hardened by hand twice in a day.

## The fix: create it secure the first time

A create-mode binds only at creation and is **ignored for a dir that already exists**, so this is two halves, both required:

1. **New paths land owner-only.** `state-permissions.ts` gains `mkdirSecure` (0700, recursive — every parent too) + `SECURE_OPEN_MODE` (0600), the single source of truth; mirrored in `scripts/lib/state-perms.mjs` for the hooks (separate build, no `src/` imports).
   - `init.ts`: the lock `openSync` gets `SECURE_OPEN_MODE` — the reported loop, closed at both the cold and stale-recovery paths in one edit.
   - **Every creator whose target is inside `~/.shieldcortex` → `mkdirSecure`.** `recursive:true` means any of them can create an audited path as a *parent* at 755, so the scope is the whole state tree, not just the named subdirs (21 sites across TS + the 6 hooks + 2 log `.mjs`). Each converted site was resolved to its real target, not matched by variable name — that is exactly how the first pass under-scoped.
   - `postinstall` writes `config.json` at `STATE_FILE_MODE` (the file half).
2. **Existing loose paths still get retro-tightened** by `secureStatePermissions` on install/update — **and now `repair`.**

## The one-call-site gap, reintroduced by its own advice

doctor's permission-fix text told operators to run `shieldcortex repair` — and `repair` never hardened permissions (only native-binding + plugin-reconcile). The command doctor recommended did not fix what doctor failed on: the #222/#103 pattern, one layer over. `repair` now runs a state-permission pass over `getConfigDir()` (the same `SHIELDCORTEX_CONFIG_DIR`-honouring resolver install/update use, not doctor's hardcoded-homedir subset), and a permission it cannot fix is a hard exit 1 — never a false all-clear.

doctor's fix text now points at `repair`, and its manual `chmod` uses an explicit `audit approvals logs` list rather than a `{…}` brace expansion — the guard's `touch-approval-store` rule gates the expanded `approvals` path, so we were printing advice our own product blocks.

## Deliberately out of scope (each verified)

`~/.openclaw` and `~/.claude` dirs, service-file dirs, `npm-inspector`'s tmpdir extracts (untrusted package content, different security context), `backups/`, the operator-configured telemetry path, and `~/.shieldcortex/state` (worker.json's prefix is dead — `auditStatePermissions` reads only files *directly* in stateDir).

## Tests

12: the two create modes, the **reproduced regression** (a mode-less open lands loose), the retro-tighten-still-needed property (why the pass must keep running), and source-level wiring proving `runRepair` invokes the pass.

Full serial suite: **379/379 suites, 4477 passed, 0 failures.** Typecheck clean. 205/205 across every suite touching a converted creator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)