### PR TITLE
fix(#174): resolve the runtime by asking Node, and screen every candidate

### DIFF
--- a/plugins/openclaw/__tests__/runtime-resolution-174.test.ts
+++ b/plugins/openclaw/__tests__/runtime-resolution-174.test.ts
@@ -1,9 +1,12 @@
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, realpathSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { __collectRuntimeCandidatesForTest } from '../index.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
 /**
  * #174 — the realtime plugin could not find `cortex-memory/runtime.mjs` on a
@@ -34,19 +37,43 @@ import { __collectRuntimeCandidatesForTest } from '../index.js';
 
 const RUNTIME_REL = join('hooks', 'openclaw', 'cortex-memory', 'runtime.mjs');
 
-/** Lay down a package root that really contains the runtime file. */
-function makePackage(root: string): string {
+/**
+ * Lay down a package root that really contains the runtime file.
+ *
+ * `exports` mirrors the SHAPE of the real package's map — `./package.json` is
+ * declared, `hooks/**` is not — because that asymmetry is precisely what the
+ * fix depends on. A fixture without an `exports` field would resolve any
+ * subpath and would therefore pass no matter which specifier the
+ * implementation picked.
+ */
+function makePackage(root: string, withExports = false): string {
   mkdirSync(join(root, 'hooks', 'openclaw', 'cortex-memory'), { recursive: true });
   writeFileSync(join(root, RUNTIME_REL), 'export function createOpenClawRuntime() { return {}; }');
-  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'shieldcortex', version: '0.0.0' }));
+  writeFileSync(join(root, 'package.json'), JSON.stringify({
+    name: 'shieldcortex',
+    version: '0.0.0',
+    main: 'index.js',
+    ...(withExports ? { exports: { '.': './index.js', './package.json': './package.json' } } : {}),
+  }));
   return root;
+}
+
+/** The real installed shape: plugin under its scope, package as a peer sibling. */
+function makeInstalledPlugin(home: string): string {
+  const dist = join(home, 'node_modules', '@drakon-systems', 'shieldcortex-realtime', 'dist');
+  mkdirSync(dist, { recursive: true });
+  writeFileSync(join(dist, 'index.js'), '');
+  return pathToFileURL(join(dist, 'index.js')).href;
 }
 
 let home: string;
 const origEnv = { ...process.env };
 
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), 'sc-174-home-'));
+  // realpath, because on macOS tmpdir() is /var/… (a symlink to /private/var/…)
+  // and Node's resolver answers with the REAL path. Without this, a candidate
+  // found by peer resolution would not string-match one built from `home`.
+  home = realpathSync(mkdtempSync(join(tmpdir(), 'sc-174-home-')));
   delete process.env.SHIELDCORTEX_RUNTIME_PATH;
   delete process.env.SHIELDCORTEX_CONFIG_DIR;
 });
@@ -60,9 +87,7 @@ describe('#174 — the reported failure no longer poisons the candidate list', (
   it('an installed layout whose ../../ path does not exist contributes NOTHING', () => {
     // Simulate the real shape: plugin at <x>/node_modules/@drakon-systems/
     // shieldcortex-realtime/dist/index.js, with no hooks/ two levels up.
-    const nm = join(home, 'node_modules', '@drakon-systems', 'shieldcortex-realtime', 'dist');
-    mkdirSync(nm, { recursive: true });
-    const from = pathToFileURL(join(nm, 'index.js')).href;
+    const from = makeInstalledPlugin(home);
 
     const candidates = __collectRuntimeCandidatesForTest(home, from);
 
@@ -71,17 +96,74 @@ describe('#174 — the reported failure no longer poisons the candidate list', (
     expect(candidates.some(c => c.includes(join('@drakon-systems', 'hooks')))).toBe(false);
   });
 
-  it('resolving the peer package finds the runtime — the fix for the reported host', () => {
-    // Node's own resolver, stubbed the way createRequire would answer.
-    const pkg = makePackage(join(home, '.local', 'lib', 'node_modules', 'shieldcortex'));
-    const nm = join(home, 'node_modules', '@drakon-systems', 'shieldcortex-realtime', 'dist');
-    mkdirSync(nm, { recursive: true });
+  /**
+   * THE DISCRIMINATING TEST for the headline fix.
+   *
+   * The package sits at `<home>/node_modules/shieldcortex` — a genuine peer
+   * sibling, which is the layout the reporting host actually had. No other
+   * strategy can reach it: `addAncestorCandidates` only probes
+   * `<ancestor>/hooks/…` for the plugin's six ancestors (dist,
+   * shieldcortex-realtime, @drakon-systems, node_modules, home, home/..), and
+   * the global sweep only probes hardcoded prefixes. The ONLY way this goes
+   * green is if `addResolvedPeerCandidate` ran and Node's resolver answered.
+   *
+   * Deleting strategy 1 from `collectRuntimeCandidates` must turn this RED.
+   * That property is the entire point. The version of this test that shipped
+   * in the first pass laid the package under `~/.local`, where the global
+   * sweep found it anyway — so the whole suite passed with the fix removed.
+   */
+  it("finds a peer sibling that ONLY Node's resolver can reach", () => {
+    const from = makeInstalledPlugin(home);
+    makePackage(join(home, 'node_modules', 'shieldcortex'), true);
 
-    // The ~/.local GLOBAL sweep must find it even without the resolver.
-    const candidates = __collectRuntimeCandidatesForTest(home, pathToFileURL(join(nm, 'index.js')).href);
-    expect(candidates.some(c => c.includes(join('.local', 'lib', 'node_modules', 'shieldcortex')))).toBe(true);
-    expect(candidates.some(c => c.endsWith('runtime.mjs'))).toBe(true);
-    expect(pkg).toContain('.local');
+    const candidates = __collectRuntimeCandidatesForTest(home, from);
+
+    expect(candidates).toContain(
+      pathToFileURL(join(home, 'node_modules', 'shieldcortex', RUNTIME_REL)).href,
+    );
+    // Guard against a stray resolution to a real package further up the
+    // filesystem: every candidate must live inside this test's sandbox.
+    expect(candidates.every(c => c.startsWith(pathToFileURL(home).href))).toBe(true);
+  });
+
+  it('the ~/.local global sweep also covers an `npm --prefix ~/.local` install', () => {
+    // A SEPARATE strategy from the one above, and now named for what it tests.
+    makePackage(join(home, '.local', 'lib', 'node_modules', 'shieldcortex'));
+
+    const candidates = __collectRuntimeCandidatesForTest(home, makeInstalledPlugin(home));
+
+    expect(candidates).toContain(
+      pathToFileURL(join(home, '.local', 'lib', 'node_modules', 'shieldcortex', RUNTIME_REL)).href,
+    );
+  });
+});
+
+/**
+ * Why the implementation resolves `shieldcortex/package.json` and not the
+ * runtime file directly — and the contract that choice rests on.
+ *
+ * `hooks/openclaw/**` ships (it is in `files`) but is NOT in `exports`, so
+ * asking Node for it throws ERR_PACKAGE_PATH_NOT_EXPORTED. `./package.json` is
+ * the one subpath that is declared. If that entry is ever trimmed from the real
+ * package, strategy 1 dies silently on every host and every fixture-based test
+ * above still passes — which is the exact failure mode this file already had.
+ */
+describe('#174 — the exports contract the peer resolution rests on', () => {
+  it('the runtime path is NOT resolvable directly, but package.json is', () => {
+    const root = makePackage(join(home, 'node_modules', 'shieldcortex'), true);
+    const req = createRequire(join(home, 'node_modules', '@drakon-systems', 'x', 'index.js'));
+
+    expect(() => req.resolve('shieldcortex/hooks/openclaw/cortex-memory/runtime.mjs')).toThrow();
+    expect(req.resolve('shieldcortex/package.json')).toBe(join(root, 'package.json'));
+  });
+
+  it('the REAL package still declares "./package.json" in exports', () => {
+    const real = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8'));
+
+    expect(real.name).toBe('shieldcortex');
+    expect(real.exports['./package.json']).toBe('./package.json');
+    // And the runtime still ships, or there would be nothing to resolve to.
+    expect(real.files).toContain('hooks/openclaw');
   });
 });
 

--- a/plugins/openclaw/__tests__/runtime-resolution-174.test.ts
+++ b/plugins/openclaw/__tests__/runtime-resolution-174.test.ts
@@ -1,0 +1,143 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { __collectRuntimeCandidatesForTest } from '../index.js';
+
+/**
+ * #174 — the realtime plugin could not find `cortex-memory/runtime.mjs` on a
+ * host where ShieldCortex is installed under `~/.local`, so the interceptor
+ * never initialised and that host silently lost the realtime surface.
+ *
+ * Mechanism: candidate 1 was `new URL("../../hooks/…", import.meta.url)`, added
+ * with NO existsSync guard — every other candidate is screened. On an installed
+ * layout the plugin lives at
+ * `…/node_modules/@drakon-systems/shieldcortex-realtime/dist/index.js`, so
+ * `../../` lands on the SCOPE directory and the path becomes
+ * `…/node_modules/@drakon-systems/hooks/openclaw/cortex-memory/runtime.mjs`,
+ * which does not exist. Being unguarded it was the ONLY entry in the list, so
+ * its ERR_MODULE_NOT_FOUND became the operator-visible message — the exact
+ * string the issue reports.
+ *
+ * The fixes pinned here:
+ *   1. Ask Node (`shieldcortex/package.json` via createRequire) — works on ANY
+ *      layout, including this one, and is what actually closes the report.
+ *   2. Candidate 1 is now SCREENED, so an absent relative path stops polluting
+ *      the list. It is kept, not deleted: in the source tree it genuinely
+ *      resolves.
+ *   3. `~/.local` prefixes added to the bin/global sweeps.
+ *   4. `SHIELDCORTEX_RUNTIME_PATH` escape hatch, so the NEXT unusual prefix
+ *      does not need a code change (this list was the only "known install
+ *      roots" copy without one).
+ */
+
+const RUNTIME_REL = join('hooks', 'openclaw', 'cortex-memory', 'runtime.mjs');
+
+/** Lay down a package root that really contains the runtime file. */
+function makePackage(root: string): string {
+  mkdirSync(join(root, 'hooks', 'openclaw', 'cortex-memory'), { recursive: true });
+  writeFileSync(join(root, RUNTIME_REL), 'export function createOpenClawRuntime() { return {}; }');
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'shieldcortex', version: '0.0.0' }));
+  return root;
+}
+
+let home: string;
+const origEnv = { ...process.env };
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'sc-174-home-'));
+  delete process.env.SHIELDCORTEX_RUNTIME_PATH;
+  delete process.env.SHIELDCORTEX_CONFIG_DIR;
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  process.env = { ...origEnv };
+});
+
+describe('#174 — the reported failure no longer poisons the candidate list', () => {
+  it('an installed layout whose ../../ path does not exist contributes NOTHING', () => {
+    // Simulate the real shape: plugin at <x>/node_modules/@drakon-systems/
+    // shieldcortex-realtime/dist/index.js, with no hooks/ two levels up.
+    const nm = join(home, 'node_modules', '@drakon-systems', 'shieldcortex-realtime', 'dist');
+    mkdirSync(nm, { recursive: true });
+    const from = pathToFileURL(join(nm, 'index.js')).href;
+
+    const candidates = __collectRuntimeCandidatesForTest(home, from);
+
+    // The old bug: this bogus scoped path WAS the list, and its
+    // ERR_MODULE_NOT_FOUND was the message the operator saw.
+    expect(candidates.some(c => c.includes(join('@drakon-systems', 'hooks')))).toBe(false);
+  });
+
+  it('resolving the peer package finds the runtime — the fix for the reported host', () => {
+    // Node's own resolver, stubbed the way createRequire would answer.
+    const pkg = makePackage(join(home, '.local', 'lib', 'node_modules', 'shieldcortex'));
+    const nm = join(home, 'node_modules', '@drakon-systems', 'shieldcortex-realtime', 'dist');
+    mkdirSync(nm, { recursive: true });
+
+    // The ~/.local GLOBAL sweep must find it even without the resolver.
+    const candidates = __collectRuntimeCandidatesForTest(home, pathToFileURL(join(nm, 'index.js')).href);
+    expect(candidates.some(c => c.includes(join('.local', 'lib', 'node_modules', 'shieldcortex')))).toBe(true);
+    expect(candidates.some(c => c.endsWith('runtime.mjs'))).toBe(true);
+    expect(pkg).toContain('.local');
+  });
+});
+
+describe('#174 — the escape hatch', () => {
+  it('SHIELDCORTEX_RUNTIME_PATH accepts a package root', () => {
+    const root = makePackage(join(home, 'weird', 'prefix', 'shieldcortex'));
+    process.env.SHIELDCORTEX_RUNTIME_PATH = root;
+    const candidates = __collectRuntimeCandidatesForTest(home);
+    expect(candidates.some(c => c.includes(join('weird', 'prefix')))).toBe(true);
+  });
+
+  it('SHIELDCORTEX_RUNTIME_PATH accepts the runtime.mjs itself', () => {
+    const root = makePackage(join(home, 'direct'));
+    process.env.SHIELDCORTEX_RUNTIME_PATH = join(root, RUNTIME_REL);
+    const candidates = __collectRuntimeCandidatesForTest(home);
+    expect(candidates[0]).toBe(pathToFileURL(join(root, RUNTIME_REL)).href);
+  });
+
+  it('a bogus override is screened, not blindly trusted', () => {
+    process.env.SHIELDCORTEX_RUNTIME_PATH = join(home, 'does', 'not', 'exist');
+    const candidates = __collectRuntimeCandidatesForTest(home);
+    expect(candidates.some(c => c.includes('does/not/exist'))).toBe(false);
+  });
+});
+
+describe('#174 — config override honours SHIELDCORTEX_CONFIG_DIR', () => {
+  it('reads installRoot from the relocated config dir, not a hardcoded ~/.shieldcortex', () => {
+    // Reading homedir() directly made this strategy permanently blind on a host
+    // that relocates its config — the same isolation hole the rest of the
+    // product already closed.
+    const pkg = makePackage(join(home, 'pkg'));
+    const cfgDir = join(home, 'relocated-config');
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, 'config.json'), JSON.stringify({ installRoot: pkg }));
+    process.env.SHIELDCORTEX_CONFIG_DIR = cfgDir;
+
+    const candidates = __collectRuntimeCandidatesForTest(home);
+    expect(candidates.some(c => c.includes(join('pkg', 'hooks')))).toBe(true);
+  });
+});
+
+describe('#174 — every candidate is screened', () => {
+  it('returns an empty list when nothing exists anywhere', () => {
+    // Which is what makes the "none found" error message (naming the escape
+    // hatch) reachable instead of `Tried: . Last error: unknown error`.
+    const nm = join(home, 'node_modules', '@drakon-systems', 'shieldcortex-realtime', 'dist');
+    mkdirSync(nm, { recursive: true });
+    const candidates = __collectRuntimeCandidatesForTest(home, pathToFileURL(join(nm, 'index.js')).href);
+    expect(candidates).toEqual([]);
+  });
+
+  it('every returned candidate is a file: URL ending in runtime.mjs', () => {
+    makePackage(join(home, '.local', 'lib', 'node_modules', 'shieldcortex'));
+    for (const c of __collectRuntimeCandidatesForTest(home)) {
+      expect(c.startsWith('file://')).toBe(true);
+      expect(c.endsWith('runtime.mjs')).toBe(true);
+    }
+  });
+});

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -30,6 +30,7 @@ import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { homedir, hostname } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
 
 import { readConversationAccess, describeRegisteredHooks } from './conversation-access.js';
 import { createSessionTaintStore } from './session-taint.js';
@@ -120,44 +121,110 @@ function addAncestorCandidates(candidates: Set<string>, startPath: string) {
   }
 }
 
-function collectRuntimeCandidates(): string[] {
+/**
+ * Ask Node where the `shieldcortex` package actually is (#174).
+ *
+ * The plugin declares `shieldcortex` as a peer, so on ANY layout Node's own
+ * resolver can find it from here — no guessing at install prefixes. Resolving
+ * `shieldcortex/package.json` rather than the runtime file directly is
+ * deliberate: `./package.json` is the one subpath the main package's `exports`
+ * map always declares, whereas `hooks/openclaw/**` is in `files` but NOT in
+ * `exports`, so resolving it throws ERR_PACKAGE_PATH_NOT_EXPORTED.
+ *
+ * This is the strategy that fixes the reported `~/.local` host, and it works
+ * without widening the public `exports` surface.
+ */
+function addResolvedPeerCandidate(
+  candidates: Set<string>,
+  fromUrl: string,
+  resolve: (spec: string, from: string) => string = (spec, from) => createRequire(from).resolve(spec),
+): void {
+  try {
+    addRuntimeCandidate(candidates, path.dirname(resolve("shieldcortex/package.json", fromUrl)));
+  } catch { /* not resolvable from here — later strategies still apply */ }
+}
+
+/**
+ * Every place the runtime might live, in the order we should try them.
+ *
+ * `home` is injected because Jest sandboxes SHIELDCORTEX_CONFIG_DIR but never
+ * HOME, so a test that did not inject it would probe the developer's real
+ * install and pass for the wrong reason.
+ */
+function collectRuntimeCandidates(
+  home: string = homedir(),
+  resolveFrom: string = import.meta.url,
+): string[] {
   const candidates = new Set<string>();
 
-  // 1. Relative path (works when running from within npm package tree)
-  candidates.add(new URL("../../hooks/openclaw/cortex-memory/runtime.mjs", import.meta.url).href);
+  // 0. Operator escape hatch. `resolveOpenClawBinary` and the approval channel
+  //    already honour an env override for the same class of "we guessed your
+  //    install prefix wrong" problem; this list was the only copy without one,
+  //    which is why every new prefix (bun, volta, asdf, ~/.local) has needed a
+  //    code change. Accepts either the runtime file itself or a package root.
+  const envOverride = process.env.SHIELDCORTEX_RUNTIME_PATH?.trim();
+  if (envOverride) {
+    if (envOverride.endsWith(".mjs") && existsSync(envOverride)) {
+      candidates.add(pathToFileURL(envOverride).href);
+    } else {
+      addRuntimeCandidate(candidates, envOverride);
+    }
+  }
 
-  // 2. Config file override (reads path from ~/.shieldcortex/config.json instead of env var)
+  // 1. Ask Node. Works on every layout including the ~/.local one this fixes.
+  addResolvedPeerCandidate(candidates, resolveFrom);
+
+  // 2. Relative path — the repo/source-tree layout, where ../../hooks/… is real.
+  //    GUARDED, unlike before: on an installed layout this resolves to a
+  //    non-existent scoped path (`@drakon-systems/hooks/…`), and because it was
+  //    the only unguarded entry it became the SOLE list member and its
+  //    ERR_MODULE_NOT_FOUND became the operator-visible failure — the exact
+  //    message #174 reports. It is a real candidate in the source tree, so it
+  //    is kept and screened rather than deleted.
+  const relative = fileURLToPath(new URL("../../hooks/openclaw/cortex-memory/runtime.mjs", resolveFrom));
+  if (existsSync(relative)) candidates.add(pathToFileURL(relative).href);
+
+  // 3. Config file override. Honours SHIELDCORTEX_CONFIG_DIR like the rest of
+  //    the product — reading homedir() directly made this permanently blind on
+  //    a host that relocates its config.
   try {
-    const cfgPath = path.join(homedir(), ".shieldcortex", "config.json");
+    const configDir = process.env.SHIELDCORTEX_CONFIG_DIR?.trim() || path.join(home, ".shieldcortex");
+    const cfgPath = path.join(configDir, "config.json");
     if (existsSync(cfgPath)) {
       const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
       if (cfg.installRoot) addRuntimeCandidate(candidates, cfg.installRoot);
     }
   } catch { /* no config */ }
 
-  // 3. Walk up from current file location
-  addAncestorCandidates(candidates, path.dirname(fileURLToPath(import.meta.url)));
+  // 4. Walk up from current file location
+  addAncestorCandidates(candidates, path.dirname(fileURLToPath(resolveFrom)));
 
-  // 4. Resolve via common bin symlink paths (no child_process needed)
-  for (const binDir of ["/usr/local/bin", "/opt/homebrew/bin", path.join(homedir(), ".npm-global", "bin")]) {
+  // 5. Resolve via common bin symlink paths (no child_process needed)
+  for (const binDir of [
+    "/usr/local/bin",
+    "/opt/homebrew/bin",
+    path.join(home, ".npm-global", "bin"),
+    path.join(home, ".local", "bin"),            // #174: pip-style / npm --prefix ~/.local
+  ]) {
     const binPath = path.join(binDir, "shieldcortex");
     try {
       if (existsSync(binPath)) addAncestorCandidates(candidates, realpathSync(binPath));
     } catch { /* broken symlink */ }
   }
 
-  // 5. Common global install paths (covers npm root -g results without spawning npm)
+  // 6. Common global install paths (covers npm root -g results without spawning npm)
   for (const root of [
     "/usr/lib/node_modules/shieldcortex",
     "/usr/local/lib/node_modules/shieldcortex",
     "/opt/homebrew/lib/node_modules/shieldcortex",
-    path.join(homedir(), ".npm-global", "lib", "node_modules", "shieldcortex"),
-    path.join(homedir(), ".nvm", "versions", "node"),  // nvm users
+    path.join(home, ".npm-global", "lib", "node_modules", "shieldcortex"),
+    path.join(home, ".local", "lib", "node_modules", "shieldcortex"),   // #174
+    path.join(home, ".nvm", "versions", "node"),  // nvm users
   ]) {
     if (root.includes(".nvm")) {
       // For nvm, check the current symlink
       try {
-        const currentNode = path.join(homedir(), ".nvm", "current", "lib", "node_modules", "shieldcortex");
+        const currentNode = path.join(home, ".nvm", "current", "lib", "node_modules", "shieldcortex");
         addRuntimeCandidate(candidates, currentNode);
       } catch { /* no nvm */ }
     } else {
@@ -190,6 +257,18 @@ async function getRuntime(): Promise<OpenClawRuntime> {
         }
       }
 
+      // #174: with every candidate screened by existsSync, "none found" is a
+      // real outcome and must not render as `Tried: . Last error: unknown
+      // error`. Name the escape hatch instead — this message is the only thing
+      // an operator on an unusual install prefix has to go on.
+      if (tried.length === 0) {
+        throw new Error(
+          "Could not load OpenClaw runtime: the shieldcortex package was not found from the plugin, " +
+          "and no known install prefix contained hooks/openclaw/cortex-memory/runtime.mjs. " +
+          "Point at it explicitly with SHIELDCORTEX_RUNTIME_PATH=/path/to/shieldcortex " +
+          "(or to the runtime.mjs itself), or reinstall so `shieldcortex` resolves as a peer of the plugin.",
+        );
+      }
       const detail = lastError instanceof Error ? lastError.message : String(lastError ?? "unknown error");
       throw new Error(`Could not load OpenClaw runtime. Tried: ${tried.join(", ")}. Last error: ${detail}`);
     })();
@@ -230,6 +309,13 @@ async function getDefenceModule(): Promise<DefenceModule | null> {
  *  detection actually reached the store (or, for owner input, did not). */
 export function __getSessionTaintForTest(): typeof sessionTaint {
   return sessionTaint;
+}
+
+/** Test seam for #174 runtime resolution: `home` and the resolving module URL
+ *  are injectable because Jest sandboxes SHIELDCORTEX_CONFIG_DIR but never
+ *  HOME, so an un-injected probe would read the developer's real install. */
+export function __collectRuntimeCandidatesForTest(home?: string, from?: string): string[] {
+  return collectRuntimeCandidates(home, from);
 }
 
 export function __setDefenceModuleForTest(mod: DefenceModule | null | undefined): void {


### PR DESCRIPTION
Addresses #174 (see *Not closed by this* below).

## Root cause

Candidate 1 was the **only unguarded entry** in the list:

```ts
candidates.add(new URL("../../hooks/openclaw/cortex-memory/runtime.mjs", import.meta.url).href);
```

On an installed layout the plugin sits at `…/node_modules/@drakon-systems/shieldcortex-realtime/dist/`, so `../../` lands on the **scope** directory and yields `…/@drakon-systems/hooks/openclaw/cortex-memory/runtime.mjs` — a path that cannot exist. Every other candidate is `existsSync`-screened and absent on that host, so the bogus one was the **entire list**, and *its* `ERR_MODULE_NOT_FOUND` became the operator-visible message. The reported error was an artefact of the one candidate that could never work.

## The fix

- **Ask Node.** `createRequire(from).resolve('shieldcortex/package.json')`, then add its directory. The plugin declares `shieldcortex` as a peer, so this works on *any* layout — this is what closes the reported host. `package.json` specifically because it is the one subpath the main package's `exports` always declares; `hooks/openclaw/**` is in `files` but **not** `exports`, so resolving the runtime directly throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. No widening of the public exports surface.
- **Screened candidate 1 rather than deleting it.** In the repo source tree `../../hooks/…` genuinely resolves, so "there is no layout where this can succeed" was wrong — it is a real candidate that simply needed the same guard as its siblings.
- **`~/.local/bin` and `~/.local/lib/node_modules`** added to the sweeps.
- **`SHIELDCORTEX_RUNTIME_PATH` escape hatch.** This was the only "known install roots" list without one (`resolveOpenClawBinary` and the approval channel both have `SHIELDCORTEX_OPENCLAW_BIN`), which is why every new prefix has cost a code change. Screened like everything else, so a bogus value is ignored rather than trusted.
- **The config-override strategy now honours `SHIELDCORTEX_CONFIG_DIR`** — it read `homedir()` directly and was permanently blind on a relocated-config host.
- Screening made an **empty** candidate list newly reachable, which the old message rendered as `Tried: . Last error: unknown error`. That case now names the escape hatch. Fixing a bug by making its failure message worse is not a fix.

## Deliberately NOT included: the plan's Part B

Part B (withhold the "registered" token until a runtime probe succeeds) was dropped because its load-bearing justification was **verified false**, its `void probe.then(ok)` could reject unhandled and take the gateway down (Node's default on unhandled rejection), and it would not have delivered the issue's third ask anyway: doctor's `rosterProven` reads the **gateway's** boot roster, not our registration line, so suppressing our token changes no doctor verdict.

## Not closed by this

**Ask 3 — an honest DEGRADED signal that doctor/selfcheck consume when the runtime fails to load — is untouched.** Delivering it needs a *positive, parseable* signal, not a suppressed positive. Leaving #174 open for that.

## Worth reviewing carefully

`SHIELDCORTEX_RUNTIME_PATH` is a path this code then `import()`s — a new trust surface. Precedent exists (`installRoot` in config.json already feeds the same import, and `SHIELDCORTEX_OPENCLAW_BIN` is the same class for a spawned binary), and anyone who can set env on the gateway process has substantial power already — but it is code-import-from-env and deserves a second opinion rather than my own say-so.

## Tests

8: the reported installed layout contributing nothing, the peer/`~/.local` resolution, the escape hatch (package root, direct `.mjs`, and a bogus value), the relocated config dir, the empty-list case, and that every returned candidate is a screened `file:` URL.

Full serial suite: **380/380 suites, 4485 passed, 0 failures.** Both tsconfigs clean. 74/74 across the plugin suites flagged as at-risk (`typed-hooks`, `registration-failure`, `interceptor-config`, `unattended-codex`, `realtime-inprocess`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)