### PR TITLE
fix(#221): stop recommending commands OpenClaw refuses to run

### DIFF
--- a/src/__tests__/child-output-report.test.ts
+++ b/src/__tests__/child-output-report.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from '@jest/globals';
+import { summariseCommandOutput, describeRunFailure } from '../integrations/child-output.js';
+import type { CapturedError } from '../integrations/child-output.js';
+
+/**
+ * #221 — a failed child process must yield the CAUSE, not a restatement of the
+ * command that failed.
+ *
+ * The two properties that are easy to get wrong and are the reason this module
+ * exists are pinned first: signal-first line selection (a tail returns
+ * OpenClaw's reassuring sign-off and discards its diagnosis) and redaction of
+ * env values we ourselves handed to the child.
+ */
+
+/** The real shape, captured from OpenClaw 2026.7.1-2 with a dangling plugin path. */
+const OPENCLAW_INVALID_STDERR = [
+  'OpenClaw config is invalid: /Users/x/.openclaw/openclaw.json',
+  '  × plugins.load.paths: plugin: plugin path not found: /tmp/definitely-does-not-exist/plugin',
+  '',
+  'Run `openclaw doctor --fix` to repair, or fix the keys above manually.',
+  'Inspect with openclaw config validate.',
+  'Audit, status, health, logs, tasks list/audit, and doctor commands still run with invalid config.',
+].join('\n');
+
+describe('#221 — signal-first selection, because a tail loses the cause', () => {
+  it('keeps OpenClaw\'s diagnosis and drops its reassuring sign-off', () => {
+    const { lines } = summariseCommandOutput(OPENCLAW_INVALID_STDERR, { maxLines: 3 });
+
+    expect(lines.join('\n')).toContain('plugin path not found');
+    // The last line is the trap: `slice(-N)` returns THIS and nothing useful.
+    expect(lines.join('\n')).not.toContain('still run with invalid config');
+  });
+
+  it('falls back to the tail when no line carries signal', () => {
+    const { lines } = summariseCommandOutput('alpha\nbravo\ncharlie\ndelta', { maxLines: 2 });
+    expect(lines).toEqual(['charlie', 'delta']);
+  });
+});
+
+describe('#221 — output is destined for a pasted report, so it is redacted', () => {
+  it('redacts an env value we handed the child, even in an unrecognised shape', () => {
+    // `runQuiet` passes {...process.env}; npm echoes the token back in the 401
+    // body. Deliberately not a shape our credential patterns recognise — this
+    // layer must not depend on the detector knowing the token's format.
+    const env = { NPM_TOKEN: 'totally-not-a-known-token-shape-1234567890' };
+    const body = `npm error 401 Unauthorized - PUT https://registry.npmjs.org/x - token ${env.NPM_TOKEN} is not valid`;
+
+    const { lines } = summariseCommandOutput(body, { env, maxLines: 4 });
+
+    const text = lines.join('\n');
+    expect(text).not.toContain(env.NPM_TOKEN);
+    expect(text).toContain('[redacted:$NPM_TOKEN]');
+  });
+
+  it('leaves short env values alone — they would redact ordinary prose', () => {
+    const env = { API_KEY: 'dev' };
+    const { lines } = summariseCommandOutput('error: the device failed to start', { env });
+    expect(lines.join('\n')).toBe('error: the device failed to start');
+  });
+
+  it('does not shred npm integrity hashes into noise', () => {
+    const line = 'npm error sha512-Kn6y87SxfnGb0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA== integrity check failed';
+    const { lines } = summariseCommandOutput(line, { env: {} });
+    expect(lines.join('\n')).toContain('integrity check failed');
+  });
+});
+
+describe('#221 — the empty-output ladder never yields a bare "failed"', () => {
+  const err = (over: Partial<CapturedError>): CapturedError =>
+    Object.assign(new Error('exit 1: openclaw plugins install'), over) as CapturedError;
+
+  it('names the command when the child produced no output at all', () => {
+    const r = describeRunFailure(err({ exitCode: 1, command: 'openclaw plugins install', stdout: '', stderr: '' }));
+    expect(r.reason).toContain('exited 1');
+    expect(r.reason).toContain('openclaw plugins install');
+    expect(r.detail).toEqual([]);
+  });
+
+  it('reports a timeout as a timeout, not as an exit code', () => {
+    const r = describeRunFailure(err({ exitCode: null, timedOut: true, command: 'openclaw plugins install' }));
+    expect(r.timedOut).toBe(true);
+    expect(r.reason).toContain('timed out');
+  });
+
+  it('reports a missing binary distinctly from a non-zero exit', () => {
+    const r = describeRunFailure(err({ code: 'ENOENT', exitCode: null, command: 'openclaw' }));
+    expect(r.spawnFailed).toBe(true);
+    expect(r.reason).toContain('command not found');
+  });
+
+  it('prefers the stream carrying signal rather than concatenating both', () => {
+    // The valid path writes to stdout, the invalid path to stderr — a blind
+    // `stderr + stdout` join buries one inside the other.
+    const r = describeRunFailure(err({
+      exitCode: 1,
+      stdout: 'Config valid: ~/.openclaw/openclaw.json',
+      stderr: OPENCLAW_INVALID_STDERR,
+    }));
+    expect(r.reason).toContain('OpenClaw config is invalid');
+    expect(r.detail.join('\n')).not.toContain('Config valid');
+  });
+
+  it('keeps the reason to a single line — step() pads it on one row', () => {
+    const r = describeRunFailure(err({ exitCode: 1, stderr: 'error: ' + 'x'.repeat(500) }));
+    expect(r.reason).not.toContain('\n');
+    expect(r.reason.length).toBeLessThanOrEqual(120);
+  });
+});

--- a/src/__tests__/child-output-report.test.ts
+++ b/src/__tests__/child-output-report.test.ts
@@ -65,6 +65,83 @@ describe('#221 — output is destined for a pasted report, so it is redacted', (
   });
 });
 
+describe('#221 — the strongest cause wins, not the earliest line', () => {
+  /**
+   * Measured on a real fleet host: `openclaw <unknown-command>` emits two
+   * `[plugins] codex failed during register …: TypeError …` lines from an
+   * unrelated third-party plugin BEFORE OpenClaw's own reason. Both match on
+   * the word "failed", so taking the first signal line reported someone else's
+   * TypeError as the cause — one misleading headline swapped for another.
+   */
+  it('drops other plugins\' registration chatter and leads with the real reason', () => {
+    const real = [
+      "[plugins] codex failed during register from /x/dist/index.js: TypeError: Cannot read properties of undefined (reading 'openSyncKeyedStore')",
+      '[plugins] codex failed during register from /x/dist/index.js: TypeError: Cannot read properties of undefined',
+      '[openclaw] Could not start the CLI.',
+      '[openclaw] Reason: Unknown command: openclaw plugins install.',
+    ].join('\n');
+
+    const { lines } = summariseCommandOutput(real, { maxLines: 3, env: {} });
+
+    expect(lines.join('\n')).not.toContain('codex failed');
+    expect(lines[0]).toContain('Unknown command');
+  });
+
+  /**
+   * The char-fit loop used to `shift()` unconditionally. On the signal path the
+   * list is ranked most-important-first, so shifting deleted the line naming
+   * WHICH config file was invalid and promoted a sibling issue to `reason`.
+   */
+  it('trims from the end when lines are ranked, keeping the header', () => {
+    const long = '/Users/x/.openclaw/npm/projects/some-quite-long-vendor-plugin-directory-name/node_modules';
+    const out = [
+      'OpenClaw config is invalid: /Users/x/.openclaw/openclaw.json',
+      `  × plugins.load.paths[0]: plugin path not found: ${long}-alpha`,
+      `  × plugins.load.paths[1]: plugin path not found: ${long}-bravo`,
+      `  × plugins.entries.foo.path: plugin path not found: ${long}-charlie`,
+    ].join('\n');
+
+    const { lines, truncated } = summariseCommandOutput(out, { maxLines: 4, maxChars: 400, env: {} });
+
+    expect(lines[0]).toContain('OpenClaw config is invalid');
+    expect(truncated).toBe(true);
+  });
+
+  it('keeps the head when output exceeds the input cap', () => {
+    // The cap used to take the tail, discarding a diagnosis printed first
+    // before the signal filter could ever see it.
+    const out = 'OpenClaw config is invalid: /Users/x/.openclaw/openclaw.json\n' + 'filler line\n'.repeat(6000);
+
+    const { lines, truncated } = summariseCommandOutput(out, { maxLines: 2, env: {} });
+
+    expect(lines.join('\n')).toContain('OpenClaw config is invalid');
+    expect(truncated).toBe(true);
+  });
+});
+
+describe('#221 — the operator\'s identity does not travel with the report', () => {
+  it('abbreviates the home directory, as every other doctor path site does', () => {
+    const home = '/Users/somebody';
+    const { lines } = summariseCommandOutput(
+      `error: plugin path not found: ${home}/.openclaw/npm/projects/acme-client-plugin/dist/index.js`,
+      { home, env: {} },
+    );
+
+    const text = lines.join('\n');
+    expect(text).not.toContain(home);
+    expect(text).toContain('~/.openclaw');
+  });
+
+  it('redacts the longer of two secrets that share a prefix', () => {
+    // Visiting the shorter first left the tail of the longer one in cleartext,
+    // and the second pass then found nothing intact to replace.
+    const env = { MY_TOKEN: 'abcdefgh', MY_TOKEN_LONG: 'abcdefghIJKLMNOP' };
+    const { lines } = summariseCommandOutput('error: rejected token abcdefghIJKLMNOP', { env, home: '/nowhere' });
+
+    expect(lines.join('\n')).not.toContain('IJKLMNOP');
+  });
+});
+
 describe('#221 — the empty-output ladder never yields a bare "failed"', () => {
   const err = (over: Partial<CapturedError>): CapturedError =>
     Object.assign(new Error('exit 1: openclaw plugins install'), over) as CapturedError;
@@ -80,6 +157,25 @@ describe('#221 — the empty-output ladder never yields a bare "failed"', () => 
     const r = describeRunFailure(err({ exitCode: null, timedOut: true, command: 'openclaw plugins install' }));
     expect(r.timedOut).toBe(true);
     expect(r.reason).toContain('timed out');
+  });
+
+  /**
+   * How the process ENDED outranks whatever it managed to print. A step killed
+   * at the 120s wall usually has a plausible network line in its buffer;
+   * reporting that alone tells the operator to retry a transient blip when the
+   * real fact is a SIGTERM mid-flight and a possibly half-applied install.
+   */
+  it('a killed process is not reported as whatever it last printed', () => {
+    const r = describeRunFailure(err({
+      timedOut: true,
+      exitCode: null,
+      command: 'openclaw plugins install',
+      stderr: 'npm error network request to https://registry.npmjs.org/x failed, reason: socket hang up',
+    }));
+
+    expect(r.reason).toContain('timed out');
+    // The partial output is still available, just not masquerading as the cause.
+    expect(r.detail.join('\n')).toContain('socket hang up');
   });
 
   it('reports a missing binary distinctly from a non-zero exit', () => {

--- a/src/__tests__/doctor-blocked-fix-tagging.test.ts
+++ b/src/__tests__/doctor-blocked-fix-tagging.test.ts
@@ -25,7 +25,7 @@ const DOCTOR = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'cli', 'do
 
 /** Commands OpenClaw refuses outright while its config is invalid. */
 const BLOCKED_COMMAND =
-  /(openclaw plugins |openclaw skills |shieldcortex openclaw (skill install|repair|install))/;
+  /(openclaw plugins |openclaw skills |openclaw config patch|shieldcortex openclaw (skill install|repair|install))/;
 
 /** How far after a remediation line the tag may sit before we call it absent. */
 const TAG_WINDOW = 14;
@@ -60,9 +60,9 @@ describe('#221 — every blocked remediation in doctor.ts carries the tag', () =
     const source = readFileSync(DOCTOR, 'utf-8');
     const tags = source.match(/needsOpenClawCli: \{[^}]*\}/g) ?? [];
 
-    expect(tags.length).toBeGreaterThanOrEqual(17);
+    expect(tags.length).toBeGreaterThanOrEqual(18);
     for (const tag of tags) {
-      expect(tag).toMatch(/subcommand: '(plugins|skills)'/);
+      expect(tag).toMatch(/subcommand: '(plugins|skills|config)'/);
     }
   });
 });

--- a/src/__tests__/doctor-blocked-fix-tagging.test.ts
+++ b/src/__tests__/doctor-blocked-fix-tagging.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from '@jest/globals';
+
+/**
+ * #221 — a SOURCE-level rail, because the runtime gate can only act on results
+ * that were tagged, and the tagging is the part a future edit will forget.
+ *
+ * The behavioural tests in doctor-openclaw-cli-gate.test.ts prove the gate
+ * withdraws a tagged remedy. Nothing there notices when someone adds a
+ * seventeenth `fix: 'Run \`openclaw plugins …\`'` without the tag — the gate
+ * would silently sail past it and the operator would be back to following a
+ * command that cannot run. That is the same shape as the defect this issue
+ * reports, so it is worth a rail of its own.
+ *
+ * Deliberately NOT matched: a bare `shieldcortex repair`. It appears on both
+ * sides of the line — blocked when it routes to `plugins install --force`, and
+ * genuinely working when it routes to restore-registration (a pure JSON write,
+ * and the only remedy for an UNPROTECTED host). No text test can separate
+ * those, which is exactly why the tag is declared per site.
+ */
+
+const DOCTOR = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'cli', 'doctor.ts');
+
+/** Commands OpenClaw refuses outright while its config is invalid. */
+const BLOCKED_COMMAND =
+  /(openclaw plugins |openclaw skills |shieldcortex openclaw (skill install|repair|install))/;
+
+/** How far after a remediation line the tag may sit before we call it absent. */
+const TAG_WINDOW = 14;
+
+describe('#221 — every blocked remediation in doctor.ts carries the tag', () => {
+  it('finds no untagged remediation that needs an OpenClaw subcommand', () => {
+    const lines = readFileSync(DOCTOR, 'utf-8').split('\n');
+    const untagged: string[] = [];
+
+    lines.forEach((line, i) => {
+      const trimmed = line.trim();
+      // Remediation only: a `fix:` value, or the one site that carries its
+      // advice in `message:`. Comments and prose are not instructions.
+      if (trimmed.startsWith('*') || trimmed.startsWith('//')) return;
+      if (!/^(fix:|message:)/.test(trimmed) && !/^\s*fix:/.test(line)) return;
+      if (!BLOCKED_COMMAND.test(line)) return;
+
+      const window = lines.slice(i, i + TAG_WINDOW).join('\n');
+      // Stop at the end of this result object so a NEIGHBOUR's tag cannot
+      // vouch for an untagged site.
+      const objectEnd = window.indexOf('\n      };');
+      const scope = objectEnd === -1 ? window : window.slice(0, objectEnd);
+      if (!scope.includes('needsOpenClawCli')) {
+        untagged.push(`doctor.ts:${i + 1}  ${trimmed.slice(0, 110)}`);
+      }
+    });
+
+    expect(untagged).toEqual([]);
+  });
+
+  it('the tag is only ever spelled in ways the gate understands', () => {
+    const source = readFileSync(DOCTOR, 'utf-8');
+    const tags = source.match(/needsOpenClawCli: \{[^}]*\}/g) ?? [];
+
+    expect(tags.length).toBeGreaterThanOrEqual(17);
+    for (const tag of tags) {
+      expect(tag).toMatch(/subcommand: '(plugins|skills)'/);
+    }
+  });
+});

--- a/src/__tests__/doctor-openclaw-cli-gate.test.ts
+++ b/src/__tests__/doctor-openclaw-cli-gate.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  applyOpenClawCliGate,
+  checkOpenClawConfigValid,
+  OPENCLAW_CONFIG_LABEL,
+} from '../cli/doctor.js';
+import type { CheckResult } from '../cli/doctor.js';
+import type { SpawnOutcome, ValidateDeps } from '../integrations/openclaw-config-validate.js';
+
+/**
+ * #221 — doctor must not recommend commands that cannot run.
+ *
+ * An operator followed three suggested fixes for five days while OpenClaw
+ * refused every one of them, reporting only "Unknown command". Advice that
+ * cannot be followed is worse than no advice: it consumes the operator's
+ * attention and hides the real cause.
+ *
+ * The two risks pulled in opposite directions, so both are pinned here:
+ * remedies that genuinely cannot run must be withdrawn, and remedies that
+ * still work must survive untouched — including one that reads
+ * "shieldcortex repair" and is the ONLY fix for an unprotected host.
+ */
+
+const HOME = '/home/tester';
+
+function deps(run: () => SpawnOutcome): ValidateDeps {
+  return {
+    exists: () => true,
+    configPath: () => `${HOME}/.openclaw/openclaw.json`,
+    resolveBin: () => '/opt/homebrew/bin/openclaw',
+    run,
+  };
+}
+
+const INVALID_CONFIG = deps(() => ({
+  status: 1,
+  stdout: '',
+  stderr: 'OpenClaw config is invalid: /home/tester/.openclaw/openclaw.json\n  × plugins: plugin manifest not found: ~/.openclaw/extensions/ekho-adapter/openclaw.plugin.json',
+}));
+
+/** The blocking row the gate keys on, as the real check would produce it. */
+async function blockingRow(): Promise<CheckResult> {
+  return await checkOpenClawConfigValid(HOME, INVALID_CONFIG);
+}
+
+describe('#221 — the config check itself', () => {
+  it('fails, quotes what OpenClaw said, and names the unblocking command', async () => {
+    const r = await checkOpenClawConfigValid(HOME, INVALID_CONFIG);
+
+    expect(r.status).toBe('fail');
+    expect(r.label).toBe(OPENCLAW_CONFIG_LABEL);
+    expect(r.message).toContain('plugin manifest not found');
+    // The operator's whole problem was not knowing WHY commands no-opped.
+    expect(r.message).toContain('Unknown command');
+    expect(r.fix).toContain('openclaw doctor --fix');
+  });
+
+  it('passes on a config that merely has warnings', async () => {
+    const r = await checkOpenClawConfigValid(HOME, deps(() => ({
+      status: 0,
+      stdout: 'Config valid: ~/.openclaw/openclaw.json\n1 warning(s):\n  ! plugins.entries.ekho-adapter: duplicate plugin id detected',
+      stderr: '',
+    })));
+
+    expect(r.status).toBe('pass');
+  });
+
+  it('is info, never fail, when the verdict could not be established', async () => {
+    const r = await checkOpenClawConfigValid(HOME, { ...INVALID_CONFIG, resolveBin: () => null });
+    expect(r.status).toBe('info');
+  });
+
+  it('returns rather than throws — a crash would render with no fix at all', async () => {
+    const r = await checkOpenClawConfigValid(HOME, deps(() => { throw new Error('boom'); }));
+    expect(r.status).toBe('info');
+  });
+});
+
+describe('#221 — the gate withdraws advice that cannot run', () => {
+  it('strips a fix whose only route is an OpenClaw subcommand', async () => {
+    const results: CheckResult[] = [
+      await blockingRow(),
+      {
+        label: 'OpenClaw plugin loaded',
+        status: 'fail',
+        message: 'realtime plugin regressed to v4.47.33',
+        fix: 'Run `openclaw plugins install --force @drakon-systems/shieldcortex-realtime@latest`',
+        needsOpenClawCli: { subcommand: 'plugins' },
+      },
+    ];
+
+    const gated = applyOpenClawCliGate(results);
+
+    expect(gated[1].fix).toBeUndefined();
+    expect(gated[1].message).toContain('remedy blocked');
+  });
+
+  it('swaps in the working half when a site has one', async () => {
+    const results: CheckResult[] = [
+      await blockingRow(),
+      {
+        label: 'OpenClaw residue',
+        status: 'warn',
+        message: 'legacy install found',
+        fix: 'Run `shieldcortex uninstall --deep --confirm` to purge, or reinstall with `shieldcortex openclaw install`',
+        needsOpenClawCli: { subcommand: 'plugins', fallbackFix: 'Run `shieldcortex uninstall --deep --confirm` to purge the residue (pure filesystem).' },
+      },
+    ];
+
+    const gated = applyOpenClawCliGate(results);
+
+    expect(gated[1].fix).toBe('Run `shieldcortex uninstall --deep --confirm` to purge the residue (pure filesystem).');
+    expect(gated[1].fix).not.toContain('openclaw install');
+  });
+
+  it('annotates a site whose remediation lives in `message`, not `fix`', async () => {
+    // The optional-skill notice. A gate that only rewrote `fix` would leave
+    // this as the one piece of unfollowable advice still on the page.
+    const results: CheckResult[] = [
+      await blockingRow(),
+      {
+        label: 'OpenClaw skill',
+        status: 'info',
+        message: 'skill not installed (optional) — `shieldcortex openclaw skill install` adds it',
+        needsOpenClawCli: { subcommand: 'skills' },
+      },
+    ];
+
+    const gated = applyOpenClawCliGate(results);
+    expect(gated[1].message).toContain('remedy blocked');
+  });
+});
+
+describe('#221 — the gate must not over-reach', () => {
+  /**
+   * THE MOST DANGEROUS OVER-REACH. `installed-not-enabled` recommends
+   * "shieldcortex repair", but that routes to restore-registration — a pure
+   * JSON write with no spawn — and it is the only working remedy for an
+   * UNPROTECTED host. Any suppression keyed on the substring "shieldcortex
+   * repair" would delete precisely the advice that still helps.
+   */
+  it('keeps an untagged `shieldcortex repair` fix even though the text matches', async () => {
+    const stillWorks = 'Restore the registration for the EXISTING install: `shieldcortex repair` (writes plugins.allow …). Nothing is reinstalled.';
+    const results: CheckResult[] = [
+      await blockingRow(),
+      { label: 'OpenClaw plugin loaded', status: 'fail', message: 'UNPROTECTED', fix: stillWorks },
+    ];
+
+    const gated = applyOpenClawCliGate(results);
+
+    expect(gated[1].fix).toBe(stillWorks);
+    expect(gated[1].message).not.toContain('remedy blocked');
+  });
+
+  it('leaves every fix alone when the config is merely indeterminate', () => {
+    // Fail-open: hiding working advice because we could not reach `openclaw`
+    // would be a worse bug than the one being fixed.
+    const results: CheckResult[] = [
+      { label: OPENCLAW_CONFIG_LABEL, status: 'info', message: 'not checked — openclaw binary not found' },
+      {
+        label: 'OpenClaw plugin loaded',
+        status: 'fail',
+        message: 'regressed',
+        fix: 'Run `openclaw plugins install --force …`',
+        needsOpenClawCli: { subcommand: 'plugins' },
+      },
+    ];
+
+    expect(applyOpenClawCliGate(results)).toEqual(results);
+  });
+
+  it('leaves every fix alone when the config is valid', () => {
+    const results: CheckResult[] = [
+      { label: OPENCLAW_CONFIG_LABEL, status: 'pass', message: 'validates' },
+      {
+        label: 'OpenClaw plugin loaded',
+        status: 'fail',
+        message: 'regressed',
+        fix: 'Run `openclaw plugins install --force …`',
+        needsOpenClawCli: { subcommand: 'plugins' },
+      },
+    ];
+
+    expect(applyOpenClawCliGate(results)).toEqual(results);
+  });
+
+  it('never changes severity — the host is exactly as broken as before', async () => {
+    const results: CheckResult[] = [
+      await blockingRow(),
+      { label: 'A', status: 'fail', message: 'm', fix: 'f', needsOpenClawCli: { subcommand: 'plugins' } },
+      { label: 'B', status: 'warn', message: 'm', fix: 'f', needsOpenClawCli: { subcommand: 'skills' } },
+      { label: 'C', status: 'pass', message: 'm' },
+    ];
+
+    const gated = applyOpenClawCliGate(results);
+
+    // Counts and doctor's exit code derive from these — a gate that softened a
+    // failure would make a blocked host look healthier than it is.
+    expect(gated.map(r => r.status)).toEqual(results.map(r => r.status));
+    expect(gated).toHaveLength(results.length);
+  });
+});

--- a/src/__tests__/doctor-openclaw-cli-gate.test.ts
+++ b/src/__tests__/doctor-openclaw-cli-gate.test.ts
@@ -214,6 +214,46 @@ describe('#221 — the gate must not over-reach', () => {
    * ShieldCortex purely as MCP memory, whose OpenClaw has some third-party
    * plugin's dangling entry, must not start failing its pipeline over it.
    */
+  /**
+   * A TAG IS NOT A FAULT.
+   *
+   * `checkOpenClawSkillVersion` returns this exact tagged `info` row whenever
+   * the skill is not installed — the DEFAULT for every host not using the
+   * OpenClaw integration. Counting tags rather than faults kept the config row
+   * at `fail`, so `shieldcortex doctor` exited 1 on hosts with nothing wrong,
+   * over a third party's config. The row must still be annotated: it does not
+   * vote on severity, but it is still advice that cannot be followed.
+   */
+  it('an optional info row does not make doctor fail, but is still annotated', () => {
+    const results: CheckResult[] = [
+      { label: OPENCLAW_CONFIG_LABEL, status: 'fail', message: 'invalid', openClawCliBlocked: true },
+      {
+        label: 'OpenClaw skill version',
+        status: 'info',
+        message: 'skill not installed (optional) — `shieldcortex openclaw skill install` adds it',
+        needsOpenClawCli: { subcommand: 'skills' },
+      },
+    ];
+
+    const gated = applyOpenClawCliGate(results);
+
+    expect(gated[0].status).toBe('warn');
+    expect(gated[1].message).toContain('remedy blocked');
+  });
+
+  it('a real fault alongside an info row still fails', () => {
+    const results: CheckResult[] = [
+      { label: OPENCLAW_CONFIG_LABEL, status: 'fail', message: 'invalid', openClawCliBlocked: true },
+      { label: 'OpenClaw skill version', status: 'info', message: 'optional', needsOpenClawCli: { subcommand: 'skills' } },
+      { label: 'OpenClaw plugin loaded', status: 'fail', message: 'UNPROTECTED', fix: 'f', needsOpenClawCli: { subcommand: 'plugins' } },
+    ];
+
+    const gated = applyOpenClawCliGate(results);
+
+    expect(gated[0].status).toBe('fail');
+    expect(gated[2].fix).toBeUndefined();
+  });
+
   it('downgrades to warn when no remedy of ours is actually blocked', () => {
     const results: CheckResult[] = [
       { label: OPENCLAW_CONFIG_LABEL, status: 'fail', message: 'invalid', openClawCliBlocked: true },

--- a/src/__tests__/doctor-openclaw-cli-gate.test.ts
+++ b/src/__tests__/doctor-openclaw-cli-gate.test.ts
@@ -184,7 +184,58 @@ describe('#221 — the gate must not over-reach', () => {
     expect(applyOpenClawCliGate(results)).toEqual(results);
   });
 
-  it('never changes severity — the host is exactly as broken as before', async () => {
+  /**
+   * The gate keys on `openClawCliBlocked`, never on `status === 'fail'`.
+   * Keying on severity would mean any later adjustment to this check's status
+   * silently switches the whole suppression feature off with no test failing —
+   * the coupling that produced #222 and #103.
+   */
+  it('still suppresses when the config row is a warn, not a fail', () => {
+    const results: CheckResult[] = [
+      { label: OPENCLAW_CONFIG_LABEL, status: 'warn', message: 'invalid', openClawCliBlocked: true },
+      { label: 'A', status: 'fail', message: 'm', fix: 'f', needsOpenClawCli: { subcommand: 'plugins' } },
+    ];
+
+    expect(applyOpenClawCliGate(results)[1].fix).toBeUndefined();
+  });
+
+  it('does not suppress on a fail row that lacks the marker', () => {
+    const results: CheckResult[] = [
+      { label: OPENCLAW_CONFIG_LABEL, status: 'fail', message: 'some other failure' },
+      { label: 'A', status: 'fail', message: 'm', fix: 'f', needsOpenClawCli: { subcommand: 'plugins' } },
+    ];
+
+    expect(applyOpenClawCliGate(results)[1].fix).toBe('f');
+  });
+
+  /**
+   * `doctor` exits 1 on any fail with no --strict opt-in, and the enforcement
+   * contract reserves that for states ShieldCortex owns. A host using
+   * ShieldCortex purely as MCP memory, whose OpenClaw has some third-party
+   * plugin's dangling entry, must not start failing its pipeline over it.
+   */
+  it('downgrades to warn when no remedy of ours is actually blocked', () => {
+    const results: CheckResult[] = [
+      { label: OPENCLAW_CONFIG_LABEL, status: 'fail', message: 'invalid', openClawCliBlocked: true },
+      { label: 'Database', status: 'pass', message: 'healthy' },
+    ];
+
+    const gated = applyOpenClawCliGate(results);
+
+    expect(gated[0].status).toBe('warn');
+    expect(gated[0].message).toContain('no ShieldCortex remedy');
+  });
+
+  it('keeps the fail when something of ours IS blocked', () => {
+    const results: CheckResult[] = [
+      { label: OPENCLAW_CONFIG_LABEL, status: 'fail', message: 'invalid', openClawCliBlocked: true },
+      { label: 'A', status: 'fail', message: 'm', fix: 'f', needsOpenClawCli: { subcommand: 'plugins' } },
+    ];
+
+    expect(applyOpenClawCliGate(results)[0].status).toBe('fail');
+  });
+
+  it('never changes severity of any OTHER check', async () => {
     const results: CheckResult[] = [
       await blockingRow(),
       { label: 'A', status: 'fail', message: 'm', fix: 'f', needsOpenClawCli: { subcommand: 'plugins' } },

--- a/src/__tests__/openclaw-config-validate.test.ts
+++ b/src/__tests__/openclaw-config-validate.test.ts
@@ -122,6 +122,32 @@ describe('#221 — a non-zero exit is not proof of an invalid config', () => {
     expect(v.state).toBe('indeterminate');
   });
 
+  /**
+   * A REFUSAL VETOES A BULLET. Unrelated plugin stderr routinely carries `✗ …`
+   * lines, and one landing beside "Unknown command" would otherwise convict a
+   * healthy config on an OpenClaw that simply lacks `config validate` —
+   * reopening the inverted case with an extra step.
+   */
+  it('a refusal plus an unrelated ✗ line is still indeterminate', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({
+        status: 1,
+        stderr: '✗ ekho-adapter: telemetry endpoint unreachable\n[openclaw] Reason: Unknown command: openclaw config validate.',
+      }),
+    }));
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('a usage dump plus an unrelated × line is still indeterminate', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({
+        status: 1,
+        stderr: 'Too many arguments for this command.\n  × unrelated plugin load failed',
+      }),
+    }));
+    expect(v.state).toBe('indeterminate');
+  });
+
   it('but a JSON invalid body IS invalid', () => {
     const v = validateOpenClawConfig(HOME, deps({
       run: () => outcome({ status: 1, stdout: '{"valid":false,"path":"/x","issues":[{"path":"a","message":"b"}]}' }),

--- a/src/__tests__/openclaw-config-validate.test.ts
+++ b/src/__tests__/openclaw-config-validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { validateOpenClawConfig } from '../integrations/openclaw-config-validate.js';
+import { validateOpenClawConfig, VALIDATE_ARGV } from '../integrations/openclaw-config-validate.js';
 import type { SpawnOutcome, ValidateDeps } from '../integrations/openclaw-config-validate.js';
 
 /**
@@ -67,12 +67,83 @@ describe('#221 — genuinely invalid', () => {
     expect(v.detail.join('\n')).toContain('plugin path not found');
   });
 
-  it('never yields an empty detail, even with no output', () => {
-    const v = validateOpenClawConfig(HOME, deps({ run: () => outcome({ status: 1 }) }));
+  it('never yields an empty detail', () => {
+    // The marker is present, so this IS invalid — but summarising could still
+    // come back empty, and a suppression with no stated cause is unarguable.
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({ status: 1, stderr: 'config is invalid' }),
+    }));
+
     expect(v.state).toBe('invalid');
     if (v.state !== 'invalid') throw new Error('unreachable');
     expect(v.detail.length).toBeGreaterThan(0);
-    expect(v.detail.join(' ')).toContain('exited 1');
+  });
+
+  it('exit 1 with NO output at all is indeterminate, not invalid', () => {
+    // Nothing said the config is bad. Silence is not evidence, and the cost of
+    // guessing wrong here is stripping every remedy from a healthy host.
+    const v = validateOpenClawConfig(HOME, deps({ run: () => outcome({ status: 1 }) }));
+    expect(v.state).toBe('indeterminate');
+  });
+});
+
+describe('#221 — a non-zero exit is not proof of an invalid config', () => {
+  /**
+   * THE INVERTED-#221 CASE, and the worst thing this module could do.
+   *
+   * An OpenClaw predating `config validate` answers an unknown subcommand with
+   * exit 1. Measured on 2026.7.1-2: `openclaw config <unknown>` exits 1 with
+   * "Too many arguments for this command." If that reads as "config invalid",
+   * a HEALTHY host gets a red config row AND has every remedy stripped —
+   * including the one on the check whose message says the gateway is running
+   * with no memory firewall and no action guard.
+   */
+  it('an OpenClaw that does not know the subcommand is indeterminate', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({
+        status: 1,
+        stdout: '',
+        stderr: 'Too many arguments for this command.\nTry: openclaw config validate --help',
+      }),
+    }));
+
+    expect(v.state).toBe('indeterminate');
+    if (v.state !== 'indeterminate') throw new Error('unreachable');
+    expect(v.reason).toContain('not supported');
+  });
+
+  it('an OpenClaw that does not know the command at all is indeterminate', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({
+        status: 1,
+        stderr: '[openclaw] Could not start the CLI.\n[openclaw] Reason: Unknown command: openclaw config validate.',
+      }),
+    }));
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('but a JSON invalid body IS invalid', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({ status: 1, stdout: '{"valid":false,"path":"/x","issues":[{"path":"a","message":"b"}]}' }),
+    }));
+    expect(v.state).toBe('invalid');
+  });
+
+  it('and a bullet-marked issue IS invalid', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({ status: 1, stderr: '  × plugins.load.paths: plugin path not found: /nope' }),
+    }));
+    expect(v.state).toBe('invalid');
+  });
+});
+
+describe('#221 — the argv must never grow a flag', () => {
+  it('is exactly `config validate`', () => {
+    // `--json` is tidier and was deliberately rejected: an OpenClaw that does
+    // not know the flag exits non-zero with a usage dump, manufacturing the
+    // false red this module exists to avoid.
+    expect([...VALIDATE_ARGV]).toEqual(['config', 'validate']);
+    expect(VALIDATE_ARGV.some(a => a.startsWith('-'))).toBe(false);
   });
 });
 

--- a/src/__tests__/openclaw-config-validate.test.ts
+++ b/src/__tests__/openclaw-config-validate.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from '@jest/globals';
+import { validateOpenClawConfig } from '../integrations/openclaw-config-validate.js';
+import type { SpawnOutcome, ValidateDeps } from '../integrations/openclaw-config-validate.js';
+
+/**
+ * #221 — the verdict is three-state, and every ambiguous case must land on
+ * `indeterminate`.
+ *
+ * Suppressing a remedy is destructive: if this module says "invalid" when it
+ * should not, doctor hides the advice that would have fixed the host. So the
+ * false-red cases below matter more than the happy path, and each was measured
+ * against the real binary before being written down.
+ */
+
+const HOME = '/home/tester';
+
+function deps(over: Partial<ValidateDeps> = {}): ValidateDeps {
+  return {
+    exists: () => true,
+    configPath: () => '/home/tester/.openclaw/openclaw.json',
+    resolveBin: () => '/opt/homebrew/bin/openclaw',
+    ...over,
+  };
+}
+
+function outcome(over: Partial<SpawnOutcome> = {}): SpawnOutcome {
+  return { status: 0, stdout: '', stderr: '', ...over };
+}
+
+describe('#221 — a valid config, including one with warnings', () => {
+  it('exit 0 is valid', () => {
+    const v = validateOpenClawConfig(HOME, deps({ run: () => outcome({ status: 0 }) }));
+    expect(v.state).toBe('valid');
+  });
+
+  /**
+   * THE FALSE-RED THIS PRODUCT WOULD HAVE SHIPPED.
+   *
+   * The dev box prints "1 warning(s): ! plugins.entries.ekho-adapter:
+   * duplicate plugin id detected" and still exits 0 — and the operator in the
+   * field report ALSO had an ekho-adapter problem, so the two states are easy
+   * to conflate. Anything that reads the output to reach a verdict fails here.
+   */
+  it('warnings on stdout with exit 0 are STILL valid', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({
+        status: 0,
+        stdout: 'Config valid: ~/.openclaw/openclaw.json\n1 warning(s):\n  ! plugins.entries.ekho-adapter: duplicate plugin id detected',
+      }),
+    }));
+    expect(v.state).toBe('valid');
+  });
+});
+
+describe('#221 — genuinely invalid', () => {
+  it('non-zero exit is invalid, and quotes what OpenClaw said', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({
+        status: 1,
+        stdout: '',
+        stderr: 'OpenClaw config is invalid: /home/tester/.openclaw/openclaw.json\n  × plugins.load.paths: plugin path not found: /nope\n\nRun `openclaw doctor --fix` to repair.',
+      }),
+    }));
+
+    expect(v.state).toBe('invalid');
+    if (v.state !== 'invalid') throw new Error('unreachable');
+    expect(v.detail.join('\n')).toContain('plugin path not found');
+  });
+
+  it('never yields an empty detail, even with no output', () => {
+    const v = validateOpenClawConfig(HOME, deps({ run: () => outcome({ status: 1 }) }));
+    expect(v.state).toBe('invalid');
+    if (v.state !== 'invalid') throw new Error('unreachable');
+    expect(v.detail.length).toBeGreaterThan(0);
+    expect(v.detail.join(' ')).toContain('exited 1');
+  });
+});
+
+describe('#221 — every uncertainty is indeterminate, never invalid', () => {
+  it('no OpenClaw config on this host — does not even spawn', () => {
+    let spawned = false;
+    const v = validateOpenClawConfig(HOME, deps({
+      exists: () => false,
+      run: () => { spawned = true; return outcome({ status: 1 }); },
+    }));
+
+    expect(v.state).toBe('indeterminate');
+    // The measured trap: `config validate` on a missing file exits 1 with
+    // {"valid":false,"error":"file not found"} — a pure exit-code gate would
+    // call an OpenClaw-less host "config invalid".
+    expect(spawned).toBe(false);
+  });
+
+  it('openclaw binary not installed', () => {
+    const v = validateOpenClawConfig(HOME, deps({ resolveBin: () => null }));
+    expect(v.state).toBe('indeterminate');
+  });
+
+  /**
+   * spawnSync reports an absent binary as status:null + error.code ENOENT, NOT
+   * as 127 (127 is the shell path only). The `status ?? 1` idiom used elsewhere
+   * in the codebase collapses this into "exit 1" — which would be read as a
+   * broken config on a host that has nothing to fix.
+   */
+  it('binary vanishing between resolve and spawn is NOT invalid', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({ status: null, error: Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }) }),
+    }));
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('a timeout is NOT invalid', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({ status: null, error: Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' }) }),
+    }));
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('a kill signal is NOT invalid', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => outcome({ status: null, signal: 'SIGTERM' }),
+    }));
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('a throwing spawn is NOT invalid', () => {
+    const v = validateOpenClawConfig(HOME, deps({
+      run: () => { throw new Error('EACCES: permission denied'); },
+    }));
+    expect(v.state).toBe('indeterminate');
+    if (v.state !== 'indeterminate') throw new Error('unreachable');
+    expect(v.reason).toContain('EACCES');
+  });
+
+  it('never spawns a real subprocess from the test runner', () => {
+    // No `run` injected: the JEST_WORKER_ID guard must catch it. If this ever
+    // regresses, the suite starts shelling out to the developer's real binary.
+    expect(process.env.JEST_WORKER_ID).toBeDefined();
+    const v = validateOpenClawConfig(HOME, deps({ run: undefined }));
+    expect(v.state).toBe('indeterminate');
+    if (v.state !== 'indeterminate') throw new Error('unreachable');
+    expect(v.reason).toContain('test runner');
+  });
+});

--- a/src/__tests__/openclaw-reconcile-detail-249.test.ts
+++ b/src/__tests__/openclaw-reconcile-detail-249.test.ts
@@ -1,8 +1,13 @@
 /**
- * Round-2 review regressions on #249 (PR review 4913640155).
+ * Review regressions on #249 (PR reviews 4913640155 and the round-3 follow-up).
  *
- * All three were reproduced against built code before being fixed; each test
- * below fails on the previous commit.
+ * Every finding was reproduced against built code before being fixed, and each
+ * test that pins a fix fails on the commit preceding it. The remainder are
+ * guard cases asserting behaviour that must NOT change, and pass either side.
+ *
+ * The theme, twice over: a third party's chatter on our streams must carry no
+ * authority. Round 2 stopped it VETOING a real verdict; round 3 stopped it
+ * MANUFACTURING one. Fixing either direction alone leaves the mirror open.
  */
 import { summariseCommandOutput } from '../integrations/child-output.js';
 import { validateOpenClawConfig } from '../integrations/openclaw-config-validate.js';
@@ -98,5 +103,43 @@ describe('#249: retained plugin chatter is a last resort, not a promotion', () =
       maxLines: 1, dropPluginChatter: false, mode: 'failure', home: HOME,
     });
     expect(r.lines[0]).toContain('x.js');
+  });
+});
+
+describe('#249: only validator-owned lines may reach a verdict', () => {
+  const run = (stdout: string, stderr: string) => validateOpenClawConfig(HOME, {
+    exists: () => true,
+    resolveBin: () => '/usr/bin/openclaw',
+    run: () => ({ status: 1, stdout, stderr } as never),
+  });
+
+  it('plugin chatter cannot MANUFACTURE strong proof under an explicit refusal', () => {
+    // The mirror of the round-2 finding: having stopped chatter vetoing a real
+    // verdict, it must not be able to supply a fake one either.
+    const v = run('[plugins] acme migration failed: cached config is invalid\nUnknown command: config validate\n', '');
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('plugin chatter cannot manufacture the JSON verdict form either', () => {
+    const v = run('[plugins] acme: last run reported "valid": false\nUnknown command: config validate\n', '');
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('plugin chatter cannot supply a REFUSAL that vetoes a real verdict', () => {
+    const v = run('OpenClaw config is invalid:\n  × bad key\n', '[plugins] acme: unknown option --x\n');
+    expect(v.state).toBe('invalid');
+  });
+
+  it('detail comes from the stream carrying the verdict, not merely from stderr', () => {
+    const v = run('OpenClaw config is invalid:\n  × channels.telegram: bad key\n', '[plugins] acme: noisy chatter\n');
+    expect(v.state).toBe('invalid');
+    expect(v.detail?.join('\n')).toContain('bad key');
+    expect(v.detail?.join('\n')).not.toMatch(/exited 1/);
+  });
+
+  it('still reports invalid from stderr in the normal inverted case', () => {
+    const v = run('', 'OpenClaw config is invalid:\n  × agents.main: unknown field\n');
+    expect(v.state).toBe('invalid');
+    expect(v.detail?.join('\n')).toContain('unknown field');
   });
 });

--- a/src/__tests__/openclaw-reconcile-detail-249.test.ts
+++ b/src/__tests__/openclaw-reconcile-detail-249.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Round-2 review regressions on #249 (PR review 4913640155).
+ *
+ * All three were reproduced against built code before being fixed; each test
+ * below fails on the previous commit.
+ */
+import { summariseCommandOutput } from '../integrations/child-output.js';
+import { validateOpenClawConfig } from '../integrations/openclaw-config-validate.js';
+
+const HOME = '/home/tester';
+const TOKEN = 'SEKRET-abc123456789';
+
+describe('#249: a non-empty guarantee must not bypass redaction', () => {
+  it('redacts the env token even when the ONLY surviving line carries it', () => {
+    // Single line, so there is no other line the picker could prefer: if the
+    // token is absent it is because redaction removed it, not because the
+    // line was not chosen.
+    const out = `npm warn auth token=${TOKEN} written to ${HOME}/.npmrc`;
+    const r = summariseCommandOutput(out, {
+      maxLines: 1, dropPluginChatter: false, mode: 'failure', neverEmpty: true,
+      env: { NPM_TOKEN: TOKEN }, home: HOME,
+    });
+    expect(r.lines).toHaveLength(1);
+    expect(r.lines[0]).not.toContain(TOKEN);
+    // Either redaction layer may claim it — env-value substitution runs first,
+    // the credential detector then rewrites its marker. Assert the secret is
+    // gone and SOMETHING said so, not which layer got there first.
+    expect(r.lines[0]).toMatch(/redacted/i);
+    expect(r.lines[0]).not.toContain(HOME);
+    expect(r.lines[0]).toContain('~/.npmrc');
+  });
+
+  it('caps an over-long noise line rather than emitting it whole', () => {
+    const out = `npm warn ${'x'.repeat(5000)}`;
+    const r = summariseCommandOutput(out, {
+      maxLines: 1, neverEmpty: true, dropPluginChatter: false, home: HOME,
+    });
+    expect(r.lines[0].length).toBeLessThanOrEqual(200);
+    expect(r.truncated).toBe(true);
+  });
+
+  it('still returns nothing when there was nothing', () => {
+    expect(summariseCommandOutput('   \n  \n', { neverEmpty: true }).lines).toEqual([]);
+  });
+
+  it('does not re-admit noise unless asked', () => {
+    expect(summariseCommandOutput('npm warn only noise here', { maxLines: 1 }).lines).toEqual([]);
+  });
+});
+
+describe('#249: strong invalid proof beats the refusal veto', () => {
+  const run = (stdout: string, stderr: string) => validateOpenClawConfig(HOME, {
+    exists: () => true,
+    resolveBin: () => '/usr/bin/openclaw',
+    run: () => ({ status: 1, stdout, stderr } as never),
+  });
+
+  it('stays invalid when unrelated plugin chatter mentions an unknown option', () => {
+    const v = run('OpenClaw config is invalid:\n  × bad key\n', '[plugins] acme: unknown option --x\n');
+    expect(v.state).toBe('invalid');
+  });
+
+  it('stays invalid on the JSON verdict form', () => {
+    const v = run('{"valid": false}', '[plugins] acme: unknown command foo\n');
+    expect(v.state).toBe('invalid');
+  });
+
+  it('still vetoes when the only invalidity evidence is a bullet', () => {
+    const v = run('Unknown command: config validate\n', '[plugins] acme: ✗ failed to load\n');
+    expect(v.state).toBe('indeterminate');
+  });
+});
+
+describe('#249: retained plugin chatter is a last resort, not a promotion', () => {
+  it('ranks the real npm failure above another plugin\'s TypeError', () => {
+    const out = [
+      '[plugins] acme: TypeError: Cannot read properties of undefined',
+      'npm error code EAI_AGAIN',
+      'npm error request to https://registry.npmjs.org failed, reason: getaddrinfo EAI_AGAIN',
+    ].join('\n');
+    const r = summariseCommandOutput(out, {
+      maxLines: 1, dropPluginChatter: false, mode: 'failure', home: HOME,
+    });
+    expect(r.lines[0]).toContain('EAI_AGAIN');
+  });
+
+  it('still surfaces plugin chatter when it is the only thing there', () => {
+    const out = '[plugins] acme: manifest not found';
+    const r = summariseCommandOutput(out, {
+      maxLines: 1, dropPluginChatter: false, mode: 'failure', home: HOME,
+    });
+    expect(r.lines[0]).toContain('manifest not found');
+  });
+
+  it('prefers a non-plugin line on the no-signal tail path too', () => {
+    const out = ['[plugins] acme: loaded late', 'at Object.<anonymous> (/app/x.js:1:1)'].join('\n');
+    const r = summariseCommandOutput(out, {
+      maxLines: 1, dropPluginChatter: false, mode: 'failure', home: HOME,
+    });
+    expect(r.lines[0]).toContain('x.js');
+  });
+});

--- a/src/__tests__/openclaw-reconcile-detail-249.test.ts
+++ b/src/__tests__/openclaw-reconcile-detail-249.test.ts
@@ -143,3 +143,130 @@ describe('#249: only validator-owned lines may reach a verdict', () => {
     expect(v.detail?.join('\n')).toContain('unknown field');
   });
 });
+
+describe('#249 round 4: chatter provenance survives wrapping and log prefixes', () => {
+  const run = (stdout: string, stderr: string) => validateOpenClawConfig(HOME, {
+    exists: () => true,
+    resolveBin: () => '/usr/bin/openclaw',
+    run: () => ({ status: 1, stdout, stderr } as never),
+  });
+
+  it('a WRAPPED continuation line under a chatter header carries no vote', () => {
+    // The round-3 fix tested the tag on the line that has it. A plugin whose
+    // message runs onto a second, indented line put `config is invalid` on a
+    // line with no tag — and manufactured strong proof under an explicit
+    // refusal, which is the same fail-open breach wearing a different shape.
+    const v = run('[plugins] acme migration failed:\n  cached config is invalid\nUnknown command: config validate\n', '');
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('a timestamp-prefixed chatter line carries no vote', () => {
+    const v = run('2026-08-12T07:00:00.123Z [plugins] acme: cached config is invalid\nUnknown command: config validate\n', '');
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('a bracketed-clock and level prefix carries no vote either', () => {
+    const v = run('[07:00:00] WARN [plugins] acme: cached "valid": false\nUnknown command: config validate\n', '');
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('an ANSI-coloured chatter tag carries no vote', () => {
+    const v = run('[36m[plugins][0m acme: cached config is invalid\nUnknown command: config validate\n', '');
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('the block ENDS at the next top-level line — OpenClaw keeps its vote', () => {
+    // The guard against over-stripping: swallowing the rest of the stream
+    // after any chatter line would silence the validator and re-open #221.
+    const v = run('', '[plugins] acme noise:\n  more acme noise\nOpenClaw config is invalid:\n  × agents.main: unknown field\n');
+    expect(v.state).toBe('invalid');
+    expect(v.detail?.join('\n')).toContain('unknown field');
+  });
+
+  it('an indented bullet with no chatter above it still convicts', () => {
+    // Indentation alone must never mean "someone else said it" — OpenClaw
+    // indents its own issue bullets.
+    const v = run('', 'OpenClaw config is invalid:\n  × agents.main: unknown field\n');
+    expect(v.state).toBe('invalid');
+  });
+});
+
+describe('#249 round 4: a split header/detail must not lose the cause', () => {
+  const run = (stdout: string, stderr: string) => validateOpenClawConfig(HOME, {
+    exists: () => true,
+    resolveBin: () => '/usr/bin/openclaw',
+    run: () => ({ status: 1, stdout, stderr } as never),
+  });
+
+  it('merges verdict-bearing evidence across BOTH streams', () => {
+    // `.find()` stopped at the first stream that matched — the header — and
+    // reported `OpenClaw config is invalid:` alone, which names no cause and
+    // leaves the operator exactly where #221 left them.
+    const v = run('  × channels.telegram: bad key\n', 'OpenClaw config is invalid:\n');
+    expect(v.state).toBe('invalid');
+    const detail = v.detail?.join('\n') ?? '';
+    expect(detail).toContain('channels.telegram');
+    expect(detail).toContain('config is invalid');
+  });
+
+  it('does not drag in a stream that carries no verdict evidence', () => {
+    const v = run('Loaded 12 plugins in 340ms\n', 'OpenClaw config is invalid:\n  × agents.main: unknown field\n');
+    expect(v.state).toBe('invalid');
+    expect(v.detail?.join('\n')).not.toContain('340ms');
+  });
+});
+
+describe('#249: chatter provenance survives wrapping and logger prefixes', () => {
+  const ESC = String.fromCharCode(27);
+  const run = (stdout: string, stderr: string) => validateOpenClawConfig(HOME, {
+    exists: () => true,
+    resolveBin: () => '/usr/bin/openclaw',
+    run: () => ({ status: 1, stdout, stderr } as never),
+  });
+  const REFUSED = 'Unknown command: config validate\n';
+
+  it('evidence on a plugin block\'s CONTINUATION line carries no authority', () => {
+    const v = run(`[plugins] acme migration failed:\n  cached config is invalid\n${REFUSED}`, '');
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('a timestamp before the tag does not launder it', () => {
+    const v = run(`2026-08-12T07:00:00Z [plugins] acme: cached config is invalid\n${REFUSED}`, '');
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('a log level before the tag does not launder it', () => {
+    const v = run(`WARN [plugins] acme: cached config is invalid\n${REFUSED}`, '');
+    expect(v.state).toBe('indeterminate');
+  });
+
+  it('ANSI colour around the tag does not launder it', () => {
+    const v = run(`${ESC}[32m[plugins]${ESC}[0m acme: cached config is invalid\n${REFUSED}`, '');
+    expect(v.state).toBe('indeterminate');
+  });
+
+  // The over-stripping risk. Indentation alone cannot mean "third party" —
+  // OpenClaw's own issue bullets are indented, and they are the entire reason
+  // an operator can act. A broad rule would pass the tests above and silently
+  // destroy this one.
+  it('does NOT swallow OpenClaw\'s own indented bullets', () => {
+    const v = run('', 'OpenClaw config is invalid:\n  × channels.telegram: bad key\n  × agents.main: unknown field\n');
+    expect(v.state).toBe('invalid');
+    expect(v.detail?.join('\n')).toContain('bad key');
+  });
+
+  it('a plugin block ENDS as soon as OpenClaw speaks again', () => {
+    const v = run('', '[plugins] acme: warming up\n  still warming\nOpenClaw config is invalid:\n  × channels.telegram: bad key\n');
+    expect(v.state).toBe('invalid');
+    expect(v.detail?.join('\n')).toContain('bad key');
+    expect(v.detail?.join('\n')).not.toContain('warming');
+  });
+
+  it('merges evidence when the header and its cause land on different streams', () => {
+    const v = run('  × channels.telegram: bad key\n', 'OpenClaw config is invalid:\n');
+    expect(v.state).toBe('invalid');
+    const detail = v.detail?.join('\n') ?? '';
+    expect(detail).toContain('config is invalid');
+    expect(detail).toContain('bad key');
+  });
+});

--- a/src/__tests__/openclaw-reconcile-summary-221.test.ts
+++ b/src/__tests__/openclaw-reconcile-summary-221.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from '@jest/globals';
+import { summariseCommandOutput } from '../integrations/child-output.js';
+
+/**
+ * #221 — the reconcile path summarises the output of `openclaw plugins …`, and
+ * that context differs from the one the summariser was written for.
+ *
+ * Two heuristics that are right for a generic child process are wrong here:
+ *
+ *  - `[plugins] …` lines are dropped as FOREIGN chatter — another plugin
+ *    talking about itself. But when the command IS a `plugins` subcommand,
+ *    those are its own words. Filtering them produced an empty summary, i.e. a
+ *    failed step with no stated reason, which is the exact defect this work
+ *    removes rather than one it may introduce.
+ *  - Failure-biased ranking applied to a command that SUCCEEDED picks whichever
+ *    line happens to contain a word like "conflict".
+ *
+ * These pin the options the reconcile call site passes. If it stops passing
+ * them, the behaviour below regresses.
+ */
+
+/** Exactly what src/setup/openclaw-reconcile.ts passes. */
+function reconcileSummary(output: string, ok: boolean): string {
+  const s = summariseCommandOutput(output, {
+    maxLines: 1,
+    dropPluginChatter: false,
+    mode: ok ? 'plain' : 'failure',
+  });
+  return s.lines[0] ?? '';
+}
+
+describe('#221 — a failed reconcile step always states a reason', () => {
+  it('keeps `[plugins] …` output when the command IS a plugins command', () => {
+    const out = '[plugins] shieldcortex-realtime failed during enable: manifest not found';
+
+    expect(reconcileSummary(out, false)).toContain('manifest not found');
+  });
+
+  it('never returns empty for a failure that produced output', () => {
+    for (const out of [
+      '[plugins] something went sideways',
+      'plain unstructured failure text',
+      '[plugins] a\n[plugins] b',
+    ]) {
+      expect(reconcileSummary(out, false)).not.toBe('');
+    }
+  });
+});
+
+describe('#221 — a successful step reports its outcome, not a scary-looking line', () => {
+  it('leads with the install line, not the later "conflicting" one', () => {
+    const out = 'Installed @drakon-systems/shieldcortex-realtime@4.47.39\nRemoved 1 conflicting entry';
+
+    // "conflict" matches the failure signal pattern, so ranking promoted the
+    // second line over the actual outcome.
+    expect(reconcileSummary(out, true)).toContain('Installed');
+  });
+
+  it('preserves source order for successful output generally', () => {
+    const out = 'Enabled shieldcortex-realtime\nNothing else to do';
+    expect(reconcileSummary(out, true)).toBe('Enabled shieldcortex-realtime');
+  });
+});
+
+describe('#221 — the foreign-chatter filter still applies where it belongs', () => {
+  it('drops other plugins\' chatter by default', () => {
+    const out = '[plugins] codex failed during register: TypeError\nnpm error E401 Unauthorized';
+
+    const { lines } = summariseCommandOutput(out, { maxLines: 2, env: {} });
+
+    expect(lines.join('\n')).not.toContain('codex');
+    expect(lines.join('\n')).toContain('E401');
+  });
+});

--- a/src/__tests__/update-openclaw-failure-surface.test.ts
+++ b/src/__tests__/update-openclaw-failure-surface.test.ts
@@ -1,0 +1,114 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { stepOpenClawPlugin } from '../cli/update.js';
+import type { CapturedError } from '../integrations/child-output.js';
+
+/**
+ * #221 — `update` must surface what the child said, not restate the command.
+ *
+ * The reported behaviour: `stepOpenClawPlugin` caught the failure and returned
+ * "update failed — run `openclaw plugins install --force …`" — the very command
+ * that had just failed. `runQuiet` had already captured OpenClaw's message,
+ * which names the offending config key and the repair, and the bare `catch {}`
+ * discarded it.
+ */
+
+/** What OpenClaw really writes when its config is invalid. */
+const INVALID_CONFIG_STDERR = [
+  'OpenClaw config is invalid: /home/x/.openclaw/openclaw.json',
+  '  × plugins: plugin manifest not found: ~/.openclaw/extensions/ekho-adapter/openclaw.plugin.json',
+  '',
+  'Run `openclaw doctor --fix` to repair, or fix the keys above manually.',
+  'Audit, status, health, logs, tasks list/audit, and doctor commands still run with invalid config.',
+].join('\n');
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'sc-221-home-'));
+  // Make the step believe the plugin is installed, so it reaches the spawn.
+  mkdirSync(join(home, '.openclaw', 'plugins'), { recursive: true });
+  writeFileSync(
+    join(home, '.openclaw', 'plugins', 'installs.json'),
+    JSON.stringify({ installRecords: { 'shieldcortex-realtime': {} } }),
+  );
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+function rejectWith(over: Partial<CapturedError>) {
+  return () => Promise.reject(Object.assign(new Error('exit 1: openclaw plugins install'), {
+    exitCode: 1,
+    command: 'openclaw plugins install --force @drakon-systems/shieldcortex-realtime@latest',
+    stdout: '',
+    stderr: '',
+    ...over,
+  }) as CapturedError);
+}
+
+describe('#221 — the reason reaches the operator', () => {
+  it('reports the config error, not the command that just failed', async () => {
+    const r = await stepOpenClawPlugin(home, {
+      run: rejectWith({ stderr: INVALID_CONFIG_STDERR }) as never,
+    });
+
+    expect(r.status).toBe('warn');
+    const shown = [r.summary ?? '', ...(r.detail ?? [])].join('\n');
+
+    expect(shown).toContain('OpenClaw config is invalid');
+    expect(shown).toContain('plugin manifest not found');
+    // The old behaviour, and the whole of the field report.
+    expect(r.summary).not.toContain('plugins install --force');
+  });
+
+  it('does not present OpenClaw\'s reassurance as the reason', async () => {
+    // The last line says audit/status/health/doctor still work. A `slice(-1)`
+    // reads exactly that and drops the cause above it.
+    const r = await stepOpenClawPlugin(home, {
+      run: rejectWith({ stderr: INVALID_CONFIG_STDERR }) as never,
+    });
+
+    expect(r.summary).not.toContain('still run with invalid config');
+  });
+
+  it('still says something useful when the child produced no output', async () => {
+    const r = await stepOpenClawPlugin(home, { run: rejectWith({}) as never });
+
+    expect(r.status).toBe('warn');
+    expect(r.summary).toContain('exited 1');
+    // Naming the command is right HERE — it is all we have — but as the
+    // fallback, not as the standard answer.
+    expect(r.summary).toContain('openclaw plugins install');
+  });
+
+  it('distinguishes a missing binary from a rejected command', async () => {
+    const r = await stepOpenClawPlugin(home, {
+      run: rejectWith({ spawnFailed: true, exitCode: null, code: 'ENOENT' }) as never,
+    });
+
+    expect(r.summary).toContain('command not found');
+  });
+});
+
+/**
+ * A source rail for the sibling site. `stepOpenClawSkill` has the same defect
+ * and the same fix, but its early-return path makes a behavioural test cost
+ * more than it proves — so the wiring is pinned directly.
+ */
+describe('#221 — no swallow is left behind in the OpenClaw steps', () => {
+  it('neither OpenClaw step restates its own command as the failure reason', () => {
+    const src = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), '..', 'cli', 'update.ts'),
+      'utf-8',
+    );
+
+    expect(src).not.toContain("summary: 'update failed — run `openclaw plugins install");
+    expect(src).not.toContain("summary: 'reinstall failed — run `shieldcortex openclaw skill install`'");
+    // Both catches must go through the shared reporter.
+    expect((src.match(/describeRunFailure\(err\)/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -56,6 +56,8 @@ import {
 // transport (cli-invoker.js) and the explainer (doctor-explainer.js) are
 // loaded with a runtime `import()` inside runDoctorAiSection() below, so a
 // plain `shieldcortex doctor` never touches either module.
+import { validateOpenClawConfig } from '../integrations/openclaw-config-validate.js';
+import type { OpenClawConfigVerdict, ValidateDeps } from '../integrations/openclaw-config-validate.js';
 import type { ModelInvoker } from '../defence/iron-dome/approval-judge.js';
 import type { DoctorExplainerOutcome } from '../defence/iron-dome/doctor-explainer.js';
 
@@ -86,6 +88,55 @@ export interface CheckResult {
    * perfectly healthy first run (#129).
    */
   skipped?: 'db-uninitialised';
+  /**
+   * Set when this remedy is carried out by an OpenClaw `plugins`/`skills`
+   * subcommand. OpenClaw refuses ALL of them — reporting only "Unknown
+   * command" — while any config entry dangles, so the advice is a no-op an
+   * operator can follow for days without noticing (#221). `applyOpenClawCliGate`
+   * strips it, or swaps in `fallbackFix`, when the config does not validate.
+   *
+   * Declared per site rather than matched from the fix text, deliberately: the
+   * `installed-not-enabled` remedy also reads "shieldcortex repair" but routes
+   * to a pure JSON write (restore-registration) and keeps working when
+   * OpenClaw is blocked — and it is the ONLY remedy for an UNPROTECTED host.
+   * No substring can tell those two apart, so a text-matching gate would
+   * delete the one piece of advice that still helps.
+   */
+  needsOpenClawCli?: { subcommand: 'plugins' | 'skills'; fallbackFix?: string };
+}
+
+/** The `OpenClaw config` check's label — the gate keys on it, so it is shared. */
+export const OPENCLAW_CONFIG_LABEL = 'OpenClaw config';
+
+/**
+ * Strip remedies that cannot execute (#221).
+ *
+ * Severity is deliberately untouched: the host is exactly as broken as it was,
+ * so the pass/warn/fail counts and the exit code must not move. Only the
+ * instruction changes — a wrong verdict must never make a host look healthier.
+ *
+ * Fail-open. Anything short of a proven-invalid config leaves every fix alone,
+ * because a doctor that hides working advice when it could not reach `openclaw`
+ * is a worse bug than the one being fixed here.
+ */
+export function applyOpenClawCliGate(results: CheckResult[]): CheckResult[] {
+  const blocked = results.some(r => r.label === OPENCLAW_CONFIG_LABEL && r.status === 'fail');
+  if (!blocked) return results;
+
+  const note = ' [remedy blocked — fix the OpenClaw config first, see "OpenClaw config" above]';
+  return results.map((r) => {
+    if (!r.needsOpenClawCli) return r;
+    // One site carries its remediation in `message` rather than `fix` (the
+    // optional-skill notice). A gate that only rewrote `fix` would sail past
+    // it and leave it as the single piece of unfollowable advice on the page —
+    // the exact class of miss this issue is about. Annotating in place also
+    // avoids promoting it into Suggested fixes on healthy hosts.
+    if (!r.fix) return { ...r, message: r.message + note };
+    const { fallbackFix } = r.needsOpenClawCli;
+    return fallbackFix
+      ? { ...r, fix: fallbackFix, message: r.message + note }
+      : { ...r, message: r.message + note, fix: undefined };
+  });
 }
 
 /**
@@ -1273,6 +1324,51 @@ export async function checkLockFile(scDir: string = getShieldCortexDir()): Promi
   }
 }
 
+// ── Check 7.4: OpenClaw config validity (#221) ───────────
+/**
+ * Runs BEFORE every OpenClaw check, because it is the prerequisite for all of
+ * their remedies. An invalid OpenClaw config makes `plugins` and `skills`
+ * refuse — reporting "Unknown command", never naming the config — so the seven
+ * checks below produce accurate findings with unfollowable advice.
+ *
+ * Returns rather than throws on every path: the runDoctor catch renders
+ * `check crashed — …` with NO fix line, which is the same unactionable outcome
+ * this check exists to remove.
+ */
+export async function checkOpenClawConfigValid(
+  home: string = os.homedir(),
+  deps: ValidateDeps = {},
+): Promise<CheckResult> {
+  const label = OPENCLAW_CONFIG_LABEL;
+  let verdict: OpenClawConfigVerdict;
+  try {
+    verdict = validateOpenClawConfig(home, deps);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { label, status: 'info', message: `not checked — ${msg}` };
+  }
+
+  switch (verdict.state) {
+    case 'valid':
+      return { label, status: 'pass', message: 'validates — OpenClaw accepts plugins/skills commands' };
+    case 'indeterminate':
+      return { label, status: 'info', message: `not checked — ${verdict.reason}` };
+    case 'invalid':
+      return {
+        label,
+        status: 'fail',
+        message:
+          'OpenClaw REFUSES every `plugins` and `skills` command until this validates — it reports '
+          + 'them as "Unknown command", so remediation looks like it ran and silently did nothing (#221). '
+          + `OpenClaw says:\n      ${verdict.detail.join('\n      ')}`,
+        fix:
+          'Fix the OpenClaw config FIRST — nothing else below can run until it validates: '
+          + '`openclaw doctor --fix` (or edit the keys quoted above), confirm with '
+          + '`openclaw config validate`, then re-run `shieldcortex doctor`.',
+      };
+  }
+}
+
 // ── Check 7.5: OpenClaw residue (orphans only) ───────────
 async function checkOpenClawResidue(): Promise<CheckResult> {
   const env = detectEnvironment();
@@ -1306,6 +1402,11 @@ async function checkOpenClawResidue(): Promise<CheckResult> {
       status: 'warn',
       message: `${report.orphanCount} orphan${report.orphanCount === 1 ? '' : 's'} — ${first}${suffix}`,
       fix: 'Run `shieldcortex uninstall --deep --confirm` to purge, or reinstall with `shieldcortex openclaw install`',
+      // Only the reinstall half needs OpenClaw; the purge is pure filesystem.
+      needsOpenClawCli: {
+        subcommand: 'plugins',
+        fallbackFix: 'Run `shieldcortex uninstall --deep --confirm` to purge the residue (pure filesystem — this half still works). Reinstalling needs a valid OpenClaw config first.',
+      },
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -1394,6 +1495,12 @@ export async function checkOpenClawPluginPackage(
         fix:
           `Remove ${barePkgDir.replace(os.homedir(), '~')} then reinstall the supported plugin: ` +
           `\`openclaw plugins install @drakon-systems/shieldcortex-realtime\``,
+        needsOpenClawCli: {
+          subcommand: 'plugins',
+          fallbackFix:
+            `Remove ${barePkgDir.replace(os.homedir(), '~')} (pure filesystem — this half still works). ` +
+            `Reinstalling the supported plugin needs a valid OpenClaw config first.`,
+        },
       };
     }
   }
@@ -1610,6 +1717,9 @@ export async function checkOpenClawDuplicateInstalls(
       fix:
         `Run \`shieldcortex openclaw repair\` to safely reinstall via the canonical path ` +
         `and clean up the legacy locations (preserves your OpenClaw plugin config).`,
+      // `openclaw repair` → repairOpenClawPlugin → `plugins enable` +
+      // `plugins install --force`. No filesystem-only half to fall back to.
+      needsOpenClawCli: { subcommand: 'plugins' },
     };
   }
 
@@ -1633,6 +1743,10 @@ export async function checkOpenClawDuplicateInstalls(
         `round-trip needed to clear OpenClaw's sticky hook-pack tracking, while preserving ` +
         `your OpenClaw plugin config. (Plain \`rm -rf\` on the hooks/ copy reverts on the ` +
         `next \`plugins update\`.)`,
+      // The worst site to leave unguarded: its own text tells the operator the
+      // filesystem escape hatch does NOT work, so a blocked host is left with
+      // zero followable action.
+      needsOpenClawCli: { subcommand: 'plugins' },
     };
   }
 
@@ -1649,6 +1763,11 @@ export async function checkOpenClawDuplicateInstalls(
     fix:
       `Run \`shieldcortex openclaw repair\` (or remove manually: ${rmCmd}) and restart OpenClaw. ` +
       `The canonical npm install at ~/.openclaw/npm/ is the supported location.`,
+    needsOpenClawCli: {
+      subcommand: 'plugins',
+      // Non-sticky case, so the manual removal genuinely works on its own.
+      fallbackFix: `Remove manually: ${rmCmd}, then restart OpenClaw. The canonical npm install at ~/.openclaw/npm/ is the supported location.`,
+    },
   };
 }
 
@@ -2517,6 +2636,7 @@ export async function checkOpenClawManagedPinDrift(
       status: 'fail',
       message: `realtime plugin is DISABLED in OpenClaw config${detail} — threat telemetry is not flowing`,
       fix: 'Run `shieldcortex openclaw repair` to reconcile the managed pins, reinstall, and re-enable the plugin.',
+      needsOpenClawCli: { subcommand: 'plugins' },
     };
   }
 
@@ -2527,6 +2647,7 @@ export async function checkOpenClawManagedPinDrift(
       status: 'warn',
       message: `managed-pin drift will EOVERRIDE on the next \`openclaw update\`: ${list}`,
       fix: 'Run `shieldcortex openclaw repair` now to reconcile the pins before an update disables the plugin.',
+      needsOpenClawCli: { subcommand: 'plugins' },
     };
   }
 
@@ -2571,6 +2692,9 @@ export async function checkOpenClawHookFreshness(
         status: 'warn',
         message: 'cortex-memory hook is out of date (installed copy differs from packaged version)',
         fix: 'Run `shieldcortex openclaw install` to refresh the hook',
+        // The hook copy itself is filesystem work, but the same command's
+        // plugin step is refused, so the command as a whole reports failure.
+        needsOpenClawCli: { subcommand: 'plugins' },
       };
     }
 
@@ -2625,6 +2749,7 @@ export async function checkOpenClawPluginVersion(
       status: 'warn',
       message: `realtime plugin v${installed} installed, v${expectedVersion} available`,
       fix: 'Run `openclaw plugins install --force @drakon-systems/shieldcortex-realtime@latest` (reliable past a pinned spec), then restart the gateway',
+      needsOpenClawCli: { subcommand: 'plugins' },
     };
   }
 
@@ -2776,6 +2901,10 @@ export function renderPluginLoadVerdict(verdict: ReconcileVerdict): CheckResult 
         message:
           'openclaw.json ENABLES the realtime plugin but no package is installed on this host — the gateway boots with NO memory firewall and NO action guard while config reports it ON',
         fix: 'Install the plugin: `openclaw plugins install @drakon-systems/shieldcortex-realtime@latest`, then restart the gateway (or run `shieldcortex repair`, which will do both).',
+        // Highest-severity unactionable site: BOTH offered routes spawn the
+        // refused subcommand, and the message says the gateway boots with no
+        // memory firewall and no action guard.
+        needsOpenClawCli: { subcommand: 'plugins' },
       };
     case 'config-unreadable':
       // #11: cannot-read is not absent. A truncated or permission-denied
@@ -2870,6 +2999,7 @@ export function renderPluginLoadVerdict(verdict: ReconcileVerdict): CheckResult 
         message:
           'realtime plugin is enabled:true in config but NOT loaded (absent from OpenClaw\'s roster) — the host is UNPROTECTED while status reports ON',
         fix,
+        needsOpenClawCli: { subcommand: 'plugins' },
       };
     case 'version-regressed':
       return {
@@ -2877,6 +3007,8 @@ export function renderPluginLoadVerdict(verdict: ReconcileVerdict): CheckResult 
         status: 'fail',
         message: `realtime plugin regressed to v${verdict.onDiskVersion ?? verdict.indexVersion} (older than expected v${verdict.expectedVersion}) — running stale, refuse the downgrade`,
         fix,
+        // The exact line the #221 operator chased for five days.
+        needsOpenClawCli: { subcommand: 'plugins' },
       };
     case 'conflicted-metadata':
       return {
@@ -2884,6 +3016,7 @@ export function renderPluginLoadVerdict(verdict: ReconcileVerdict): CheckResult 
         status: 'warn',
         message: `installs.json and the SQLite index disagree on the realtime plugin — a toggle can silently drop it. ${verdict.reasons[verdict.reasons.length - 1] ?? ''}`.trim(),
         fix,
+        needsOpenClawCli: { subcommand: 'plugins' },
       };
     case 'duplicate-install':
       return {
@@ -2891,6 +3024,7 @@ export function renderPluginLoadVerdict(verdict: ReconcileVerdict): CheckResult 
         status: 'warn',
         message: `${(verdict.onDiskVersion && 'realtime plugin has ') || ''}multiple install dirs on disk — prune the stale duplicate before a toggle re-resolves to it`,
         fix,
+        needsOpenClawCli: { subcommand: 'plugins' },
       };
     // EXPLICIT, not `default:`. #222 was a state that fell through to a green
     // tick because no branch claimed it, and a `default: → pass` arm is that
@@ -3215,7 +3349,14 @@ export async function checkOpenClawSkillVersion(
   const { findInstalledSkillDirs, readInstalledSkillVersion } = await import('../setup/openclaw.js');
   const dirs = findInstalledSkillDirs(home);
   if (dirs.length === 0) {
-    return { label, status: 'info', message: 'skill not installed (optional) — `shieldcortex openclaw skill install` adds it' };
+    // Remediation lives in `message`, not `fix` — this is the only such site,
+    // and it is tagged so the gate annotates it too (#221).
+    return {
+      label,
+      status: 'info',
+      message: 'skill not installed (optional) — `shieldcortex openclaw skill install` adds it',
+      needsOpenClawCli: { subcommand: 'skills' },
+    };
   }
   const v = readInstalledSkillVersion(dirs[0]);
   if (!v) {
@@ -3223,6 +3364,7 @@ export async function checkOpenClawSkillVersion(
       label, status: 'warn',
       message: `skill present at ${dirs[0]} but its SKILL.md version is unreadable`,
       fix: 'Run shieldcortex openclaw skill install to reinstall a clean copy',
+      needsOpenClawCli: { subcommand: 'skills' },
     };
   }
   if (v === cliVersion) {
@@ -3232,6 +3374,7 @@ export async function checkOpenClawSkillVersion(
     label, status: 'warn',
     message: `skill v${v} does not match CLI v${cliVersion} — agents are reading stale instructions`,
     fix: 'Run shieldcortex openclaw skill install',
+    needsOpenClawCli: { subcommand: 'skills' },
   };
 }
 
@@ -3496,6 +3639,9 @@ export async function runDoctor(
     checkDiskUsage,
     checkStatePermissions,
     checkLockFile,
+    // #221: ahead of every OpenClaw check, so the root cause prints above the
+    // symptoms and its fix leads the Suggested-fixes block.
+    checkOpenClawConfigValid,
     checkOpenClawResidue,
     checkOpenClawHookFreshness,
     checkOpenClawPluginVersion,
@@ -3577,10 +3723,16 @@ export async function runDoctor(
     }
   }
 
+  // #221: strip remedies that cannot execute while OpenClaw's config is
+  // invalid. Placed here because `results` is final and nothing has yet been
+  // printed, filtered, counted or exited on — and it must not disturb any of
+  // those. No-op unless the config check actually failed.
+  const gated = applyOpenClawCliGate(results);
+
   // Collapse the dependent "no database yet" checks into one dim note. On a
   // fresh install they added Schema/Write path/Memories lines that all restate
   // the same single fact already reported by the Database line (#129).
-  const { visible, suppressed } = partitionUninitialisedSkips(results);
+  const { visible, suppressed } = partitionUninitialisedSkips(gated);
 
   // Print results
   for (const r of visible) {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -102,7 +102,7 @@ export interface CheckResult {
    * No substring can tell those two apart, so a text-matching gate would
    * delete the one piece of advice that still helps.
    */
-  needsOpenClawCli?: { subcommand: 'plugins' | 'skills'; fallbackFix?: string };
+  needsOpenClawCli?: { subcommand: 'plugins' | 'skills' | 'config'; fallbackFix?: string };
   /**
    * Set by `checkOpenClawConfigValid` when the config is PROVEN invalid, so
    * `applyOpenClawCliGate` keys on the fact rather than on the severity.
@@ -140,17 +140,35 @@ export function applyOpenClawCliGate(results: CheckResult[]): CheckResult[] {
   // Keyed on the explicit marker, never on severity — see `openClawCliBlocked`.
   if (!results.some(r => r.openClawCliBlocked)) return results;
 
-  // Nothing of ours is actually blocked: report it, do not fail the run.
-  if (!results.some(r => r.needsOpenClawCli)) {
-    return results.map(r =>
-      r.openClawCliBlocked
-        ? { ...r, status: 'warn' as const, message: `${r.message}\n      (no ShieldCortex remedy on this host depends on it)` }
-        : r);
-  }
+  // Nothing of ours is actually BROKEN by it: report, do not fail the run.
+  //
+  // "Has a tag" is not the same as "is a problem". The optional-skill notice is
+  // an `info` row that is tagged and is present by DEFAULT on every host not
+  // using the OpenClaw skill — so counting tags alone kept the config row at
+  // `fail`, and `doctor` exited 1, on hosts with nothing wrong. Only a row that
+  // is itself a fault (fail/warn) justifies failing the run; info rows are
+  // still annotated below, they just do not vote.
+  const blockedFault = results.some(
+    r => r.needsOpenClawCli && (r.status === 'fail' || r.status === 'warn'),
+  );
 
   const note = ' [remedy blocked — fix the OpenClaw config first, see "OpenClaw config" above]';
   return results.map((r) => {
+    // The config row is the only one whose severity may move, and only down.
+    if (r.openClawCliBlocked) {
+      return blockedFault
+        ? r
+        : {
+            ...r,
+            status: 'warn' as const,
+            message: `${r.message}\n      (no ShieldCortex remedy on this host depends on it)`,
+          };
+    }
+
     if (!r.needsOpenClawCli) return r;
+    // Annotation runs regardless of `blockedFault` — an info row does not vote
+    // on severity, but it is still unfollowable advice and must say so.
+    //
     // One site carries its remediation in `message` rather than `fix` (the
     // optional-skill notice). A gate that only rewrote `fix` would sail past
     // it and leave it as the single piece of unfollowable advice on the page —
@@ -938,6 +956,14 @@ export async function checkOpenClawApprovalButtons(
     status: 'info',
     message: `Telegram approval prompts fall back to "/approve" text (inlineButtons: ${scope ?? 'unset → allowlist'})`,
     fix: "Make approvals tappable: set channels.telegram.capabilities.inlineButtons to 'all' (or 'dm'/'group' for a tighter surface) via `openclaw config patch`, then restart the gateway.",
+    // MEASURED, not assumed: `openclaw config patch` is refused under an
+    // invalid config too (exit 1, "OpenClaw config is invalid"). It was
+    // initially left untagged on the theory that a *config* subcommand would be
+    // the operator's escape hatch — it is not. Hand-editing the file is.
+    needsOpenClawCli: {
+      subcommand: 'config',
+      fallbackFix: "Make approvals tappable: set channels.telegram.capabilities.inlineButtons to 'all' (or 'dm'/'group') by editing ~/.openclaw/openclaw.json directly — `openclaw config patch` is refused while the config is invalid — then restart the gateway.",
+    },
   }];
 }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -103,25 +103,50 @@ export interface CheckResult {
    * delete the one piece of advice that still helps.
    */
   needsOpenClawCli?: { subcommand: 'plugins' | 'skills'; fallbackFix?: string };
+  /**
+   * Set by `checkOpenClawConfigValid` when the config is PROVEN invalid, so
+   * `applyOpenClawCliGate` keys on the fact rather than on the severity.
+   *
+   * Keying the gate on `status === 'fail'` would mean any future adjustment to
+   * this check's severity silently switches the whole suppression feature off
+   * with no test failing — the class of coupling that produced #222 and #103.
+   */
+  openClawCliBlocked?: true;
 }
 
-/** The `OpenClaw config` check's label — the gate keys on it, so it is shared. */
+/** The `OpenClaw config` check's label. */
 export const OPENCLAW_CONFIG_LABEL = 'OpenClaw config';
 
 /**
  * Strip remedies that cannot execute (#221).
  *
- * Severity is deliberately untouched: the host is exactly as broken as it was,
- * so the pass/warn/fail counts and the exit code must not move. Only the
- * instruction changes — a wrong verdict must never make a host look healthier.
+ * Every OTHER check's severity is deliberately untouched: the host is exactly
+ * as broken as it was, so its counts and the exit code must not move. A wrong
+ * verdict must never make a blocked host look healthier.
+ *
+ * The config row itself is the one exception, and only downwards. `doctor`
+ * exits 1 on any `fail`, with no `--strict` opt-in — and the enforcement
+ * contract above `doctorExitCode` reserves that for states ShieldCortex owns.
+ * An invalid OpenClaw config with NOTHING of ours blocked by it (a host using
+ * ShieldCortex purely for MCP memory, whose OpenClaw has some third-party
+ * plugin's dangling entry) is a real finding but not our failure, so it warns.
+ * The moment it actually blocks one of our remedies, it fails.
  *
  * Fail-open. Anything short of a proven-invalid config leaves every fix alone,
  * because a doctor that hides working advice when it could not reach `openclaw`
  * is a worse bug than the one being fixed here.
  */
 export function applyOpenClawCliGate(results: CheckResult[]): CheckResult[] {
-  const blocked = results.some(r => r.label === OPENCLAW_CONFIG_LABEL && r.status === 'fail');
-  if (!blocked) return results;
+  // Keyed on the explicit marker, never on severity — see `openClawCliBlocked`.
+  if (!results.some(r => r.openClawCliBlocked)) return results;
+
+  // Nothing of ours is actually blocked: report it, do not fail the run.
+  if (!results.some(r => r.needsOpenClawCli)) {
+    return results.map(r =>
+      r.openClawCliBlocked
+        ? { ...r, status: 'warn' as const, message: `${r.message}\n      (no ShieldCortex remedy on this host depends on it)` }
+        : r);
+  }
 
   const note = ' [remedy blocked — fix the OpenClaw config first, see "OpenClaw config" above]';
   return results.map((r) => {
@@ -1357,6 +1382,7 @@ export async function checkOpenClawConfigValid(
       return {
         label,
         status: 'fail',
+        openClawCliBlocked: true,
         message:
           'OpenClaw REFUSES every `plugins` and `skills` command until this validates — it reports '
           + 'them as "Unknown command", so remediation looks like it ran and silently did nothing (#221). '
@@ -2692,9 +2718,16 @@ export async function checkOpenClawHookFreshness(
         status: 'warn',
         message: 'cortex-memory hook is out of date (installed copy differs from packaged version)',
         fix: 'Run `shieldcortex openclaw install` to refresh the hook',
-        // The hook copy itself is filesystem work, but the same command's
-        // plugin step is refused, so the command as a whole reports failure.
-        needsOpenClawCli: { subcommand: 'plugins' },
+        needsOpenClawCli: {
+          subcommand: 'plugins',
+          // The hook refresh is a file copy that happens BEFORE OpenClaw is
+          // invoked at all (copyHookFiles at openclaw.ts:1276, installPlugin at
+          // :1320), and `--no-plugins` skips the OpenClaw half outright. So the
+          // useful work lands even on a blocked host — withdrawing this outright
+          // would leave the operator on a stale memory-capture hook with no
+          // action, which is the same withheld-advice failure #221 is about.
+          fallbackFix: 'Run `shieldcortex openclaw install --no-plugins` to refresh the hook (a file copy — this half still works). Refreshing the plugin needs a valid OpenClaw config first.',
+        },
       };
     }
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -17,6 +17,8 @@ import path from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { resolveRealtimePluginInstallPath, readInstalledRealtimePluginVersion } from '../integrations/openclaw-plugin-state.js';
+import { describeRunFailure } from '../integrations/child-output.js';
+import type { CapturedError } from '../integrations/child-output.js';
 
 // ── ANSI ────────────────────────────────────────────────────
 
@@ -46,6 +48,13 @@ const LABEL_WIDTH = 24;
 interface StepResult {
   status: 'ok' | 'warn' | 'skip';
   summary?: string;
+  /**
+   * What the failing child process actually said (#221). `summary` is padded
+   * onto a single line, so anything multi-line has to live here or it destroys
+   * the layout — and a cause that does not fit on one line is exactly the kind
+   * that was previously thrown away.
+   */
+  detail?: string[];
 }
 
 async function step(
@@ -89,6 +98,12 @@ async function step(
       process.stdout.write(
         `  ${result.status === 'ok' ? '✓' : result.status === 'warn' ? '⚠' : '·'}  ${label}: ${result.summary ?? 'done'} (${elapsed})\n`,
       );
+    }
+    // #221: print what the child actually said, indented under its step. This
+    // is the difference between "update failed — run <the command that just
+    // failed>" and a message naming the config key to fix.
+    for (const line of result.detail ?? []) {
+      process.stdout.write(`     ${paint('gray', line)}\n`);
     }
     return result;
   } catch (err) {
@@ -151,21 +166,33 @@ function runQuiet(cmd: string, args: string[], opts: RunOpts = {}): Promise<{ st
 
     child.on('error', (err) => {
       if (timer) clearTimeout(timer);
-      reject(err);
+      // #221: a spawn failure is a DIFFERENT thing from a non-zero exit, and
+      // reporting them identically is how "openclaw is not installed" reads as
+      // "openclaw rejected the command".
+      const e = err as CapturedError;
+      e.spawnFailed = true;
+      e.exitCode = null;
+      e.command = `${cmd} ${args.join(' ')}`;
+      reject(e);
     });
 
     child.on('close', (code) => {
       if (timer) clearTimeout(timer);
       if (timedOut) {
-        const err = new Error(`timeout: ${cmd} ${args.join(' ')}`) as Error & { stdout?: string; stderr?: string };
+        const err = new Error(`timeout: ${cmd} ${args.join(' ')}`) as CapturedError;
         err.stdout = stdout;
         err.stderr = stderr;
+        err.timedOut = true;
+        err.exitCode = null;
+        err.command = `${cmd} ${args.join(' ')}`;
         return reject(err);
       }
       if (typeof code === 'number' && code !== 0) {
-        const err = new Error(`exit ${code}: ${cmd} ${args.join(' ')}`) as Error & { stdout?: string; stderr?: string };
+        const err = new Error(`exit ${code}: ${cmd} ${args.join(' ')}`) as CapturedError;
         err.stdout = stdout;
         err.stderr = stderr;
+        err.exitCode = code;
+        err.command = `${cmd} ${args.join(' ')}`;
         return reject(err);
       }
       resolve({ stdout, stderr });
@@ -301,7 +328,12 @@ export function isRealtimePluginRegistered(home: string): boolean {
   }
 }
 
-async function stepOpenClawPlugin(home: string): Promise<StepResult> {
+/** `run` is injectable so the failure path can be tested without a real spawn. */
+export async function stepOpenClawPlugin(
+  home: string,
+  deps: { run?: typeof runQuiet } = {},
+): Promise<StepResult> {
+  const run = deps.run ?? runQuiet;
   const extDir = path.join(home, '.openclaw', 'extensions', 'shieldcortex-realtime');
   const legacy = fs.existsSync(extDir);
   const registered = isRealtimePluginRegistered(home);
@@ -320,7 +352,7 @@ async function stepOpenClawPlugin(home: string): Promise<StepResult> {
       // spec (observed 2026-06-09: the index pinned @4.30.2 → "up to date" while
       // npm had 4.31.0). A forced @latest install reliably advances the plugin
       // AND rewrites the tracked spec to @latest so future updates work.
-      await runQuiet('openclaw', ['plugins', 'install', '--force', '@drakon-systems/shieldcortex-realtime@latest'],
+      await run('openclaw', ['plugins', 'install', '--force', '@drakon-systems/shieldcortex-realtime@latest'],
         { timeout: 120000, env: { ...process.env, HOME: home } });
       // Report the ACTUAL on-disk transition, not just command success — the old
       // "updated via openclaw" was printed even when the version never moved.
@@ -328,9 +360,20 @@ async function stepOpenClawPlugin(home: string): Promise<StepResult> {
       if (before && after && before !== after) return `${before} → ${after}`;
       if (after) return `up to date (v${after})`;
       return 'reinstalled';
-    } catch {
+    } catch (err) {
       // Don't propagate — surface as warn instead of failing the whole flow.
-      return { status: 'warn' as const, summary: 'update failed — run `openclaw plugins install --force @drakon-systems/shieldcortex-realtime@latest`' };
+      //
+      // #221: this used to restate the command that had just failed and throw
+      // the reason away. When OpenClaw's config is invalid it says so exactly,
+      // names the offending key and gives the repair — and an operator chased
+      // this line for five days because that message was discarded here while
+      // `runQuiet` had it in hand the whole time.
+      const report = describeRunFailure(err);
+      return {
+        status: 'warn' as const,
+        summary: `update failed — ${report.reason}`,
+        detail: report.detail,
+      };
     }
   });
 }
@@ -363,8 +406,17 @@ async function stepOpenClawSkill(home: string): Promise<StepResult> {
       const dirs = findInstalledSkillDirs(home);
       const v = dirs.length > 0 ? readInstalledSkillVersion(dirs[0]) : null;
       return v ? `v${v} installed` : { status: 'warn' as const, summary: 'installed but version unreadable' };
-    } catch {
-      return { status: 'warn' as const, summary: 'reinstall failed — run `shieldcortex openclaw skill install`' };
+    } catch (err) {
+      // #221: same defect as the plugin step, and worse here — ClawHub skill
+      // installs fail for several distinct reasons (moderation lag, the
+      // acknowledge flag, an invalid OpenClaw config) and all of them read
+      // identically once the reason is dropped.
+      const report = describeRunFailure(err);
+      return {
+        status: 'warn' as const,
+        summary: `reinstall failed — ${report.reason}`,
+        detail: report.detail,
+      };
     }
   });
 }

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -55,6 +55,8 @@ interface StepResult {
    * that was previously thrown away.
    */
   detail?: string[];
+  /** True when `detail` is a reduction of longer output (#221). */
+  truncated?: boolean;
 }
 
 async function step(
@@ -104,6 +106,9 @@ async function step(
     // failed>" and a message naming the config key to fix.
     for (const line of result.detail ?? []) {
       process.stdout.write(`     ${paint('gray', line)}\n`);
+    }
+    if (result.truncated) {
+      process.stdout.write(`     ${paint('gray', '… output truncated — run the command directly for the full text')}\n`);
     }
     return result;
   } catch (err) {
@@ -373,6 +378,7 @@ export async function stepOpenClawPlugin(
         status: 'warn' as const,
         summary: `update failed — ${report.reason}`,
         detail: report.detail,
+        truncated: report.truncated,
       };
     }
   });
@@ -416,6 +422,7 @@ async function stepOpenClawSkill(home: string): Promise<StepResult> {
         status: 'warn' as const,
         summary: `reinstall failed — ${report.reason}`,
         detail: report.detail,
+        truncated: report.truncated,
       };
     }
   });

--- a/src/integrations/child-output.ts
+++ b/src/integrations/child-output.ts
@@ -63,6 +63,22 @@ export interface SummariseOptions {
   env?: NodeJS.ProcessEnv;
   /** Injected for tests; defaults to the real home directory. */
   home?: string;
+  /**
+   * `failure` (default) ranks signal-bearing lines and drops reassurance.
+   * `plain` preserves source order — for the output of a command that
+   * SUCCEEDED, where there is no failure to find and failure-biased ranking
+   * picks the wrong line (it promoted "Removed 1 conflicting entry" over
+   * "Installed …@4.47.39", because "conflict" reads as signal).
+   */
+  mode?: 'failure' | 'plain';
+  /**
+   * Drop `[plugins] …` lines as foreign chatter. Correct when summarising a
+   * command that merely happened to load plugins; WRONG when the command IS a
+   * `plugins` subcommand, where those lines are its own output — filtering
+   * them there produced an empty summary, i.e. a failure with no stated
+   * reason, which is the class of defect this module exists to remove.
+   */
+  dropPluginChatter?: boolean;
 }
 
 /** Read no more than this from either stream before doing regex work. */
@@ -118,7 +134,10 @@ const REASSURANCE_PATTERN = /\bstill (run|work|available)|\bunaffected\b|no acti
  * about itself — real, but never the answer to "why did OUR command fail".
  */
 const NOISE_PATTERN =
-  /^(npm notice|npm warn|npm WARN|added \d+ package|found \d+ vulnerabilit|up to date|audited \d+ package|\[plugins\]\s)/i;
+  /^(npm notice|npm warn|npm WARN|added \d+ package|found \d+ vulnerabilit|up to date|audited \d+ package)/i;
+
+/** Another plugin telling us about itself — see `dropPluginChatter`. */
+const PLUGIN_CHATTER_PATTERN = /^\[plugins\]\s/i;
 
 const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
 
@@ -169,14 +188,15 @@ function scrubHome(text: string, home: string): string {
   return text.split(home).join('~');
 }
 
-function cleanLines(raw: string): string[] {
+function cleanLines(raw: string, dropPluginChatter: boolean): string[] {
   return raw
     .replace(ANSI_PATTERN, '')
     .replace(/\r/g, '')
     .split('\n')
     .map(line => line.trimEnd())
     .filter(line => line.trim().length > 0)
-    .filter(line => !NOISE_PATTERN.test(line.trim()));
+    .filter(line => !NOISE_PATTERN.test(line.trim()))
+    .filter(line => !(dropPluginChatter && PLUGIN_CHATTER_PATTERN.test(line.trim())));
 }
 
 /**
@@ -214,10 +234,14 @@ export function summariseCommandOutput(
     allowlist: ['sha512-', 'sha1-', 'sha256-'],
   });
 
-  const all = cleanLines(scrubHome(redacted, home));
+  const all = cleanLines(scrubHome(redacted, home), opts.dropPluginChatter ?? true);
   if (all.length === 0) return { lines: [], truncated };
 
-  const signal = all.filter(line => SIGNAL_PATTERN.test(line) && !REASSURANCE_PATTERN.test(line));
+  // `plain` skips ranking entirely: for output of a command that succeeded there
+  // is no cause to hunt for, and the failure heuristics pick the wrong line.
+  const signal = (opts.mode ?? 'failure') === 'plain'
+    ? []
+    : all.filter(line => SIGNAL_PATTERN.test(line) && !REASSURANCE_PATTERN.test(line));
   const usedSignal = signal.length > 0;
   // Strongest cause first, original order preserved within each band — the
   // EARLIEST signal line is not reliably the most informative one.
@@ -225,7 +249,12 @@ export function summariseCommandOutput(
     ? [...signal.filter(l => STRONG_SIGNAL_PATTERN.test(l)), ...signal.filter(l => !STRONG_SIGNAL_PATTERN.test(l))]
     : all;
 
-  let picked = usedSignal ? ranked.slice(0, maxLines) : ranked.slice(-maxLines);
+  // plain: keep the head (the primary outcome line comes first).
+  // failure+signal: ranked head. failure+no-signal: tail, where a stack trace's
+  // most specific frame sits.
+  let picked = usedSignal || (opts.mode ?? 'failure') === 'plain'
+    ? ranked.slice(0, maxLines)
+    : ranked.slice(-maxLines);
   if (picked.length < all.length) truncated = true;
 
   picked = picked.map(line =>

--- a/src/integrations/child-output.ts
+++ b/src/integrations/child-output.ts
@@ -77,8 +77,26 @@ export interface SummariseOptions {
    * `plugins` subcommand, where those lines are its own output — filtering
    * them there produced an empty summary, i.e. a failure with no stated
    * reason, which is the class of defect this module exists to remove.
+   *
+   * Keeping them does NOT promote them: a retained `[plugins] …` line ranks
+   * below every non-plugin line in its band, so another plugin's TypeError
+   * cannot outrank the real `npm error … EAI_AGAIN` that actually failed the
+   * step. Last resort, not equal citizen.
    */
   dropPluginChatter?: boolean;
+  /**
+   * Guarantee a non-empty result whenever the raw output had ANY content, by
+   * re-admitting noise lines when the filters would otherwise leave nothing.
+   *
+   * The caller's need is real — a failed step must never report a blank
+   * reason. It must be served HERE rather than by the call site falling back
+   * to `output.split('\n')[0]`, because every safety guarantee of this module
+   * (env-value redaction, credential patterns, home scrubbing, line and char
+   * caps) lives on this path and none of it exists on a raw string. A probe
+   * with `NPM_TOKEN` set proved the call-site fallback emitted the token
+   * verbatim, plus the absolute home path, whenever output was all `npm warn`.
+   */
+  neverEmpty?: boolean;
 }
 
 /** Read no more than this from either stream before doing regex work. */
@@ -188,15 +206,34 @@ function scrubHome(text: string, home: string): string {
   return text.split(home).join('~');
 }
 
-function cleanLines(raw: string, dropPluginChatter: boolean): string[] {
+function cleanLines(raw: string, dropPluginChatter: boolean, keepNoise = false): string[] {
   return raw
     .replace(ANSI_PATTERN, '')
     .replace(/\r/g, '')
     .split('\n')
     .map(line => line.trimEnd())
     .filter(line => line.trim().length > 0)
-    .filter(line => !NOISE_PATTERN.test(line.trim()))
+    .filter(line => keepNoise || !NOISE_PATTERN.test(line.trim()))
     .filter(line => !(dropPluginChatter && PLUGIN_CHATTER_PATTERN.test(line.trim())));
+}
+
+/**
+ * Plugin chatter last, source order preserved within each band.
+ *
+ * Only reachable when `dropPluginChatter` is false, i.e. when the command IS a
+ * plugins subcommand. Its own `[plugins]` lines must remain available as a
+ * reason of last resort without being allowed to outrank the actual failure.
+ */
+function pluginsLast(lines: string[], takeHead: boolean): string[] {
+  const chatter = (line: string) => PLUGIN_CHATTER_PATTERN.test(line.trim());
+  const own = lines.filter(l => !chatter(l));
+  const theirs = lines.filter(chatter);
+  // "Last resort" is a statement about the PICK, not about array order: the
+  // head paths slice from the front, the no-signal failure path slices from the
+  // tail. Demoting chatter therefore means pushing it to the opposite end from
+  // wherever the slice is taken — sorting it to the back unconditionally would
+  // hand the tail path nothing BUT chatter.
+  return takeHead ? [...own, ...theirs] : [...theirs, ...own];
 }
 
 /**
@@ -234,7 +271,16 @@ export function summariseCommandOutput(
     allowlist: ['sha512-', 'sha1-', 'sha256-'],
   });
 
-  const all = cleanLines(scrubHome(redacted, home), opts.dropPluginChatter ?? true);
+  const scrubbed = scrubHome(redacted, home);
+  const dropPluginChatter = opts.dropPluginChatter ?? true;
+  let all = cleanLines(scrubbed, dropPluginChatter);
+  if (all.length === 0 && opts.neverEmpty) {
+    // Everything was noise. Re-admit it rather than hand the caller nothing —
+    // still redacted, scrubbed and capped, because it comes back through the
+    // same path.
+    all = cleanLines(scrubbed, dropPluginChatter, true);
+    if (all.length > 0) truncated = true;
+  }
   if (all.length === 0) return { lines: [], truncated };
 
   // `plain` skips ranking entirely: for output of a command that succeeded there
@@ -243,18 +289,21 @@ export function summariseCommandOutput(
     ? []
     : all.filter(line => SIGNAL_PATTERN.test(line) && !REASSURANCE_PATTERN.test(line));
   const usedSignal = signal.length > 0;
-  // Strongest cause first, original order preserved within each band — the
-  // EARLIEST signal line is not reliably the most informative one.
-  const ranked = usedSignal
-    ? [...signal.filter(l => STRONG_SIGNAL_PATTERN.test(l)), ...signal.filter(l => !STRONG_SIGNAL_PATTERN.test(l))]
-    : all;
-
   // plain: keep the head (the primary outcome line comes first).
   // failure+signal: ranked head. failure+no-signal: tail, where a stack trace's
   // most specific frame sits.
-  let picked = usedSignal || (opts.mode ?? 'failure') === 'plain'
-    ? ranked.slice(0, maxLines)
-    : ranked.slice(-maxLines);
+  const takeHead = usedSignal || (opts.mode ?? 'failure') === 'plain';
+  // Strongest cause first, original order preserved within each band — the
+  // EARLIEST signal line is not reliably the most informative one. Retained
+  // plugin chatter sinks away from the end being picked.
+  const ranked = pluginsLast(
+    usedSignal
+      ? [...signal.filter(l => STRONG_SIGNAL_PATTERN.test(l)), ...signal.filter(l => !STRONG_SIGNAL_PATTERN.test(l))]
+      : all,
+    takeHead,
+  );
+
+  let picked = takeHead ? ranked.slice(0, maxLines) : ranked.slice(-maxLines);
   if (picked.length < all.length) truncated = true;
 
   picked = picked.map(line =>

--- a/src/integrations/child-output.ts
+++ b/src/integrations/child-output.ts
@@ -29,6 +29,8 @@
  * report an operator may paste into a GitHub issue. Env-value redaction runs
  * first and does not depend on a pattern matching the token's shape.
  */
+import os from 'os';
+
 import { redactCredentials } from '../defence/credential-leak/index.js';
 
 /** A rejected `runQuiet` error, with the fields it attaches. */
@@ -59,6 +61,8 @@ export interface SummariseOptions {
   maxChars?: number;
   /** Injected for tests; defaults to the real environment. */
   env?: NodeJS.ProcessEnv;
+  /** Injected for tests; defaults to the real home directory. */
+  home?: string;
 }
 
 /** Read no more than this from either stream before doing regex work. */
@@ -79,7 +83,23 @@ const MIN_SECRET_VALUE_CHARS = 8;
  * operator the cause, whereas a false positive costs one line of noise.
  */
 const SIGNAL_PATTERN =
-  /(error|invalid|refus|denied|missing|conflict|unknown command|EACCES|EPERM|ENOENT|EOVERRIDE|EEXIST|E40[134]|ETIMEDOUT|ENOTFOUND|not found|failed|cannot|unable|✗|×)/i;
+  /(error|invalid|refus|denied|missing|conflict|unknown command|EACCES|EPERM|ENOENT|EOVERRIDE|EEXIST|E40[134]|ETIMEDOUT|ENOTFOUND|not found|failed|cannot|could ?not|unable|✗|×)/i;
+
+/**
+ * Lines that name the failure ITSELF, as opposed to merely containing a word
+ * like "failed". Ranked ahead of generic matches, because the first
+ * signal-bearing line is not reliably the important one.
+ *
+ * Measured: on this fleet `openclaw <unknown-command>` emits two
+ * `[plugins] codex failed during register …: TypeError …` lines from an
+ * unrelated third-party plugin BEFORE its own "Could not start the CLI /
+ * Reason: Unknown command". Taking the earliest match reported someone else's
+ * TypeError as the cause — swapping one misleading headline for another.
+ */
+const STRONG_SIGNAL_PATTERN =
+  /(config is invalid|unknown command|unknown option|too many arguments|refus|denied|EACCES|EPERM|ENOENT|EOVERRIDE|E40[134]|^\s*[×✗])/i;
+// Note "could not start the CLI" is deliberately NOT strong: it is a header,
+// and the `Reason: …` line beneath it carries the actual cause.
 
 /**
  * Prose about what STILL WORKS. Never the cause of a failure, and actively
@@ -92,9 +112,13 @@ const SIGNAL_PATTERN =
  */
 const REASSURANCE_PATTERN = /\bstill (run|work|available)|\bunaffected\b|no action (is )?(required|needed)/i;
 
-/** npm chatter that is never the cause. */
+/**
+ * Chatter that is never the cause: npm's own noise, and OTHER plugins'
+ * registration failures. The `[plugins] …` prefix is a third party telling us
+ * about itself — real, but never the answer to "why did OUR command fail".
+ */
 const NOISE_PATTERN =
-  /^(npm notice|npm warn|npm WARN|added \d+ package|found \d+ vulnerabilit|up to date|audited \d+ package)/i;
+  /^(npm notice|npm warn|npm WARN|added \d+ package|found \d+ vulnerabilit|up to date|audited \d+ package|\[plugins\]\s)/i;
 
 const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
 
@@ -112,14 +136,37 @@ function escapeRegExp(value: string): string {
  * environment.
  */
 function redactEnvValues(text: string, env: NodeJS.ProcessEnv): string {
+  // LONGEST FIRST. When one secret is a prefix of another — two tokens minted
+  // from the same base, say — replacing the short one first leaves the tail of
+  // the long one in cleartext, and the second pass then finds nothing to do
+  // because its value no longer appears intact.
+  const secrets = Object.entries(env)
+    .filter(([key, value]) =>
+      typeof value === 'string' && value.length >= MIN_SECRET_VALUE_CHARS && SECRET_KEY_PATTERN.test(key))
+    .sort((a, b) => (b[1] as string).length - (a[1] as string).length);
+
   let out = text;
-  for (const [key, value] of Object.entries(env)) {
-    if (!value || value.length < MIN_SECRET_VALUE_CHARS) continue;
-    if (!SECRET_KEY_PATTERN.test(key)) continue;
-    if (!out.includes(value)) continue;
-    out = out.replace(new RegExp(escapeRegExp(value), 'g'), `[redacted:$${key}]`);
+  for (const [key, value] of secrets) {
+    if (!out.includes(value as string)) continue;
+    out = out.replace(new RegExp(escapeRegExp(value as string), 'g'), `[redacted:$${key}]`);
   }
   return out;
+}
+
+/**
+ * Replace the operator's home directory with `~`.
+ *
+ * Every other path-printing site in doctor.ts already does this. This output is
+ * bound for reports pasted into public issues, and OpenClaw's config errors
+ * quote absolute plugin paths — which carry the OS username and, through
+ * project directory names, client and vendor names. OpenClaw abbreviates on its
+ * success path but not on its failure path.
+ *
+ * Runs AFTER redaction so it cannot split a secret mid-match.
+ */
+function scrubHome(text: string, home: string): string {
+  if (!home || home === '/' || home.length < 2) return text;
+  return text.split(home).join('~');
 }
 
 function cleanLines(raw: string): string[] {
@@ -146,12 +193,20 @@ export function summariseCommandOutput(
   const maxLines = opts.maxLines ?? DEFAULT_MAX_LINES;
   const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
   const env = opts.env ?? process.env;
+  const home = opts.home ?? os.homedir();
 
   if (!output || !output.trim()) return { lines: [], truncated: false };
 
   // Cap before any regex work — a failed `npm install -g` emits megabytes.
-  const capped = output.length > MAX_INPUT_BYTES ? output.slice(-MAX_INPUT_BYTES) : output;
-  let truncated = capped.length < output.length;
+  // BOTH ENDS, not the tail: the diagnosis is printed first and the noise
+  // follows, so a tail-only cap discards the cause before the signal filter
+  // ever sees it — the very mistake this module exists to correct, moved one
+  // stage earlier where nothing downstream can compensate.
+  const half = Math.floor(MAX_INPUT_BYTES / 2);
+  const capped = output.length > MAX_INPUT_BYTES
+    ? `${output.slice(0, half)}\n…\n${output.slice(-half)}`
+    : output;
+  let truncated = output.length > MAX_INPUT_BYTES;
 
   const redacted = redactCredentials(redactEnvValues(capped, env), {
     // npm integrity hashes are high-entropy but not secrets; without this the
@@ -159,21 +214,30 @@ export function summariseCommandOutput(
     allowlist: ['sha512-', 'sha1-', 'sha256-'],
   });
 
-  const all = cleanLines(redacted);
+  const all = cleanLines(scrubHome(redacted, home));
   if (all.length === 0) return { lines: [], truncated };
 
   const signal = all.filter(line => SIGNAL_PATTERN.test(line) && !REASSURANCE_PATTERN.test(line));
-  let picked = signal.length > 0 ? signal.slice(0, maxLines) : all.slice(-maxLines);
+  const usedSignal = signal.length > 0;
+  // Strongest cause first, original order preserved within each band — the
+  // EARLIEST signal line is not reliably the most informative one.
+  const ranked = usedSignal
+    ? [...signal.filter(l => STRONG_SIGNAL_PATTERN.test(l)), ...signal.filter(l => !STRONG_SIGNAL_PATTERN.test(l))]
+    : all;
+
+  let picked = usedSignal ? ranked.slice(0, maxLines) : ranked.slice(-maxLines);
   if (picked.length < all.length) truncated = true;
 
   picked = picked.map(line =>
     line.length > MAX_LINE_CHARS ? `${line.slice(0, MAX_LINE_CHARS - 1)}…` : line,
   );
 
-  // Drop from the front until the block fits — the last kept line is the most
-  // specific one when the fallback tail is in play.
+  // Trim from the END on the signal path (lines are ranked, so the first is the
+  // most important) and from the FRONT on the tail path (where the last line is
+  // the most specific). Dropping from the front of a ranked list would delete
+  // the very line that was selected as the cause.
   while (picked.length > 1 && picked.join('\n').length > maxChars) {
-    picked.shift();
+    if (usedSignal) picked.pop(); else picked.shift();
     truncated = true;
   }
   if (picked.length === 1 && picked[0].length > maxChars) {
@@ -211,17 +275,25 @@ export function describeRunFailure(err: unknown, opts: SummariseOptions = {}): R
 
   const { lines, truncated } = summariseCommandOutput(chosen, opts);
 
+  // How the process ENDED outranks whatever it managed to print. A step killed
+  // at the 120s wall often has a plausible-looking network line in its buffer;
+  // reporting that alone tells the operator to retry a transient blip when the
+  // real fact is a half-applied install. Partial output is still surfaced, but
+  // as detail behind the terminal condition, never in place of it.
+  const sanitise = (text: string): string =>
+    scrubHome(redactEnvValues(text, opts.env ?? process.env), opts.home ?? os.homedir());
+
   let reason: string;
-  if (lines.length > 0) {
-    reason = firstSentence(lines[0]);
-  } else if (spawnFailed) {
-    reason = firstSentence(`command not found${command}`);
+  if (spawnFailed) {
+    reason = firstSentence(sanitise(`command not found${command}`));
   } else if (timedOut) {
-    reason = firstSentence(`timed out${command}`);
+    reason = firstSentence(sanitise(`timed out${command}`));
+  } else if (lines.length > 0) {
+    reason = firstSentence(lines[0]);
   } else if (exitCode !== null) {
-    reason = firstSentence(`exited ${exitCode} with no output${command}`);
+    reason = firstSentence(sanitise(`exited ${exitCode} with no output${command}`));
   } else {
-    reason = firstSentence(e.message || 'failed with no output');
+    reason = firstSentence(sanitise(e.message || 'failed with no output'));
   }
 
   return { reason, detail: lines, exitCode, timedOut, spawnFailed, truncated };

--- a/src/integrations/child-output.ts
+++ b/src/integrations/child-output.ts
@@ -1,0 +1,228 @@
+/**
+ * Turning a failed child process into something an operator can act on (#221).
+ *
+ * The field report behind #221: an operator followed `doctor`'s advice for five
+ * days while every suggested command was a guaranteed no-op, because OpenClaw's
+ * own config was invalid. OpenClaw said so clearly, every time. ShieldCortex
+ * threw the message away and printed the command again:
+ *
+ *   } catch {
+ *     return { status: 'warn', summary: 'update failed — run `openclaw plugins
+ *              install --force …`' };   // the command that just failed
+ *   }
+ *
+ * `runQuiet` had already captured stdout AND stderr and attached both to the
+ * rejected error. The cause was in hand and discarded.
+ *
+ * Two details here are not obvious and are the reason this is a module rather
+ * than a one-liner:
+ *
+ * SIGNAL-FIRST, NOT TAIL. The four existing `slice(-N)` call sites take the
+ * LAST few lines. OpenClaw states its diagnosis first and signs off with
+ * "Audit, status, health, logs, tasks list/audit, and doctor commands still run
+ * with invalid config." A tail therefore returns the reassurance and drops the
+ * cause — the precise failure this module exists to stop.
+ *
+ * REDACT WHAT WE OURSELVES HANDED OVER. `runQuiet` passes `{...process.env}` to
+ * the child, so NPM_TOKEN and CLAWHUB_TOKEN are values WE supplied — and npm
+ * echoes them back verbatim in a 401 body. This output is destined for a doctor
+ * report an operator may paste into a GitHub issue. Env-value redaction runs
+ * first and does not depend on a pattern matching the token's shape.
+ */
+import { redactCredentials } from '../defence/credential-leak/index.js';
+
+/** A rejected `runQuiet` error, with the fields it attaches. */
+export interface CapturedError extends Error {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  timedOut?: boolean;
+  spawnFailed?: boolean;
+  command?: string;
+  /** Node's spawn errno (ENOENT, EACCES, …). */
+  code?: string;
+}
+
+export interface RunFailureReport {
+  /** ONE line, ≤120 chars — `step()` pads the summary on a single line. */
+  reason: string;
+  /** Redacted detail lines, most informative first. */
+  detail: string[];
+  exitCode: number | null;
+  timedOut: boolean;
+  spawnFailed: boolean;
+  truncated: boolean;
+}
+
+export interface SummariseOptions {
+  maxLines?: number;
+  maxChars?: number;
+  /** Injected for tests; defaults to the real environment. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/** Read no more than this from either stream before doing regex work. */
+const MAX_INPUT_BYTES = 32 * 1024;
+const DEFAULT_MAX_LINES = 4;
+const DEFAULT_MAX_CHARS = 400;
+const MAX_LINE_CHARS = 160;
+const MAX_REASON_CHARS = 120;
+
+/** Env var names whose VALUES must never reach a pasted report. */
+const SECRET_KEY_PATTERN = /(TOKEN|SECRET|KEY|PASSWORD|PASSWD|CREDENTIAL|AUTH|COOKIE|SESSION)/i;
+/** Below this length a value is too short to be a real secret and too likely to
+ *  appear as an ordinary substring (a 3-char value would redact half the text). */
+const MIN_SECRET_VALUE_CHARS = 8;
+
+/**
+ * Lines worth surfacing. Deliberately broad: a missed signal line costs the
+ * operator the cause, whereas a false positive costs one line of noise.
+ */
+const SIGNAL_PATTERN =
+  /(error|invalid|refus|denied|missing|conflict|unknown command|EACCES|EPERM|ENOENT|EOVERRIDE|EEXIST|E40[134]|ETIMEDOUT|ENOTFOUND|not found|failed|cannot|unable|✗|×)/i;
+
+/**
+ * Prose about what STILL WORKS. Never the cause of a failure, and actively
+ * misleading directly under a blocking error.
+ *
+ * This exists because OpenClaw signs off an invalid-config report with
+ * "Audit, status, health, logs, tasks list/audit, and doctor commands still run
+ * with invalid config." — which contains the word "invalid" and so matches the
+ * signal pattern on a keyword. Reassurance is not signal, however it is worded.
+ */
+const REASSURANCE_PATTERN = /\bstill (run|work|available)|\bunaffected\b|no action (is )?(required|needed)/i;
+
+/** npm chatter that is never the cause. */
+const NOISE_PATTERN =
+  /^(npm notice|npm warn|npm WARN|added \d+ package|found \d+ vulnerabilit|up to date|audited \d+ package)/i;
+
+const ANSI_PATTERN = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+/** Escape a string for literal use inside a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Replace the literal values of secret-looking env vars.
+ *
+ * Runs BEFORE the pattern-based detector because it needs no pattern: the value
+ * is known exactly. A token that our own credential patterns do not recognise
+ * still gets caught here, provided we were the ones who put it in the child's
+ * environment.
+ */
+function redactEnvValues(text: string, env: NodeJS.ProcessEnv): string {
+  let out = text;
+  for (const [key, value] of Object.entries(env)) {
+    if (!value || value.length < MIN_SECRET_VALUE_CHARS) continue;
+    if (!SECRET_KEY_PATTERN.test(key)) continue;
+    if (!out.includes(value)) continue;
+    out = out.replace(new RegExp(escapeRegExp(value), 'g'), `[redacted:$${key}]`);
+  }
+  return out;
+}
+
+function cleanLines(raw: string): string[] {
+  return raw
+    .replace(ANSI_PATTERN, '')
+    .replace(/\r/g, '')
+    .split('\n')
+    .map(line => line.trimEnd())
+    .filter(line => line.trim().length > 0)
+    .filter(line => !NOISE_PATTERN.test(line.trim()));
+}
+
+/**
+ * Reduce raw child output to a few lines an operator can act on.
+ *
+ * Signal-bearing lines are taken from the FRONT (see the module note on why a
+ * tail is wrong here); only when nothing matches does it fall back to the tail,
+ * which is the right default for a generic stack trace.
+ */
+export function summariseCommandOutput(
+  output: string,
+  opts: SummariseOptions = {},
+): { lines: string[]; truncated: boolean } {
+  const maxLines = opts.maxLines ?? DEFAULT_MAX_LINES;
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+  const env = opts.env ?? process.env;
+
+  if (!output || !output.trim()) return { lines: [], truncated: false };
+
+  // Cap before any regex work — a failed `npm install -g` emits megabytes.
+  const capped = output.length > MAX_INPUT_BYTES ? output.slice(-MAX_INPUT_BYTES) : output;
+  let truncated = capped.length < output.length;
+
+  const redacted = redactCredentials(redactEnvValues(capped, env), {
+    // npm integrity hashes are high-entropy but not secrets; without this the
+    // entropy pass eats them and the real message drowns in [REDACTED].
+    allowlist: ['sha512-', 'sha1-', 'sha256-'],
+  });
+
+  const all = cleanLines(redacted);
+  if (all.length === 0) return { lines: [], truncated };
+
+  const signal = all.filter(line => SIGNAL_PATTERN.test(line) && !REASSURANCE_PATTERN.test(line));
+  let picked = signal.length > 0 ? signal.slice(0, maxLines) : all.slice(-maxLines);
+  if (picked.length < all.length) truncated = true;
+
+  picked = picked.map(line =>
+    line.length > MAX_LINE_CHARS ? `${line.slice(0, MAX_LINE_CHARS - 1)}…` : line,
+  );
+
+  // Drop from the front until the block fits — the last kept line is the most
+  // specific one when the fallback tail is in play.
+  while (picked.length > 1 && picked.join('\n').length > maxChars) {
+    picked.shift();
+    truncated = true;
+  }
+  if (picked.length === 1 && picked[0].length > maxChars) {
+    picked[0] = `${picked[0].slice(0, maxChars - 1)}…`;
+    truncated = true;
+  }
+
+  return { lines: picked, truncated };
+}
+
+function firstSentence(value: string, limit = MAX_REASON_CHARS): string {
+  const single = value.replace(/\s+/g, ' ').trim();
+  return single.length > limit ? `${single.slice(0, limit - 1)}…` : single;
+}
+
+/**
+ * Describe a rejected child-process error without discarding what it captured.
+ *
+ * The empty-output ladder matters as much as the happy path: a bare "failed" is
+ * what #221 is about. Even with no output at all, the caller gets the exit code
+ * and the command, which is the minimum needed to reproduce it by hand.
+ */
+export function describeRunFailure(err: unknown, opts: SummariseOptions = {}): RunFailureReport {
+  const e = (err ?? {}) as CapturedError;
+  const exitCode = e.exitCode ?? null;
+  const timedOut = e.timedOut === true;
+  const spawnFailed = e.spawnFailed === true || e.code === 'ENOENT';
+  const command = e.command ? ` (${e.command})` : '';
+
+  // Invalid configs write to stderr, valid runs to stdout, npm to stderr — so
+  // pick the stream carrying signal rather than concatenating both.
+  const streams = [e.stderr ?? '', e.stdout ?? ''];
+  const withSignal = streams.find(s => s.trim() && SIGNAL_PATTERN.test(s));
+  const chosen = withSignal ?? streams.find(s => s.trim()) ?? '';
+
+  const { lines, truncated } = summariseCommandOutput(chosen, opts);
+
+  let reason: string;
+  if (lines.length > 0) {
+    reason = firstSentence(lines[0]);
+  } else if (spawnFailed) {
+    reason = firstSentence(`command not found${command}`);
+  } else if (timedOut) {
+    reason = firstSentence(`timed out${command}`);
+  } else if (exitCode !== null) {
+    reason = firstSentence(`exited ${exitCode} with no output${command}`);
+  } else {
+    reason = firstSentence(e.message || 'failed with no output');
+  }
+
+  return { reason, detail: lines, exitCode, timedOut, spawnFailed, truncated };
+}

--- a/src/integrations/openclaw-config-validate.ts
+++ b/src/integrations/openclaw-config-validate.ts
@@ -64,7 +64,7 @@ export interface ValidateDeps {
   resolveBin?: (home: string) => string | null;
   configPath?: (home: string) => string;
   exists?: (target: string) => boolean;
-  run?: (bin: string) => SpawnOutcome;
+  run?: (bin: string, home: string) => SpawnOutcome;
 }
 
 /**
@@ -75,15 +75,33 @@ export interface ValidateDeps {
  */
 export const VALIDATE_TIMEOUT_MS = 10_000;
 
+/**
+ * The argv, exported so a test can pin it. `--json` must never be added: an
+ * OpenClaw that does not know the flag exits non-zero with a usage dump.
+ */
+export const VALIDATE_ARGV = ['config', 'validate'] as const;
+
+/**
+ * OpenClaw positively asserting that the config is bad, in each shape it uses:
+ * the human header, the JSON body, and a per-issue bullet. A non-zero exit
+ * WITHOUT one of these is a CLI that did not understand us, not a broken config.
+ */
+const SAYS_INVALID = /config is invalid|"valid"\s*:\s*false|^\s*[×✗]\s/m;
+
 export function defaultConfigPath(home: string): string {
   return process.env.OPENCLAW_CONFIG_PATH?.trim() || path.join(home, '.openclaw', 'openclaw.json');
 }
 
-function defaultRun(bin: string): SpawnOutcome {
-  const r = spawnSync(bin, ['config', 'validate'], {
+function defaultRun(bin: string, home: string): SpawnOutcome {
+  const r = spawnSync(bin, [...VALIDATE_ARGV], {
     encoding: 'utf-8',
     timeout: VALIDATE_TIMEOUT_MS,
+    // stdin closed: a child that decided to prompt gets EOF rather than
+    // blocking doctor forever.
     stdio: ['ignore', 'pipe', 'pipe'],
+    // HOME threaded through, like every sibling spawn in the codebase — the
+    // verdict must describe the same account the checks it gates are about.
+    env: { ...process.env, HOME: home },
   });
   return {
     status: r.status,
@@ -126,7 +144,7 @@ export function validateOpenClawConfig(
 
   let r: SpawnOutcome;
   try {
-    r = (deps.run ?? defaultRun)(bin);
+    r = (deps.run ?? defaultRun)(bin, home);
   } catch (err) {
     return {
       state: 'indeterminate',
@@ -144,9 +162,32 @@ export function validateOpenClawConfig(
     return { state: 'indeterminate', reason: '`openclaw config validate` did not report an exit code' };
   }
 
-  // Exit code IS the verdict. Output is never inspected to reach it — that is
-  // what keeps a warnings-but-valid config (exit 0) out of the invalid arm.
+  // Exit 0 is ALWAYS valid, whatever the output says. That one-way rule is what
+  // keeps a warnings-but-valid config out of the invalid arm, and it is not
+  // weakened below: output is consulted only to DOWNGRADE a non-zero result.
   if (r.status === 0) return { state: 'valid' };
+
+  // A non-zero exit is not proof of an invalid config.
+  //
+  // Measured on 2026.7.1-2: `openclaw config <unknown-sub>` exits 1 with
+  // "Too many arguments for this command.", and `openclaw <unknown-cmd>` exits
+  // 1 with "Unknown command: …". An OpenClaw predating `config validate`
+  // answers exactly like that — so keying on the exit code alone would report a
+  // HEALTHY host as config-broken and then strip every remedy doctor has,
+  // including the one on a check whose own message says the gateway is running
+  // with no memory firewall and no action guard.
+  //
+  // That is #221 inverted, and strictly worse than the bug it fixes. This
+  // module's header already rejects `--json` for this exact reason; the same
+  // argument applies to the subcommand itself. So: require OpenClaw to SAY the
+  // config is invalid. Anything else fails open.
+  const blob = `${r.stderr}\n${r.stdout}`;
+  if (!SAYS_INVALID.test(blob)) {
+    return {
+      state: 'indeterminate',
+      reason: '`openclaw config validate` is not supported by this OpenClaw',
+    };
+  }
 
   // Invalid: stdout is empty and everything goes to stderr, inverted from the
   // valid case — so prefer stderr but do not assume it.

--- a/src/integrations/openclaw-config-validate.ts
+++ b/src/integrations/openclaw-config-validate.ts
@@ -99,6 +99,16 @@ const SAYS_INVALID = /config is invalid|"valid"\s*:\s*false|^\s*[×✗]\s/m;
  */
 const SAYS_REFUSED = /unknown command|too many arguments|unknown option|unrecognized (command|option)|could ?not start the cli/i;
 
+/**
+ * OpenClaw stating a VERDICT, as opposed to a bullet that merely looks like
+ * one. These are proof that `config validate` ran and judged — the refusal veto
+ * must not override them, or unrelated plugin stderr containing "unknown
+ * option" (which OpenClaw's own plugin loader emits routinely) turns a proven
+ * invalid config into `indeterminate` and the operator is told nothing is
+ * wrong. The veto exists to discount the WEAK `×`/`✗` bullet evidence only.
+ */
+const SAYS_INVALID_STRONG = /config is invalid|"valid"\s*:\s*false/i;
+
 export function defaultConfigPath(home: string): string {
   return process.env.OPENCLAW_CONFIG_PATH?.trim() || path.join(home, '.openclaw', 'openclaw.json');
 }
@@ -193,7 +203,8 @@ export function validateOpenClawConfig(
   // argument applies to the subcommand itself. So: require OpenClaw to SAY the
   // config is invalid. Anything else fails open.
   const blob = `${r.stderr}\n${r.stdout}`;
-  if (SAYS_REFUSED.test(blob) || !SAYS_INVALID.test(blob)) {
+  // Strong proof wins over the refusal veto; the veto only discounts bullets.
+  if ((SAYS_REFUSED.test(blob) && !SAYS_INVALID_STRONG.test(blob)) || !SAYS_INVALID.test(blob)) {
     return {
       state: 'indeterminate',
       reason: '`openclaw config validate` is not supported by this OpenClaw',

--- a/src/integrations/openclaw-config-validate.ts
+++ b/src/integrations/openclaw-config-validate.ts
@@ -88,6 +88,17 @@ export const VALIDATE_ARGV = ['config', 'validate'] as const;
  */
 const SAYS_INVALID = /config is invalid|"valid"\s*:\s*false|^\s*[×✗]\s/m;
 
+/**
+ * The CLI rejecting the COMMAND, as opposed to judging the config. This VETOES
+ * the invalid verdict outright, because a bullet is weak evidence and a refusal
+ * is strong: unrelated plugin stderr routinely carries `✗ …` lines, and one
+ * landing alongside "Unknown command" would otherwise convict a healthy config
+ * on an OpenClaw that simply does not have `config validate`.
+ *
+ * Checked BEFORE `SAYS_INVALID`, never after — the whole point is that it wins.
+ */
+const SAYS_REFUSED = /unknown command|too many arguments|unknown option|unrecognized (command|option)|could ?not start the cli/i;
+
 export function defaultConfigPath(home: string): string {
   return process.env.OPENCLAW_CONFIG_PATH?.trim() || path.join(home, '.openclaw', 'openclaw.json');
 }
@@ -182,7 +193,7 @@ export function validateOpenClawConfig(
   // argument applies to the subcommand itself. So: require OpenClaw to SAY the
   // config is invalid. Anything else fails open.
   const blob = `${r.stderr}\n${r.stdout}`;
-  if (!SAYS_INVALID.test(blob)) {
+  if (SAYS_REFUSED.test(blob) || !SAYS_INVALID.test(blob)) {
     return {
       state: 'indeterminate',
       reason: '`openclaw config validate` is not supported by this OpenClaw',

--- a/src/integrations/openclaw-config-validate.ts
+++ b/src/integrations/openclaw-config-validate.ts
@@ -1,0 +1,158 @@
+/**
+ * Is OpenClaw's own config in a state where its CLI will actually run? (#221)
+ *
+ * OpenClaw refuses EVERY `plugins` and `skills` subcommand while any config
+ * entry dangles — and the refusal reads `Unknown command: openclaw plugins
+ * list`, not "your config is invalid". Verified live against 2026.7.1-2 with a
+ * dangling plugin path: `plugins list` and `skills list` both exit 1 with that
+ * message; fix the config and the identical command exits 0. OpenClaw itself
+ * names the survivors on stderr — "Audit, status, health, logs, tasks
+ * list/audit, and doctor commands still run with invalid config."
+ *
+ * That is why the operator in #221 followed doctor's advice for five days: the
+ * commands did not say they were refusing, so nothing pointed at the cause.
+ *
+ * THE VERDICT IS THREE-STATE, AND THAT IS THE WHOLE DESIGN.
+ *
+ * Suppressing a remedy is destructive — if we are wrong, we hide the advice
+ * that would have fixed the host. So only a PROVEN-invalid config suppresses
+ * anything; every uncertainty resolves to `indeterminate` and changes nothing.
+ * Each of these was measured, and each would otherwise be a false red:
+ *
+ *   - no config file        → OpenClaw exits 1 with {"valid":false,"error":
+ *                             "file not found"} and NO issues[]. A pure
+ *                             exit-code gate calls an OpenClaw-less host
+ *                             "config invalid".
+ *   - binary absent         → spawnSync gives status: null + error.code
+ *                             ENOENT, NOT 127 (127 is the shell path only).
+ *                             The `status ?? 1` idiom used elsewhere collapses
+ *                             this into "exit 1" — indistinguishable from a
+ *                             genuinely invalid config.
+ *   - timed out             → status null again, same trap.
+ *   - warnings but valid    → exits 0. The dev box does this today with a
+ *                             duplicate-plugin-id warning. Keying on output
+ *                             text rather than exit code would report a
+ *                             healthy host as broken.
+ *
+ * `--json` is deliberately NOT passed. It exists on 2026.7.1-2 and is tidier,
+ * but an OpenClaw old enough not to know the flag exits non-zero with a usage
+ * dump — manufacturing the exact false red this module exists to avoid. The
+ * exit code of the bare command is the verdict; output is quoted detail only.
+ */
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+import { resolveOpenClawBinary } from '../setup/openclaw.js';
+import { summariseCommandOutput } from './child-output.js';
+
+export type OpenClawConfigVerdict =
+  | { state: 'valid' }
+  | { state: 'invalid'; detail: string[] }
+  | { state: 'indeterminate'; reason: string };
+
+export interface SpawnOutcome {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: NodeJS.ErrnoException;
+  signal?: NodeJS.Signals | null;
+}
+
+export interface ValidateDeps {
+  resolveBin?: (home: string) => string | null;
+  configPath?: (home: string) => string;
+  exists?: (target: string) => boolean;
+  run?: (bin: string) => SpawnOutcome;
+}
+
+/**
+ * ~7-10x the measured worst case (1.0-1.5 s on macOS arm64; cost is Node
+ * startup and plugin registration, not config size, so valid and invalid
+ * configs cost the same). Do not lower below 5 s — a cold start on a loaded
+ * host would exceed it and manufacture a spurious "invalid" verdict.
+ */
+export const VALIDATE_TIMEOUT_MS = 10_000;
+
+export function defaultConfigPath(home: string): string {
+  return process.env.OPENCLAW_CONFIG_PATH?.trim() || path.join(home, '.openclaw', 'openclaw.json');
+}
+
+function defaultRun(bin: string): SpawnOutcome {
+  const r = spawnSync(bin, ['config', 'validate'], {
+    encoding: 'utf-8',
+    timeout: VALIDATE_TIMEOUT_MS,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    status: r.status,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    error: r.error as NodeJS.ErrnoException | undefined,
+    signal: r.signal,
+  };
+}
+
+/**
+ * Determine whether OpenClaw's CLI will accept plugin/skill subcommands.
+ *
+ * Read-only: `config validate` mutates nothing, which is why this is safe to
+ * run from `doctor` without a repair-consent prompt.
+ */
+export function validateOpenClawConfig(
+  home: string = os.homedir(),
+  deps: ValidateDeps = {},
+): OpenClawConfigVerdict {
+  const exists = deps.exists ?? ((target: string) => fs.existsSync(target));
+  const configPath = (deps.configPath ?? defaultConfigPath)(home);
+
+  // Cheapest fail-open first, and it sidesteps the file-not-found trap above.
+  if (!exists(configPath)) {
+    return { state: 'indeterminate', reason: 'OpenClaw not configured on this host' };
+  }
+
+  // `resolveOpenClawBinary`, not a bare command name: a bare `openclaw` is
+  // invisible to non-interactive shells on part of the fleet (#146).
+  const bin = (deps.resolveBin ?? resolveOpenClawBinary)(home);
+  if (!bin) return { state: 'indeterminate', reason: 'openclaw binary not found' };
+
+  // Never spawn a real subprocess from the test runner. Mapped to
+  // indeterminate rather than to a status — inheriting a hard-fail here would
+  // report every CI host as config-broken.
+  if (!deps.run && process.env.JEST_WORKER_ID !== undefined) {
+    return { state: 'indeterminate', reason: 'skipped under test runner' };
+  }
+
+  let r: SpawnOutcome;
+  try {
+    r = (deps.run ?? defaultRun)(bin);
+  } catch (err) {
+    return {
+      state: 'indeterminate',
+      reason: `could not run \`openclaw config validate\` (${(err as Error).message})`,
+    };
+  }
+
+  if (r.error?.code === 'ENOENT') {
+    return { state: 'indeterminate', reason: 'openclaw binary disappeared before it could run' };
+  }
+  if (r.error?.code === 'ETIMEDOUT' || r.signal) {
+    return { state: 'indeterminate', reason: `\`openclaw config validate\` did not finish within ${VALIDATE_TIMEOUT_MS / 1000}s` };
+  }
+  if (r.status === null) {
+    return { state: 'indeterminate', reason: '`openclaw config validate` did not report an exit code' };
+  }
+
+  // Exit code IS the verdict. Output is never inspected to reach it — that is
+  // what keeps a warnings-but-valid config (exit 0) out of the invalid arm.
+  if (r.status === 0) return { state: 'valid' };
+
+  // Invalid: stdout is empty and everything goes to stderr, inverted from the
+  // valid case — so prefer stderr but do not assume it.
+  const { lines } = summariseCommandOutput(r.stderr || r.stdout, { maxLines: 4 });
+  return {
+    state: 'invalid',
+    detail: lines.length > 0 ? lines : [`\`openclaw config validate\` exited ${r.status}`],
+  };
+}

--- a/src/integrations/openclaw-config-validate.ts
+++ b/src/integrations/openclaw-config-validate.ts
@@ -125,14 +125,49 @@ const SAYS_INVALID_STRONG = /config is invalid|"valid"\s*:\s*false/i;
  * the summariser's `dropPluginChatter`, which may legitimately KEEP such lines
  * as a reason of last resort; they may be worth showing an operator while still
  * carrying no authority over the verdict.
+ *
+ * A plain `^\[plugins\]` anchor is NOT enough, and the gap is not theoretical —
+ * all three of these manufactured an `invalid` verdict against an OpenClaw that
+ * had explicitly refused the command:
+ *
+ *   [plugins] acme migration failed:      ← tag on THIS line
+ *     cached config is invalid            ← evidence on the NEXT one
+ *   2026-08-12T07:00:00Z [plugins] acme: cached config is invalid
+ *   \x1b[32m[plugins]\x1b[0m acme: cached config is invalid
+ *
+ * So ownership is tracked as a BLOCK, not per line, and the tag is matched
+ * after ANSI removal and past common logger prefixes. Broad stripping was the
+ * alternative and is worse: it would swallow OpenClaw's own indented `×` issue
+ * bullets, which is how the operator learns what is actually wrong.
  */
-const PLUGIN_CHATTER_LINE = /^\s*\[plugins\]\s/i;
+const PLUGIN_CHATTER_LINE =
+  /^\s*(?:(?:\[?\d{4}-\d{2}-\d{2}[T ][\d:.]+Z?\]?|\[\d{2}:\d{2}:\d{2}(?:\.\d+)?\]|(?:TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL))\s+)*\[plugins\]\s/i;
 
-/** Drop third-party chatter so only validator-owned lines classify. */
+/** A line indented under whatever came before it, i.e. a continuation. */
+const CONTINUATION_LINE = /^\s+\S/;
+
+const ANSI = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+/**
+ * Drop third-party chatter so only validator-owned lines classify.
+ *
+ * Continuation lines inherit the OWNER of the block they sit in, which is the
+ * whole point: OpenClaw's own bullets are indented too, so indentation alone
+ * says nothing about provenance. A non-indented line always re-decides
+ * ownership, so a plugin block ends the moment OpenClaw speaks again.
+ */
 function validatorOwnedLines(stream: string): string {
+  let insidePluginBlock = false;
   return stream
     .split('\n')
-    .filter(line => !PLUGIN_CHATTER_LINE.test(line))
+    .filter((line) => {
+      const bare = line.replace(ANSI, '');
+      // Blank lines carry no evidence and end nothing — a wrapped message may
+      // legitimately contain one.
+      if (!bare.trim()) return true;
+      if (!CONTINUATION_LINE.test(bare)) insidePluginBlock = PLUGIN_CHATTER_LINE.test(bare);
+      return !insidePluginBlock;
+    })
     .join('\n');
 }
 
@@ -242,14 +277,19 @@ export function validateOpenClawConfig(
     };
   }
 
-  // Invalid: stdout is empty and everything goes to stderr, inverted from the
-  // valid case — so prefer stderr but do not assume it. Prefer whichever stream
-  // actually carries the verdict, though: "prefer stderr" alone reported the
-  // generic exit-code fallback when stderr held nothing but plugin chatter and
-  // the real `× bad key` sat in stdout.
-  const verdictStream = [ownStderr, ownStdout].find(s => SAYS_INVALID.test(s))
-    ?? (ownStderr.trim() ? ownStderr : ownStdout);
-  const { lines } = summariseCommandOutput(verdictStream, { maxLines: 4 });
+  // MERGE the streams rather than choosing one.
+  //
+  // Two failed attempts are recorded here because each looked right and lost
+  // the operator's actual answer. "Prefer stderr" reported the generic exit
+  // code when the verdict sat in stdout. Picking the first stream that matches
+  // then split a header from its own cause: OpenClaw wrote `OpenClaw config is
+  // invalid:` to stderr and `  × channels.telegram: bad key` to stdout, and the
+  // detail became the header alone — true, and useless.
+  //
+  // Nothing needs to be chosen. Both streams are validator-owned by this point;
+  // concatenating them lets the summariser rank across the whole evidence.
+  const evidence = [ownStderr, ownStdout].map(s => s.trim()).filter(Boolean).join('\n');
+  const { lines } = summariseCommandOutput(evidence, { maxLines: 4 });
   return {
     state: 'invalid',
     detail: lines.length > 0 ? lines : [`\`openclaw config validate\` exited ${r.status}`],

--- a/src/integrations/openclaw-config-validate.ts
+++ b/src/integrations/openclaw-config-validate.ts
@@ -109,6 +109,33 @@ const SAYS_REFUSED = /unknown command|too many arguments|unknown option|unrecogn
  */
 const SAYS_INVALID_STRONG = /config is invalid|"valid"\s*:\s*false/i;
 
+/**
+ * Another plugin narrating its own troubles on our streams. Removed BEFORE any
+ * verdict classification, in both directions:
+ *
+ * - it must not manufacture proof — `[plugins] acme migration failed: cached
+ *   config is invalid` alongside `Unknown command: config validate` otherwise
+ *   convicts a config on an OpenClaw that plainly refused the command, which is
+ *   #221 inverted and the exact failure this module's fail-open contract exists
+ *   to prevent;
+ * - and it must not supply a refusal — an `unknown option` from a plugin loader
+ *   would otherwise veto a verdict OpenClaw really did give.
+ *
+ * Only lines OpenClaw itself owns get a vote. Note this is a stricter rule than
+ * the summariser's `dropPluginChatter`, which may legitimately KEEP such lines
+ * as a reason of last resort; they may be worth showing an operator while still
+ * carrying no authority over the verdict.
+ */
+const PLUGIN_CHATTER_LINE = /^\s*\[plugins\]\s/i;
+
+/** Drop third-party chatter so only validator-owned lines classify. */
+function validatorOwnedLines(stream: string): string {
+  return stream
+    .split('\n')
+    .filter(line => !PLUGIN_CHATTER_LINE.test(line))
+    .join('\n');
+}
+
 export function defaultConfigPath(home: string): string {
   return process.env.OPENCLAW_CONFIG_PATH?.trim() || path.join(home, '.openclaw', 'openclaw.json');
 }
@@ -202,7 +229,11 @@ export function validateOpenClawConfig(
   // module's header already rejects `--json` for this exact reason; the same
   // argument applies to the subcommand itself. So: require OpenClaw to SAY the
   // config is invalid. Anything else fails open.
-  const blob = `${r.stderr}\n${r.stdout}`;
+  // Classify on validator-owned lines only — a third party's chatter can
+  // neither convict nor acquit. See `PLUGIN_CHATTER_LINE`.
+  const ownStderr = validatorOwnedLines(r.stderr ?? '');
+  const ownStdout = validatorOwnedLines(r.stdout ?? '');
+  const blob = `${ownStderr}\n${ownStdout}`;
   // Strong proof wins over the refusal veto; the veto only discounts bullets.
   if ((SAYS_REFUSED.test(blob) && !SAYS_INVALID_STRONG.test(blob)) || !SAYS_INVALID.test(blob)) {
     return {
@@ -212,8 +243,13 @@ export function validateOpenClawConfig(
   }
 
   // Invalid: stdout is empty and everything goes to stderr, inverted from the
-  // valid case — so prefer stderr but do not assume it.
-  const { lines } = summariseCommandOutput(r.stderr || r.stdout, { maxLines: 4 });
+  // valid case — so prefer stderr but do not assume it. Prefer whichever stream
+  // actually carries the verdict, though: "prefer stderr" alone reported the
+  // generic exit-code fallback when stderr held nothing but plugin chatter and
+  // the real `× bad key` sat in stdout.
+  const verdictStream = [ownStderr, ownStdout].find(s => SAYS_INVALID.test(s))
+    ?? (ownStderr.trim() ? ownStderr : ownStdout);
+  const { lines } = summariseCommandOutput(verdictStream, { maxLines: 4 });
   return {
     state: 'invalid',
     detail: lines.length > 0 ? lines : [`\`openclaw config validate\` exited ${r.status}`],

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -16,6 +16,7 @@ import { runPluginSelfCheck, type SelfCheckRunResult } from './openclaw-selfchec
 import { waitForGatewayReady } from './gateway-readiness.js';
 import { summariseRepair, renderRepairHeadline } from './repair-verdict.js';
 import { resolveRepairConsent } from './repair-consent.js';
+import { summariseCommandOutput } from '../integrations/child-output.js';
 
 /**
  * The #74 metadata reconciler orchestrator.
@@ -291,8 +292,14 @@ export async function reconcileOpenClawPluginState(options: ReconcileOptions): P
     // openclaw-* command steps.
     const r = runCommand(step.command ?? []);
     const ok = r.status === 0;
-    stepResults.push({ kind: step.kind, ok, detail: r.output.trim().split('\n').slice(-1)[0] ?? '' });
-    if (!ok) messages.push(`command failed (openclaw ${(step.command ?? []).join(' ')}): ${r.output.trim().split('\n').slice(-1)[0] ?? ''}`);
+    // #221: was `split('\n').slice(-1)[0]` — the LAST line. When OpenClaw
+    // refuses because its config is invalid, its last line is the reassurance
+    // "Audit, status, health, logs, tasks list/audit, and doctor commands still
+    // run with invalid config." — so the reported reason was the sign-off and
+    // the actual cause, printed first, was discarded.
+    const summary = summariseCommandOutput(r.output, { maxLines: 1 }).lines[0] ?? '';
+    stepResults.push({ kind: step.kind, ok, detail: summary });
+    if (!ok) messages.push(`command failed (openclaw ${(step.command ?? []).join(' ')}): ${summary}`);
   }
 
   // #145: re-read the state AFTER remediation. The pre-remediation snapshot is

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -303,13 +303,18 @@ export async function reconcileOpenClawPluginState(options: ReconcileOptions): P
     // and filtering them left a failed step with a blank reason. `mode` follows
     // the outcome — failure ranking on a successful command promotes whichever
     // line happens to contain a word like "conflict".
+    // `neverEmpty` rather than a fallback here: a raw `r.output` fallback at
+    // this call site skipped env-value redaction, home scrubbing and the line
+    // caps, and a probe with NPM_TOKEN set proved it emitted the token verbatim
+    // whenever the output was all `npm warn`. The guarantee belongs on the path
+    // that owns the redaction.
     const summarised = summariseCommandOutput(r.output, {
       maxLines: 1,
       dropPluginChatter: false,
       mode: ok ? 'plain' : 'failure',
+      neverEmpty: true,
     });
-    // Never report a failure with no reason — that is the defect, not the fix.
-    const summary = summarised.lines[0] ?? r.output.trim().split('\n')[0]?.trim() ?? '';
+    const summary = summarised.lines[0] ?? '';
     stepResults.push({ kind: step.kind, ok, detail: summary });
     if (!ok) messages.push(`command failed (openclaw ${(step.command ?? []).join(' ')}): ${summary}`);
   }

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -297,7 +297,19 @@ export async function reconcileOpenClawPluginState(options: ReconcileOptions): P
     // "Audit, status, health, logs, tasks list/audit, and doctor commands still
     // run with invalid config." — so the reported reason was the sign-off and
     // the actual cause, printed first, was discarded.
-    const summary = summariseCommandOutput(r.output, { maxLines: 1 }).lines[0] ?? '';
+    //
+    // `dropPluginChatter: false` because THIS command is a `plugins`
+    // subcommand: `[plugins] …` lines are its own output, not a third party's,
+    // and filtering them left a failed step with a blank reason. `mode` follows
+    // the outcome — failure ranking on a successful command promotes whichever
+    // line happens to contain a word like "conflict".
+    const summarised = summariseCommandOutput(r.output, {
+      maxLines: 1,
+      dropPluginChatter: false,
+      mode: ok ? 'plain' : 'failure',
+    });
+    // Never report a failure with no reason — that is the defect, not the fix.
+    const summary = summarised.lines[0] ?? r.output.trim().split('\n')[0]?.trim() ?? '';
     stepResults.push({ kind: step.kind, ok, detail: summary });
     if (!ok) messages.push(`command failed (openclaw ${(step.command ?? []).join(' ')}): ${summary}`);
   }


### PR DESCRIPTION
Closes #221.

## The report

An operator followed `doctor`'s three suggested fixes for five days. Every one was a guaranteed no-op: an unrelated plugin's manifest had been renamed while its config entry stayed `enabled: true`, and OpenClaw refuses **every** `plugins`/`skills` subcommand while any entry dangles. It reports the refusal as `Unknown command`, never naming the config — so nothing pointed at the cause. The moment the config was made valid, the identical suggested command worked first time.

Verified end-to-end against OpenClaw 2026.7.1-2 with a dangling plugin path in a throwaway config: `plugins list` and `skills list` both exit 1 with "Unknown command"; fix the config and the same commands exit 0. OpenClaw names the survivors itself — *"Audit, status, health, logs, tasks list/audit, and doctor commands still run with invalid config."*

## What changed

`doctor` runs `openclaw config validate` ahead of every OpenClaw check. When it does not validate, that is reported as the blocking cause with OpenClaw's own message, and the remedies that cannot execute are withdrawn or swapped for the half that still works.

`update`'s two OpenClaw steps now surface what the child said. `runQuiet` had captured OpenClaw's message all along; a bare `catch {}` replaced it with a restatement of the command that had just failed.

`openclaw-reconcile` took `split('\n').slice(-1)[0]` — the **last** line — which for an invalid config is OpenClaw's reassurance that audit/status/doctor still work, discarding the cause printed above it.

## Three things worth reviewer attention

**The tag is per-site, never matched on fix text.** `installed-not-enabled` also recommends `shieldcortex repair`, but it routes to restore-registration — a pure JSON write, no spawn — and it is the *only* working remedy for an UNPROTECTED host. A substring gate would delete exactly the advice that helps. 17 sites tagged; the mapping found 11 the issue did not list, including four arms sharing one `fix` const where a fifth arm must **not** be suppressed, and one site whose remediation lives in `message` rather than `fix`.

**Three-state verdict, fail-open on everything but proven invalidity.** Suppressing a remedy is destructive, so only a config that OpenClaw *says* is invalid suppresses anything. Measured false-reds that all resolve to `indeterminate`: missing config file (exit 1, no `issues[]`), absent binary (`spawnSync` gives `status: null` + ENOENT, not 127 — the `status ?? 1` idiom elsewhere collapses that into "exit 1"), timeout, kill signal, and an OpenClaw with no `config validate` subcommand.

**Exit-code blast radius is bounded.** An invalid OpenClaw config with none of our remedies depending on it warns rather than fails, because `doctor` exits 1 on any fail with no `--strict` opt-in and that is reserved for states ShieldCortex owns.

## Adversarial review found the inverted case

A three-lens challenge against this diff caught one blocker: the first version treated *any* non-zero exit as proven-invalid. An OpenClaw too old to have `config validate` exits 1 with `Too many arguments for this command.` — so a healthy older host would have been reported config-broken and had all 17 remedies stripped. That is #221 pointed the other way, and worse. Fixed, with tests. Five other real defects came out of the same pass — signal-ranking, a trim loop deleting the highest-ranked line, a killed process reporting as a network blip, an unscrubbed home directory in output bound for public issues, and a prefix collision in env redaction. All fixed in 84e5f672.

## Verification

- **384 suites, 4532 passed, exit 0.**
- 5 new suites, 55 tests.
- The source-level tagging rail was confirmed to go **red** when a single tag is removed, and it names the offending line.
- Live on a box whose config is valid-*with*-warnings — the exit-0 duplicate-plugin-id case that a text-scraping gate would false-red: verdict `valid`, check `pass`, every fix untouched.

Not verified by me: a live `shieldcortex doctor` render. Our own Action Guard denied it in a non-interactive session, so the three functions were exercised directly against the real config instead. Worth one run in a real terminal before merge.

## Deliberately out of scope

#248 — five other `update.ts` swallows, one path that over-shares *unredacted* child output, and `defaultRunCommand`'s `status ?? 1` conflating ENOENT/timeout with exit 1.