### PR TITLE
ci: run the suite on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,46 @@ on:
     branches: [main]
 
 jobs:
+  # ── macOS ────────────────────────────────────────────────────────────────
+  # Every other job here runs on Linux, which makes a whole class of defect
+  # invisible BY CONSTRUCTION: anything that assumes `/proc` semantics.
+  #
+  # The case that bought this job: a change replaced `appendFileSync` with an
+  # `appendFileNoFollow` whose symlink check called `readlinkSync('/dev/fd/N')`.
+  # Correct on Linux, where `/proc/self/fd/N` is a symlink — EINVAL on macOS,
+  # where `/dev/fd/N` is not. The failure path returned false, the caller was a
+  # bare `return`, and the result was an audit file created with ZERO bytes,
+  # exit 0, nothing on stderr. A silently empty audit trail on every Mac in the
+  # fleet, on the fail-closed hot path of a security product — and a 1,133-line
+  # test suite went green because it only ever ran on Linux.
+  #
+  # One Node version, not the matrix: this exists to catch PLATFORM defects, and
+  # the Node-version axis is already covered on Linux. macOS runners bill at a
+  # multiple of Linux minutes, so the dashboard build/lint is deliberately not
+  # duplicated here either — it is pure JS and platform-independent.
+  macos-test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build:ts
+
+      # The whole suite, because platform assumptions are not confined to the
+      # tests that look filesystem-shaped. `hook-audit-write-smoke.test.ts` in
+      # particular spawns the real hook as a real process and asserts a row
+      # actually landed — the assertion that would have caught the above.
+      - name: Test
+        run: npm test
+
   build-and-test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Every CI job ran on Linux, which made a whole class of defect invisible **by construction**: anything that assumes `/proc` semantics.

## The case that bought this

Measured on a real Mac while reviewing #247, not hypothetical.

That branch replaces `appendFileSync` with an `appendFileNoFollow` whose symlink check calls `readlinkSync('/dev/fd/N')`. Correct on Linux, where `/proc/self/fd/N` **is** a symlink. On macOS `/dev/fd/N` is not, so:

`readlinkSync` → `EINVAL` → `catch { return false }` → `appendFileNoFollow` false → **`if (!appendFileNoFollow(...)) return;`**

Observed by running the hook with a temp `HOME` on this box: an audit file created with **zero bytes**, exit 0, nothing on stderr. A silently empty Action Guard trail on every Mac in the fleet, on the fail-closed hot path of a security product — while its 1,133-line test suite stayed green, because it only ever ran on Linux.

A zero-byte audit file is worse than a missing one: it looks like the trail is working.

## What this adds

A `macos-test` job: checkout → setup-node 22 → `npm ci` → `npm run build:ts` → `npm test`.

**One Node version, not the matrix.** This exists to catch *platform* defects; the Node axis is already covered on Linux. The dashboard build and lint are deliberately not duplicated either — pure JS, platform-independent, and macOS runners bill at a multiple of Linux minutes.

## It only works because of the paired test

`src/__tests__/hook-audit-write-smoke.test.ts` (already on main, shipped in v4.47.40) spawns the real hook as a real process and asserts a row actually landed, with non-zero bytes and parseable JSON. It asserts the **outcome**, not the mechanism — any future write strategy is fine so long as the row exists.

That distinction is the point. A unit test over the write helper can pass on a platform where the process silently writes nothing; only running the thing catches it.

Verified passing on macOS locally: 381 suites, 4,490 passed, exit 0.

## Cost note

macOS minutes bill at a multiple of Linux. If this proves too expensive on every PR, the cheap next step is a `paths:` filter for `scripts/**`, `src/setup/**` and `src/defence/**` rather than dropping the job — but I would rather start unconditional and narrow it with evidence than start narrow and miss the next one.

No untrusted input is interpolated anywhere in the new job (no `github.event.*`, no `ref:`), so there is no workflow-injection surface.