### PR TITLE
fix(#254): read the OpenClaw version from a global install, not only the managed runtime

### DIFF
--- a/src/__tests__/host-version-discovery-254.test.ts
+++ b/src/__tests__/host-version-discovery-254.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { readOpenClawHostVersion } from '../integrations/openclaw-conversation-capability.js';
+
+/**
+ * #254 — the capability probe searched ONE install layout.
+ *
+ * `readOpenClawHostVersion` only looked under `~/.openclaw/tools/<node>/lib/
+ * node_modules/openclaw`, which is the MANAGED runtime layout. A plain global
+ * `npm i -g openclaw` puts it somewhere on PATH instead (`~/.npm-global`,
+ * `/usr/local`, nvm, volta). On those hosts `readdirSync` threw, the function
+ * returned null, and doctor reported "enforcement support UNKNOWN — could not
+ * read the installed OpenClaw version" on every run, forever — while the
+ * version sat plainly readable next to the binary.
+ *
+ * That is a false UNKNOWN: the probe is capable of a confident verdict and
+ * declines to give one. These tests pin BOTH layouts, and pin that a genuinely
+ * absent install still yields null rather than a guess.
+ */
+
+let tmp: string;
+
+function makeInstall(dir: string, version: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'openclaw', version }));
+}
+
+/** A global npm install: bin/openclaw symlinked at ../lib/node_modules/openclaw. */
+function makeGlobalInstall(prefix: string, version: string): string {
+  const pkgDir = path.join(prefix, 'lib', 'node_modules', 'openclaw');
+  makeInstall(pkgDir, version);
+  fs.writeFileSync(path.join(pkgDir, 'openclaw.mjs'), '#!/usr/bin/env node\n');
+  const binDir = path.join(prefix, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.symlinkSync(path.join(pkgDir, 'openclaw.mjs'), path.join(binDir, 'openclaw'));
+  return binDir;
+}
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-254-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('#254 — host version discovery across install layouts', () => {
+  it('still reads the managed runtime layout', () => {
+    const home = path.join(tmp, 'home');
+    makeInstall(
+      path.join(home, '.openclaw', 'tools', 'node-v24.15.0', 'lib', 'node_modules', 'openclaw'),
+      '2026.6.1',
+    );
+    expect(readOpenClawHostVersion(home, '')).toBe('2026.6.1');
+  });
+
+  it('reads a global npm install found on PATH — the #254 regression', () => {
+    const home = path.join(tmp, 'home');
+    fs.mkdirSync(home, { recursive: true });
+    // No ~/.openclaw/tools at all: this is the shape that returned null.
+    const binDir = makeGlobalInstall(path.join(tmp, 'npm-global'), '2026.7.1-2');
+    expect(readOpenClawHostVersion(home, binDir)).toBe('2026.7.1-2');
+  });
+
+  it('prefers the highest version when both layouts are present', () => {
+    const home = path.join(tmp, 'home');
+    makeInstall(
+      path.join(home, '.openclaw', 'tools', 'node-v24.15.0', 'lib', 'node_modules', 'openclaw'),
+      '2026.5.12',
+    );
+    const binDir = makeGlobalInstall(path.join(tmp, 'npm-global'), '2026.7.1');
+    expect(readOpenClawHostVersion(home, binDir)).toBe('2026.7.1');
+  });
+
+  it('a stale global install does not beat a newer managed one', () => {
+    const home = path.join(tmp, 'home');
+    makeInstall(
+      path.join(home, '.openclaw', 'tools', 'node-v24.15.0', 'lib', 'node_modules', 'openclaw'),
+      '2026.7.1',
+    );
+    const binDir = makeGlobalInstall(path.join(tmp, 'npm-global'), '2026.4.23');
+    expect(readOpenClawHostVersion(home, binDir)).toBe('2026.7.1');
+  });
+
+  it('returns null when there is genuinely no install — never a guess', () => {
+    const home = path.join(tmp, 'home');
+    fs.mkdirSync(home, { recursive: true });
+    expect(readOpenClawHostVersion(home, path.join(tmp, 'empty-bin'))).toBeNull();
+  });
+
+  it('ignores a same-named binary that is not openclaw', () => {
+    const home = path.join(tmp, 'home');
+    fs.mkdirSync(home, { recursive: true });
+    const prefix = path.join(tmp, 'impostor');
+    const pkgDir = path.join(prefix, 'lib', 'node_modules', 'something-else');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'something-else', version: '9999.1.1' }),
+    );
+    fs.writeFileSync(path.join(pkgDir, 'openclaw.mjs'), '');
+    const binDir = path.join(prefix, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.symlinkSync(path.join(pkgDir, 'openclaw.mjs'), path.join(binDir, 'openclaw'));
+    expect(readOpenClawHostVersion(home, binDir)).toBeNull();
+  });
+
+  it('survives an unreadable PATH entry without throwing', () => {
+    const home = path.join(tmp, 'home');
+    fs.mkdirSync(home, { recursive: true });
+    const binDir = makeGlobalInstall(path.join(tmp, 'npm-global'), '2026.7.1');
+    const bogus = path.join(tmp, 'does-not-exist');
+    expect(readOpenClawHostVersion(home, `${bogus}${path.delimiter}${binDir}`)).toBe('2026.7.1');
+  });
+});

--- a/src/integrations/openclaw-conversation-capability.ts
+++ b/src/integrations/openclaw-conversation-capability.ts
@@ -74,28 +74,91 @@ export function evaluateEnforcementSupport(hostVersion: string | null): Conversa
 }
 
 /**
- * Read the installed OpenClaw version. The managed install lives under a
- * node-version-specific directory (`tools/node-v24.15.0/lib/node_modules`),
- * so the path is discovered rather than assumed. Never throws — an unreadable
- * install yields `unknown`, never a confident answer.
+ * Managed-runtime candidates: `~/.openclaw/tools/<node>/lib/node_modules/openclaw`.
+ * The node directory is version-specific, so it is discovered rather than assumed.
  */
-export function readOpenClawHostVersion(home: string): string | null {
+function managedLayoutCandidates(home: string): string[] {
   const toolsDir = path.join(home, '.openclaw', 'tools');
-  let candidates: string[] = [];
   try {
-    candidates = fs
+    return fs
       .readdirSync(toolsDir)
       .map((d) => path.join(toolsDir, d, 'lib', 'node_modules', 'openclaw', 'package.json'));
   } catch {
-    return null;
+    // No managed runtime on this host. NOT a reason to stop looking — a plain
+    // `npm i -g openclaw` never creates this directory (#254).
+    return [];
   }
+}
+
+/**
+ * Global-install candidates, resolved from PATH.
+ *
+ * A global npm install puts a symlink in some `bin/` and the package itself in
+ * a sibling `lib/node_modules/openclaw` — the prefix varies by installer
+ * (`~/.npm-global`, `/usr/local`, nvm, volta), so the only portable anchor is
+ * the binary on PATH. Follow it to its real location and walk up to the
+ * `package.json` that owns it.
+ *
+ * The name check matters: the walk must not accept the first package.json it
+ * meets. A differently-named package shipping an `openclaw` bin would
+ * otherwise donate its version number to the verdict.
+ */
+function pathLayoutCandidates(pathEnv: string): string[] {
+  const found: string[] = [];
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const name of ['openclaw', 'openclaw.mjs', 'openclaw.js']) {
+      const bin = path.join(dir, name);
+      let real: string;
+      try {
+        real = fs.realpathSync(bin);
+      } catch {
+        continue; // absent, dangling symlink, or unreadable PATH entry
+      }
+      let cursor = path.dirname(real);
+      // Bounded walk: a package root is never far above its own bin script.
+      for (let depth = 0; depth < 4; depth++) {
+        found.push(path.join(cursor, 'package.json'));
+        const parent = path.dirname(cursor);
+        if (parent === cursor) break;
+        cursor = parent;
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * Read the installed OpenClaw version, across BOTH install layouts — the
+ * managed runtime and a plain global npm install on PATH.
+ *
+ * Never throws. Returns null only when no readable install exists anywhere, so
+ * `unknown` means "genuinely could not find it" rather than "did not look
+ * there" (#254: searching only the managed layout made every globally
+ * installed host report UNKNOWN forever, with the version sitting readable
+ * beside the binary).
+ *
+ * `pathEnv` is injectable so the discovery itself is testable without
+ * depending on the machine running the suite.
+ */
+export function readOpenClawHostVersion(
+  home: string,
+  pathEnv: string = process.env.PATH ?? '',
+): string | null {
+  const candidates = [...managedLayoutCandidates(home), ...pathLayoutCandidates(pathEnv)];
 
   // Prefer the highest version found: a box can carry more than one managed
-  // node runtime, and a stale one must not decide the verdict.
+  // node runtime — and now a global install alongside them — and a stale one
+  // must not decide the verdict.
   let best: string | null = null;
   for (const file of candidates) {
     try {
-      const v = (JSON.parse(fs.readFileSync(file, 'utf-8')) as { version?: unknown }).version;
+      const pkg = JSON.parse(fs.readFileSync(file, 'utf-8')) as {
+        name?: unknown;
+        version?: unknown;
+      };
+      if (pkg.name !== 'openclaw') continue;
+      const v = pkg.version;
       if (typeof v !== 'string') continue;
       const coerced = semver.valid(semver.coerce(v) ?? '');
       if (!coerced) continue;


### PR DESCRIPTION
Closes #254.

## The report

`doctor` prints this on every run on this host, and would on any host with a plain global `npm i -g openclaw`:

```
ℹ️ Conversation scanning: ... conversation enforcement support UNKNOWN — could not read the installed OpenClaw version
```

The version was sitting readable at `~/.npm-global/lib/node_modules/openclaw/package.json` the whole time — `2026.7.1-2`, comfortably above the `2026.5.12` floor and trivially comparable against it.

`readOpenClawHostVersion` searched exactly one place:

```js
const toolsDir = path.join(home, '.openclaw', 'tools');
candidates = fs.readdirSync(toolsDir).map(...)   // throws → return null
```

That is the **managed node-runtime** layout. A global install never creates that directory, so `readdirSync` threw, the function returned `null` on the spot, and the verdict was `unknown`.

## Why this is worth a fix rather than a docs note

This module's entire purpose is to avoid the false-green family described in its own header — a hook that registers successfully and enforces nothing. It answers "can this host block on the conversation path at all?" A **false UNKNOWN is the same defect wearing the opposite sign**: the probe was capable of a confident verdict and declined to give one, and the message blames the host (*"could not read the installed OpenClaw version"*) for something the probe never attempted.

## What changed

- **The managed-layout read no longer short-circuits the function.** An absent `tools/` means "no managed runtime here", not "stop looking".
- **PATH-based discovery added.** Follow an `openclaw` bin through `realpathSync` and walk up (bounded, 4 levels) to the `package.json` that owns it. The binary on PATH is the only portable anchor — the prefix differs across `~/.npm-global`, `/usr/local`, nvm and volta.
- **Every candidate is name-checked** (`pkg.name === 'openclaw'`). The walk must not accept the first `package.json` it meets, or a differently-named package shipping an `openclaw` bin donates its version number to the verdict. This one is easy to leave out and produces a confidently wrong answer rather than a missing one.
- Both layouts feed the **existing** highest-version-wins loop, so a stale global install cannot outrank a newer managed one, or vice versa.
- `pathEnv` is injectable (defaults to `process.env.PATH`) so discovery is testable without depending on whichever machine runs the suite.

Returning `null` still means "no readable install anywhere". The original docstring's fail-safe intent is preserved — it just no longer fires for a layout we never searched.

## Verification

**Observed on a real host from the built artifact, not only asserted in tests.**

Before:
```
conversation enforcement support UNKNOWN — could not read the installed OpenClaw version
```
After:
```
conversation enforcement AVAILABLE on OpenClaw 2026.7.1-2 (>= 2026.5.12) — not yet enabled; scanning remains observation-only
```

- **7 new tests, where there were previously zero.** `readOpenClawHostVersion` had no coverage at all, which is why a whole install layout went unsearched without anything going red. Covered: both layouts, both precedence directions, the impostor-binary case, an unreadable PATH entry, and genuine absence still returning `null`.
- Confirmed red before the change on exactly the three global-install cases, green after.
- Full suite **401 suites / 4,726 passed / 7 skipped**; `test:dist` clean.

## Reviewer attention

The bounded 4-level walk is a deliberate compromise: unbounded would eventually hit a parent `package.json` belonging to something else, and the name check would reject it, but the walk would still do pointless I/O per PATH entry. If anyone knows a global layout deeper than 4 from the bin, that number is the thing to challenge.

## Not addressed here

The `doctor` exit-1 visible in local runs of this branch is the plugin-version check comparing an installed 4.47.37 against this worktree's unreleased build — unrelated to this change, and confirmed absent under the host's own globally installed CLI.