### PR TITLE
fix(credential-leak): redact every occurrence, not just the first

### DIFF
--- a/src/defence/__tests__/credential-repeated-token-redaction.test.ts
+++ b/src/defence/__tests__/credential-repeated-token-redaction.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from '@jest/globals';
+import { scanForCredentials, redactCredentials } from '../credential-leak/index.js';
+
+/**
+ * REDACTION MUST COVER EVERY OCCURRENCE, NOT THE FIRST ONE.
+ *
+ * `extractHighEntropyTokens` de-duplicated candidates by token STRING, so when
+ * the same secret appeared more than once only the first occurrence produced a
+ * `matchedRange` — and `buildRedactedContent` cannot redact a range it was
+ * never given. `redactCredentials` therefore returned successfully with the
+ * secret still present in its output:
+ *
+ *   redactCredentials(S + ' ' + S + ' ' + S)  ->  2 raw copies survived
+ *   redactCredentials(JSON with S twice)      ->  1 raw copy survived
+ *
+ * A redaction primitive that reports success while leaking is worse than one
+ * that fails loudly, and this one feeds tool-response redaction and the
+ * operator-facing report paths. The pattern layer never had the bug (a repeated
+ * `sk-proj-…` was fully redacted), so it was specific to the entropy net — the
+ * layer that exists precisely for secrets whose shape we do not know.
+ *
+ * The contract pinned here is about COVERAGE, not counting: how many findings a
+ * repeat produces is a reporting choice and deliberately left unchanged, but
+ * every occurrence must be redacted.
+ */
+
+/** No known pattern matches this, so only the entropy net can catch it. */
+const UNKNOWN_SHAPE_SECRET = 'X7fQ2mZp9RtL4vNc8KwB3JhD6sYgA1eU5oXiTbMr0PlWnQzVfKjSxE9uYwGdTpAaCvBn';
+
+/** A known-shape key, to prove the pattern layer's behaviour is untouched. */
+const KNOWN_SHAPE_KEY = 'sk-proj-Ab3dEfGh1JkLmNoPqRsTuVwXyZ0123456789AbCdEfGhIjKlMnOpQrStUvWxYz';
+
+function rawCopiesLeft(content: string, secret: string): number {
+  return redactCredentials(content).split(secret).length - 1;
+}
+
+describe('entropy redaction covers every occurrence of a repeated secret', () => {
+  it('leaves no raw copy when the secret appears three times', () => {
+    const content = `${UNKNOWN_SHAPE_SECRET} ${UNKNOWN_SHAPE_SECRET} ${UNKNOWN_SHAPE_SECRET}`;
+
+    expect(rawCopiesLeft(content, UNKNOWN_SHAPE_SECRET)).toBe(0);
+  });
+
+  it('leaves no raw copy when the secret is echoed inside a JSON body', () => {
+    // The shape that made this reachable in practice: a session value stored
+    // once and echoed back in a nested object.
+    const content = JSON.stringify({
+      session: UNKNOWN_SHAPE_SECRET,
+      refresh: 'noise',
+      echo: { session: UNKNOWN_SHAPE_SECRET },
+    });
+
+    expect(rawCopiesLeft(content, UNKNOWN_SHAPE_SECRET)).toBe(0);
+  });
+
+  it('still leaves no raw copy for a single occurrence', () => {
+    // Must-not-break: the case that always worked.
+    expect(rawCopiesLeft(UNKNOWN_SHAPE_SECRET, UNKNOWN_SHAPE_SECRET)).toBe(0);
+  });
+
+  it('reports the leak, and reporting volume is unchanged for a repeat', () => {
+    const once = scanForCredentials(UNKNOWN_SHAPE_SECRET);
+    const thrice = scanForCredentials(`${UNKNOWN_SHAPE_SECRET} ${UNKNOWN_SHAPE_SECRET} ${UNKNOWN_SHAPE_SECRET}`);
+
+    expect(once.leaked).toBe(true);
+    expect(thrice.leaked).toBe(true);
+    // Deliberate: the fix is about redaction coverage. Turning one repeated
+    // secret into N findings would inflate audit counts and severity grades for
+    // no gain, so the reporting shape is held still.
+    expect(thrice.findings.length).toBe(once.findings.length);
+  });
+});
+
+describe('the pattern layer is untouched', () => {
+  it('still redacts every occurrence of a known-shape key', () => {
+    expect(rawCopiesLeft(`${KNOWN_SHAPE_KEY} ${KNOWN_SHAPE_KEY}`, KNOWN_SHAPE_KEY)).toBe(0);
+  });
+
+  it('still reports a known-shape key at its pattern severity', () => {
+    const r = scanForCredentials(KNOWN_SHAPE_KEY);
+    expect(r.findings.some(f => f.type !== 'high_entropy')).toBe(true);
+  });
+});
+
+describe('mixed content redacts both layers', () => {
+  it('redacts a repeated unknown-shape secret alongside a known-shape key', () => {
+    const content = [
+      `api_key=${KNOWN_SHAPE_KEY}`,
+      `session=${UNKNOWN_SHAPE_SECRET}`,
+      `echo=${UNKNOWN_SHAPE_SECRET}`,
+    ].join('\n');
+
+    const redacted = redactCredentials(content);
+
+    expect(redacted).not.toContain(UNKNOWN_SHAPE_SECRET);
+    expect(redacted).not.toContain(KNOWN_SHAPE_KEY);
+  });
+});

--- a/src/defence/credential-leak/entropy.ts
+++ b/src/defence/credential-leak/entropy.ts
@@ -61,6 +61,19 @@ export function checkHighEntropy(str: string): { entropy: number; confidence: nu
  * Extract candidate high-entropy tokens from content.
  * Looks for long contiguous alphanumeric+special strings
  * that could be secrets.
+ *
+ * EVERY OCCURRENCE IS RETURNED, including repeats of the same token.
+ *
+ * This used to de-duplicate on the token string, which quietly made redaction
+ * incomplete: the caller derives its redaction ranges from these results, so
+ * occurrences 2..N had no range and survived verbatim into "redacted" output.
+ * `redactCredentials(S + ' ' + S + ' ' + S)` returned two raw copies of S. A
+ * redaction primitive that reports success while leaking is worse than one that
+ * fails loudly, and the pattern layer never had the bug — it was specific to
+ * the entropy net, which exists for secrets whose shape we do not know.
+ *
+ * De-duplication is a REPORTING concern and now lives with the caller, which is
+ * the only place that can tell a duplicate finding from a duplicate range.
  */
 export function extractHighEntropyTokens(
   content: string,
@@ -68,13 +81,10 @@ export function extractHighEntropyTokens(
   // Match long strings of alphanumeric + common secret chars
   const tokenRegex = /[A-Za-z0-9\-_./+=]{20,}/g;
   const results: Array<{ token: string; position: number; entropy: number; confidence: number }> = [];
-  const seen = new Set<string>();
 
   let match: RegExpExecArray | null;
   while ((match = tokenRegex.exec(content)) !== null) {
     const token = match[0];
-    if (seen.has(token)) continue;
-    seen.add(token);
 
     // Skip common false positives
     if (isLikelyFalsePositive(token)) continue;

--- a/src/defence/credential-leak/index.ts
+++ b/src/defence/credential-leak/index.ts
@@ -180,8 +180,19 @@ export function scanForCredentials(
     }
   }
 
-  // Run entropy-based detection for anything not already caught
+  // Run entropy-based detection for anything not already caught.
+  //
+  // `extractHighEntropyTokens` returns EVERY occurrence, so the two concerns
+  // are separated deliberately here:
+  //
+  //   redaction — every occurrence gets a range. Missing one leaves the secret
+  //               verbatim in output the caller believes is redacted.
+  //   reporting — one finding per distinct secret. Turning a repeat into N
+  //               findings would inflate audit counts and severity grades
+  //               (`medium > 0` drops the grade to C, which exits 1) without
+  //               telling the operator anything they did not already know.
   const entropyTokens = extractHighEntropyTokens(content);
+  const reportedEntropyTokens = new Set<string>();
   for (const token of entropyTokens) {
     const start = token.position;
     const end = start + token.token.length;
@@ -195,6 +206,13 @@ export function scanForCredentials(
     // Skip allowlisted
     if (isAllowlisted(token.token, cfg.allowlist)) continue;
 
+    // Range FIRST, and unconditionally — a repeat must still be redacted even
+    // though it will not produce a second finding below.
+    matchedRanges.push({ start, end, replacement: '[REDACTED-high_entropy]' });
+
+    if (reportedEntropyTokens.has(token.token)) continue;
+    reportedEntropyTokens.add(token.token);
+
     const severity: CredentialSeverity = token.confidence >= 0.8 ? 'medium' : 'low';
     const action = actionForSeverity(severity, cfg);
 
@@ -206,8 +224,6 @@ export function scanForCredentials(
       position: start,
       action,
     });
-
-    matchedRanges.push({ start, end, replacement: '[REDACTED-high_entropy]' });
   }
 
   // Sort findings by position


### PR DESCRIPTION
`redactCredentials` returned successfully with the secret still present in its output.

## Measured, before the fix

| input | findings | raw copies left in "redacted" output |
|---|---|---|
| secret ×1 | 1 | 0 |
| **secret ×3** | **1** | **2** |
| **secret ×2 inside a JSON body** | **1** | **1** |
| `sk-proj-…` ×2 *(pattern-layer control)* | 2 | 0 |

## Cause

`extractHighEntropyTokens` de-duplicated candidates on the token **string**, so occurrences 2..N never reached the caller, never produced a `matchedRange`, and `buildRedactedContent` cannot redact a range it was never given. The de-dupe existed to avoid duplicate *findings*; it silently took redaction coverage with it.

Two things make this worse than a counting bug:

- **It is specific to the entropy net** — the layer that exists precisely for secrets whose shape we do not recognise. Nothing else was covering these. The pattern layer never had it.
- **It is the shared redaction primitive**, so a repeated secret could reach any consumer of "redacted" content verbatim.

A redaction primitive that reports success while leaking is worse than one that fails loudly: the caller gets no signal that anything went wrong.

## Fix

The two concerns are separated where each belongs. Extraction returns every occurrence; the caller adds a range for each, and reports one finding per distinct secret.

**Reporting volume is deliberately unchanged.** Turning one repeated secret into N findings would inflate audit counts and push `medium > 0`, which drops the grade to C and makes `shieldcortex audit` exit 1 — without telling the operator anything they did not already know. The contract pinned here is coverage, not counting.

## Verification

- 7 new tests. **Verified RED before the fix on exactly the two repeat cases**, with the single-occurrence and pattern-layer must-not-breaks passing throughout.
- Independent probe outside the suite confirms 0 raw copies in all three cases post-fix.
- Full suite: **382 suites, 4,497 passed, exit 0.**

## Provenance, and what this does NOT fix

Found while investigating #210. That issue reports entropy *false positives*; the FPs turned out to be the less serious half of what lives in this file. See #210 for why its suggested suppressions should not be implemented.

A second, separate defect found in the same pass is **not** fixed here and is filed separately: padding a secret with low-entropy filler (`'aaaa-'.repeat(12) + <secret>`) drops whole-token entropy to 4.31, below the 4.5 threshold, and the detector goes silent — 0 findings, secret untouched. That needs a design decision (sliding-window entropy has real false-positive blast radius), not a quick patch.