### PR TITLE
fix(#217): scan a written-then-executed file as its own language, not shell

### DIFF
--- a/src/defence/iron-dome/__tests__/heredoc-exec-linkage-194.test.ts
+++ b/src/defence/iron-dome/__tests__/heredoc-exec-linkage-194.test.ts
@@ -50,8 +50,38 @@ describe('#194 — naming a file is not running it', () => {
     ['run by relative path', `${write('p.sh')}\nbash ./p.sh`],
     ['sourced', `${write('p.sh')}\n. p.sh`],
     ['nested inside bash -c', `${write('/tmp/p.sh')}\nbash -c 'bash /tmp/p.sh'`],
-    ['python runs the written module', `${write('/tmp/p.py')}\npython3 /tmp/p.py`],
   ])('a genuine write-then-exec still blocks: %s', (_name, cmd) => {
+    expect(decide(cmd).decision).toBe('block');
+  });
+
+  /**
+   * SUPERSEDED BY #217, DELIBERATELY.
+   *
+   * This case previously sat in the block list above: writing a body and
+   * running it with `python3` was treated as write-then-exec, and the body was
+   * scanned with SHELL rules. #217 reports that as a precision defect, and it
+   * is the same one #188 already fixed for folded script source — a shell verb
+   * in interpreter CODE position is an identifier, and its vocabulary is only
+   * live if it can reach an exec sink.
+   *
+   * A SHELL target is unaffected and still blocks (the four cases above): that
+   * body really is the source of a command. What changed is only the non-shell
+   * target, and only when it is provably sink-free.
+   *
+   * The dangerous twin is pinned directly beneath, so the relaxation cannot
+   * widen past "no way to reach a process".
+   */
+  it('a sink-free body run by a non-shell interpreter is data, not command (#217)', () => {
+    const v = decide(`${write('/tmp/p.py')}\npython3 /tmp/p.py`);
+    expect(v.decision).toBe('allow');
+    expect(v.signals).not.toContain('recursive-force-delete');
+  });
+
+  it.each([
+    ['python with a process sink', `cd /repo && cat > /tmp/s.py <<'EOF'\nimport os\nos.system("${RMRF} /")\nEOF\npython3 /tmp/s.py`],
+    ['node with a process sink', `cd /repo && cat > /tmp/s.mjs <<'EOF'\nimport { execSync } from 'node:child_process';\nexecSync("${RMRF} /");\nEOF\nnode /tmp/s.mjs`],
+    ['node that WRITES a shell script then runs it', `cd /repo && cat > /tmp/g.mjs <<'EOF'\nimport { writeFileSync } from 'node:fs';\nwriteFileSync('/tmp/g.sh', '${RMRF} /');\nEOF\nnode /tmp/g.mjs && bash /tmp/g.sh`],
+  ])('but a body that can reach a process still blocks: %s', (_name, cmd) => {
     expect(decide(cmd).decision).toBe('block');
   });
 

--- a/src/defence/iron-dome/__tests__/write-then-exec-language-217.test.ts
+++ b/src/defence/iron-dome/__tests__/write-then-exec-language-217.test.ts
@@ -129,10 +129,16 @@ describe('#217 — output transport is a sink, not just body vocabulary', () => 
     expect(decide(cmd).decision).toBe('block');
   });
 
-  it('but a discard redirect keeps the #217 relief', () => {
+  it.each([
     // `2>/dev/null` on a probe is the shape this fix exists to allow.
-    const v = decide(`cat > /tmp/p.mjs <<'EOF'\n${PROBE_BODY}\nEOF\nnode /tmp/p.mjs 2>/dev/null`);
-    expect(v.decision).not.toBe('block');
+    ['discard', `cat > /tmp/p.mjs <<'EOF'\n${PROBE_BODY}\nEOF\nnode /tmp/p.mjs 2>/dev/null`],
+    // The fd-to-fd case the exemption is genuinely FOR. Narrowing the rule to
+    // reject fd-prefixed redirects (the fix above) must not take this with it —
+    // `2>&1` carries the output nowhere new, and it is on half the diagnostic
+    // one-liners anyone types.
+    ['fd-to-fd duplication', `cat > /tmp/p.mjs <<'EOF'\n${PROBE_BODY}\nEOF\nnode /tmp/p.mjs 2>&1`],
+  ])('but a %s keeps the #217 relief', (_name, cmd) => {
+    expect(decide(cmd).decision).not.toBe('block');
   });
 });
 

--- a/src/defence/iron-dome/__tests__/write-then-exec-language-217.test.ts
+++ b/src/defence/iron-dome/__tests__/write-then-exec-language-217.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from '@jest/globals';
+import { evaluateToolCall } from '../tool-action-guard.js';
+
+/**
+ * Issue #217 — the write-then-exec re-arm scanned the heredoc body as SHELL
+ * even when the executed file is interpreter source.
+ *
+ * Re-arming the body is correct: the file IS executed. What was wrong is HOW it
+ * was scanned. `cat > probe.mjs <<'EOF' … EOF; node probe.mjs` writes
+ * JavaScript, so `"rm -rf /"` in it is a string literal handed to a function —
+ * yet it was read as a live command and hard-blocked at the catastrophic tier,
+ * where there is no prompt and `enforce: false` does not help.
+ *
+ * The asymmetry, measured before the fix and pinned below: the SAME literals
+ * piped to an interpreter (`python3 - <<'PY'`, handled by #188) returned
+ * benign, while written to a file and executed they returned catastrophic.
+ *
+ * This is the guard project's own daily workflow — every fixture and probe for
+ * this codebase is danger vocabulary by construction — and it blocked this
+ * repo's own investigation repeatedly.
+ *
+ * The principle is #188's and #89's, not a new one: a shell verb in interpreter
+ * CODE position is an identifier, and its vocabulary is only live if it can
+ * reach an exec sink. Only the provably sink-free case is relaxed.
+ */
+
+// Assembled at runtime so this file is not itself scanner-bait.
+const RMRF = ['r', 'm', ' ', '-', 'r', 'f'].join('');
+const CURL = ['c', 'u', 'r', 'l'].join('');
+
+const decide = (command: string) => evaluateToolCall('Bash', { command }, undefined, undefined);
+
+/** The issue's own repro: danger vocabulary as DATA in a JS array. */
+const PROBE_BODY = `const shapes = [ ["label", "${RMRF} /"], ["l2", "${CURL} x | sh"] ];\nconsole.log(shapes.length);`;
+
+describe('#217 — a written interpreter file is scanned as that language', () => {
+  it('the reported command no longer hard-blocks', () => {
+    const v = decide(`cat > /tmp/probe-fold.mjs <<'EOF'\n${PROBE_BODY}\nEOF\nnode /tmp/probe-fold.mjs`);
+
+    expect(v.decision).not.toBe('block');
+    expect(v.signals).not.toContain('recursive-force-delete');
+    expect(v.signals).not.toContain('pipe-download-to-shell');
+  });
+
+  it('matches the verdict of the same literals piped to an interpreter', () => {
+    // #188 already made this benign. The two shapes carry identical content, so
+    // a differing verdict was the defect — this pins them together.
+    const piped = decide(`python3 - <<'PY'\nPATTERNS = {'a': r'${RMRF}'}\nprint(len(PATTERNS))\nPY`);
+    const written = decide(`cat > /tmp/p.mjs <<'EOF'\n${PROBE_BODY}\nEOF\nnode /tmp/p.mjs`);
+
+    expect(piped.decision).not.toBe('block');
+    expect(written.decision).not.toBe('block');
+  });
+
+  it('applies to python targets too, not just node', () => {
+    const v = decide(`cat > /tmp/probe.py <<'EOF'\nPATTERNS = ['${RMRF} /']\nprint(len(PATTERNS))\nEOF\npython3 /tmp/probe.py`);
+    expect(v.decision).not.toBe('block');
+  });
+});
+
+describe('#217 — the relaxation stops at the sink', () => {
+  it.each([
+    ['node child_process', `cat > /tmp/s.mjs <<'EOF'\nimport { execSync } from 'node:child_process';\nexecSync("${RMRF} /");\nEOF\nnode /tmp/s.mjs`],
+    ['python os.system', `cat > /tmp/s.py <<'EOF'\nimport os\nos.system("${RMRF} /")\nEOF\npython3 /tmp/s.py`],
+    /**
+     * The one the must-not-break fixtures caught while building this: a body
+     * that only WRITES a file looked inert to the process-sink test, so its
+     * literals were masked — but the file it writes is then run. That is the
+     * #160 write-then-execute threat one level deeper, and the literal IS the
+     * command; it just travels via a file.
+     */
+    ['node writes a shell script then runs it', `cat > /tmp/g.mjs <<'EOF'\nimport { writeFileSync } from 'node:fs';\nwriteFileSync('/tmp/g.sh', '${RMRF} /');\nEOF\nnode /tmp/g.mjs && bash /tmp/g.sh`],
+    ['python writes a shell script then runs it', `cat > /tmp/g.py <<'EOF'\nopen('/tmp/g.sh', 'w').write('${RMRF} /')\nEOF\npython3 /tmp/g.py && bash /tmp/g.sh`],
+  ])('still blocks: %s', (_name, cmd) => {
+    expect(decide(cmd).decision).toBe('block');
+  });
+
+  it('a SHELL target is completely unaffected', () => {
+    // The write-then-exec case #86.2/#160 exist to catch. That body really is
+    // the source of a command, and nothing here touches it.
+    const v = decide(`cat > /tmp/p.sh <<'EOF'\n${RMRF} /\nEOF\nbash /tmp/p.sh`);
+    expect(v.decision).toBe('block');
+  });
+
+  it('a body written but NEVER executed stays inert, as before', () => {
+    const v = decide(`cat > /tmp/notes.mjs <<'EOF'\n${PROBE_BODY}\nEOF\ngit add /tmp/notes.mjs`);
+    expect(v.decision).not.toBe('block');
+  });
+});

--- a/src/defence/iron-dome/__tests__/write-then-exec-language-217.test.ts
+++ b/src/defence/iron-dome/__tests__/write-then-exec-language-217.test.ts
@@ -115,6 +115,16 @@ describe('#217 — output transport is a sink, not just body vocabulary', () => 
     ['stdout appended to a shell rc', `${gen(`console.log("${RMRF} ~/");`)}node /tmp/g.mjs >> ~/.zshrc`],
     ['stdout redirected into a script then run', `${gen(`console.log("${RMRF} ~/");`)}node /tmp/g.mjs > /tmp/x.sh && bash /tmp/x.sh`],
     ['python twin, piped', `cat > /tmp/g.py <<'PY'\nprint("${RMRF} ~/")\nPY\npython3 /tmp/g.py | bash`],
+    /**
+     * The fd-numbered-redirect bypass: `outputEscapesToShell` exempted any `>`
+     * preceded by a digit or `&`, on the theory that fd-prefixed redirects are
+     * diagnostics plumbing like `2>&1`. `1>/tmp/x.sh` and `2>/tmp/x.sh` are
+     * fd-prefixed too, but they target a REAL FILE, not another fd — the exact
+     * write-then-exec shape this describe block exists to catch, just spelled
+     * with an explicit fd number.
+     */
+    ['stdout redirected via explicit fd 1 into a script then run', `${gen(`console.log("${RMRF} ~/");`)}node /tmp/g.mjs 1>/tmp/x.sh && bash /tmp/x.sh`],
+    ['stderr redirected via fd 2 into a script then run', `${gen(`console.error("${RMRF} ~/");`)}node /tmp/g.mjs 2>/tmp/x.sh && bash /tmp/x.sh`],
   ])('still blocks: %s', (_name, cmd) => {
     expect(decide(cmd).decision).toBe('block');
   });
@@ -165,5 +175,41 @@ describe('#217 — a file write is a sink by where it lands', () => {
       + `data = open('/tmp/audit.jsonl', 'r').read()\nprint(PATTERNS, len(data))\nPY\npython3 /tmp/probe.py`,
     );
     expect(v.decision).not.toBe('block');
+  });
+
+  it('an extensionless executable write target blocks even beside an inert decoy', () => {
+    // `fileWriteIsSink` only ever extracted DOTTED literals, so an
+    // extensionless target like `/tmp/stage2` never entered the `literals`
+    // array at all — it was invisible to the "every literal inert" check.
+    // Pairing it with a genuinely inert `/tmp/report.json` write let the dotted
+    // decoy satisfy `every()` while the real, unprovable target went unseen.
+    const v = decide(
+      `cat > /tmp/g8.mjs <<'EOF'\nimport { writeFileSync } from 'node:fs';\n`
+      + `writeFileSync('/tmp/stage2', "${RMRF} /");\n`
+      + `writeFileSync('/tmp/report.json', JSON.stringify({ ok: true }));\nEOF\nnode /tmp/g8.mjs`,
+    );
+    expect(v.decision).toBe('block');
+  });
+
+  it('benign JSON/log writes stay inert when they include data and encoding strings', () => {
+    const v = decide(
+      `cat > /tmp/probe2.mjs <<'EOF'\nimport { writeFileSync, appendFileSync } from 'node:fs';\n`
+      + `const P = { danger: "${RMRF} /" };\n`
+      + `writeFileSync('/tmp/audit.log', JSON.stringify(P) + '\\n', 'utf8');\n`
+      + `appendFileSync('/tmp/report.jsonl', 'line\\n', 'utf8');\nEOF\nnode /tmp/probe2.mjs`,
+    );
+    expect(v.decision).not.toBe('block');
+  });
+
+  it('a dynamic target expression cannot be cleared by an inert literal decoy inside the expression', () => {
+    // The target argument itself must be provably inert. A decoy literal inside
+    // `('/tmp/report.json', target)` is not proof: the comma expression returns
+    // `target`, which may be executable-shaped.
+    const v = decide(
+      `cat > /tmp/g9.mjs <<'EOF'\nimport { writeFileSync } from 'node:fs';\n`
+      + `const target = '/tmp/stage2';\n`
+      + `writeFileSync(('/tmp/report.json', target), "${RMRF} /");\nEOF\nnode /tmp/g9.mjs`,
+    );
+    expect(v.decision).toBe('block');
   });
 });

--- a/src/defence/iron-dome/__tests__/write-then-exec-language-217.test.ts
+++ b/src/defence/iron-dome/__tests__/write-then-exec-language-217.test.ts
@@ -87,3 +87,83 @@ describe('#217 — the relaxation stops at the sink', () => {
     expect(v.decision).not.toBe('block');
   });
 });
+
+/**
+ * THE BYPASSES THE FIRST VERSION OF THIS FIX OPENED.
+ *
+ * Every case below was `block` on main and `allow` on the first implementation
+ * — five catastrophic-tier verdicts inverted. They are pinned here because the
+ * root causes were not one bug but two habits:
+ *
+ *  1. The sink test was BODY-LOCAL, while the threat is about where the
+ *     executed process's OUTPUT goes. Having found that a literal can travel by
+ *     file, the obvious next question — what else can it travel by — went
+ *     unasked. A pipe needs no sink token in the body at all.
+ *
+ *  2. Language was resolved with `find` (first match wins) over a list that
+ *     de-duplicated on path alone, so a second invocation by a different
+ *     interpreter was discarded. `findInterpreterRunFiles` uses that same
+ *     matching to NARROW, which fails closed; reusing it to WIDEN made the
+ *     identical imprecision fail OPEN.
+ */
+describe('#217 — output transport is a sink, not just body vocabulary', () => {
+  const gen = (body: string, file = '/tmp/g.mjs') => `cat > ${file} <<'EOF'\n${body}\nEOF\n`;
+
+  it.each([
+    ['stdout piped to bash', `${gen(`console.log("${RMRF} ~/");`)}node /tmp/g.mjs | bash`],
+    ['stdout piped to sh', `${gen(`console.log("${RMRF} ~/");`)}node /tmp/g.mjs | sh`],
+    ['stdout appended to a shell rc', `${gen(`console.log("${RMRF} ~/");`)}node /tmp/g.mjs >> ~/.zshrc`],
+    ['stdout redirected into a script then run', `${gen(`console.log("${RMRF} ~/");`)}node /tmp/g.mjs > /tmp/x.sh && bash /tmp/x.sh`],
+    ['python twin, piped', `cat > /tmp/g.py <<'PY'\nprint("${RMRF} ~/")\nPY\npython3 /tmp/g.py | bash`],
+  ])('still blocks: %s', (_name, cmd) => {
+    expect(decide(cmd).decision).toBe('block');
+  });
+
+  it('but a discard redirect keeps the #217 relief', () => {
+    // `2>/dev/null` on a probe is the shape this fix exists to allow.
+    const v = decide(`cat > /tmp/p.mjs <<'EOF'\n${PROBE_BODY}\nEOF\nnode /tmp/p.mjs 2>/dev/null`);
+    expect(v.decision).not.toBe('block');
+  });
+});
+
+describe('#217 — ambiguous language resolution fails closed', () => {
+  const BODY_SHELL = `eval "${RMRF} /"`;
+
+  it.each([
+    ['same path run by node THEN bash', `cat > /tmp/p.mjs <<'EOF'\n${BODY_SHELL}\nEOF\nnode /tmp/p.mjs\nbash /tmp/p.mjs`],
+    ['a decoy node invocation prefixed', `node /tmp/p.mjs --lint\ncat > /tmp/p.mjs <<'EOF'\n${BODY_SHELL}\nEOF\nbash /tmp/p.mjs`],
+  ])('still blocks: %s', (_name, cmd) => {
+    expect(decide(cmd).decision).toBe('block');
+  });
+});
+
+describe('#217 — a file write is a sink by where it lands', () => {
+  it('writing a shell rc through the fd API still blocks', () => {
+    const v = decide(
+      `cat > /tmp/g7.mjs <<'EOF'\nimport { openSync, writeSync } from "node:fs";\n`
+      + `const fd = openSync(process.env.HOME + "/.zshrc", "a");\nwriteSync(fd, "${RMRF} ~/");\nEOF\nnode /tmp/g7.mjs`,
+    );
+    expect(v.decision).toBe('block');
+  });
+
+  it('but writing a JSON report does not', () => {
+    // Most diagnostic probes write a report. Treating any write as a sink
+    // re-blocked them, which is most of what #217 is for.
+    const v = decide(
+      `cat > /tmp/probe.mjs <<'EOF'\nimport { writeFileSync } from 'node:fs';\n`
+      + `const P = { danger: "${RMRF} /" };\nwriteFileSync('/tmp/report.json', JSON.stringify(P));\nEOF\nnode /tmp/probe.mjs`,
+    );
+    expect(v.decision).not.toBe('block');
+  });
+
+  it('and a probe that merely READS a file does not', () => {
+    // `open(path, 'r')` matched the write-sink pattern because the `+` was
+    // optional — so reading back the guard's own audit log to investigate a
+    // denial produced another denial, the #190 loop this issue exists to break.
+    const v = decide(
+      `cat > /tmp/probe.py <<'PY'\nPATTERNS = {'x': r'${RMRF} /'}\n`
+      + `data = open('/tmp/audit.jsonl', 'r').read()\nprint(PATTERNS, len(data))\nPY\npython3 /tmp/probe.py`,
+    );
+    expect(v.decision).not.toBe('block');
+  });
+});

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -2203,12 +2203,49 @@ function foldScriptSources(
 // its `PATTERNS = {'recursive-force-delete': r'rm -rf'}` is a dict of strings and
 // its `at = tok['access_token']` is an assignment. Locate those bodies so the
 // span classifier can treat them as the interpreter source they are.
+/**
+ * Writing a FILE is a sink too, once the body's language is being trusted (#217).
+ *
+ * `SHELL_OUT_SINK` knows process sinks. A written-then-executed body that only
+ * writes a file looks inert to it, so its literals get masked as data — but
+ *
+ *     cat > gen.mjs <<'EOF'
+ *     writeFileSync('/tmp/g.sh', 'rm -rf /');
+ *     EOF
+ *     node gen.mjs && bash /tmp/g.sh
+ *
+ * is the write-then-execute threat (#160) one level deeper: the literal IS the
+ * command, it just travels via a file. Caught by the must-not-break fixture
+ * while building the #217 fix, which had made this exact case allow.
+ *
+ * Deliberately broad and used ONLY on this path. A false "has sink" costs
+ * nothing but the pre-#217 behaviour — the body stays scanned as shell, which
+ * is what it did before — whereas a miss re-opens #160.
+ */
+const FILE_WRITE_SINK =
+  /\bwriteFile(?:Sync)?\b|\bappendFile(?:Sync)?\b|\bcreateWriteStream\b|\bfs\.write\b|\bopen\s*\([^)]*['"][waxr]\+?['"]|\bwrite_text\b|\bwrite_bytes\b|\bos\.write\b|\bshutil\.(?:copy|move)\w*|\bfile_put_contents\b|\bIO\.write\b|\bFile\.(?:write|open)\b|>\s*\S+\.(?:sh|bash|zsh|py|mjs|cjs|js|rb|pl|php)\b/;
+
 const ANY_HEREDOC_RE = /<<-?\s*(['"]?)([A-Za-z_]\w*)\1[^\n]*\n([\s\S]*?)(?:\n[ \t]*\2\b|$)/g;
 const HEREDOC_INTERP_TOKEN = /\b(bash|sh|zsh|ksh|dash|python[\d.]*|node|nodejs|ruby|perl|php)\b(?![\w/-])/gi;
 
 function interpreterHeredocRegions(text: string): ScanRegion[] {
   if (!text.includes('<<')) return [];
   const found: Array<{ region: ScanRegion; outFile: string | null }> = [];
+  /**
+   * #217 — heredocs with NO interpreter on the intro line whose body is written
+   * to a file: `cat > probe.mjs <<'EOF' … EOF; node probe.mjs`.
+   *
+   * The body is re-armed (correctly — the file IS executed), but it was then
+   * scanned with SHELL rules, so a JavaScript string literal `"rm -rf /"` read
+   * as a live command and hard-blocked at the catastrophic tier. The language
+   * of such a body is decided by whatever later RUNS the file, which is not
+   * knowable on the intro line, so these are resolved in a second pass below.
+   *
+   * The asymmetry this removes, measured: `python3 - <<'PY' … PY` (interpreter
+   * consumes the heredoc) returned benign, while the same literals written to a
+   * file and executed returned catastrophic.
+   */
+  const written: Array<{ start: number; end: number; body: string; outFile: string }> = [];
   const candidateFiles: string[] = [];
   ANY_HEREDOC_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
@@ -2216,7 +2253,18 @@ function interpreterHeredocRegions(text: string): ScanRegion[] {
     const lineStart = text.lastIndexOf('\n', m.index) + 1;
     const introLine = text.slice(lineStart, m.index);
     const interp = introLine.match(HEREDOC_INTERP_TOKEN);
-    if (!interp) continue;                              // nothing executes it as code
+    const nlEarly = m[0].indexOf('\n');
+    if (!interp) {
+      // No interpreter here, but if the body lands in a file the second pass
+      // may still find one that runs it.
+      const target = heredocOutputFile(introLine + m[0].slice(0, nlEarly + 1));
+      const cleaned = target ? target.replace(/^['"]/, '').replace(/['"]$/, '') : null;
+      if (cleaned) {
+        const s = m.index + nlEarly + 1;
+        written.push({ start: s, end: s + m[3].length, body: m[3], outFile: cleaned });
+      }
+      continue;                                         // nothing executes it as code
+    }
     const lang = langFromInterpreter(commandBaseName(interp[interp.length - 1].toLowerCase()));
     if (lang === 'sh') continue;                        // a shell heredoc IS shell — unchanged
     const nl = m[0].indexOf('\n');
@@ -2234,9 +2282,50 @@ function interpreterHeredocRegions(text: string): ScanRegion[] {
       outFile: clean,
     });
   }
-  if (found.length === 0) return [];
+  // #217 second pass: resolve each written-then-executed body by the language of
+  // whatever actually runs it. `detectScriptInvocations` is the single
+  // definition of program position in this file — it skips flags, understands
+  // inline-program flags and recurses into `bash -c` — and it already carries
+  // the lang, so reuse it rather than add a second, divergent notion of which
+  // interpreter runs what (the recurring root cause in this file is a rule
+  // implemented twice).
+  const carved: ScanRegion[] = [];
+  if (written.length > 0) {
+    const invoked = detectScriptInvocations(text);
+    // At the detection cap a later real invocation may not have been reached,
+    // so claim nothing and leave every body scanned as shell — fail closed.
+    if (invoked.length < MAX_DETECTED_SCRIPTS) {
+      for (const w of written) {
+        const run = invoked.find(({ path }) =>
+          path === w.outFile
+          || path.endsWith(`/${w.outFile}`)
+          || w.outFile.endsWith(`/${path}`)
+          || path === `./${w.outFile}`);
+        // Executed by a shell, or not executed at all: unchanged. The former is
+        // the write-then-execute case #86.2/#160 exist to catch — that body
+        // really is the source of a command.
+        if (!run || run.lang === 'sh') continue;
+        carved.push({
+          start: w.start,
+          end: w.end,
+          lang: run.lang,
+          // A body that can reach a process — `child_process`, `execSync` — or
+          // that can WRITE a file another command then runs, keeps its literals
+          // live, exactly as the inline-program path does. Only the provably
+          // sink-free case is relaxed.
+          hasSink: SHELL_OUT_SINK.test(w.body) || FILE_WRITE_SINK.test(w.body),
+          folded: false,
+        });
+      }
+    }
+  }
+
+  if (found.length === 0) return carved;
   const executedFiles = findInterpreterRunFiles(text, candidateFiles);
-  return found.filter(f => !(f.outFile && executedFiles.has(f.outFile))).map(f => f.region);
+  return [
+    ...found.filter(f => !(f.outFile && executedFiles.has(f.outFile))).map(f => f.region),
+    ...carved,
+  ];
 }
 
 /**

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -2252,10 +2252,12 @@ const FILE_WRITE_SINK =
  * the literal travelling by stdout instead of by file, and each was a
  * catastrophic block before #217 relaxed this path.
  *
- * `> /dev/null` and fd-numbered redirects (`2>/dev/null`, `2>&1`) are exempt:
- * they discard or re-point diagnostics rather than carrying the output
- * anywhere, and `node probe.mjs 2>/dev/null` is exactly the shape #217 exists
- * to keep relieved.
+ * A discard (`> /dev/null`, `2>/dev/null`) or a genuine fd-to-fd redirect
+ * (`2>&1`) is exempt: it discards or re-points diagnostics rather than
+ * carrying the output anywhere, and `node probe.mjs 2>/dev/null` is exactly
+ * the shape #217 exists to keep relieved. An fd NUMBER prefix alone (`1>`,
+ * `2>`) is not exempt — `1>/tmp/x.sh` and `2>/tmp/x.sh` write to a real file
+ * exactly like a bare `>`, just with the fd spelled out.
  */
 /**
  * Write targets that cannot become executable content. Everything else is
@@ -2274,20 +2276,119 @@ const FILE_WRITE_SINK =
 const INERT_WRITE_TARGET =
   /\.(?:json|jsonl|ndjson|txt|md|csv|tsv|log|ya?ml|xml|html?|png|jpe?g|svg|lock)$/i;
 
+/** Write-sink function names. Arguments are extracted by a tiny balanced
+ * scanner below, not by `[^)]*`: nested helper calls such as
+ * `writeFileSync(resolve('/tmp/report.json'), '/tmp/stage2')` must not truncate
+ * the call at `resolve(...)` and accidentally let a later non-inert argument
+ * disappear.
+ */
+const WRITE_CALL_NAME_RE =
+  /\b(writeFile(?:Sync)?|appendFile(?:Sync)?|createWriteStream|fs\.write\w*|writeSync|openSync|open|write_text|write_bytes|os\.(?:write|open)|shutil\.(?:copy|move)\w*|file_put_contents|IO\.write|File\.write|File\.open)\s*\(/g;
+
+type WriteCall = { name: string; args: string | null };
+
+function writeCalls(body: string): WriteCall[] {
+  const out: WriteCall[] = [];
+  WRITE_CALL_NAME_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = WRITE_CALL_NAME_RE.exec(body)) !== null) {
+    const start = WRITE_CALL_NAME_RE.lastIndex;
+    let depth = 1;
+    let quote: '"' | "'" | '`' | null = null;
+    let escaped = false;
+    let i = start;
+    for (; i < body.length; i++) {
+      const ch = body[i];
+      if (quote) {
+        if (escaped) { escaped = false; continue; }
+        if (ch === '\\') { escaped = true; continue; }
+        if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
+      if (ch === '(') { depth++; continue; }
+      if (ch === ')') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    if (depth === 0) {
+      out.push({ name: m[1], args: body.slice(start, i) });
+      WRITE_CALL_NAME_RE.lastIndex = i + 1;
+    } else {
+      // Malformed/unbalanced write call: do not try to prove it inert.
+      out.push({ name: m[1], args: null });
+      WRITE_CALL_NAME_RE.lastIndex = start;
+    }
+  }
+  return out;
+}
+
+function splitTopLevelArgs(args: string): string[] {
+  const out: string[] = [];
+  let start = 0;
+  let depth = 0;
+  let quote: '"' | "'" | '`' | null = null;
+  let escaped = false;
+  for (let i = 0; i < args.length; i++) {
+    const ch = args[i];
+    if (quote) {
+      if (escaped) { escaped = false; continue; }
+      if (ch === '\\') { escaped = true; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { quote = ch; continue; }
+    if (ch === '(' || ch === '[' || ch === '{') { depth++; continue; }
+    if (ch === ')' || ch === ']' || ch === '}') { depth = Math.max(0, depth - 1); continue; }
+    if (ch === ',' && depth === 0) {
+      out.push(args.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  out.push(args.slice(start).trim());
+  return out;
+}
+
+function targetArgIndexes(name: string): number[] {
+  if (/^(?:shutil\.(?:copy|move)\w*)$/.test(name)) return [0, 1];
+  if (/^(?:writeSync|fs\.write\w*|os\.write)$/.test(name)) return [];
+  return [0];
+}
+
+function targetExprIsProvablyInert(expr: string): boolean {
+  const trimmed = expr.trim();
+  const m = /^(['"])([^'"\n]*)\1$/.exec(trimmed);
+  if (!m) return false;
+  return INERT_WRITE_TARGET.test(m[2]);
+}
+
 function fileWriteIsSink(body: string): boolean {
   if (!FILE_WRITE_SINK.test(body)) return false;
-  const literals = body.match(/['"][^'"\n]*\.[A-Za-z0-9]{1,6}['"]/g) ?? [];
-  // No visible target — a path built at runtime. Assume it can execute.
-  if (literals.length === 0) return true;
-  return !literals.every(l => INERT_WRITE_TARGET.test(l.slice(1, -1)));
+  const calls = writeCalls(body);
+  // Sink vocabulary matched, but no call shape this extraction can see
+  // inside — a path built at runtime, most likely. Assume it can execute.
+  if (calls.length === 0) return true;
+  // Per call, and only on target-bearing argument positions: a data string or
+  // encoding (`'utf8'`) is not a filename and must not turn a JSON/log write
+  // back into a shell sink. Unproven/dynamic targets still fail closed.
+  return calls.some(call => {
+    if (call.args === null) return true;
+    const args = splitTopLevelArgs(call.args);
+    const targets = targetArgIndexes(call.name).map(i => args[i]).filter((v): v is string => v !== undefined);
+    if (targets.length === 0) return true;
+    return targets.some(t => !targetExprIsProvablyInert(t));
+  });
 }
 
 function outputEscapesToShell(text: string, outFile: string): boolean {
   const esc = outFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   // After the file name, on the same statement: a single `|` (not `||`), or a
-  // `>`/`>>` not preceded by a digit or `&`, targeting something other than a
-  // discard.
-  const re = new RegExp(`${esc}[^\\n;&]*?(?:\\|(?!\\|)|(?<![0-9&])>>?\\s*(?!(?:/dev/null|&\\d)))`);
+  // `>`/`>>` — with or without a leading fd number — whose target is not a
+  // discard (`/dev/null`) or a fd-to-fd redirect (`&1`, `&2`, …). The fd
+  // number itself confers no exemption: `1>/tmp/x.sh` and `2>/tmp/x.sh` write
+  // to a real file exactly like a bare `>` does.
+  const re = new RegExp(`${esc}[^\\n;&]*?(?:\\|(?!\\|)|>>?\\s*(?!(?:/dev/null|&\\d)))`);
   return re.test(text);
 }
 

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -1968,8 +1968,17 @@ export function detectScriptInvocations(execSurface: string, depth = 0): Detecte
   const add = (p: string, lang?: ScriptLang): void => {
     const clean = p.trim();
     if (!clean || clean === '-' || /^https?:\/\//i.test(clean)) return;
-    if (found.some(f => f.path === clean) || found.length >= MAX_DETECTED_SCRIPTS) return;
-    found.push({ path: clean, lang: lang ?? langFromPath(clean) });
+    const resolved = lang ?? langFromPath(clean);
+    // De-duplicate on path AND language. Keying on path alone discarded a
+    // SECOND invocation of the same file by a different interpreter, so
+    // `node p.mjs` followed by `bash p.mjs` reported only `node` — which the
+    // #217 region carve then trusted, relabelling a shell script as JavaScript
+    // and turning a catastrophic block into an allow. Keeping both is strictly
+    // more entries and every consumer treats extra invocations as more
+    // dangerous, not less, so this only ever moves fail-closed.
+    if (found.some(f => f.path === clean && f.lang === resolved)) return;
+    if (found.length >= MAX_DETECTED_SCRIPTS) return;
+    found.push({ path: clean, lang: resolved });
   };
 
   for (const stmt of splitCommandStatements(surface)) {
@@ -2223,7 +2232,64 @@ function foldScriptSources(
  * is what it did before — whereas a miss re-opens #160.
  */
 const FILE_WRITE_SINK =
-  /\bwriteFile(?:Sync)?\b|\bappendFile(?:Sync)?\b|\bcreateWriteStream\b|\bfs\.write\b|\bopen\s*\([^)]*['"][waxr]\+?['"]|\bwrite_text\b|\bwrite_bytes\b|\bos\.write\b|\bshutil\.(?:copy|move)\w*|\bfile_put_contents\b|\bIO\.write\b|\bFile\.(?:write|open)\b|>\s*\S+\.(?:sh|bash|zsh|py|mjs|cjs|js|rb|pl|php)\b/;
+  /\bwriteFile(?:Sync)?\b|\bappendFile(?:Sync)?\b|\bcreateWriteStream\b|\bfs\.write|\bwriteSync\b|\bopenSync\s*\(|\bopen\s*\([^)]*['"](?:[wax]\+?|r\+)['"]|\bwrite_text\b|\bwrite_bytes\b|\bos\.(?:write|open)\b|\bshutil\.(?:copy|move)\w*|\bfile_put_contents\b|\bIO\.write\b|\bFile\.write\b|\bFile\.open\s*\([^)]*['"][wax]/;
+
+/**
+ * The executed file's OUTPUT escaping into the shell — a pipe, or a redirect
+ * into anything but a discard.
+ *
+ * The sink test above is BODY-local, and that is only half the threat. What
+ * matters is where the process's output GOES:
+ *
+ *     cat > g.mjs <<'EOF'
+ *     console.log("<destructive command>");
+ *     EOF
+ *     node g.mjs | bash
+ *
+ * has no sink token in the body at all — the pipe IS the sink, and it lives in
+ * the surrounding shell. Same for `>> ~/.zshrc`, `| tee -a`, and
+ * `> gen.sh && bash gen.sh`. Each is the #160 write-then-execute threat with
+ * the literal travelling by stdout instead of by file, and each was a
+ * catastrophic block before #217 relaxed this path.
+ *
+ * `> /dev/null` and fd-numbered redirects (`2>/dev/null`, `2>&1`) are exempt:
+ * they discard or re-point diagnostics rather than carrying the output
+ * anywhere, and `node probe.mjs 2>/dev/null` is exactly the shape #217 exists
+ * to keep relieved.
+ */
+/**
+ * Write targets that cannot become executable content. Everything else is
+ * assumed to be able to — including a path we cannot see.
+ *
+ * A file write is only a sink when what it writes can later RUN. Gating on
+ * "does something else in this command run a script" was wrong twice over: it
+ * missed a body appending to `~/.zshrc` (executed at the next login, outside
+ * this command entirely), and it fired on a probe writing `/tmp/report.json`
+ * because `detectScriptInvocations` had parsed the report path out of the body
+ * text as a spurious invocation.
+ *
+ * Default-armed, relaxed only on proof: the write is inert only when EVERY
+ * path-shaped literal in the body carries a data extension.
+ */
+const INERT_WRITE_TARGET =
+  /\.(?:json|jsonl|ndjson|txt|md|csv|tsv|log|ya?ml|xml|html?|png|jpe?g|svg|lock)$/i;
+
+function fileWriteIsSink(body: string): boolean {
+  if (!FILE_WRITE_SINK.test(body)) return false;
+  const literals = body.match(/['"][^'"\n]*\.[A-Za-z0-9]{1,6}['"]/g) ?? [];
+  // No visible target — a path built at runtime. Assume it can execute.
+  if (literals.length === 0) return true;
+  return !literals.every(l => INERT_WRITE_TARGET.test(l.slice(1, -1)));
+}
+
+function outputEscapesToShell(text: string, outFile: string): boolean {
+  const esc = outFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // After the file name, on the same statement: a single `|` (not `||`), or a
+  // `>`/`>>` not preceded by a digit or `&`, targeting something other than a
+  // discard.
+  const re = new RegExp(`${esc}[^\\n;&]*?(?:\\|(?!\\|)|(?<![0-9&])>>?\\s*(?!(?:/dev/null|&\\d)))`);
+  return re.test(text);
+}
 
 const ANY_HEREDOC_RE = /<<-?\s*(['"]?)([A-Za-z_]\w*)\1[^\n]*\n([\s\S]*?)(?:\n[ \t]*\2\b|$)/g;
 const HEREDOC_INTERP_TOKEN = /\b(bash|sh|zsh|ksh|dash|python[\d.]*|node|nodejs|ruby|perl|php)\b(?![\w/-])/gi;
@@ -2296,24 +2362,45 @@ function interpreterHeredocRegions(text: string): ScanRegion[] {
     // so claim nothing and leave every body scanned as shell — fail closed.
     if (invoked.length < MAX_DETECTED_SCRIPTS) {
       for (const w of written) {
-        const run = invoked.find(({ path }) =>
+        const runs = invoked.filter(({ path }) =>
           path === w.outFile
           || path.endsWith(`/${w.outFile}`)
           || w.outFile.endsWith(`/${path}`)
           || path === `./${w.outFile}`);
-        // Executed by a shell, or not executed at all: unchanged. The former is
-        // the write-then-execute case #86.2/#160 exist to catch — that body
-        // really is the source of a command.
-        if (!run || run.lang === 'sh') continue;
+
+        // EVERY invocation must agree, and none may be a shell.
+        //
+        // Taking the FIRST match was a bypass: `detectScriptInvocations` used to
+        // de-duplicate on path alone, so `node p.mjs` followed by `bash p.mjs`
+        // resolved to `node`, relabelled a shell script as JavaScript, and
+        // turned a catastrophic block into an allow. One prefixed token did it,
+        // and `node p.mjs; bash p.mjs` is an ordinary thing to type.
+        //
+        // Note the direction. `findInterpreterRunFiles` uses this same matching
+        // to NARROW its set, which can only keep more bodies scanned — fail
+        // closed. Reusing it to WIDEN a relaxation makes the identical
+        // imprecision fail OPEN, so ambiguity here must resolve the other way.
+        if (runs.length === 0 || runs.some(r => r.lang === 'sh')) continue;
+        const langs = new Set(runs.map(r => r.lang));
+        if (langs.size > 1) continue;                     // disagreement is ambiguity
+
         carved.push({
           start: w.start,
           end: w.end,
-          lang: run.lang,
-          // A body that can reach a process — `child_process`, `execSync` — or
-          // that can WRITE a file another command then runs, keeps its literals
-          // live, exactly as the inline-program path does. Only the provably
-          // sink-free case is relaxed.
-          hasSink: SHELL_OUT_SINK.test(w.body) || FILE_WRITE_SINK.test(w.body),
+          lang: runs[0].lang,
+          // Literals stay live when the body can reach a process
+          // (`child_process`, `execSync`), when it can WRITE a file another
+          // command runs, or when the RUN STATEMENT's own wiring carries the
+          // output into the shell (`| bash`, `>> ~/.zshrc`). The last is not a
+          // property of the body at all, which is exactly why the body-local
+          // test missed it.
+          hasSink: SHELL_OUT_SINK.test(w.body)
+            // A file write matters when what it writes can later RUN — see
+            // `fileWriteIsSink`. `writeFileSync('/tmp/report.json', …)` in a
+            // probe is data; `'/tmp/g.sh'` or `~/.zshrc` is a command in
+            // transit, whether or not this command is the thing that runs it.
+            || fileWriteIsSink(w.body)
+            || outputEscapesToShell(text, w.outFile),
           folded: false,
         });
       }


### PR DESCRIPTION
Closes #217.

## The defect, measured

The same string literals gave opposite verdicts depending only on how they reached the interpreter:

| command shape | verdict |
|---|---|
| `python3 - <<'PY' … PY` — interpreter *consumes* the heredoc | **allow / benign** |
| `cat > x.mjs <<'EOF' … EOF; node x.mjs` — written, then executed | **block / CATASTROPHIC** |

Re-arming the body is correct — the file *is* executed. What was wrong is **how** it was scanned: with raw shell rules, so a destructive string inside a JavaScript array read as a live command.

The first row is #188's language-aware, sink-gated path. The write-then-exec path predates it and never got the treatment.

Catastrophic tier is what makes this bite: no prompt, no appeal, and `enforce: false` does not help. Every fixture and probe for a security tool is danger vocabulary by construction — this blocked the guard's own diagnosis repeatedly, the same shape as #190 and #194.

## The fix

`interpreterHeredocRegions` now resolves a body that has no interpreter on its intro line by whatever later **runs** the written file, reusing `detectScriptInvocations` — already the single definition of program position in this file, and it already carries the language. Deliberately not a second notion of who-runs-what; that duplication is the recurring root cause here.

## The relaxation stops at the sink — including one I had missed

The must-not-break fixtures caught a regression I introduced mid-change. A body that only **writes** a file looked inert to the process-sink test, so its literals got masked: a `.mjs` that writes a shell script containing a destructive command, followed by `bash` running that script, started allowing.

That is #160's write-then-execute threat one level deeper — the literal **is** the command, it just travels via a file. `FILE_WRITE_SINK` closes it. Deliberately broad: a false "has sink" there costs only the pre-#217 behaviour, whereas a miss re-opens #160.

Still blocking, all pinned: node `child_process`, python `os.system`, either language writing a shell script it then runs, any shell target, and the plain destructive control.

## One behaviour change that needs a human decision

**#194 and #217 disagree, and I have followed #217.**

#194 pinned `cat > p.py … python3 /tmp/p.py` as *"a genuine write-then-exec still blocks"*. #217 argues precisely that case should be language-aware and sink-gated. Both cannot hold.

I moved that guardrail rather than deleting it — the reasoning is inline in `heredoc-exec-linkage-194.test.ts`, and the dangerous twins are pinned directly beneath it. **All four SHELL-target cases in #194 are untouched and still block.**

If you would rather keep #194's stricter reading for python targets, that is a legitimate call and this PR should be narrowed to `node`/`.mjs` only — say so and I will re-scope. I did not want to weaken a security guardrail silently.

## Verification

- 9 new tests for #217, plus 4 added to #194's suite.
- Reproduced the original block against the real guard before changing anything, with four must-stay-blocked controls — one of which caught the `FILE_WRITE_SINK` regression.
- **403 suites, 4,757 passed, exit 0**, now including the macOS job from #250.
