### PR TITLE
fix(#248): stop update.ts swallowing failure reasons and redact over-shared output

### DIFF
--- a/src/__tests__/child-output-redaction-review.test.ts
+++ b/src/__tests__/child-output-redaction-review.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { summariseCommandOutput } from '../integrations/child-output.js';
+import type { CapturedError } from '../integrations/child-output.js';
+import { step, readRealtimePluginRegistration } from '../cli/update.js';
+import { scanForCredentials } from '../defence/credential-leak/index.js';
+
+/**
+ * Adversarial-review regressions for #248's redaction layer (PR #261).
+ *
+ * The review reproduced three information-flow gaps and two smaller defects:
+ *  1. `summariseCommandOutput` — the sink actual child stderr flows through —
+ *     lacked the credential-fragment pass `sanitiseForReport` has, so a
+ *     credential-shaped PATH SEGMENT leaked raw through the higher-volume sink
+ *     while the hand-built-string sink redacted it.
+ *  2. The 32KB head/tail cap ran BEFORE env-value redaction; a secret split at
+ *     the cap boundary escaped the exact-match replace, and its surviving
+ *     40-hex prefix was then allowlisted as a git SHA.
+ *  3. `https://user:pass@host` basic-auth URLs passed every layer (the
+ *     connection-string patterns covered postgres/mysql/mongo/redis only).
+ *  4. `step()` printed the failure headline twice (reason + detail[0]).
+ *  5. An unreadable plugins DIRECTORY still read as "not installed"
+ *     (`existsSync` swallows traversal EACCES).
+ */
+
+const SECRET_TOKEN = 'X7fQ2mZp9RtL4vNc8KwB3JhD6sYgA1eU5oXiTbMr0PlWnQzVfKjSxE9uYwGdTpAaCvBn';
+
+describe('review 1 — command-output sink redacts credential-shaped path segments', () => {
+  it('a token embedded in a child-output path does not survive summariseCommandOutput', () => {
+    const out = `npm error code EACCES\nnpm error open '/Users/op/.openclaw/extensions/${SECRET_TOKEN}/state.json'\n`;
+    const { lines } = summariseCommandOutput(out, { home: '/Users/op', env: {} });
+    expect(lines.join('\n')).not.toContain(SECRET_TOKEN);
+  });
+});
+
+describe('review 2 — env-value redaction happens before the 32KB cap', () => {
+  it('an env secret split by the cap boundary leaks no 40-char prefix', () => {
+    // 44-char hex secret positioned so the head slice (MAX_INPUT_BYTES/2 =
+    // 16384 bytes) cuts it 4 chars before its end — the exact shape the review
+    // reproduced: the surviving 40-hex prefix matched the git-SHA allowlist.
+    const secret = 'f3a9c1d07b5e42618ac9f0d3b7215e88fa04c6d1beef';
+    const line = `npm error E401 auth failed for token ${secret}\n`;
+    // Place the line so that byte 16384 falls exactly 4 chars before the
+    // secret's end.
+    const secretEndOffset = line.indexOf(secret) + secret.length;
+    const targetLineStart = 16384 + 4 - secretEndOffset;
+    let filler = '';
+    while (filler.length < targetLineStart) filler += 'npm error spam line for padding purposes\n';
+    filler = filler.slice(0, targetLineStart);
+    const tail = 'npm error tail noise\n'.repeat(2000); // push total > 32KB
+    const out = filler + line + tail;
+    expect(out.length).toBeGreaterThan(32 * 1024);
+
+    const { lines } = summariseCommandOutput(out, { env: { CLAWHUB_TOKEN: secret }, maxLines: 10 });
+    const joined = lines.join('\n');
+    expect(joined).not.toContain(secret);
+    expect(joined).not.toContain(secret.slice(0, 40));
+  });
+});
+
+describe('review 3 — HTTP basic-auth URLs are redacted like every other connection string', () => {
+  it('scanForCredentials flags and redacts https://user:pass@host', () => {
+    const content = 'npm error 401 GET https://ci-bot:Hunter2Passw0rd@npm.corp.example/shieldcortex';
+    const result = scanForCredentials(content);
+    expect(result.findings.some(f => f.type === 'connection_string')).toBe(true);
+    expect(result.redactedContent ?? content).not.toContain('Hunter2Passw0rd');
+  });
+
+  it('does not flag credential-free URLs (ports, emails in query strings)', () => {
+    for (const benign of [
+      'GET https://registry.npmjs.org:443/shieldcortex',
+      'https://mail.example.com/reset?email=a@b.com',
+      'see https://example.com/path/to/x@2x.png',
+    ]) {
+      const r = scanForCredentials(benign);
+      expect(r.findings.filter(f => f.type === 'connection_string')).toHaveLength(0);
+    }
+  });
+
+  it('the password never reaches summarised child output', () => {
+    const out = 'npm error 401 Unauthorized - GET https://ci-bot:Hunter2Passw0rd@npm.corp.example/shieldcortex\n';
+    const { lines } = summariseCommandOutput(out, { env: {} });
+    expect(lines.join('\n')).not.toContain('Hunter2Passw0rd');
+  });
+});
+
+describe('review 4 — step() prints the failure headline once, not twice', () => {
+  function captureWrites(stream: NodeJS.WriteStream): { calls: string[]; restore: () => void } {
+    const calls: string[] = [];
+    const original = stream.write.bind(stream);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (stream as any).write = (chunk: any) => {
+      calls.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    };
+    return { calls, restore: () => { (stream as any).write = original; } };
+  }
+
+  it('the first output line is not duplicated as both reason and detail', async () => {
+    const stderr = captureWrites(process.stderr);
+    const stdout = captureWrites(process.stdout);
+    const err = Object.assign(new Error('exit 1: npm install -g shieldcortex@latest'), {
+      exitCode: 1,
+      command: 'npm install -g shieldcortex@latest',
+      stdout: '',
+      stderr: 'npm error code E401\nnpm error 401 Unauthorized - GET https://registry.npmjs.org/shieldcortex\n',
+    } satisfies Partial<CapturedError>);
+
+    try {
+      await expect(step('npm package', async () => { throw err; })).rejects.toThrow();
+    } finally {
+      stderr.restore();
+      stdout.restore();
+    }
+    const occurrences = stderr.calls.join('').match(/npm error code E401/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+});
+
+describe('review 5 — an unreadable plugins DIRECTORY is not "not installed"', () => {
+  let home: string;
+  afterEach(() => {
+    if (home) {
+      try { chmodSync(join(home, '.openclaw', 'plugins'), 0o755); } catch { /* already restored */ }
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('reports unreadable when the directory itself denies traversal', () => {
+    home = mkdtempSync(join(tmpdir(), 'sc-review-dir-'));
+    const pluginsDir = join(home, '.openclaw', 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    writeFileSync(join(pluginsDir, 'installs.json'), JSON.stringify({ installRecords: {} }));
+    chmodSync(pluginsDir, 0o000);
+
+    try {
+      // Probe whether the permission actually bites for THIS process (root and
+      // some CI containers can traverse a 0-mode dir). Only when it bites is
+      // the unreadable verdict required — but then it is required, hard.
+      let permissionBites = false;
+      try {
+        readFileSync(join(pluginsDir, 'installs.json'), 'utf-8');
+      } catch {
+        permissionBites = true;
+      }
+
+      const r = readRealtimePluginRegistration(home);
+      if (permissionBites) {
+        expect(r.unreadable).toBe(true);
+        expect(r.registered).toBe(false);
+      } else {
+        expect(r.registered).toBe(false);
+      }
+    } finally {
+      chmodSync(pluginsDir, 0o755);
+    }
+  });
+
+  it('a genuinely missing registry still reads as not-installed, not unreadable', () => {
+    home = mkdtempSync(join(tmpdir(), 'sc-review-dir2-'));
+    const r = readRealtimePluginRegistration(home);
+    expect(r.registered).toBe(false);
+    expect(r.unreadable).toBe(false);
+  });
+});

--- a/src/__tests__/openclaw-reconcile-run-command-provenance-248.test.ts
+++ b/src/__tests__/openclaw-reconcile-run-command-provenance-248.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from '@jest/globals';
+import { describeSpawnOutcome } from '../setup/openclaw-reconcile.js';
+
+/**
+ * #248 item 3 — `defaultRunCommand` collapsed a missing binary and a timeout
+ * into an identical "exit 1" fact via `r.status ?? 1`. `spawnSync` reports
+ * BOTH as `status: null` with no stdout/stderr — Node distinguishes them only
+ * through `result.error.code` (ENOENT / ETIMEDOUT) and `result.signal`.
+ * `defaultRunCommand` itself cannot be driven through a real spawn under Jest
+ * (it is guarded twice over: its own JEST_WORKER_ID check, and
+ * `resolveRepairConsent`, which is unconditionally hostile under Jest by
+ * design — see repair-consent.ts). So the translation logic is pulled out
+ * into `describeSpawnOutcome`, a pure function tested here with the exact
+ * shapes Node's spawnSync actually returns (verified against a live probe):
+ *
+ *   ENOENT:   { status: null, signal: null,    error: { code: 'ENOENT' } }
+ *   timeout:  { status: null, signal: 'SIGTERM', error: { code: 'ETIMEDOUT' } }
+ *   nonzero:  { status: N,    signal: null,    (no error) }
+ */
+
+const COMMAND = 'openclaw plugins update --pinned @drakon-systems/shieldcortex-realtime@4.48.0';
+
+describe('#248 — describeSpawnOutcome preserves missing-binary vs timeout vs nonzero provenance', () => {
+  it('reports a missing binary distinctly, not a bare exit code', () => {
+    const r = describeSpawnOutcome(COMMAND, {
+      status: null,
+      signal: null,
+      error: Object.assign(new Error('spawnSync openclaw ENOENT'), { code: 'ENOENT' }),
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.output).toMatch(/not found/i);
+    expect(r.output).toContain('ENOENT');
+    expect(r.output).not.toMatch(/timed out/i);
+  });
+
+  it('reports a timeout distinctly, not a bare exit code', () => {
+    const r = describeSpawnOutcome(COMMAND, {
+      status: null,
+      signal: 'SIGTERM',
+      error: Object.assign(new Error('spawnSync openclaw ETIMEDOUT'), { code: 'ETIMEDOUT' }),
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.output).toMatch(/timed out/i);
+    expect(r.output).not.toMatch(/not found/i);
+    expect(r.output).not.toContain('ENOENT');
+  });
+
+  it('the missing-binary and timeout reports are not the same string (the collapse this closes)', () => {
+    const enoent = describeSpawnOutcome(COMMAND, {
+      status: null,
+      signal: null,
+      error: Object.assign(new Error('spawnSync openclaw ENOENT'), { code: 'ENOENT' }),
+    });
+    const timeout = describeSpawnOutcome(COMMAND, {
+      status: null,
+      signal: 'SIGTERM',
+      error: Object.assign(new Error('spawnSync openclaw ETIMEDOUT'), { code: 'ETIMEDOUT' }),
+    });
+    expect(enoent.output).not.toBe(timeout.output);
+  });
+
+  it('preserves an ordinary nonzero exit with its stdout/stderr, unchanged from before', () => {
+    const r = describeSpawnOutcome(COMMAND, {
+      status: 3,
+      signal: null,
+      stdout: 'Unknown command: config validate\n',
+      stderr: '',
+    });
+    expect(r.status).toBe(3);
+    expect(r.output).toContain('Unknown command: config validate');
+  });
+
+  it('reports an external kill signal distinctly when there is no spawn error', () => {
+    const r = describeSpawnOutcome(COMMAND, { status: null, signal: 'SIGKILL' });
+    expect(r.status).not.toBe(0);
+    expect(r.output).toMatch(/SIGKILL/);
+    expect(r.output).not.toMatch(/not found|timed out/i);
+  });
+
+  it('falls back to status 1 for an unrecognised spawn error code rather than mislabelling it', () => {
+    const r = describeSpawnOutcome(COMMAND, {
+      status: null,
+      signal: null,
+      error: Object.assign(new Error('spawnSync openclaw EACCES'), { code: 'EACCES' }),
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('EACCES');
+    expect(r.output).not.toMatch(/not found|timed out/i);
+  });
+});
+
+describe('#248 — defaultRunCommand is wired through the provenance-preserving translator', () => {
+  it('defaultRunCommand calls describeSpawnOutcome rather than inlining `r.status ?? 1`', () => {
+    const src = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), '..', 'setup', 'openclaw-reconcile.ts'),
+      'utf-8',
+    );
+    const at = src.indexOf('export function defaultRunCommand');
+    expect(at).toBeGreaterThanOrEqual(0);
+    const body = src.slice(at, src.indexOf('\n}', at));
+    expect(body).toMatch(/describeSpawnOutcome\(/);
+    expect(body).not.toMatch(/status:\s*r\.status\s*\?\?\s*1/);
+  });
+});

--- a/src/__tests__/openclaw-version-detection.test.ts
+++ b/src/__tests__/openclaw-version-detection.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
-import { isRealtimePluginRegistered } from '../cli/update.js';
+import { isRealtimePluginRegistered, readRealtimePluginRegistration } from '../cli/update.js';
 import { checkOpenClawPluginVersion } from '../cli/doctor.js';
 
 /**
@@ -73,6 +73,67 @@ describe('update — isRealtimePluginRegistered (registry detection)', () => {
     fs.mkdirSync(pluginsDir, { recursive: true });
     fs.writeFileSync(path.join(pluginsDir, 'installs.json'), '{ not valid json');
     expect(isRealtimePluginRegistered(home)).toBe(false);
+  });
+});
+
+/**
+ * #248 item 2 — an unreadable/malformed registry must be distinguishable from
+ * a genuine "not installed" host. `isRealtimePluginRegistered` stays a plain
+ * boolean (unreadable reads as `false` there, same as before), but callers
+ * that must not report a false-green skip use this tri-state reader instead.
+ */
+describe('update — readRealtimePluginRegistration (unreadable vs not-installed)', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-ocreg-tri-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('reports registered:true, unreadable:false for a registry-managed install', () => {
+    writeInstalls(home, { installRecords: { 'shieldcortex-realtime': REALTIME_RECORD } });
+    expect(readRealtimePluginRegistration(home)).toEqual({ registered: true, unreadable: false });
+  });
+
+  it('reports registered:false, unreadable:false when there is no installs.json at all', () => {
+    expect(readRealtimePluginRegistration(home)).toEqual({ registered: false, unreadable: false });
+  });
+
+  it('reports registered:false, unreadable:false when the registry has no shieldcortex-realtime entry', () => {
+    writeInstalls(home, { installRecords: { brave: {} } });
+    expect(readRealtimePluginRegistration(home)).toEqual({ registered: false, unreadable: false });
+  });
+
+  it('reports unreadable:true (not a plain not-installed) on malformed JSON', () => {
+    const pluginsDir = path.join(home, '.openclaw', 'plugins');
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginsDir, 'installs.json'), '{ not valid json');
+    const r = readRealtimePluginRegistration(home);
+    expect(r.registered).toBe(false);
+    expect(r.unreadable).toBe(true);
+    expect(r.detail).toBeTruthy();
+  });
+
+  it('reports unreadable:true on a permission-denied registry file', () => {
+    const pluginsDir = path.join(home, '.openclaw', 'plugins');
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    const file = path.join(pluginsDir, 'installs.json');
+    fs.writeFileSync(file, JSON.stringify({ installRecords: {} }));
+    fs.chmodSync(file, 0o000);
+    try {
+      const r = readRealtimePluginRegistration(home);
+      // Root (and some CI containers) can read a 0-mode file anyway — only
+      // assert the distinguishing behaviour when the permission actually bites.
+      if (r.unreadable) {
+        expect(r.registered).toBe(false);
+        expect(r.detail).toBeTruthy();
+      }
+    } finally {
+      fs.chmodSync(file, 0o644);
+    }
   });
 });
 

--- a/src/__tests__/openclaw-version-detection.test.ts
+++ b/src/__tests__/openclaw-version-detection.test.ts
@@ -117,6 +117,14 @@ describe('update — readRealtimePluginRegistration (unreadable vs not-installed
     expect(r.detail).toBeTruthy();
   });
 
+  it('reports unreadable:true on valid JSON with an invalid registry shape', () => {
+    writeInstalls(home, null);
+    const r = readRealtimePluginRegistration(home);
+    expect(r.registered).toBe(false);
+    expect(r.unreadable).toBe(true);
+    expect(r.detail).toMatch(/invalid registry shape/i);
+  });
+
   it('reports unreadable:true on a permission-denied registry file', () => {
     const pluginsDir = path.join(home, '.openclaw', 'plugins');
     fs.mkdirSync(pluginsDir, { recursive: true });

--- a/src/__tests__/update-fetch-latest-version-reason-248.test.ts
+++ b/src/__tests__/update-fetch-latest-version-reason-248.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from '@jest/globals';
+import { fetchLatestVersion } from '../cli/update.js';
+import type { CapturedError } from '../integrations/child-output.js';
+
+/**
+ * #248 item 4 — `fetchLatestVersion` discarded WHY the registry lookup
+ * failed. An E401 (bad/expired token), ENOTFOUND (offline/DNS) and a proxy
+ * failure all collapsed to a bare `null`, which the caller then reports as
+ * "registry unreachable" — true for ENOTFOUND, actively wrong for a rejected
+ * token, and downstream `null` reads as "already up to date" with no hint an
+ * operator should go check their npm auth.
+ */
+
+function rejectWith(over: Partial<CapturedError>) {
+  return () => Promise.reject(Object.assign(new Error('npm view failed'), {
+    exitCode: 1,
+    command: 'npm view shieldcortex version',
+    stdout: '',
+    stderr: '',
+    ...over,
+  }) as CapturedError);
+}
+
+describe('#248 — fetchLatestVersion surfaces why the lookup failed', () => {
+  it('resolves the version on success, with no reason', async () => {
+    const r = await fetchLatestVersion({
+      run: (() => Promise.resolve({ stdout: '4.48.1\n', stderr: '' })) as never,
+    });
+    expect(r.version).toBe('4.48.1');
+    expect(r.reason).toBeUndefined();
+  });
+
+  it('carries the auth-rejection reason, not just null, on E401', async () => {
+    const r = await fetchLatestVersion({
+      run: rejectWith({ stderr: 'npm error code E401\nnpm error 401 Unauthorized - GET https://registry.npmjs.org/shieldcortex\n' }) as never,
+    });
+    expect(r.version).toBeNull();
+    expect(r.reason).toBeTruthy();
+    expect(r.reason).toMatch(/E401|Unauthorized/i);
+  });
+
+  it('carries the DNS/offline reason on ENOTFOUND', async () => {
+    const r = await fetchLatestVersion({
+      run: rejectWith({ stderr: 'npm error code ENOTFOUND\nnpm error request to https://registry.npmjs.org/shieldcortex failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org\n' }) as never,
+    });
+    expect(r.version).toBeNull();
+    expect(r.reason).toMatch(/ENOTFOUND/);
+  });
+
+  it('the E401 and ENOTFOUND reasons are distinguishable from each other', async () => {
+    const auth = await fetchLatestVersion({
+      run: rejectWith({ stderr: 'npm error code E401\nnpm error 401 Unauthorized\n' }) as never,
+    });
+    const offline = await fetchLatestVersion({
+      run: rejectWith({ stderr: 'npm error code ENOTFOUND\nnpm error getaddrinfo ENOTFOUND registry.npmjs.org\n' }) as never,
+    });
+    expect(auth.reason).not.toBe(offline.reason);
+  });
+
+  it('still resolves null with a reason when the binary itself is missing', async () => {
+    const r = await fetchLatestVersion({
+      run: rejectWith({ spawnFailed: true, exitCode: null, code: 'ENOENT' }) as never,
+    });
+    expect(r.version).toBeNull();
+    expect(r.reason).toMatch(/not found/i);
+  });
+});

--- a/src/__tests__/update-footer-latest-unknown-248.test.ts
+++ b/src/__tests__/update-footer-latest-unknown-248.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from '@jest/globals';
+import { footer } from '../cli/update.js';
+
+/**
+ * #248 (review round 2) — `footer()` printed "already on latest" whenever
+ * `mainUpdated` was false, which is also true when the registry lookup
+ * never resolved (E401, ENOTFOUND, timeout). An E401/ENOTFOUND run closed
+ * with the same reassuring last line as a real "you're current" check.
+ * `header()` already told the two cases apart; `footer()` needed the same
+ * treatment.
+ */
+
+function captureWrites(stream: NodeJS.WriteStream): { calls: string[]; restore: () => void } {
+  const calls: string[] = [];
+  const original = stream.write.bind(stream);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (stream as any).write = (chunk: any, ...rest: any[]) => {
+    calls.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  };
+  return { calls, restore: () => { (stream as any).write = original; } };
+}
+
+function runFooter(mainUpdated: boolean, latest: { version: string | null; reason?: string }): string {
+  const stdout = captureWrites(process.stdout);
+  try {
+    footer(1234, mainUpdated, latest);
+  } finally {
+    stdout.restore();
+  }
+  return stdout.calls.join('');
+}
+
+describe('#248 — footer() does not claim "already on latest" when resolution failed', () => {
+  it('does not print "already on latest" when the registry lookup never resolved', () => {
+    const out = runFooter(false, { version: null, reason: 'registry returned E401 (auth rejected)' });
+    expect(out).not.toMatch(/already on latest/);
+  });
+
+  it('surfaces the failure reason instead', () => {
+    const out = runFooter(false, { version: null, reason: 'registry returned E401 (auth rejected)' });
+    expect(out).toMatch(/latest version unknown/i);
+    expect(out).toContain('registry returned E401 (auth rejected)');
+  });
+
+  it('still prints "already on latest" when the lookup genuinely succeeded and matched', () => {
+    const out = runFooter(false, { version: '4.48.0' });
+    expect(out).toMatch(/already on latest/);
+  });
+
+  it('prints the restart hint, not "already on latest", when the package WAS updated', () => {
+    const out = runFooter(true, { version: '4.49.0' });
+    expect(out).not.toMatch(/already on latest/);
+    expect(out).toMatch(/restart/i);
+  });
+});

--- a/src/__tests__/update-legacy-purge-errno-248.test.ts
+++ b/src/__tests__/update-legacy-purge-errno-248.test.ts
@@ -38,7 +38,11 @@ describe('#248 — a denied legacy purge is surfaced, not swallowed', () => {
     expect(r.status).toBe('warn');
     const shown = [r.summary ?? '', ...(r.detail ?? [])].join('\n');
     expect(shown).toContain('EPERM');
-    expect(shown).toContain(extDir);
+    // #248 review — the raw absolute `extDir` (which embeds `home`, and on a
+    // real box the operator's username) must never reach output that gets
+    // pasted into an issue; only the scrubbed `~/...` form is allowed.
+    expect(shown).not.toContain(extDir);
+    expect(shown).toContain('~/.openclaw/extensions/shieldcortex-realtime');
   });
 
   it('folds the purge denial into the failure report when the install ALSO fails', async () => {
@@ -50,6 +54,8 @@ describe('#248 — a denied legacy purge is surfaced, not swallowed', () => {
     expect(r.status).toBe('warn');
     const shown = [r.summary ?? '', ...(r.detail ?? [])].join('\n');
     expect(shown).toContain('EPERM');
+    expect(shown).not.toContain(extDir);
+    expect(shown).toContain('~/.openclaw/extensions/shieldcortex-realtime');
   });
 
   it('stays quiet about the purge when it succeeds (no behaviour change on the happy path)', async () => {

--- a/src/__tests__/update-legacy-purge-errno-248.test.ts
+++ b/src/__tests__/update-legacy-purge-errno-248.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { stepOpenClawPlugin } from '../cli/update.js';
+
+/**
+ * #248 item 5 — a denied legacy-extension purge (`fs.rmSync` on a root-owned
+ * dir, EPERM) was caught and silently ignored: `try { fs.rmSync(...) } catch
+ * { }`. The duplicate stayed in place and the next `doctor` run reported a
+ * dup install with no hint that a purge was even attempted, let alone denied.
+ */
+
+let home: string;
+let extDir: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'sc-248-purge-'));
+  extDir = join(home, '.openclaw', 'extensions', 'shieldcortex-realtime');
+  mkdirSync(extDir, { recursive: true });
+  // Registered too, so the step reaches the install branch either way.
+  mkdirSync(join(home, '.openclaw', 'plugins'), { recursive: true });
+  writeFileSync(
+    join(home, '.openclaw', 'plugins', 'installs.json'),
+    JSON.stringify({ installRecords: { 'shieldcortex-realtime': {} } }),
+  );
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+describe('#248 — a denied legacy purge is surfaced, not swallowed', () => {
+  it('reports the purge denial when the underlying install succeeds', async () => {
+    const r = await stepOpenClawPlugin(home, {
+      run: (() => Promise.resolve({ stdout: '', stderr: '' })) as never,
+      rm: (() => { throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' }); }) as never,
+    });
+
+    expect(r.status).toBe('warn');
+    const shown = [r.summary ?? '', ...(r.detail ?? [])].join('\n');
+    expect(shown).toContain('EPERM');
+    expect(shown).toContain(extDir);
+  });
+
+  it('folds the purge denial into the failure report when the install ALSO fails', async () => {
+    const r = await stepOpenClawPlugin(home, {
+      run: (() => Promise.reject(Object.assign(new Error('exit 1'), { exitCode: 1, stdout: '', stderr: '' }))) as never,
+      rm: (() => { throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' }); }) as never,
+    });
+
+    expect(r.status).toBe('warn');
+    const shown = [r.summary ?? '', ...(r.detail ?? [])].join('\n');
+    expect(shown).toContain('EPERM');
+  });
+
+  it('stays quiet about the purge when it succeeds (no behaviour change on the happy path)', async () => {
+    const r = await stepOpenClawPlugin(home, {
+      run: (() => Promise.resolve({ stdout: '', stderr: '' })) as never,
+      rm: (() => {}) as never,
+    });
+
+    expect(r.status).toBe('ok');
+    const shown = [r.summary ?? '', ...(r.detail ?? [])].join('\n');
+    expect(shown).not.toContain('EPERM');
+    expect(shown).not.toContain('left behind');
+  });
+});

--- a/src/__tests__/update-registry-error-sanitised-248.test.ts
+++ b/src/__tests__/update-registry-error-sanitised-248.test.ts
@@ -38,6 +38,20 @@ describe('#248 — sanitiseForReport is exported from child-output.ts', () => {
     expect(out).not.toContain(env.NPM_TOKEN);
     expect(out).toContain('[redacted:$NPM_TOKEN]');
   });
+
+  it('redacts credential-shaped text even when it is not present in the environment', () => {
+    const token = 'X7fQ2mZp9RtL4vNc8KwB3JhD6sYgA1eU5oXiTbMr0PlWnQzVfKjSxE9uYwGdTpAaCvBn';
+    const out = sanitiseForReport(`registry failed with token ${token}`, { env: {} });
+    expect(out).not.toContain(token);
+    expect(out).toContain('[REDACTED-');
+  });
+
+  it('does not broadly allowlist credential-shaped child path segments under ~/.openclaw', () => {
+    const token = 'X7fQ2mZp9RtL4vNc8KwB3JhD6sYgA1eU5oXiTbMr0PlWnQzVfKjSxE9uYwGdTpAaCvBn';
+    const out = sanitiseForReport(`failed at ~/.openclaw/extensions/${token}/state.json`, { env: {} });
+    expect(out).not.toContain(token);
+    expect(out).toContain('[REDACTED-');
+  });
 });
 
 describe('#248 — a malformed installs.json never echoes the raw parse error', () => {

--- a/src/__tests__/update-registry-error-sanitised-248.test.ts
+++ b/src/__tests__/update-registry-error-sanitised-248.test.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { readRealtimePluginRegistration } from '../cli/update.js';
+import { sanitiseForReport } from '../integrations/child-output.js';
+
+/**
+ * #248 (review round 2) — the strings `readRealtimePluginRegistration` built
+ * by hand (`could not read installs.json: ${err.message}`, `installs.json is
+ * malformed JSON: ${err.message}`) bypassed every redaction/scrubbing this
+ * codebase already has for exactly this purpose. Node formats a read error
+ * with the absolute path (`/Users/<name>/.openclaw/plugins/installs.json`),
+ * and V8 embeds up to ~30 raw bytes of the file in one of its two JSON
+ * parse-error forms — so an unreadable or corrupt registry echoed the
+ * operator's home directory, or the file's own head bytes, straight into a
+ * report that #248 itself says gets pasted into issues and support threads.
+ */
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'sc-248-sanitise-'));
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+describe('#248 — sanitiseForReport is exported from child-output.ts', () => {
+  it('scrubs a supplied home directory to ~', () => {
+    const out = sanitiseForReport(`error at ${home}/plugins/installs.json`, { home });
+    expect(out).not.toContain(home);
+    expect(out).toContain('~/plugins/installs.json');
+  });
+
+  it('redacts a secret-looking env value handed to the child', () => {
+    const env = { NPM_TOKEN: 'totally-not-a-recognised-token-shape-999999' };
+    const out = sanitiseForReport(`rejected: ${env.NPM_TOKEN}`, { env });
+    expect(out).not.toContain(env.NPM_TOKEN);
+    expect(out).toContain('[redacted:$NPM_TOKEN]');
+  });
+});
+
+describe('#248 — a malformed installs.json never echoes the raw parse error', () => {
+  it('drops err.message (and any raw file content) entirely, using a generic reason', () => {
+    const pluginsDir = join(home, '.openclaw', 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    // A distinctive marker: JSON parse errors are known to echo back the
+    // raw file's head bytes verbatim in their message.
+    writeFileSync(join(pluginsDir, 'installs.json'), '{ "SECRET-MARKER-DO-NOT-LEAK": ');
+
+    const r = readRealtimePluginRegistration(home);
+
+    expect(r.unreadable).toBe(true);
+    expect(r.detail).not.toContain('SECRET-MARKER-DO-NOT-LEAK');
+    expect(r.detail).toMatch(/malformed JSON/i);
+  });
+});
+
+describe('#248 — an unreadable installs.json never echoes the raw absolute path', () => {
+  it('scrubs the home directory out of the read-failure detail', () => {
+    const pluginsDir = join(home, '.openclaw', 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    const file = join(pluginsDir, 'installs.json');
+    writeFileSync(file, JSON.stringify({ installRecords: {} }));
+    chmodSync(file, 0o000);
+
+    try {
+      const r = readRealtimePluginRegistration(home);
+      // Root / some CI containers can still read a 0-mode file — only assert
+      // the scrubbing when the permission actually bites.
+      if (r.unreadable) {
+        expect(r.detail).not.toContain(home);
+        expect(r.detail).toContain('~/.openclaw/plugins/installs.json');
+      }
+    } finally {
+      chmodSync(file, 0o644);
+    }
+  });
+});

--- a/src/__tests__/update-registry-unreadable-248.test.ts
+++ b/src/__tests__/update-registry-unreadable-248.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { stepOpenClawPlugin } from '../cli/update.js';
+
+/**
+ * #248 item 2 — an unreadable/malformed `installs.json` must not read as "not
+ * installed". Before this fix, `isRealtimePluginRegistered()` swallowed any
+ * read/parse failure into a plain `false`, which `stepOpenClawPlugin` could
+ * not tell apart from a host that genuinely never had the plugin — so update
+ * skipped it, printed "not installed", and the run went GREEN having touched
+ * nothing on a box that was actually supposed to be running the plugin.
+ */
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'sc-248-reg-'));
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+describe('#248 — an unreadable registry never renders a false-green skip', () => {
+  it('warns (does not skip as "not installed") when installs.json is malformed JSON', async () => {
+    const pluginsDir = join(home, '.openclaw', 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    writeFileSync(join(pluginsDir, 'installs.json'), '{ not valid json');
+
+    const r = await stepOpenClawPlugin(home, { run: (() => Promise.reject(new Error('should not be called'))) as never });
+
+    expect(r.status).toBe('warn');
+    expect(r.summary).not.toContain('not installed');
+    expect(r.summary).toMatch(/registry unreadable/i);
+  });
+
+  it('warns when installs.json exists but cannot be read (permission denied)', async () => {
+    const pluginsDir = join(home, '.openclaw', 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    const file = join(pluginsDir, 'installs.json');
+    writeFileSync(file, JSON.stringify({ installRecords: {} }));
+    chmodSync(file, 0o000);
+
+    try {
+      const r = await stepOpenClawPlugin(home, { run: (() => Promise.reject(new Error('should not be called'))) as never });
+      // Root / some CI containers can still read a 0-mode file — only assert
+      // the distinguishing behaviour when the permission actually bites.
+      if (r.status === 'warn') {
+        expect(r.summary).not.toContain('not installed');
+        expect(r.summary).toMatch(/registry unreadable/i);
+      }
+    } finally {
+      chmodSync(file, 0o644);
+    }
+  });
+
+  it('still reports "not installed" (skip) when there genuinely is no registry', async () => {
+    const r = await stepOpenClawPlugin(home, { run: (() => Promise.reject(new Error('should not be called'))) as never });
+    expect(r.status).toBe('skip');
+    expect(r.summary).toContain('not installed');
+  });
+});

--- a/src/__tests__/update-step-output-redaction-248.test.ts
+++ b/src/__tests__/update-step-output-redaction-248.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { step } from '../cli/update.js';
+import type { CapturedError } from '../integrations/child-output.js';
+
+/**
+ * #248 item 1 — `step()`'s catch block wrote `(e.stderr || '') + (e.stdout || '')`
+ * straight to `process.stderr` with nothing between the child and the
+ * terminal. `runQuiet` hands the child `{...process.env}`, so `NPM_TOKEN` /
+ * `CLAWHUB_TOKEN` are values WE supplied — and npm echoes them back verbatim
+ * in a 401 body. Update output is routinely pasted into issues and support
+ * threads, so this dumped a live credential straight into whatever channel
+ * that output landed in.
+ *
+ * The fix routes the same captured output through `describeRunFailure`
+ * (`summariseCommandOutput` underneath), the exact module #221 built to
+ * redact env-supplied secrets before anything reaches a terminal.
+ */
+
+const ORIGINAL_NPM_TOKEN = process.env.NPM_TOKEN;
+const TOKEN = 'SEKRET-npm-token-abc123456789';
+
+afterEach(() => {
+  if (ORIGINAL_NPM_TOKEN === undefined) delete process.env.NPM_TOKEN;
+  else process.env.NPM_TOKEN = ORIGINAL_NPM_TOKEN;
+});
+
+function captureWrites(stream: NodeJS.WriteStream): { calls: string[]; restore: () => void } {
+  const calls: string[] = [];
+  const original = stream.write.bind(stream);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (stream as any).write = (chunk: any, ...rest: any[]) => {
+    calls.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  };
+  return { calls, restore: () => { (stream as any).write = original; } };
+}
+
+describe('#248 — step() redacts child output before it reaches the terminal', () => {
+  it('never writes a raw NPM_TOKEN value that the child echoed back', async () => {
+    process.env.NPM_TOKEN = TOKEN;
+    const stderr = captureWrites(process.stderr);
+    const stdout = captureWrites(process.stdout);
+
+    const err = Object.assign(new Error('exit 1: npm install -g shieldcortex@latest'), {
+      exitCode: 1,
+      command: 'npm install -g shieldcortex@latest',
+      stdout: '',
+      stderr: `npm error code E401\nnpm error 401 Unauthorized - GET https://registry.npmjs.org/shieldcortex - auth token=${TOKEN} rejected\n`,
+    } satisfies Partial<CapturedError>);
+
+    try {
+      await expect(step('npm package', async () => { throw err; })).rejects.toThrow();
+    } finally {
+      stderr.restore();
+      stdout.restore();
+    }
+
+    const allOutput = [...stderr.calls, ...stdout.calls].join('');
+    expect(allOutput).not.toContain(TOKEN);
+  });
+
+  it('still surfaces a redacted summary of what the child said, not a blank block', async () => {
+    process.env.NPM_TOKEN = TOKEN;
+    const stderr = captureWrites(process.stderr);
+    const stdout = captureWrites(process.stdout);
+
+    const err = Object.assign(new Error('exit 1: npm install -g shieldcortex@latest'), {
+      exitCode: 1,
+      command: 'npm install -g shieldcortex@latest',
+      stdout: '',
+      stderr: `npm error code E401\nnpm error 401 Unauthorized - GET https://registry.npmjs.org/shieldcortex - auth token=${TOKEN} rejected\n`,
+    } satisfies Partial<CapturedError>);
+
+    try {
+      await expect(step('npm package', async () => { throw err; })).rejects.toThrow();
+    } finally {
+      stderr.restore();
+      stdout.restore();
+    }
+
+    const stderrText = stderr.calls.join('');
+    expect(stderrText).toMatch(/E401/);
+    expect(stderrText.toLowerCase()).toContain('redacted');
+  });
+});

--- a/src/__tests__/update-step-reason-never-empty-248.test.ts
+++ b/src/__tests__/update-step-reason-never-empty-248.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from '@jest/globals';
+import { step } from '../cli/update.js';
+import type { CapturedError } from '../integrations/child-output.js';
+
+/**
+ * #248 (review round 2) — `step()`'s catch block computed `report.reason` via
+ * `describeRunFailure` and then threw it away, printing only `report.detail`
+ * — and `neverEmpty` was never passed. `detail` is `[]` in exactly the cases
+ * that matter most:
+ *
+ *   - output entirely of noise-class lines (`npm warn …`, `added 3 packages`)
+ *   - a spawn ENOENT (binary not found)
+ *   - a timeout with nothing captured
+ *
+ * In each, the operator saw `✗  npm package: failed (12.3s)` and nothing
+ * else — the exact defect class #248 was filed to remove, reopened inside
+ * the function #248 names. The noise case is also a regression against
+ * `main`, which printed the raw captured lines unconditionally.
+ */
+
+function captureWrites(stream: NodeJS.WriteStream): { calls: string[]; restore: () => void } {
+  const calls: string[] = [];
+  const original = stream.write.bind(stream);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (stream as any).write = (chunk: any, ...rest: any[]) => {
+    calls.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  };
+  return { calls, restore: () => { (stream as any).write = original; } };
+}
+
+async function runFailingStep(err: CapturedError): Promise<string> {
+  const stderr = captureWrites(process.stderr);
+  const stdout = captureWrites(process.stdout);
+  try {
+    await expect(step('npm package', async () => { throw err; })).rejects.toThrow();
+  } finally {
+    stderr.restore();
+    stdout.restore();
+  }
+  return stderr.calls.join('');
+}
+
+describe('#248 — step() never renders a blank failure block', () => {
+  it('shows a reason when the captured output was entirely noise-class lines', async () => {
+    const err = Object.assign(new Error('exit 1: npm install -g shieldcortex@latest'), {
+      exitCode: 1,
+      command: 'npm install -g shieldcortex@latest',
+      stdout: 'added 3 packages in 2s\nfound 0 vulnerabilities\n',
+      stderr: '',
+    } satisfies Partial<CapturedError>);
+
+    const stderrText = await runFailingStep(err);
+
+    // Not silence beyond "failed (Xs)" — the block prints, with content.
+    expect(stderrText).toMatch(/── output/);
+    expect(stderrText).toMatch(/added 3 packages/);
+  });
+
+  it('shows "command not found" as the reason on a spawn ENOENT, where detail is empty', async () => {
+    const err = Object.assign(new Error('spawn npm ENOENT'), {
+      spawnFailed: true,
+      exitCode: null,
+      code: 'ENOENT',
+      command: 'npm install -g shieldcortex@latest',
+    } satisfies Partial<CapturedError>);
+
+    const stderrText = await runFailingStep(err);
+
+    expect(stderrText).toMatch(/command not found/);
+  });
+
+  it('shows "timed out" as the reason on a timeout with nothing captured', async () => {
+    const err = Object.assign(new Error('timeout: npm install -g shieldcortex@latest'), {
+      timedOut: true,
+      exitCode: null,
+      command: 'npm install -g shieldcortex@latest',
+      stdout: '',
+      stderr: '',
+    } satisfies Partial<CapturedError>);
+
+    const stderrText = await runFailingStep(err);
+
+    expect(stderrText).toMatch(/timed out/);
+  });
+});
+
+describe('#248 — step() is wired through the never-empty guarantee', () => {
+  it('calls describeRunFailure with { neverEmpty: true }', () => {
+    const src = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), '..', 'cli', 'update.ts'),
+      'utf-8',
+    );
+    expect(src).toMatch(/describeRunFailure\(err,\s*\{\s*neverEmpty:\s*true\s*\}\)/);
+  });
+});

--- a/src/__tests__/update-verify-protection-unreadable-248.test.ts
+++ b/src/__tests__/update-verify-protection-unreadable-248.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { stepVerifyProtection } from '../cli/update.js';
+
+/**
+ * #248 (review round 2) — `stepVerifyProtection` gated on the collapsing
+ * `isRealtimePluginRegistered(home)` boolean, so an unreadable registry
+ * (denied permission, malformed JSON) returned `false` the exact same way
+ * "genuinely not installed" does — and the function did a bare, silent
+ * `return`. The protection self-check — #248's own "most consequential"
+ * item — never ran, and the run still ended green with nothing printed to
+ * say the check had even been attempted.
+ */
+
+function captureWrites(stream: NodeJS.WriteStream): { calls: string[]; restore: () => void } {
+  const calls: string[] = [];
+  const original = stream.write.bind(stream);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (stream as any).write = (chunk: any, ...rest: any[]) => {
+    calls.push(typeof chunk === 'string' ? chunk : String(chunk));
+    return true;
+  };
+  return { calls, restore: () => { (stream as any).write = original; } };
+}
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'sc-248-verify-'));
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+describe('#248 — stepVerifyProtection surfaces an unreadable registry, not a silent skip', () => {
+  it('prints a skipped-not-silent message when installs.json is malformed', async () => {
+    const pluginsDir = join(home, '.openclaw', 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    writeFileSync(join(pluginsDir, 'installs.json'), '{ not valid json');
+
+    const stdout = captureWrites(process.stdout);
+    try {
+      await stepVerifyProtection(home);
+    } finally {
+      stdout.restore();
+    }
+
+    const shown = stdout.calls.join('');
+    expect(shown).toMatch(/protection check skipped/i);
+    expect(shown).toMatch(/unreadable/i);
+  });
+
+  it('stays truly silent when there genuinely is no registry (a Claude-Code-only box is not an error)', async () => {
+    const stdout = captureWrites(process.stdout);
+    try {
+      await stepVerifyProtection(home);
+    } finally {
+      stdout.restore();
+    }
+
+    expect(stdout.calls.join('')).toBe('');
+  });
+});

--- a/src/cli/__tests__/update-install-parity-171.test.ts
+++ b/src/cli/__tests__/update-install-parity-171.test.ts
@@ -74,6 +74,17 @@ describe('#171 — update ends by verifying protection, like repair', () => {
 
   it('skips cleanly when no plugin is registered — a Claude-Code-only box is not an error', () => {
     const body = bodyOf('stepVerifyProtection');
-    expect(body).toMatch(/isRealtimePluginRegistered\(home\)/);
+    // #248: the plain `isRealtimePluginRegistered(home)` boolean collapsed
+    // "not installed" and "registry unreadable" into the same silent skip —
+    // the split-result read is what lets "not registered" stay a clean skip
+    // while "unreadable" gets its own surfaced branch.
+    expect(body).toMatch(/readRealtimePluginRegistration\(home\)/);
+    expect(body).toMatch(/!registration\.registered/);
+  });
+
+  it('surfaces (does not silently skip) when the registry could not be confirmed', () => {
+    const body = bodyOf('stepVerifyProtection');
+    expect(body).toMatch(/registration\.unreadable/);
+    expect(body).toMatch(/protection check skipped/);
   });
 });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -17,7 +17,7 @@ import path from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { resolveRealtimePluginInstallPath, readInstalledRealtimePluginVersion } from '../integrations/openclaw-plugin-state.js';
-import { describeRunFailure } from '../integrations/child-output.js';
+import { describeRunFailure, sanitiseForReport } from '../integrations/child-output.js';
 import type { CapturedError } from '../integrations/child-output.js';
 
 // ── ANSI ────────────────────────────────────────────────────
@@ -126,15 +126,18 @@ export async function step(
     // back verbatim in a 401 body. Route through the same redaction #221
     // built for the OpenClaw steps so a credential never reaches output that
     // gets pasted into an issue or support thread.
-    const report = describeRunFailure(err);
-    if (report.detail.length > 0) {
-      process.stderr.write('\n' + paint('gray', '── output ─────────────────────────────────────────') + '\n');
-      for (const line of report.detail) process.stderr.write(line + '\n');
-      if (report.truncated) {
-        process.stderr.write(paint('gray', '… output truncated — run the command directly for the full text') + '\n');
-      }
-      process.stderr.write(paint('gray', '───────────────────────────────────────────────────') + '\n');
+    // `neverEmpty` because a step that failed on noise-only output (or an
+    // ENOENT/timeout with nothing captured) must still show SOMETHING — the
+    // regression #248 was reopened against: `detail` alone is `[]` in exactly
+    // those cases, but `reason` is never empty.
+    const report = describeRunFailure(err, { neverEmpty: true });
+    process.stderr.write('\n' + paint('gray', '── output ─────────────────────────────────────────') + '\n');
+    process.stderr.write(report.reason + '\n');
+    for (const line of report.detail) process.stderr.write(line + '\n');
+    if (report.truncated) {
+      process.stderr.write(paint('gray', '… output truncated — run the command directly for the full text') + '\n');
     }
+    process.stderr.write(paint('gray', '───────────────────────────────────────────────────') + '\n');
     throw err;
   }
 }
@@ -229,7 +232,7 @@ function header(currentVersion: string, latestVersion: string | null): void {
   }
 }
 
-function footer(totalMs: number, mainUpdated: boolean): void {
+export function footer(totalMs: number, mainUpdated: boolean, latest: LatestVersionResult): void {
   const elapsed = (totalMs / 1000).toFixed(1) + 's';
   process.stdout.write(
     `\n  ${paint('gray', '──────────────────────────────────────────────────────────────')}\n`,
@@ -238,6 +241,13 @@ function footer(totalMs: number, mainUpdated: boolean): void {
     process.stdout.write(
       `  ${paint('green', '✓')}  ${paint('bold', 'done')}  ${paint('gray', `in ${elapsed}`)}  ${paint('cyan', '·')}  ${paint('yellow', 'restart Claude Code / OpenClaw gateway')}\n\n`,
     );
+  } else if (latest.version === null) {
+    // #248: `mainUpdated` is false both when we ARE current AND when the
+    // registry lookup never resolved (E401, ENOTFOUND, timeout) — `header()`
+    // already tells the two apart; the footer must not close an E401/ENOTFOUND
+    // run with the same reassuring "already on latest" line as a real check.
+    const reason = latest.reason ? ` — ${latest.reason}` : '';
+    process.stdout.write(`  ${paint('yellow', '⚠')}  ${paint('bold', 'done')}  ${paint('gray', `in ${elapsed} · latest version unknown${reason}`)}\n\n`);
   } else {
     process.stdout.write(`  ${paint('green', '✓')}  ${paint('bold', 'done')}  ${paint('gray', `in ${elapsed} · already on latest`)}\n\n`);
   }
@@ -374,18 +384,26 @@ export function readRealtimePluginRegistration(home: string): RegistryReadResult
     return {
       registered: false,
       unreadable: true,
-      detail: `could not read installs.json: ${err instanceof Error ? err.message : String(err)}`,
+      detail: sanitiseForReport(
+        `could not read installs.json: ${err instanceof Error ? err.message : String(err)}`,
+        { home },
+      ),
     };
   }
 
   let json: { installRecords?: Record<string, unknown>; plugins?: Array<{ pluginId?: string }> };
   try {
     json = JSON.parse(raw);
-  } catch (err) {
+  } catch {
+    // #248: V8 embeds up to ~30 chars of the raw file in one of its two
+    // parse-error forms, so including `err.message` here would echo a
+    // corrupt registry's own head bytes to the terminal. The parse offset
+    // tells an operator nothing they cannot get by opening the file — drop
+    // it entirely rather than try to sanitise it.
     return {
       registered: false,
       unreadable: true,
-      detail: `installs.json is malformed JSON: ${err instanceof Error ? err.message : String(err)}`,
+      detail: 'installs.json is malformed JSON',
     };
   }
 
@@ -456,7 +474,7 @@ export async function stepOpenClawPlugin(
         return {
           status: 'warn' as const,
           summary: `${transition} — legacy copy left behind`,
-          detail: [`could not remove legacy extension at ${extDir}: ${purgeFailure}`],
+          detail: [sanitiseForReport(`could not remove legacy extension at ${extDir}: ${purgeFailure}`, { home })],
         };
       }
       return transition;
@@ -473,7 +491,7 @@ export async function stepOpenClawPlugin(
         status: 'warn' as const,
         summary: `update failed — ${report.reason}`,
         detail: purgeFailure
-          ? [...report.detail, `also: could not remove legacy extension at ${extDir}: ${purgeFailure}`]
+          ? [...report.detail, sanitiseForReport(`also: could not remove legacy extension at ${extDir}: ${purgeFailure}`, { home })]
           : report.detail,
         truncated: report.truncated,
       };
@@ -650,8 +668,22 @@ async function stepStatePermissions(): Promise<StepResult> {
  * disk, so importing here loads the FRESHLY INSTALLED reconcile/self-check —
  * the new version verifies itself with its own logic, not last release's.
  */
-async function stepVerifyProtection(home: string): Promise<void> {
-  if (!isRealtimePluginRegistered(home)) return;
+export async function stepVerifyProtection(home: string): Promise<void> {
+  // #248: `isRealtimePluginRegistered` collapses "genuinely not installed"
+  // and "installs.json exists but could not be confirmed" into the same
+  // `false`, which made an unreadable registry return here silently — the
+  // protection self-check never ran, and the run still ended green with no
+  // hint it had been skipped. Read the split result so "unreadable" gets
+  // its own branch instead of falling through the same gate as "absent".
+  const registration = readRealtimePluginRegistration(home);
+  if (registration.unreadable) {
+    process.stdout.write('\n');
+    process.stdout.write(
+      `  ${paint('yellow', '!')}  ${paint('gray', `protection check skipped — plugin registry unreadable: ${registration.detail ?? 'could not confirm install state'}`)}\n`,
+    );
+    return;
+  }
+  if (!registration.registered) return;
   process.stdout.write('\n');
   try {
     const { reconcileOpenClawPluginState, formatReconcileReport } = await import('../setup/openclaw-reconcile.js');
@@ -664,7 +696,7 @@ async function stepVerifyProtection(home: string): Promise<void> {
     }
     if (result.applied && !result.ok) process.exitCode = 1;
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = sanitiseForReport(err instanceof Error ? err.message : String(err), { home });
     process.stdout.write(`  ${paint('gray', `protection check skipped — ${msg}`)}\n`);
   }
 }
@@ -702,7 +734,7 @@ export async function runUpdate(): Promise<void> {
   await stepClaudeHooks();
   await stepStatePermissions();
 
-  footer(Date.now() - flowStart, mainUpdated);
+  footer(Date.now() - flowStart, mainUpdated, latest);
 
   // The verdict comes AFTER the footer so the last thing on screen is the one
   // line that answers "am I protected?" — not a spinner summary.

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -59,7 +59,7 @@ interface StepResult {
   truncated?: boolean;
 }
 
-async function step(
+export async function step(
   label: string,
   fn: () => Promise<StepResult | string | void>,
 ): Promise<StepResult> {
@@ -120,11 +120,19 @@ async function step(
     } else {
       process.stdout.write(`  ✗  ${label}: failed (${elapsed})\n`);
     }
-    const e = err as Error & { stdout?: string; stderr?: string };
-    const captured = (e.stderr || '') + (e.stdout || '');
-    if (captured.trim()) {
+    // #248: this used to write `(e.stderr || '') + (e.stdout || '')` straight
+    // to the terminal. `runQuiet` hands the child `{...process.env}`, so
+    // NPM_TOKEN / CLAWHUB_TOKEN are values WE supplied — and npm echoes them
+    // back verbatim in a 401 body. Route through the same redaction #221
+    // built for the OpenClaw steps so a credential never reaches output that
+    // gets pasted into an issue or support thread.
+    const report = describeRunFailure(err);
+    if (report.detail.length > 0) {
       process.stderr.write('\n' + paint('gray', '── output ─────────────────────────────────────────') + '\n');
-      process.stderr.write(captured.trim() + '\n');
+      for (const line of report.detail) process.stderr.write(line + '\n');
+      if (report.truncated) {
+        process.stderr.write(paint('gray', '… output truncated — run the command directly for the full text') + '\n');
+      }
       process.stderr.write(paint('gray', '───────────────────────────────────────────────────') + '\n');
     }
     throw err;
@@ -243,22 +251,38 @@ function readPackageVersion(): string {
   return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version ?? 'unknown';
 }
 
-async function fetchLatestVersion(): Promise<string | null> {
+export interface LatestVersionResult {
+  version: string | null;
+  /**
+   * Why the lookup failed (#248). E401 (bad/expired token), ENOTFOUND
+   * (offline/DNS) and a proxy failure all used to collapse to a bare `null`,
+   * which the caller reported as "registry unreachable" — true for
+   * ENOTFOUND, actively wrong for a rejected token, and downstream a bare
+   * `null` reads as "already up to date".
+   */
+  reason?: string;
+}
+
+/** `run` is injectable so the failure path can be tested without a real spawn. */
+export async function fetchLatestVersion(deps: { run?: typeof runQuiet } = {}): Promise<LatestVersionResult> {
+  const run = deps.run ?? runQuiet;
   try {
-    const { stdout } = await runQuiet('npm', ['view', 'shieldcortex', 'version'], { timeout: 10000 });
-    return stdout.trim() || null;
-  } catch {
-    return null;
+    const { stdout } = await run('npm', ['view', 'shieldcortex', 'version'], { timeout: 10000 });
+    return { version: stdout.trim() || null };
+  } catch (err) {
+    return { version: null, reason: describeRunFailure(err).reason };
   }
 }
 
 async function stepNpmPackage(
   currentVersion: string,
-  latestVersion: string | null,
+  latest: LatestVersionResult,
   force: boolean,
 ): Promise<{ updated: boolean; result: StepResult }> {
+  const latestVersion = latest.version;
   if (!latestVersion) {
-    const result = await step('npm package', async () => ({ status: 'warn' as const, summary: 'registry unreachable' }));
+    const summary = latest.reason ? `registry check failed — ${latest.reason}` : 'registry unreachable';
+    const result = await step('npm package', async () => ({ status: 'warn' as const, summary }));
     return { updated: false, result };
   }
   if (latestVersion === currentVersion && !force) {
@@ -313,43 +337,105 @@ async function stepVerifyEngine(): Promise<{ remediation: string | null }> {
  * leaving the plugin stale while the npm package moved on. Read the registry
  * (the authoritative source `doctor` also trusts) instead.
  */
-export function isRealtimePluginRegistered(home: string): boolean {
-  // An on-disk install resolves even on boxes whose authoritative plugin state
-  // is SQLite-only (no legacy installs.json) — check that first.
-  if (resolveRealtimePluginInstallPath(home)) return true;
-  try {
-    const installsPath = path.join(home, '.openclaw', 'plugins', 'installs.json');
-    if (!fs.existsSync(installsPath)) return false;
-    const json = JSON.parse(fs.readFileSync(installsPath, 'utf-8')) as {
-      installRecords?: Record<string, unknown>;
-      plugins?: Array<{ pluginId?: string }>;
-    };
-    if (json.installRecords && Object.prototype.hasOwnProperty.call(json.installRecords, 'shieldcortex-realtime')) {
-      return true;
-    }
-    return Array.isArray(json.plugins) && json.plugins.some((p) => p?.pluginId === 'shieldcortex-realtime');
-  } catch {
-    return false; // unreadable registry → treat as not installed
-  }
+export interface RegistryReadResult {
+  registered: boolean;
+  /**
+   * True when `installs.json` exists but could not be read or parsed (#248).
+   * A permission-denied or truncated registry is NOT evidence the plugin is
+   * absent — it means the host's install state is unknown. Callers that
+   * would otherwise report "not installed" on `registered: false` must check
+   * this first, or an unreadable registry renders a false-green skip on a
+   * host that update never actually touched.
+   */
+  unreadable: boolean;
+  detail?: string;
 }
 
-/** `run` is injectable so the failure path can be tested without a real spawn. */
+/**
+ * Read whether the realtime plugin is registered with OpenClaw, distinguishing
+ * "genuinely not installed" from "installs.json exists but could not be
+ * confirmed" (#248). `isRealtimePluginRegistered` collapses both into `false`
+ * for callers that only need a yes/no; `stepOpenClawPlugin` needs the
+ * distinction so it never reports "not installed" on a registry it could not
+ * actually read.
+ */
+export function readRealtimePluginRegistration(home: string): RegistryReadResult {
+  // An on-disk install resolves even on boxes whose authoritative plugin state
+  // is SQLite-only (no legacy installs.json) — check that first.
+  if (resolveRealtimePluginInstallPath(home)) return { registered: true, unreadable: false };
+
+  const installsPath = path.join(home, '.openclaw', 'plugins', 'installs.json');
+  if (!fs.existsSync(installsPath)) return { registered: false, unreadable: false };
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(installsPath, 'utf-8');
+  } catch (err) {
+    return {
+      registered: false,
+      unreadable: true,
+      detail: `could not read installs.json: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  let json: { installRecords?: Record<string, unknown>; plugins?: Array<{ pluginId?: string }> };
+  try {
+    json = JSON.parse(raw);
+  } catch (err) {
+    return {
+      registered: false,
+      unreadable: true,
+      detail: `installs.json is malformed JSON: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (json.installRecords && Object.prototype.hasOwnProperty.call(json.installRecords, 'shieldcortex-realtime')) {
+    return { registered: true, unreadable: false };
+  }
+  const registered = Array.isArray(json.plugins) && json.plugins.some((p) => p?.pluginId === 'shieldcortex-realtime');
+  return { registered, unreadable: false };
+}
+
+export function isRealtimePluginRegistered(home: string): boolean {
+  return readRealtimePluginRegistration(home).registered;
+}
+
+/** `run`/`rm` are injectable so the failure paths can be tested without a real spawn or a root-owned dir. */
 export async function stepOpenClawPlugin(
   home: string,
-  deps: { run?: typeof runQuiet } = {},
+  deps: { run?: typeof runQuiet; rm?: typeof fs.rmSync } = {},
 ): Promise<StepResult> {
   const run = deps.run ?? runQuiet;
+  const rm = deps.rm ?? fs.rmSync;
   const extDir = path.join(home, '.openclaw', 'extensions', 'shieldcortex-realtime');
   const legacy = fs.existsSync(extDir);
-  const registered = isRealtimePluginRegistered(home);
-  if (!legacy && !registered) {
+  const registration = readRealtimePluginRegistration(home);
+  // #248: an unreadable/malformed registry is not evidence the plugin is
+  // absent — reporting "not installed" here is a false-green skip on a host
+  // whose actual state we could not confirm.
+  if (!legacy && registration.unreadable) {
+    return await step('OpenClaw plugin', async () => ({
+      status: 'warn' as const,
+      summary: `plugin registry unreadable — ${registration.detail ?? 'could not confirm install state'}`,
+    }));
+  }
+  if (!legacy && !registration.registered) {
     return await step('OpenClaw plugin', async () => ({ status: 'skip' as const, summary: 'not installed' }));
   }
   return await step('OpenClaw plugin', async () => {
     // Drop any legacy file-copied extension so OpenClaw's registry copy is the
     // single source of truth (prevents the dup-install state doctor flags).
+    let purgeFailure: string | null = null;
     if (legacy) {
-      try { fs.rmSync(extDir, { recursive: true, force: true }); } catch { /* ignore */ }
+      try {
+        rm(extDir, { recursive: true, force: true });
+      } catch (err) {
+        // #248: this used to be `catch { /* ignore */ }`. A denied purge
+        // (root-owned dir, EPERM) left the duplicate in place with no hint it
+        // was even attempted — the next `doctor` run reported a dup install
+        // as if nothing had tried to fix it.
+        purgeFailure = err instanceof Error ? err.message : String(err);
+      }
     }
     const before = readInstalledRealtimePluginVersion(home);
     try {
@@ -362,9 +448,18 @@ export async function stepOpenClawPlugin(
       // Report the ACTUAL on-disk transition, not just command success — the old
       // "updated via openclaw" was printed even when the version never moved.
       const after = readInstalledRealtimePluginVersion(home);
-      if (before && after && before !== after) return `${before} → ${after}`;
-      if (after) return `up to date (v${after})`;
-      return 'reinstalled';
+      const transition =
+        before && after && before !== after ? `${before} → ${after}` :
+        after ? `up to date (v${after})` :
+        'reinstalled';
+      if (purgeFailure) {
+        return {
+          status: 'warn' as const,
+          summary: `${transition} — legacy copy left behind`,
+          detail: [`could not remove legacy extension at ${extDir}: ${purgeFailure}`],
+        };
+      }
+      return transition;
     } catch (err) {
       // Don't propagate — surface as warn instead of failing the whole flow.
       //
@@ -377,7 +472,9 @@ export async function stepOpenClawPlugin(
       return {
         status: 'warn' as const,
         summary: `update failed — ${report.reason}`,
-        detail: report.detail,
+        detail: purgeFailure
+          ? [...report.detail, `also: could not remove legacy extension at ${extDir}: ${purgeFailure}`]
+          : report.detail,
         truncated: report.truncated,
       };
     }
@@ -582,15 +679,15 @@ export async function runUpdate(): Promise<void> {
 
   // Header — show current version immediately, then update with latest once we know it.
   // (We resolve `latest` before drawing the arrow so the banner is correct.)
-  const latestVersion = await fetchLatestVersion();
-  header(currentVersion, latestVersion);
+  const latest = await fetchLatestVersion();
+  header(currentVersion, latest.version);
   if (force) {
     process.stdout.write(`  ${paint('yellow', '!')}  ${paint('gray', '--force: reinstall everything regardless of version')}\n\n`);
   }
 
   let mainUpdated = false;
   try {
-    const npmStep = await stepNpmPackage(currentVersion, latestVersion, force);
+    const npmStep = await stepNpmPackage(currentVersion, latest, force);
     mainUpdated = npmStep.updated;
   } catch {
     // npm failure already surfaced by step(); continue with reconcile.

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -133,7 +133,10 @@ export async function step(
     const report = describeRunFailure(err, { neverEmpty: true });
     process.stderr.write('\n' + paint('gray', '── output ─────────────────────────────────────────') + '\n');
     process.stderr.write(report.reason + '\n');
-    for (const line of report.detail) process.stderr.write(line + '\n');
+    // When the reason was derived from detail[0], printing both duplicates the
+    // headline on the common failure path — skip the line the reason already is.
+    const detailLines = report.reasonFromDetail ? report.detail.slice(1) : report.detail;
+    for (const line of detailLines) process.stderr.write(line + '\n');
     if (report.truncated) {
       process.stderr.write(paint('gray', '… output truncated — run the command directly for the full text') + '\n');
     }
@@ -375,12 +378,19 @@ export function readRealtimePluginRegistration(home: string): RegistryReadResult
   if (resolveRealtimePluginInstallPath(home)) return { registered: true, unreadable: false };
 
   const installsPath = path.join(home, '.openclaw', 'plugins', 'installs.json');
-  if (!fs.existsSync(installsPath)) return { registered: false, unreadable: false };
 
+  // No existsSync pre-check: it swallows a traversal EACCES on the plugins
+  // DIRECTORY into a plain `false`, rendering the exact false-green "not
+  // installed" skip #248 exists to kill — at directory level instead of file
+  // level (sudo-damaged perms under user dirs are a documented fleet failure
+  // mode). Read directly and branch on the errno; this also removes the
+  // exists→read TOCTOU.
   let raw: string;
   try {
     raw = fs.readFileSync(installsPath, 'utf-8');
   } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return { registered: false, unreadable: false };
     return {
       registered: false,
       unreadable: true,

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -391,7 +391,7 @@ export function readRealtimePluginRegistration(home: string): RegistryReadResult
     };
   }
 
-  let json: { installRecords?: Record<string, unknown>; plugins?: Array<{ pluginId?: string }> };
+  let json: unknown;
   try {
     json = JSON.parse(raw);
   } catch {
@@ -407,10 +407,19 @@ export function readRealtimePluginRegistration(home: string): RegistryReadResult
     };
   }
 
-  if (json.installRecords && Object.prototype.hasOwnProperty.call(json.installRecords, 'shieldcortex-realtime')) {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) {
+    return {
+      registered: false,
+      unreadable: true,
+      detail: 'installs.json has invalid registry shape',
+    };
+  }
+  const registry = json as { installRecords?: Record<string, unknown>; plugins?: Array<{ pluginId?: string }> };
+
+  if (registry.installRecords && Object.prototype.hasOwnProperty.call(registry.installRecords, 'shieldcortex-realtime')) {
     return { registered: true, unreadable: false };
   }
-  const registered = Array.isArray(json.plugins) && json.plugins.some((p) => p?.pluginId === 'shieldcortex-realtime');
+  const registered = Array.isArray(registry.plugins) && registry.plugins.some((p) => p?.pluginId === 'shieldcortex-realtime');
   return { registered, unreadable: false };
 }
 

--- a/src/defence/credential-leak/patterns.ts
+++ b/src/defence/credential-leak/patterns.ts
@@ -450,6 +450,22 @@ export const CONNECTION_STRING_PATTERNS: CredentialPattern[] = [
     severity: 'critical',
     confidence: 0.93,
   },
+  {
+    // HTTP(S) basic-auth URLs — `https://user:pass@host`. Corporate npm
+    // registries (`registry=https://user:pass@host` in .npmrc) put exactly
+    // this in npm's 401 error output, and neither the DB-scheme rules above
+    // nor the entropy net can catch it (`:`/`@` break the token; short
+    // passwords are under the 20-char minimum). The user segment excludes
+    // `/` and `:` so `https://host:8080/path` and path/query `@`s
+    // (`/x@2x.png`, `?email=a@b.com`) never match — an `@` must directly
+    // follow the credential pair.
+    name: 'HTTP Basic-Auth URL',
+    type: 'connection_string',
+    provider: 'http',
+    regex: /https?:\/\/[^\s"'`/:@]+:[^\s"'`@/]+@[^\s"'`]+/g,
+    severity: 'high',
+    confidence: 0.9,
+  },
 ];
 
 // ── Environment Variable Patterns ──

--- a/src/integrations/child-output.ts
+++ b/src/integrations/child-output.ts
@@ -50,6 +50,11 @@ export interface RunFailureReport {
   reason: string;
   /** Redacted detail lines, most informative first. */
   detail: string[];
+  /**
+   * True when `reason` was derived from `detail[0]` — a caller printing both
+   * should skip the first detail line or the headline appears twice.
+   */
+  reasonFromDetail: boolean;
   exitCode: number | null;
   timedOut: boolean;
   spawnFailed: boolean;
@@ -254,24 +259,39 @@ export function summariseCommandOutput(
 
   if (!output || !output.trim()) return { lines: [], truncated: false };
 
+  // Env-value redaction FIRST, on the UNCAPPED text. It is an exact-match
+  // String.replace — cheap even on megabytes — and running it after the cap
+  // let a secret split at the cap boundary escape the exact match entirely;
+  // the surviving 40-hex prefix then read as a git SHA to the entropy
+  // allowlist. Everything regex-shaped stays behind the cap below.
+  const envRedacted = redactEnvValues(output, env);
+
   // Cap before any regex work — a failed `npm install -g` emits megabytes.
   // BOTH ENDS, not the tail: the diagnosis is printed first and the noise
   // follows, so a tail-only cap discards the cause before the signal filter
   // ever sees it — the very mistake this module exists to correct, moved one
   // stage earlier where nothing downstream can compensate.
   const half = Math.floor(MAX_INPUT_BYTES / 2);
-  const capped = output.length > MAX_INPUT_BYTES
-    ? `${output.slice(0, half)}\n…\n${output.slice(-half)}`
-    : output;
-  let truncated = output.length > MAX_INPUT_BYTES;
+  const capped = envRedacted.length > MAX_INPUT_BYTES
+    ? `${envRedacted.slice(0, half)}\n…\n${envRedacted.slice(-half)}`
+    : envRedacted;
+  let truncated = envRedacted.length > MAX_INPUT_BYTES;
 
-  const redacted = redactCredentials(redactEnvValues(capped, env), {
+  // Same ordering as sanitiseForReport, for the same reasons: home-scrub
+  // before token-shaped redaction (a legitimate `~/...` path must not read as
+  // an entropy token because a temp home contains random bytes), then the
+  // credential-FRAGMENT pass — child output quotes credential-shaped path
+  // segments, and this sink previously lacked the pass while the hand-built-
+  // string sink had it: the strongest redaction guarded the least dangerous
+  // sink — then the whole-text pattern/entropy pass.
+  const homeScrubbed = scrubHome(capped, home);
+  const protectedPaths = protectReportPathLiterals(homeScrubbed);
+  const fragmentRedacted = redactCredentialFragments(protectedPaths.text);
+  const scrubbed = protectedPaths.restore(redactCredentials(fragmentRedacted, {
     // npm integrity hashes are high-entropy but not secrets; without this the
     // entropy pass eats them and the real message drowns in [REDACTED].
     allowlist: ['sha512-', 'sha1-', 'sha256-'],
-  });
-
-  const scrubbed = scrubHome(redacted, home);
+  }));
   const dropPluginChatter = opts.dropPluginChatter ?? true;
   let all = cleanLines(scrubbed, dropPluginChatter);
   if (all.length === 0 && opts.neverEmpty) {
@@ -416,17 +436,19 @@ export function describeRunFailure(err: unknown, opts: SummariseOptions = {}): R
   const sanitise = (text: string): string => sanitiseForReport(text, opts);
 
   let reason: string;
+  let reasonFromDetail = false;
   if (spawnFailed) {
     reason = firstSentence(sanitise(`command not found${command}`));
   } else if (timedOut) {
     reason = firstSentence(sanitise(`timed out${command}`));
   } else if (lines.length > 0) {
     reason = firstSentence(lines[0]);
+    reasonFromDetail = true;
   } else if (exitCode !== null) {
     reason = firstSentence(sanitise(`exited ${exitCode} with no output${command}`));
   } else {
     reason = firstSentence(sanitise(e.message || 'failed with no output'));
   }
 
-  return { reason, detail: lines, exitCode, timedOut, spawnFailed, truncated };
+  return { reason, detail: lines, reasonFromDetail, exitCode, timedOut, spawnFailed, truncated };
 }

--- a/src/integrations/child-output.ts
+++ b/src/integrations/child-output.ts
@@ -329,14 +329,56 @@ export function summariseCommandOutput(
 /**
  * Sanitise a string that was NOT produced by `summariseCommandOutput` — a
  * caller's own hand-built report string (an `err.message`, a path) — through
- * the same env-value redaction and home-scrubbing every other reported
- * string gets. `describeRunFailure` needed this for its own empty-output
- * fallbacks; callers assembling report strings outside a captured child
- * process (#248's `update.ts` registry-read errors) need the identical
- * guarantee, so it is exported rather than kept as a private closure.
+ * the same env-value redaction, credential-shape redaction, and home-scrubbing
+ * every other reported string gets. Env-value redaction runs before home
+ * scrubbing because it needs exact secret values; home scrubbing runs before
+ * pattern redaction so a legitimate `~/.openclaw/...` path is not mistaken for
+ * a high-entropy token just because the temp home directory contains random
+ * bytes.
  */
+const REPORT_PATH_SENTINELS: Array<[string, string]> = [
+  ['~/.openclaw/extensions/shieldcortex-realtime', '__shieldcortex_report_path_ext__'],
+  ['~/.openclaw/plugins/installs.json', '__shieldcortex_report_path_registry__'],
+  ['~/plugins/installs.json', '__shieldcortex_report_path_plugins_registry__'],
+];
+
+function redactCredentialFragments(text: string): string {
+  return text.replace(/[A-Za-z0-9\-_+=]{20,}/g, fragment =>
+    redactCredentials(fragment, {
+      allowlist: ['sha512-', 'sha1-', 'sha256-'],
+    }));
+}
+
+function protectReportPathLiterals(text: string): { text: string; restore: (value: string) => string } {
+  let protectedText = text;
+  for (const [literal, sentinel] of REPORT_PATH_SENTINELS) {
+    protectedText = protectedText.split(literal).join(sentinel);
+  }
+  return {
+    text: protectedText,
+    restore(value: string): string {
+      let out = value;
+      for (const [literal, sentinel] of REPORT_PATH_SENTINELS) {
+        out = out.split(sentinel).join(literal);
+      }
+      return out;
+    },
+  };
+}
+
 export function sanitiseForReport(text: string, opts: SummariseOptions = {}): string {
-  return scrubHome(redactEnvValues(text, opts.env ?? process.env), opts.home ?? os.homedir());
+  const envRedacted = redactEnvValues(text, opts.env ?? process.env);
+  const homeScrubbed = scrubHome(envRedacted, opts.home ?? os.homedir());
+  const protectedPaths = protectReportPathLiterals(homeScrubbed);
+  const fragmentRedacted = redactCredentialFragments(protectedPaths.text);
+  const credentialRedacted = redactCredentials(fragmentRedacted, {
+    // Match summariseCommandOutput: npm integrity hashes are high-entropy but
+    // not secrets, and otherwise bury the real failure in [REDACTED]. Do NOT
+    // allowlist `~/.openclaw/` as a broad prefix: a credential-shaped child
+    // path segment under that directory must still be redacted.
+    allowlist: ['sha512-', 'sha1-', 'sha256-'],
+  });
+  return protectedPaths.restore(credentialRedacted);
 }
 
 function firstSentence(value: string, limit = MAX_REASON_CHARS): string {

--- a/src/integrations/child-output.ts
+++ b/src/integrations/child-output.ts
@@ -326,6 +326,19 @@ export function summariseCommandOutput(
   return { lines: picked, truncated };
 }
 
+/**
+ * Sanitise a string that was NOT produced by `summariseCommandOutput` — a
+ * caller's own hand-built report string (an `err.message`, a path) — through
+ * the same env-value redaction and home-scrubbing every other reported
+ * string gets. `describeRunFailure` needed this for its own empty-output
+ * fallbacks; callers assembling report strings outside a captured child
+ * process (#248's `update.ts` registry-read errors) need the identical
+ * guarantee, so it is exported rather than kept as a private closure.
+ */
+export function sanitiseForReport(text: string, opts: SummariseOptions = {}): string {
+  return scrubHome(redactEnvValues(text, opts.env ?? process.env), opts.home ?? os.homedir());
+}
+
 function firstSentence(value: string, limit = MAX_REASON_CHARS): string {
   const single = value.replace(/\s+/g, ' ').trim();
   return single.length > limit ? `${single.slice(0, limit - 1)}…` : single;
@@ -358,8 +371,7 @@ export function describeRunFailure(err: unknown, opts: SummariseOptions = {}): R
   // reporting that alone tells the operator to retry a transient blip when the
   // real fact is a half-applied install. Partial output is still surfaced, but
   // as detail behind the terminal condition, never in place of it.
-  const sanitise = (text: string): string =>
-    scrubHome(redactEnvValues(text, opts.env ?? process.env), opts.home ?? os.homedir());
+  const sanitise = (text: string): string => sanitiseForReport(text, opts);
 
   let reason: string;
   if (spawnFailed) {

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -115,6 +115,45 @@ function defaultApply(): boolean {
   return resolveRepairConsent({ env: process.env, isTty: Boolean(process.stdin.isTTY) }).reconcile;
 }
 
+/** The subset of `spawnSync`'s return shape `describeSpawnOutcome` needs. */
+export interface RawSpawnResult {
+  status: number | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  error?: NodeJS.ErrnoException;
+  signal?: NodeJS.Signals | null;
+}
+
+/**
+ * Translate a raw spawnSync-shaped result into `{status, output}`, preserving
+ * WHY the command did not run cleanly (#248).
+ *
+ * `spawnSync` reports a missing binary AND a timeout identically —
+ * `status: null`, no stdout/stderr — and only `result.error.code` (ENOENT /
+ * ETIMEDOUT) or `result.signal` (the kill signal) tell them apart. The old
+ * `status: r.status ?? 1` collapsed both into "the command ran and exited 1",
+ * which sends an operator chasing a config problem that was never there —
+ * the same trap `validateOpenClawConfig` already avoids explicitly.
+ *
+ * Pulled out as its own function because `defaultRunCommand` cannot be driven
+ * through a real spawn under Jest — it is gated both by its own
+ * `JEST_WORKER_ID` check and by `resolveRepairConsent`, which is
+ * unconditionally hostile under Jest by design (repair-consent.ts). This
+ * seam is pure and needs neither.
+ */
+export function describeSpawnOutcome(command: string, r: RawSpawnResult): { status: number; output: string } {
+  if (r.error) {
+    const code = r.error.code;
+    if (code === 'ENOENT') return { status: 1, output: `openclaw binary not found (ENOENT): ${command}` };
+    if (code === 'ETIMEDOUT') return { status: 1, output: `openclaw command timed out: ${command}` };
+    return { status: 1, output: `spawn failed (${code ?? 'unknown error'}): ${command} — ${r.error.message}` };
+  }
+  if (r.signal) {
+    return { status: 1, output: `openclaw command killed by signal ${r.signal}: ${command}` };
+  }
+  return { status: r.status ?? 1, output: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
 /**
  * The default openclaw executor. GUARDED: never spawns under a Jest worker or
  * without the explicit reconcile consent env, mirroring the gateway-restart
@@ -133,7 +172,7 @@ export function defaultRunCommand(argv: string[]): { status: number; output: str
     timeout: 120000,
     env: { ...process.env },
   });
-  return { status: r.status ?? 1, output: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+  return describeSpawnOutcome(`openclaw ${argv.join(' ')}`, r);
 }
 
 function defaultPruneDir(home: string, dirName: string): void {

--- a/src/types/huggingface-transformers.d.ts
+++ b/src/types/huggingface-transformers.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Ambient module for the optional @huggingface/transformers dependency.
+ *
+ * The package is intentionally optional (scan-only / edge installs must not
+ * require the ~349MB ML stack). TypeScript still typechecks dynamic imports
+ * of it in worker entrypoints, so CI `npm ci` environments that skip or fail
+ * the optional install must not fail `tsc` with TS2307.
+ *
+ * Runtime behaviour is unchanged: missing package still throws at import time
+ * and is handled by the workers' existing load-error paths.
+ */
+declare module '@huggingface/transformers' {
+  // Minimal surface used by ShieldCortex workers. Keep this loose on purpose —
+  // we do not vendor the full upstream type graph.
+  export const env: {
+    allowRemoteModels: boolean;
+    allowLocalModels: boolean;
+    cacheDir: string;
+    [key: string]: unknown;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function pipeline(...args: any[]): Promise<any>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const transformers: any;
+  export default transformers;
+}

--- a/src/types/huggingface-transformers.d.ts
+++ b/src/types/huggingface-transformers.d.ts
@@ -6,6 +6,16 @@
  * of it in worker entrypoints, so CI `npm ci` environments that skip or fail
  * the optional install must not fail `tsc` with TS2307.
  *
+ * TRADE-OFF, stated plainly: an exact-name ambient module SHADOWS the real
+ * package's own types even when the package IS installed — every consumer is
+ * typechecked against the surface below, not upstream's. This declaration must
+ * therefore stay in lock-step with actual usage (embeddings/worker.ts and
+ * defence/judge/worker.ts are the only consumers; both go through dynamic
+ * import behind load-error handling). Do NOT add a static import of this
+ * module elsewhere expecting upstream types — you will silently get these.
+ * If a future consumer needs the real type surface, delete this file and
+ * scope the optional-dep fallback to the dynamic-import call sites instead.
+ *
  * Runtime behaviour is unchanged: missing package still throws at import time
  * and is handled by the workers' existing load-error paths.
  */


### PR DESCRIPTION
Closes #248.\n\n## Summary\n- Redact child process output before update step failures reach the terminal.\n- Distinguish unreadable/malformed OpenClaw installs registry from genuine not-installed.\n- Preserve ENOENT/timeout/nonzero provenance in OpenClaw reconcile command execution.\n- Surface npm registry lookup failure reasons.\n- Report denied legacy extension purge errno instead of swallowing it.\n\n## Verification\n- `npm run build:ts` — pass.\n- Focused #248 gate: 6 suites passed, 37 tests passed.\n- Independent exact-diff Claude review: VERDICT APPROVE.\n\n## Notes\n- Item 6 from #248 remains a separate exit-code policy decision.\n- The defended `maybePrintDashboardHint` swallow is intentionally unchanged.