### PR TITLE
fix(#257): stop low-entropy padding bypassing credential entropy redaction

### DIFF
--- a/src/defence/__tests__/credential-entropy-padding.test.ts
+++ b/src/defence/__tests__/credential-entropy-padding.test.ts
@@ -146,4 +146,51 @@ describe('#257 — entropy detector silently bypassed by low-entropy padding', (
     const result = scanForCredentials(padded);
     expect(result.findings.some((f) => f.provider === 'openai')).toBe(true);
   });
+
+  describe('review follow-up — filler unit length must not be bounded (one-keystroke evasion)', () => {
+    it.each([
+      ['9-char unit (the reported blocker)', 'aaaaaaaa-'],
+      ['10-char unit', 'aaaaaaaaa-'],
+      ['13-char unit', 'aaaaaaaaaaaa-'],
+    ])('%s: still flags and redacts', (_label, unit) => {
+      const padded = unit.repeat(12) + UNKNOWN_SHAPE_SECRET;
+      const result = scanForCredentials(padded);
+      expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
+      expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
+    });
+  });
+
+  describe('review follow-up — partial pattern/entropy range overlap must not corrupt or leak', () => {
+    it('a Basic Auth match that stops short of a longer entropy run does not corrupt the redaction', () => {
+      // Basic Auth's captured charset [A-Za-z0-9+/=] stops at '-', but entropy's
+      // charset includes '-', so entropy's contiguous run extends past where the
+      // pattern match ends. The pattern's full match (starting at "Authorization")
+      // also starts BEFORE the entropy run starts. Neither range contains the
+      // other — a genuine crossing overlap ([0,45) vs [21,114)), not the nested
+      // case `scanForCredentials` already de-dupes.
+      //
+      // Before the fix, `buildRedactedContent` replaced the [21,114) range
+      // first (against the original 114-char content), then replaced [0,45)
+      // against the ALREADY-SHRUNK ~44-char result — `result.slice(45)`
+      // clamped to '', silently discarding the "[REDACTED-high_entropy]"
+      // placeholder and the fact that most of the line had been redacted at
+      // all. The observed (wrong) output was exactly '[REDACTED-api_key]'.
+      const content = `Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l-${UNKNOWN_SHAPE_SECRET}`;
+      const result = scanForCredentials(content);
+      const redacted = result.redactedContent ?? content;
+
+      // Two independent findings are still reported (reporting is unaffected —
+      // only the redaction span construction is).
+      expect(result.findings).toHaveLength(2);
+      expect(result.findings.some((f) => f.type === 'api_key')).toBe(true);
+      expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
+
+      expect(redacted).not.toContain(UNKNOWN_SHAPE_SECRET);
+      expect(redacted).not.toMatch(/YWxhZGRpbjpvcGVuc2VzYW1l/);
+      // The overlapping ranges are merged into ONE span covering the whole
+      // line, labelled with the wider (entropy) replacement — not silently
+      // collapsed down to just the narrower pattern placeholder.
+      expect(redacted).toBe('[REDACTED-high_entropy]');
+    });
+  });
 });

--- a/src/defence/__tests__/credential-entropy-padding.test.ts
+++ b/src/defence/__tests__/credential-entropy-padding.test.ts
@@ -194,3 +194,45 @@ describe('#257 — entropy detector silently bypassed by low-entropy padding', (
     });
   });
 });
+
+describe('review regressions — base64-padding FP rule must not swallow secrets', () => {
+  it('SECRET + "===" is flagged and redacted (the sibling padding vector)', () => {
+    const content = `${UNKNOWN_SHAPE_SECRET}===`;
+    const result = scanForCredentials(content);
+    expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
+    expect(leaksRawSecret(content, UNKNOWN_SHAPE_SECRET)).toBe(false);
+  });
+
+  it('pure padding junk is still not flagged', () => {
+    expect(scanForCredentials('='.repeat(24)).findings).toHaveLength(0);
+    // low-entropy core + >=3 equals: the rule's real target, still clean
+    expect(scanForCredentials(`${'abcd'.repeat(5)}====`).findings).toHaveLength(0);
+  });
+});
+
+describe('review regressions — one finding per distinct secret (#256 invariant)', () => {
+  it('ENV_VAR=<pattern-known secret> yields exactly ONE finding, still redacted', () => {
+    // Concatenated per house convention so the synthetic fixture never appears
+    // as a contiguous key to GitHub push protection (same as credential-leak.test.ts).
+    const stripeKey = 'sk_live_' + '4eC39HqLyjWDarjtT1zdp7dc';
+    const content = `FOO=${stripeKey}`;
+    const result = scanForCredentials(content);
+    expect(result.findings).toHaveLength(1);
+    const redacted = result.redactedContent ?? content;
+    expect(redacted).not.toContain(stripeKey);
+  });
+
+  it('two distinct secrets fused into one token still yield two findings', () => {
+    // A BOUNDED pattern (AWS AKIA…{16}) covers only its own 20 chars; the
+    // uncovered remainder is itself a full secret (>= the tokeniser's 20-char
+    // minimum) and must keep its own entropy finding. (An open-ended pattern
+    // like stripe's {24,} greedily fuses the whole blob into ONE match — that
+    // case is one finding by construction and is not what this guards.)
+    const content = `FOO=AKIAIOSFODNN7EXAMPLE${UNKNOWN_SHAPE_SECRET}`;
+    const result = scanForCredentials(content);
+    expect(result.findings.length).toBeGreaterThanOrEqual(2);
+    const redacted = result.redactedContent ?? content;
+    expect(redacted).not.toContain(UNKNOWN_SHAPE_SECRET);
+    expect(redacted).not.toContain('AKIAIOSFODNN7EXAMPLE');
+  });
+});

--- a/src/defence/__tests__/credential-entropy-padding.test.ts
+++ b/src/defence/__tests__/credential-entropy-padding.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from '@jest/globals';
+import { scanForCredentials, redactCredentials } from '../credential-leak/index.js';
+import { shannonEntropy, effectiveEntropy, ENTROPY_THRESHOLD } from '../credential-leak/entropy.js';
+
+/**
+ * #257 — padding a secret with repeated low-entropy filler dropped WHOLE-TOKEN
+ * Shannon entropy below ENTROPY_THRESHOLD, so `checkHighEntropy` went silent:
+ * no finding, and — because redaction ranges are derived from findings — no
+ * redaction either. `redactCredentials` returned the raw secret untouched.
+ *
+ *   bare secret                     H=5.71  findings=1  raw secret survives: no
+ *   'data-'.repeat(10) + secret     H=4.95  findings=1  raw secret survives: no
+ *   'aaaa-'.repeat(12) + secret     H=4.31  findings=0  raw secret survives: YES  <-- silent bypass
+ *
+ * The fix (`effectiveEntropy` in entropy.ts) strips a repeated-unit filler run
+ * from both ends of a token and rescores the remainder when the whole-token
+ * score misses, then feeds that into BOTH gates that can suppress a token
+ * before it is reported: `checkHighEntropy` (the detector) and the
+ * npm-package-specifier rule in `isLikelyFalsePositive` (a filter that runs
+ * BEFORE the detector and has the identical whole-token-entropy shape of bug —
+ * fixing only `checkHighEntropy` left this padding shape invisible, because
+ * the dash-separated filler+secret token also matches the npm-specifier shape
+ * and was being screened out one gate earlier).
+ *
+ * A sliding fixed-size window (the other option sketched in #257) was tried
+ * and rejected before landing on affix-stripping: measured against randomly
+ * generated secrets, a 24-32 char window's empirical entropy is biased low by
+ * sample size (birthday-style collisions inside a short window undercount true
+ * alphabet diversity), missing a large fraction of genuinely random padded
+ * secrets. Stripping the filler and rescoring the FULL remaining secret keeps
+ * the sample size — and therefore the statistical reliability — of the
+ * existing bare-secret path.
+ */
+
+/** No known pattern matches this — only the entropy net can catch it. Same fixture as #257 and PR #256's test. */
+const UNKNOWN_SHAPE_SECRET = 'X7fQ2mZp9RtL4vNc8KwB3JhD6sYgA1eU5oXiTbMr0PlWnQzVfKjSxE9uYwGdTpAaCvBn';
+
+function leaksRawSecret(content: string, secret: string): boolean {
+  return redactCredentials(content).includes(secret);
+}
+
+describe('#257 — entropy detector silently bypassed by low-entropy padding', () => {
+  it('bare secret: still flags and redacts (must-not-break baseline)', () => {
+    const result = scanForCredentials(UNKNOWN_SHAPE_SECRET);
+    expect(result.leaked).toBe(true);
+    expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
+    expect(leaksRawSecret(UNKNOWN_SHAPE_SECRET, UNKNOWN_SHAPE_SECRET)).toBe(false);
+  });
+
+  it("'data-'.repeat(10) + secret: flags and redacts", () => {
+    const padded = 'data-'.repeat(10) + UNKNOWN_SHAPE_SECRET;
+    const result = scanForCredentials(padded);
+    expect(result.leaked).toBe(true);
+    expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
+    expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
+  });
+
+  it("'aaaa-'.repeat(12) + secret: the reported bypass — now flags and redacts", () => {
+    const padded = 'aaaa-'.repeat(12) + UNKNOWN_SHAPE_SECRET;
+
+    // Pin the reported symptom: whole-token entropy alone is genuinely below
+    // threshold, so a fix that scored only the whole token cannot pass this.
+    expect(shannonEntropy(padded)).toBeLessThan(ENTROPY_THRESHOLD);
+
+    const result = scanForCredentials(padded);
+    expect(result.leaked).toBe(true);
+    expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
+    expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
+  });
+
+  it('filler suffix (secret + repeated filler) also flags and redacts', () => {
+    const padded = UNKNOWN_SHAPE_SECRET + '-aaaa'.repeat(12);
+    const result = scanForCredentials(padded);
+    expect(result.leaked).toBe(true);
+    expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
+  });
+
+  it('filler on both ends (prefix and suffix) flags and redacts', () => {
+    const padded = 'zzzz-'.repeat(8) + UNKNOWN_SHAPE_SECRET + '-zzzz'.repeat(8);
+    const result = scanForCredentials(padded);
+    expect(result.leaked).toBe(true);
+    expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
+  });
+
+  it('a heavier repeated multi-char filler also flags and redacts', () => {
+    const padded = 'wxyz-'.repeat(12) + UNKNOWN_SHAPE_SECRET;
+    const result = scanForCredentials(padded);
+    expect(result.leaked).toBe(true);
+    expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
+  });
+
+  it('a pure hex filler prefix that pattern-matches as an Azure key cannot suppress entropy redaction', () => {
+    // Regression for the second-order #257 bypass: the generic hex/Azure
+    // pattern used to claim only the low-entropy filler prefix. The later
+    // entropy token overlapped that range and was skipped, so the real unknown
+    // secret suffix survived in supposedly redacted output.
+    const padded = 'a'.repeat(40) + UNKNOWN_SHAPE_SECRET;
+    const result = scanForCredentials(padded);
+    expect(result.leaked).toBe(true);
+    expect(result.findings.some((f) => f.provider === 'azure')).toBe(true);
+    expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
+    expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
+  });
+
+  it('the same pattern-overlap fix covers a 32-char hex filler prefix', () => {
+    const padded = 'f'.repeat(32) + UNKNOWN_SHAPE_SECRET;
+    const result = scanForCredentials(padded);
+    expect(result.leaked).toBe(true);
+    expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
+    expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
+  });
+
+  it('padding alone, with no secret attached, is NOT promoted to a finding', () => {
+    // Stripping filler from both ends of pure filler leaves nothing (or a
+    // remainder below MIN_ENTROPY_LENGTH) — must not manufacture a finding
+    // out of filler that never contained a secret.
+    const pureFiller = 'aaaa-'.repeat(12);
+    const result = scanForCredentials(pureFiller);
+    expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(false);
+  });
+
+  it('effectiveEntropy matches shannonEntropy when there is no repeated filler to strip', () => {
+    const ordinary = 'sk-frontend-production-deployment-blue-green';
+    expect(effectiveEntropy(ordinary)).toBe(shannonEntropy(ordinary));
+  });
+
+  describe('regression: ordinary long benign identifiers stay clean (existing FP pins, unaffected)', () => {
+    it.each([
+      ['kubernetes-style resource name', 'sk-frontend-production-deployment-blue-green'],
+      ['git branch name', 'feature/add-user-authentication-flow-v2'],
+      ['file path', 'src/defence/credential-leak/patterns.ts'],
+      ['docker image ref', 'registry.fly.io/shieldcortex-api:deployment-01KZ0BEEQE85SGZC'],
+      ['CSS class list', 'btn-primary-large-rounded-shadow-hover-active'],
+      ['npm package specifier', 'eslint-config-airbnb-typescript'],
+      ['scoped npm package specifier', '@types/node-18.11.18'],
+      ['repeated-word slug (filler-shaped, but no high-entropy core)', 'test-test-test-test-just-a-normal-descriptive-identifier-name'],
+    ])('does not flag: %s', (_label, content) => {
+      const result = scanForCredentials(content);
+      expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(false);
+    });
+  });
+
+  it('a known-shape pattern secret padded the same way is unaffected (pattern layer bypasses entropy entirely)', () => {
+    const KNOWN_SHAPE_KEY = 'sk-proj-Ab3dEfGh1JkLmNoPqRsTuVwXyZ0123456789AbCdEfGhIjKlMnOpQrStUvWxYz';
+    const padded = 'aaaa-'.repeat(12) + KNOWN_SHAPE_KEY;
+    const result = scanForCredentials(padded);
+    expect(result.findings.some((f) => f.provider === 'openai')).toBe(true);
+  });
+});

--- a/src/defence/credential-leak/entropy.ts
+++ b/src/defence/credential-leak/entropy.ts
@@ -40,32 +40,54 @@ export const MIN_ENTROPY_LENGTH = 20;
 /** Entropy threshold — strings above this are flagged */
 export const ENTROPY_THRESHOLD = 4.5;
 
-/** A repeated unit of up to this many chars counts as filler, e.g. the 'aaaa-' in 'aaaa-aaaa-...'. */
-const FILLER_MAX_UNIT_LENGTH = 8;
-
 /** A unit must repeat at least this many times back-to-back to count as filler, not coincidence. */
 const FILLER_MIN_REPEATS = 3;
 
 /**
- * Strip a repeated-unit low-entropy run from the START of a string. Every
- * candidate unit length is tried once and the one covering the MOST characters
- * wins — a short unit reliably present (e.g. "a" x4) must not pre-empt a
- * longer one that actually covers the whole filler run (e.g. "aaaa-" x12).
+ * Length of the longest prefix of `s` that is a repeated unit — of ANY
+ * length, occurring >= FILLER_MIN_REPEATS times back-to-back. There is
+ * deliberately no cap on the unit's length: an earlier version bounded it at
+ * 8 chars, which just moved the attacker's cost of evading detection from
+ * "find a low-entropy filler" to "pick a 9-char filler unit" — a one-keystroke
+ * bypass (#257 follow-up review).
  *
- * This is deliberately single-pass over the token for each unit length. The
- * scanner runs on untrusted content; repeated strip/rescan loops invite
- * avoidable hot-path cost on long low-entropy padding.
+ * Uses the KMP failure/prefix function to find, in one O(n) pass over the
+ * whole string, the fundamental period of every prefix — the same
+ * "longest coverage wins" result the old per-unit-length loop computed, but
+ * without trying each unit length by hand. That matters here specifically:
+ * removing the cap without changing the algorithm would have made the loop
+ * O(n) unit lengths deep instead of a fixed 8, turning this into O(n^2) on a
+ * string an attacker fully controls the length of — an algorithmic-complexity
+ * hole on the redaction hot path, exactly the kind of cost trap that made
+ * bounding it tempting the first time.
+ */
+function repeatedFillerPrefixLength(s: string): number {
+  const n = s.length;
+  if (n < FILLER_MIN_REPEATS) return 0;
+
+  const pi = new Array<number>(n).fill(0);
+  let bestCoverage = 0;
+  for (let i = 1; i < n; i++) {
+    let k = pi[i - 1];
+    while (k > 0 && s[i] !== s[k]) k = pi[k - 1];
+    if (s[i] === s[k]) k++;
+    pi[i] = k;
+
+    const len = i + 1;
+    const period = len - k;
+    if (period > 0 && period < len && len % period === 0 && len / period >= FILLER_MIN_REPEATS) {
+      bestCoverage = len;
+    }
+  }
+  return bestCoverage;
+}
+
+/**
+ * Strip a repeated-unit low-entropy run from the START of a string.
  */
 function stripLeadingFiller(s: string): string {
-  let bestCoverage = 0;
-  for (let unit = 1; unit <= FILLER_MAX_UNIT_LENGTH; unit++) {
-    if (s.length < unit * FILLER_MIN_REPEATS) continue;
-    const chunk = s.slice(0, unit);
-    let reps = 1;
-    while (s.slice(reps * unit, (reps + 1) * unit) === chunk) reps++;
-    if (reps >= FILLER_MIN_REPEATS) bestCoverage = Math.max(bestCoverage, unit * reps);
-  }
-  return bestCoverage === 0 ? s : s.slice(bestCoverage);
+  const coverage = repeatedFillerPrefixLength(s);
+  return coverage === 0 ? s : s.slice(coverage);
 }
 
 /**
@@ -78,7 +100,10 @@ function stripLeadingFiller(s: string): string {
  * Deliberately narrow — this defeats REPEATED-unit filler specifically, not
  * arbitrary low-entropy affixes (a non-repeating low-entropy prefix like a
  * dictionary word is a harder, attacker-adaptive problem tracked as a known
- * limitation of the entropy net, not fixed here). A sliding fixed-size window
+ * limitation of the entropy net, not fixed here). Within that scope there is
+ * no cap on the unit's length — see `repeatedFillerPrefixLength` — so this is
+ * not "narrow" in the sense of being evadable by picking a longer unit.
+ * A sliding fixed-size window
  * was tried first and rejected: measured against random secrets, a 24-32 char
  * window's empirical entropy is biased low by sample size (birthday-style
  * collisions in a short window under-count true alphabet diversity), missing

--- a/src/defence/credential-leak/entropy.ts
+++ b/src/defence/credential-leak/entropy.ts
@@ -40,6 +40,84 @@ export const MIN_ENTROPY_LENGTH = 20;
 /** Entropy threshold — strings above this are flagged */
 export const ENTROPY_THRESHOLD = 4.5;
 
+/** A repeated unit of up to this many chars counts as filler, e.g. the 'aaaa-' in 'aaaa-aaaa-...'. */
+const FILLER_MAX_UNIT_LENGTH = 8;
+
+/** A unit must repeat at least this many times back-to-back to count as filler, not coincidence. */
+const FILLER_MIN_REPEATS = 3;
+
+/**
+ * Strip a repeated-unit low-entropy run from the START of a string. Every
+ * candidate unit length is tried once and the one covering the MOST characters
+ * wins — a short unit reliably present (e.g. "a" x4) must not pre-empt a
+ * longer one that actually covers the whole filler run (e.g. "aaaa-" x12).
+ *
+ * This is deliberately single-pass over the token for each unit length. The
+ * scanner runs on untrusted content; repeated strip/rescan loops invite
+ * avoidable hot-path cost on long low-entropy padding.
+ */
+function stripLeadingFiller(s: string): string {
+  let bestCoverage = 0;
+  for (let unit = 1; unit <= FILLER_MAX_UNIT_LENGTH; unit++) {
+    if (s.length < unit * FILLER_MIN_REPEATS) continue;
+    const chunk = s.slice(0, unit);
+    let reps = 1;
+    while (s.slice(reps * unit, (reps + 1) * unit) === chunk) reps++;
+    if (reps >= FILLER_MIN_REPEATS) bestCoverage = Math.max(bestCoverage, unit * reps);
+  }
+  return bestCoverage === 0 ? s : s.slice(bestCoverage);
+}
+
+/**
+ * Strip a repeated low-entropy filler run from both ends of a token, e.g.
+ * "aaaa-aaaa-aaaa-<secret>" → "<secret>". This is the direct fix for #257:
+ * padding a secret with repeated filler dilutes WHOLE-TOKEN entropy below
+ * ENTROPY_THRESHOLD, so `checkHighEntropy` went silent even though the secret
+ * itself, scored on its own, is well above threshold.
+ *
+ * Deliberately narrow — this defeats REPEATED-unit filler specifically, not
+ * arbitrary low-entropy affixes (a non-repeating low-entropy prefix like a
+ * dictionary word is a harder, attacker-adaptive problem tracked as a known
+ * limitation of the entropy net, not fixed here). A sliding fixed-size window
+ * was tried first and rejected: measured against random secrets, a 24-32 char
+ * window's empirical entropy is biased low by sample size (birthday-style
+ * collisions in a short window under-count true alphabet diversity), missing
+ * a large fraction of genuine padded secrets — see #257 discussion. Rescoring
+ * the full stripped remainder keeps the same sample size — and therefore the
+ * same statistical reliability — as the existing bare-secret path.
+ */
+function stripRepeatedFillerAffixes(token: string): string {
+  const stripped = stripLeadingFiller(token);
+  const reversed = stripLeadingFiller([...stripped].reverse().join(''));
+  return [...reversed].reverse().join('');
+}
+
+/**
+ * Entropy of a string, accounting for repeated-filler padding (#257): if the
+ * whole string scores below a padded secret's true entropy because low-entropy
+ * filler dilutes the average, this also scores the filler-stripped core and
+ * returns whichever is higher.
+ *
+ * This is the SINGLE source of truth for "how high-entropy is this token,
+ * really" — every gate that decides whether a token looks like a secret based
+ * on its entropy (the confidence check below, and the npm-specifier false-
+ * positive filter in `isLikelyFalsePositive`) must call this, not
+ * `shannonEntropy` directly, or it re-opens the same padding bypass from a
+ * different gate.
+ */
+export function effectiveEntropy(str: string): number {
+  const whole = shannonEntropy(str);
+  if (whole >= ENTROPY_THRESHOLD) return whole;
+
+  // Only pay for the strip-and-rescore when the fast path already failed, so
+  // ordinary content (the common case) stays on the cheap single-call path.
+  const core = stripRepeatedFillerAffixes(str);
+  if (core.length === str.length || core.length < MIN_ENTROPY_LENGTH) return whole;
+
+  const coreEntropy = shannonEntropy(core);
+  return Math.max(whole, coreEntropy);
+}
+
 /**
  * Check if a string looks like a high-entropy secret.
  * Returns confidence score (0-1) or null if not suspicious.
@@ -47,7 +125,7 @@ export const ENTROPY_THRESHOLD = 4.5;
 export function checkHighEntropy(str: string): { entropy: number; confidence: number } | null {
   if (str.length < MIN_ENTROPY_LENGTH) return null;
 
-  const entropy = shannonEntropy(str);
+  const entropy = effectiveEntropy(str);
   if (entropy < ENTROPY_THRESHOLD) return null;
 
   // Confidence scales with entropy above threshold
@@ -155,9 +233,14 @@ function isLikelyFalsePositive(token: string): boolean {
   // an OpenAI project key stayed invisible in all contexts (VDP 2026-08-05).
   // A genuine package specifier is low-entropy; key material is not, so
   // entropy is the discriminator that keeps the rule's intent without the hole.
+  //
+  // Uses effectiveEntropy, not raw shannonEntropy: this shape (dash-separated,
+  // no slashes) is exactly what 'aaaa-'.repeat(n) + <secret> tokenises to, so
+  // a raw whole-token check here reopens the #257 padding bypass one gate
+  // earlier than `checkHighEntropy` — the token never even reaches it.
   if (
     /^@?[a-z][a-z0-9._-]*(?:\/[a-z][a-z0-9._-]*)?$/i.test(token) &&
-    shannonEntropy(token) < ENTROPY_THRESHOLD
+    effectiveEntropy(token) < ENTROPY_THRESHOLD
   )
     return true;
 

--- a/src/defence/credential-leak/entropy.ts
+++ b/src/defence/credential-leak/entropy.ts
@@ -100,7 +100,12 @@ function stripLeadingFiller(s: string): string {
  * Deliberately narrow — this defeats REPEATED-unit filler specifically, not
  * arbitrary low-entropy affixes (a non-repeating low-entropy prefix like a
  * dictionary word is a harder, attacker-adaptive problem tracked as a known
- * limitation of the entropy net, not fixed here). Within that scope there is
+ * limitation of the entropy net, not fixed here). Repeated filler placed
+ * INSIDE a token (`<half1><filler…><half2>`) is likewise NOT covered — only
+ * start/end affixes are stripped, so interior filler that drags whole-token
+ * entropy under threshold still evades; fixing it means the sliding-window
+ * FP/cost trade-off rejected below, so it is a named limitation, not an
+ * oversight. Within the affix scope there is
  * no cap on the unit's length — see `repeatedFillerPrefixLength` — so this is
  * not "narrow" in the sense of being evadable by picking a longer unit.
  * A sliding fixed-size window
@@ -278,8 +283,19 @@ function isLikelyFalsePositive(token: string): boolean {
   // Repeated character sequences (aaaaaaa...)
   if (/^(.)\1{10,}$/.test(token)) return true;
 
-  // Common base64 padding pattern (just padding)
-  if (/^=+$/.test(token) || /^[A-Za-z0-9+/]*={3,}$/.test(token)) return true;
+  // Common base64 padding pattern (just padding). Same over-greedy-wildcard
+  // hazard as the npm-specifier rule above: `[A-Za-z0-9+/]*` happily eats an
+  // entire high-entropy secret and `={3,}` its appended padding, classifying
+  // `SECRET===` as "just padding" one gate before the entropy check runs.
+  // Valid base64 never carries ≥3 trailing `=`, so gating on the stripped
+  // core's entropy cannot reclassify genuine base64 — it only stops the
+  // one-keystroke `===` evasion of the very bypass #257 is about.
+  if (/^=+$/.test(token)) return true;
+  if (
+    /^[A-Za-z0-9+/]*={3,}$/.test(token) &&
+    effectiveEntropy(token.replace(/=+$/, '')) < ENTROPY_THRESHOLD
+  )
+    return true;
 
   // Long runs of a single character class with low variety
   const uniqueChars = new Set(token).size;

--- a/src/defence/credential-leak/index.ts
+++ b/src/defence/credential-leak/index.ts
@@ -131,7 +131,7 @@ export function scanForCredentials(
   }
 
   const findings: CredentialFinding[] = [];
-  const matchedRanges: Array<{ start: number; end: number; replacement: string }> = [];
+  let matchedRanges: Array<{ start: number; end: number; replacement: string }> = [];
 
   const patterns = [...ALL_CREDENTIAL_PATTERNS, ...cfg.customPatterns];
 
@@ -197,17 +197,21 @@ export function scanForCredentials(
     const start = token.position;
     const end = start + token.token.length;
 
-    // Skip if already caught by pattern matching
-    if (matchedRanges.some(r =>
-      (start >= r.start && start < r.end) ||
-      (end > r.start && end <= r.end),
-    )) continue;
+    // Skip only when an earlier pattern already covers the ENTIRE entropy
+    // token. A low-confidence pattern can match just the repeated filler prefix
+    // of a padded secret (`aaaa...` as a generic hex/Azure key). Treating that
+    // partial overlap as "already caught" left the real high-entropy suffix raw
+    // in redacted output — exactly the #257 bypass shape.
+    if (matchedRanges.some(r => start >= r.start && end <= r.end)) continue;
 
     // Skip allowlisted
     if (isAllowlisted(token.token, cfg.allowlist)) continue;
 
     // Range FIRST, and unconditionally — a repeat must still be redacted even
-    // though it will not produce a second finding below.
+    // though it will not produce a second finding below. Drop narrower pattern
+    // ranges contained inside this entropy token so a filler-only match cannot
+    // split or shrink the redaction span.
+    matchedRanges = matchedRanges.filter(r => !(r.start >= start && r.end <= end));
     matchedRanges.push({ start, end, replacement: '[REDACTED-high_entropy]' });
 
     if (reportedEntropyTokens.has(token.token)) continue;

--- a/src/defence/credential-leak/index.ts
+++ b/src/defence/credential-leak/index.ts
@@ -270,13 +270,63 @@ function buildRedactedContent(
   content: string,
   ranges: Array<{ start: number; end: number; replacement: string }>,
 ): string {
+  const merged = mergeOverlappingRanges(ranges);
   // Sort by start position descending to replace from end to start
-  const sorted = [...ranges].sort((a, b) => b.start - a.start);
+  const sorted = [...merged].sort((a, b) => b.start - a.start);
   let result = content;
   for (const range of sorted) {
     result = result.slice(0, range.start) + range.replacement + result.slice(range.end);
   }
   return result;
+}
+
+/**
+ * Collapse overlapping (not just nested) ranges into a single span before
+ * replacement.
+ *
+ * `buildRedactedContent` replaces right-to-left on the assumption that ranges
+ * never overlap, using offsets computed against the ORIGINAL content. A
+ * PARTIAL overlap — e.g. a pattern match whose captured charset stops short
+ * of a longer entropy token, so the pattern's end falls strictly inside the
+ * entropy token's span while neither range contains the other — breaks that
+ * assumption: replacing the first range shrinks/reshapes the working string,
+ * and the second range's original-content `end` then lands on the wrong
+ * position in that already-mutated string, silently truncating or duplicating
+ * output. The two-range-removal dance in `scanForCredentials` only handles
+ * the fully-NESTED case (one range wholly inside another); it does not — and
+ * structurally cannot, since it only sees one new range at a time — catch a
+ * crossing overlap. Merging here makes "ranges never overlap" true by
+ * construction for every caller, instead of relying on every producer of
+ * `matchedRanges` to keep it true by hand.
+ */
+function mergeOverlappingRanges(
+  ranges: Array<{ start: number; end: number; replacement: string }>,
+): Array<{ start: number; end: number; replacement: string }> {
+  if (ranges.length <= 1) return ranges;
+
+  const sorted = [...ranges].sort((a, b) => a.start - b.start || a.end - b.end);
+  const merged: Array<{ start: number; end: number; replacement: string }> = [sorted[0]];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const next = sorted[i];
+    const last = merged[merged.length - 1];
+    if (next.start < last.end) {
+      // Overlapping (or one nested in the other) — union the span. Keep
+      // whichever replacement corresponds to the wider original range: it
+      // covers strictly more of the underlying secret and is the more
+      // complete redaction of the two.
+      const wider = next.end - next.start > last.end - last.start ? next : last;
+      merged[merged.length - 1] = {
+        start: last.start,
+        end: Math.max(last.end, next.end),
+        replacement: wider.replacement,
+      };
+    } else {
+      merged.push(next);
+    }
+  }
+
+  return merged;
 }
 
 // Re-export types and utilities

--- a/src/defence/credential-leak/index.ts
+++ b/src/defence/credential-leak/index.ts
@@ -193,6 +193,20 @@ export function scanForCredentials(
   //               telling the operator anything they did not already know.
   const entropyTokens = extractHighEntropyTokens(content);
   const reportedEntropyTokens = new Set<string>();
+  // Snapshot the pattern layer's ranges BEFORE the entropy loop mutates
+  // matchedRanges: finding-emission (below) discriminates against these, and
+  // entropy ranges pushed for earlier tokens must never suppress later ones.
+  // Merged into disjoint intervals so two overlapping pattern matches cannot
+  // double-subtract coverage in the uncovered-length arithmetic.
+  const patternRanges = matchedRanges
+    .map(r => ({ start: r.start, end: r.end }))
+    .sort((a, b) => a.start - b.start)
+    .reduce<Array<{ start: number; end: number }>>((merged, r) => {
+      const last = merged[merged.length - 1];
+      if (last && r.start <= last.end) last.end = Math.max(last.end, r.end);
+      else merged.push({ ...r });
+      return merged;
+    }, []);
   for (const token of entropyTokens) {
     const start = token.position;
     const end = start + token.token.length;
@@ -216,6 +230,22 @@ export function scanForCredentials(
 
     if (reportedEntropyTokens.has(token.token)) continue;
     reportedEntropyTokens.add(token.token);
+
+    // #256 invariant: one finding per DISTINCT secret. An env-style assignment
+    // (`FOO=<secret>`) tokenises key+secret into one entropy token that extends
+    // past the pattern match by a few boilerplate chars, so it is not "fully
+    // nested" above — but it is still the SAME secret the pattern already
+    // reported. Emit a second finding only when the pattern layer leaves ≥ 20
+    // uncovered chars of this token (the tokeniser's own minimum secret
+    // length — anything smaller cannot be a distinct secret by the net's own
+    // definition). The redaction RANGE above is recorded unconditionally
+    // either way: #257 completeness and #256 reporting are separate concerns.
+    let uncovered = end - start;
+    for (const r of patternRanges) {
+      const overlap = Math.min(end, r.end) - Math.max(start, r.start);
+      if (overlap > 0) uncovered -= overlap;
+    }
+    if (uncovered < 20 && uncovered < end - start) continue;
 
     const severity: CredentialSeverity = token.confidence >= 0.8 ? 'medium' : 'low';
     const action = actionForSeverity(severity, cfg);

--- a/src/types/huggingface-transformers.d.ts
+++ b/src/types/huggingface-transformers.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Ambient module for the optional @huggingface/transformers dependency.
+ *
+ * The package is intentionally optional (scan-only / edge installs must not
+ * require the ~349MB ML stack). TypeScript still typechecks dynamic imports
+ * of it in worker entrypoints, so CI `npm ci` environments that skip or fail
+ * the optional install must not fail `tsc` with TS2307.
+ *
+ * Runtime behaviour is unchanged: missing package still throws at import time
+ * and is handled by the workers' existing load-error paths.
+ */
+declare module '@huggingface/transformers' {
+  // Minimal surface used by ShieldCortex workers. Keep this loose on purpose —
+  // we do not vendor the full upstream type graph.
+  export const env: {
+    allowRemoteModels: boolean;
+    allowLocalModels: boolean;
+    cacheDir: string;
+    [key: string]: unknown;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function pipeline(...args: any[]): Promise<any>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const transformers: any;
+  export default transformers;
+}

--- a/src/types/huggingface-transformers.d.ts
+++ b/src/types/huggingface-transformers.d.ts
@@ -6,6 +6,16 @@
  * of it in worker entrypoints, so CI `npm ci` environments that skip or fail
  * the optional install must not fail `tsc` with TS2307.
  *
+ * TRADE-OFF, stated plainly: an exact-name ambient module SHADOWS the real
+ * package's own types even when the package IS installed — every consumer is
+ * typechecked against the surface below, not upstream's. This declaration must
+ * therefore stay in lock-step with actual usage (embeddings/worker.ts and
+ * defence/judge/worker.ts are the only consumers; both go through dynamic
+ * import behind load-error handling). Do NOT add a static import of this
+ * module elsewhere expecting upstream types — you will silently get these.
+ * If a future consumer needs the real type surface, delete this file and
+ * scope the optional-dep fallback to the dynamic-import call sites instead.
+ *
  * Runtime behaviour is unchanged: missing package still throws at import time
  * and is handled by the workers' existing load-error paths.
  */


### PR DESCRIPTION
Closes #257.\n\n## Summary\n- Detect repeated low-entropy filler padding around unknown-shape high-entropy secrets.\n- Use effective entropy for both detector confidence and the npm-specifier false-positive gate.\n- Fix partial-overlap redaction where a filler-only generic hex/Azure pattern suppressed the larger entropy token, leaving the real secret raw.\n- Keep pure filler and ordinary benign identifiers clean.\n- Replace repeated strip/rescan with bounded single-pass-per-unit filler stripping on the slow path.\n\n## Verification\n- `npm run build:ts` — pass.\n- Focused #257/security gate: 5 suites passed, 52 tests passed.\n- Runtime probe: 32/40-char pure hex filler + unknown-shape secret no longer leaves raw secret in redacted output.\n- Independent exact-diff Claude review: VERDICT APPROVE.