### PR TITLE
fix(audit): bind plane, instance, hook, nonce, seq and actionKey (#224)

### DIFF
--- a/plugins/openclaw/__tests__/interceptor.audit-fields.test.ts
+++ b/plugins/openclaw/__tests__/interceptor.audit-fields.test.ts
@@ -5,6 +5,10 @@ import {
   DEFAULT_CONFIG,
   type InterceptAuditEntry,
 } from '../interceptor.js';
+import {
+  attachEnforcementBinding,
+  hasRequiredBinding,
+} from '../../../src/defence/iron-dome/enforcement-binding.js';
 
 /**
  * Task 2: the InterceptAuditEntry emitted by the interceptor must carry the full
@@ -96,5 +100,56 @@ describe('InterceptAuditEntry — full pipeline metadata', () => {
     expect(autoDenied!.sensitivityLevel).toBe('INTERNAL');
     expect(autoDenied!.fragmentationScore).toBeNull();
     expect(autoDenied!.pipelineDurationMs).toBe(0);
+  });
+});
+
+describe('#224 InterceptAuditEntry is bound when bindAudit is injected', () => {
+  it('stamps plane, hook, nonce, seq and an action key on a gated Bash call', async () => {
+    const { mkdtempSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const home = mkdtempSync(join(tmpdir(), 'sc-224-int-'));
+    const prevAudit = process.env.SHIELDCORTEX_AUDIT_DIR;
+    process.env.SHIELDCORTEX_AUDIT_DIR = join(home, '.shieldcortex', 'audit');
+    const captured: InterceptAuditEntry[] = [];
+    const { handleToolCall } = createInterceptor(
+      DEFAULT_CONFIG,
+      makeStubPipeline() as never,
+      {
+        evaluateToolCall: () => ({
+          decision: 'block',
+          severity: 'catastrophic',
+          family: 'exec',
+          action: 'execute_command',
+          reason: 'blocked',
+          signals: ['recursive-force-delete'],
+        }),
+        bindAudit: (entry, args) => attachEnforcementBinding(entry, {
+          plane: 'action_guard',
+          hookName: 'before_tool_call',
+          pluginId: 'shieldcortex-realtime',
+          tool: entry.tool,
+          args: args ?? {},
+          home,
+        }),
+        onAuditEntry: (e) => captured.push(e),
+      },
+    );
+
+    await handleToolCall({
+      toolName: 'Bash',
+      arguments: { command: 'rm -rf /', description: 'clean tmp' },
+    }).catch(() => { /* catastrophic throws after the audit row is written */ });
+
+    const denied = captured.find((e) => e.action === 'auto_deny' || e.outcome === 'auto_denied' || e.action === 'require_approval');
+    expect(denied).toBeDefined();
+    expect(hasRequiredBinding(denied)).toBe(true);
+    expect(denied!.plane).toBe('action_guard');
+    expect(denied!.hookName).toBe('before_tool_call');
+    expect(denied!.actionKey).toContain('rm');
+    expect(denied!.actionKey).not.toMatch(/clean tmp/);
+    if (prevAudit === undefined) delete process.env.SHIELDCORTEX_AUDIT_DIR;
+    else process.env.SHIELDCORTEX_AUDIT_DIR = prevAudit;
+    try { rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
   });
 });

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -100,6 +100,19 @@ type DefenceModule = {
     notification: unknown,
     deps: { channels: NotifyChannelLike[]; timeoutMs?: number },
   ) => Promise<{ deliveredVia: string | null; attempts: Array<{ channel: string; result: { delivered: boolean; reason?: string } }> }>;
+  /** #224 — stamp binding fields on a realtime audit row. Optional so an
+   *  older installed package degrades to unbound records, not a crash. */
+  attachEnforcementBinding?: (
+    entry: Record<string, unknown>,
+    ctx: {
+      plane: 'action_guard' | 'conversation_firewall';
+      hookName: string;
+      pluginId: string;
+      tool?: string;
+      args?: Record<string, unknown>;
+      actionKey?: string;
+    },
+  ) => Record<string, unknown>;
 };
 
 let runtimePromise: Promise<OpenClawRuntime> | null = null;
@@ -2036,10 +2049,24 @@ const MIN_NOVELTY_CHARS = 40;
 async function auditLog(entry: Record<string, unknown>): Promise<boolean> {
   const dir = auditDir();
   try {
+    const hookName = typeof entry.hook === 'string' && entry.hook ? entry.hook : 'llm_input';
+    const plane = hookName === 'before_tool_call' ? 'action_guard' : 'conversation_firewall';
+    let bound = entry;
+    try {
+      const defenceMod = await getDefenceModule();
+      if (typeof defenceMod?.attachEnforcementBinding === 'function') {
+        bound = defenceMod.attachEnforcementBinding(entry, {
+          plane,
+          hookName,
+          pluginId: 'shieldcortex-realtime',
+          actionKey: typeof entry.actionKey === 'string' ? entry.actionKey : `conversation:${hookName}`,
+        });
+      }
+    } catch { /* older package / bind failure — write the unbound row */ }
     await fs.mkdir(dir, { recursive: true });
     await fs.appendFile(
       path.join(dir, `realtime-${new Date().toISOString().slice(0, 10)}.jsonl`),
-      JSON.stringify(entry) + "\n",
+      JSON.stringify(bound) + "\n",
     );
     return true;
   } catch (err) {
@@ -3448,6 +3475,15 @@ export default {
             cloudBaseUrl: (scConfig as any).cloudBaseUrl ?? 'https://api.shieldcortex.ai',
             cloudEnabled: (scConfig as any).cloudEnabled ?? false,
           }),
+          bindAudit: typeof (defenceMod as any).attachEnforcementBinding === 'function'
+            ? (entry, args) => (defenceMod as any).attachEnforcementBinding(entry, {
+                plane: 'action_guard',
+                hookName: 'before_tool_call',
+                pluginId: 'shieldcortex-realtime',
+                tool: entry.tool,
+                args: args ?? {},
+              }) as typeof entry
+            : undefined,
         });
         const guardState = interceptorConfig.actionGuard?.enabled
           ? (interceptorConfig.actionGuard.enforce ? 'Action Guard: enforce' : 'Action Guard: warn')

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -202,6 +202,14 @@ export interface InterceptAuditEntry {
   escalated?: { by: 'session-taint'; from: string; to: string; reason: string };
   /** Files the reviewed-script allowlist exempted from folding (#189). */
   reviewedScripts?: string[];
+  /** #224 — binding fields. Present once the host injects `bindAudit`. */
+  plane?: 'action_guard' | 'conversation_firewall';
+  gatewayInstanceId?: string;
+  hookName?: string;
+  pluginId?: string;
+  nonce?: string;
+  seq?: number;
+  actionKey?: string;
 }
 
 const WATCHED_TOOLS = ['remember', 'mcp__memory__remember'] as const;
@@ -798,6 +806,10 @@ interface InterceptorOptions {
    *  limit, so a looping or compromised agent must not be able to spend it
    *  without bound. Exhausting it yields no judge, which yields a hold. */
   maxJudgeCallsPerMinute?: number;
+  /** #224 — stamp plane/instance/hook/nonce/seq/actionKey before the row hits
+   *  disk. Injected from `shieldcortex/defence` at runtime so this plugin does
+   *  not grow a second schema. Absent = unbound (older installed package). */
+  bindAudit?: (entry: InterceptAuditEntry, args?: Record<string, unknown>) => InterceptAuditEntry;
 }
 
 /** How many recent tool NAMES the judge is told about. Names only, never
@@ -820,6 +832,9 @@ export function createInterceptor(
   const rateLimiter = new RateLimiter(options?.maxPromptsPerMinute ?? 5);
   const log = config.logger ?? { info: console.log, warn: console.warn };
   const onAuditEntry = options?.onAuditEntry;
+  const bindAudit = options?.bindAudit;
+  /** Args of the in-flight tool call — used only to mint #224 actionKey. */
+  let lastCallArgs: Record<string, unknown> | undefined;
   const actionGuardCfg: ActionGuardConfig = config.actionGuard ?? { enabled: true, enforce: true, autoApprove: [] };
   const evaluateToolCall = options?.evaluateToolCall;
   const broker = options?.broker;
@@ -831,8 +846,9 @@ export function createInterceptor(
   const recentTools: string[] = [];
 
   function emitAudit(entry: InterceptAuditEntry): void {
-    writeAuditEntry(entry);
-    onAuditEntry?.(entry);
+    const bound = bindAudit ? bindAudit(entry, lastCallArgs) : entry;
+    writeAuditEntry(bound);
+    onAuditEntry?.(bound);
   }
 
   function guardAuditBase(toolName: string, v: ToolGuardVerdictLike, preview: string): Omit<InterceptAuditEntry, 'action' | 'outcome'> {
@@ -1249,6 +1265,7 @@ export function createInterceptor(
   }
 
   async function handleToolCall(context: ToolCallContext): Promise<void> {
+    lastCallArgs = context.arguments;
     // Remember the NAME only. This is the entirety of what the approval broker's
     // judge will ever learn about the session — see buildSessionSummary.
     noteToolForSession(context.toolName);

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -61,6 +61,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 
 const DEFAULT_ACTION_GUARD = { enabled: true, enforce: true, autoApprove: [], auditAllows: true };
 
+/** #224 binding module, loaded once in main. Null when dist predates it. */
+let bindingMod = null;
+
 function loadActionGuardConfig() {
   try {
     const configPath = join(homedir(), '.shieldcortex', 'config.json');
@@ -224,6 +227,19 @@ async function loadApprovals() {
     return typeof mod.consumeApproval === 'function' && typeof mod.recordPending === 'function'
       ? mod
       : null;
+  } catch {
+    return null;
+  }
+}
+
+/** #224 — optional: stamp binding fields. Missing dist degrades to unbound. */
+async function loadBinding() {
+  const distRoot = process.env.SHIELDCORTEX_DIST_ROOT ?? resolve(here, '..', 'dist');
+  try {
+    const mod = await import(
+      pathToFileURL(resolve(distRoot, 'defence', 'iron-dome', 'enforcement-binding.js')).href
+    );
+    return typeof mod.attachEnforcementBinding === 'function' ? mod : null;
   } catch {
     return null;
   }
@@ -754,7 +770,7 @@ function writeTerminalOutcomeAudit(toolName, verdict, toolInput, action, outcome
     redactedAuditArgs(toolName, toolInput),
     action,
     outcome,
-    extra,
+    { ...extra, intentArgs: toolInput },
   );
 }
 
@@ -1185,7 +1201,7 @@ function writeAuditEntry(toolName, verdict, args, action, outcome, extra = {}) {
       return;
     }
     const date = new Date().toISOString().slice(0, 10);
-    const entry = {
+    let entry = {
       type: 'intercept',
       origin: 'claude-code-hook',
       tool: toolName,
@@ -1219,6 +1235,19 @@ function writeAuditEntry(toolName, verdict, args, action, outcome, extra = {}) {
       // #139 adds `permissionMode` + its outcome the same way.
       ...extra,
     };
+    delete entry.intentArgs;
+    if (bindingMod?.attachEnforcementBinding) {
+      try {
+        const intentArgs = extra.intentArgs && typeof extra.intentArgs === 'object' ? extra.intentArgs : args;
+        entry = bindingMod.attachEnforcementBinding(entry, {
+          plane: 'action_guard',
+          hookName: 'PreToolUse',
+          pluginId: 'claude-code-hook',
+          tool: toolName,
+          args: intentArgs && typeof intentArgs === 'object' ? intentArgs : {},
+        });
+      } catch { /* write the unbound row rather than drop the event */ }
+    }
     if (!appendFileNoFollow(join(auditDir, `realtime-${date}.jsonl`), JSON.stringify(entry) + '\n')) {
       noteAuditSinkFailure(`append failed for realtime-${date}.jsonl`);
       return;
@@ -1271,7 +1300,7 @@ async function emitApprovalRequired(toolName, auditVerdict, toolInput, permissio
       redactedAuditArgs(toolName, toolInput),
       action,
       'asked',
-      { ...baseExtra, ...(safePermissionMode(permissionMode) ? { permissionMode: safePermissionMode(permissionMode) } : {}), ...broker },
+      { ...baseExtra, intentArgs: toolInput, ...(safePermissionMode(permissionMode) ? { permissionMode: safePermissionMode(permissionMode) } : {}), ...broker },
     );
     emitDecision('ask', safeDiagnosticApprovalReason(reason));
     return;
@@ -1402,6 +1431,7 @@ process.stdin.on('readable', () => {
 
 process.stdin.on('end', async () => {
   try {
+    bindingMod = await loadBinding();
     const cfg = loadActionGuardConfig();
     if (!cfg.enabled) process.exit(0);
 
@@ -1462,6 +1492,7 @@ process.stdin.on('end', async () => {
     }
 
     const guard = await loadGuard();
+    bindingMod = await loadBinding();
     if (!guard) {
       await handleDegradedGuard(toolName, toolInput, cfg, 'missing dist build', permissionMode, await getNotify(), baseExtra); // always exits
       return;

--- a/scripts/replay-guard-corpus.mts
+++ b/scripts/replay-guard-corpus.mts
@@ -2,7 +2,7 @@
  * Replay a corpus of real Action Guard stop events through `evaluateToolCall`
  * and report how many still stop.
  *
- * Usage:  npx tsx scripts/replay-guard-corpus.mts <corpus.json> [--by-threat] [--show <threat>]
+ * Usage:  npx tsx scripts/replay-guard-corpus.mts <corpus.json> [--by-threat] [--show <threat>] [--fp-intents]
  *
  * The corpus is a JSON array of audit records of the shape
  *   { ts, action, threats[], severity, preview }
@@ -18,6 +18,7 @@
 
 import { readFileSync } from 'node:fs';
 import { evaluateToolCall } from '../src/defence/iron-dome/tool-action-guard.js';
+import { actionKeyForToolCall } from '../src/defence/iron-dome/enforcement-binding.js';
 
 interface CorpusEvent {
   ts: string;
@@ -65,6 +66,7 @@ let stops = 0;
 let passes = 0;
 let unparsed = 0;
 const perThreat = new Map<string, { total: number; nowPasses: number }>();
+const perIntent = new Map<string, { total: number; stops: number }>();
 const escalations: Array<{ was: string; now: string; preview: string }> = [];
 const relaxed: string[] = [];
 const stillStopping: string[] = [];
@@ -75,6 +77,11 @@ for (const ev of corpus) {
   const v = evaluateToolCall(parsed.tool, parsed.args);
   const nowStops = v.decision !== 'allow';
   if (nowStops) stops++; else passes++;
+  const intent = actionKeyForToolCall(parsed.tool, parsed.args as Record<string, unknown>);
+  const intentSlot = perIntent.get(intent) ?? { total: 0, stops: 0 };
+  intentSlot.total++;
+  if (nowStops) intentSlot.stops++;
+  perIntent.set(intent, intentSlot);
   for (const t of ev.threats) {
     const e = perThreat.get(t) ?? { total: 0, nowPasses: 0 };
     e.total++;
@@ -101,6 +108,12 @@ const replayed = stops + passes;
 console.log(`corpus: ${corpus.length} events (${unparsed} unparseable, ${replayed} replayed)`);
 console.log(`still stops:  ${stops}  (${((stops / replayed) * 100).toFixed(1)}%)`);
 console.log(`now passes:   ${passes}  (${((passes / replayed) * 100).toFixed(1)}%)`);
+if (flags.includes('--fp-intents')) {
+  const intents = perIntent.size;
+  const intentStops = [...perIntent.values()].filter((e) => e.stops > 0).length;
+  console.log(`distinct intents: ${intents}  (records collapsed by actionKey)`);
+  console.log(`intents that still stop: ${intentStops}  (${intents ? ((intentStops / intents) * 100).toFixed(1) : '0.0'}%)`);
+}
 
 if (flags.includes('--by-threat')) {
   console.log('\nper original threat  (now-passes / events carrying that threat)');

--- a/src/__tests__/pre-tool-hook.test.ts
+++ b/src/__tests__/pre-tool-hook.test.ts
@@ -183,6 +183,14 @@ describe('pre-tool hook — WS1 enforce-by-default on Claude Code', () => {
     expect(entry.origin).toBe('claude-code-hook');
     expect(entry.tool).toBe('Bash');
     expect(entry.firewallResult).toBe('ACTION_GUARD');
+    // #224 — a deny that cannot name its plane is not evidence.
+    expect(entry.plane).toBe('action_guard');
+    expect(entry.hookName).toBe('PreToolUse');
+    expect(entry.pluginId).toBe('claude-code-hook');
+    expect(entry.nonce).toMatch(/^[0-9a-f]{32}$/);
+    expect(entry.seq).toBeGreaterThan(0);
+    expect(entry.actionKey).toContain('rm');
+    expect(entry.gatewayInstanceId).toEqual(expect.any(String));
   });
 
   it('audits the ask verdict so unattended denials are visible', async () => {

--- a/src/defence/index.ts
+++ b/src/defence/index.ts
@@ -80,6 +80,16 @@ export {
 // Tool Action Guard — gates what the agent DOES at runtime (shell/file/network/git).
 export { evaluateToolCall, classifyFamily, isCriticalPath, normaliseToolName, detectScriptInvocation } from './iron-dome/tool-action-guard.js';
 export type { ToolGuardVerdict, ToolGuardDecision, ToolGuardSeverity, ToolFamily, ToolGuardOptions } from './iron-dome/tool-action-guard.js';
+export {
+  REQUIRED_BINDING_FIELDS,
+  hasRequiredBinding,
+  attachEnforcementBinding,
+  actionKeyForToolCall,
+  nextAuditSeq,
+  resolveInstanceId,
+  bindRuntimeInspectPayload,
+} from './iron-dome/enforcement-binding.js';
+export type { EnforcementPlane, EnforcementBinding, BindingContext } from './iron-dome/enforcement-binding.js';
 // Session action lease (#227) — the freeze that binds every self, not just the
 // careful one. Pure core + fs layer exported through the same runtime seam as
 // `evaluateToolCall` so both enforcement planes reach ONE implementation.

--- a/src/defence/iron-dome/__tests__/enforcement-binding-224.test.ts
+++ b/src/defence/iron-dome/__tests__/enforcement-binding-224.test.ts
@@ -1,0 +1,150 @@
+/**
+ * #224 — enforcement evidence must be bound: plane, instance, hook, plugin,
+ * nonce, seq, and a stable action key. A record that cannot say what it is
+ * about cannot feed Athena's acceptance contract or Veronica's FP benchmark.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  REQUIRED_BINDING_FIELDS,
+  hasRequiredBinding,
+  attachEnforcementBinding,
+  actionKeyForToolCall,
+  nextAuditSeq,
+  resolveInstanceId,
+  bindRuntimeInspectPayload,
+  type EnforcementPlane,
+} from '../enforcement-binding.js';
+
+describe('#224 enforcement binding schema', () => {
+  it('names every field the acceptance contract needs', () => {
+    expect([...REQUIRED_BINDING_FIELDS].sort()).toEqual(
+      ['actionKey', 'gatewayInstanceId', 'hookName', 'nonce', 'plane', 'pluginId', 'seq'].sort(),
+    );
+  });
+
+  it('fails when any required field is dropped', () => {
+    const full = attachEnforcementBinding(
+      { type: 'intercept', tool: 'Bash' },
+      { plane: 'action_guard', hookName: 'before_tool_call', pluginId: 'shieldcortex-realtime', tool: 'Bash', args: { command: 'git status' } },
+    );
+    expect(hasRequiredBinding(full)).toBe(true);
+    for (const field of REQUIRED_BINDING_FIELDS) {
+      const clone = { ...full };
+      delete (clone as Record<string, unknown>)[field];
+      expect(hasRequiredBinding(clone)).toBe(false);
+    }
+  });
+
+  it('rejects an unknown plane', () => {
+    const row = attachEnforcementBinding(
+      {},
+      { plane: 'not_a_plane' as EnforcementPlane, hookName: 'x', pluginId: 'p' },
+    );
+    expect(hasRequiredBinding(row)).toBe(false);
+  });
+});
+
+describe('#224 action key — same intent collapses, different intents do not', () => {
+  it('excludes the mutable description (and timeout) so retries of the same command collapse', () => {
+    const a = actionKeyForToolCall('Bash', { command: 'git push origin feat/x', description: 'push the branch', timeout: 120000 });
+    const b = actionKeyForToolCall('Bash', { command: 'git push origin feat/y', description: 'push again', timeout: 60000 });
+    expect(a).toBe(b);
+    expect(a).toContain('git');
+    expect(a).not.toMatch(/description|push the branch|120000/);
+  });
+
+  it('classifies paths so /tmp/foo and /tmp/bar are one intent', () => {
+    expect(actionKeyForToolCall('Bash', { command: 'rm -rf /tmp/clone-a' }))
+      .toBe(actionKeyForToolCall('Bash', { command: 'rm -rf /tmp/clone-b' }));
+    expect(actionKeyForToolCall('Bash', { command: 'rm -rf /tmp/clone-a' }))
+      .not.toBe(actionKeyForToolCall('Bash', { command: 'rm -rf /etc/passwd' }));
+  });
+
+  it('classifies targeted PIDs so kill -9 4021 and kill -9 9999 collapse', () => {
+    expect(actionKeyForToolCall('Bash', { command: 'kill -9 4021' }))
+      .toBe(actionKeyForToolCall('Bash', { command: 'kill -9 9999' }));
+    expect(actionKeyForToolCall('Bash', { command: 'kill -9 4021' }))
+      .not.toBe(actionKeyForToolCall('Bash', { command: 'killall sshd' }));
+  });
+
+  it('keeps force vs merged-delete as different intents', () => {
+    expect(actionKeyForToolCall('Bash', { command: 'git branch -D feat/a' }))
+      .not.toBe(actionKeyForToolCall('Bash', { command: 'git branch -d feat/a' }));
+    expect(actionKeyForToolCall('Bash', { command: 'git push --force origin main' }))
+      .not.toBe(actionKeyForToolCall('Bash', { command: 'git push origin main' }));
+  });
+
+  it('does not treat a Write of different files as the same intent class as a Bash delete', () => {
+    expect(actionKeyForToolCall('Write', { path: 'src/foo.ts' }))
+      .not.toBe(actionKeyForToolCall('Bash', { command: 'rm -rf src/foo.ts' }));
+  });
+});
+
+describe('#224 nonce / seq / instance', () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'sc-224-'));
+  });
+  afterEach(() => {
+    try { rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  it('mints a unique nonce per record', () => {
+    const a = attachEnforcementBinding({}, { plane: 'action_guard', hookName: 'PreToolUse', pluginId: 'claude-code-hook', home });
+    const b = attachEnforcementBinding({}, { plane: 'action_guard', hookName: 'PreToolUse', pluginId: 'claude-code-hook', home });
+    expect(a.nonce).toMatch(/^[0-9a-f]{32}$/);
+    expect(a.nonce).not.toBe(b.nonce);
+  });
+
+  it('seq is monotonic and durable across process-equivalent calls', () => {
+    const a = attachEnforcementBinding({}, { plane: 'conversation_firewall', hookName: 'llm_input', pluginId: 'shieldcortex-realtime', home });
+    const b = attachEnforcementBinding({}, { plane: 'conversation_firewall', hookName: 'llm_input', pluginId: 'shieldcortex-realtime', home });
+    expect(b.seq).toBe(a.seq + 1);
+    expect(nextAuditSeq(home)).toBe(b.seq + 1);
+  });
+
+  it('instance id is stable on a home and is persisted', () => {
+    const id1 = resolveInstanceId(home);
+    const id2 = resolveInstanceId(home);
+    expect(id1).toBe(id2);
+    expect(id1).toMatch(/^[0-9a-f-]{36}$/);
+    expect(existsSync(join(home, '.shieldcortex', 'instance-id'))).toBe(true);
+    expect(readFileSync(join(home, '.shieldcortex', 'instance-id'), 'utf8').trim()).toBe(id1);
+  });
+
+  it('gatewayInstanceId names the instance, not "any gateway"', () => {
+    const row = attachEnforcementBinding(
+      {},
+      { plane: 'action_guard', hookName: 'before_tool_call', pluginId: 'shieldcortex-realtime', home, gatewayPid: 4242 },
+    );
+    expect(row.gatewayInstanceId).toContain(resolveInstanceId(home));
+    expect(row.gatewayInstanceId).toContain('4242');
+  });
+});
+
+describe('#224 runtime inspect payload is bound to a host', () => {
+  it('stamps configPath, pid and timestamp onto the inspect JSON', () => {
+    const bound = bindRuntimeInspectPayload(
+      { healthy: true, plugin: 'shieldcortex-realtime' },
+      { configPath: '/tmp/scratch/openclaw.json', pid: 99, timestamp: '2026-08-13T16:00:00.000Z' },
+    );
+    expect(bound).toMatchObject({
+      healthy: true,
+      plugin: 'shieldcortex-realtime',
+      configPath: '/tmp/scratch/openclaw.json',
+      pid: 99,
+      timestamp: '2026-08-13T16:00:00.000Z',
+    });
+  });
+
+  it('still binds a non-object payload rather than dropping it', () => {
+    const bound = bindRuntimeInspectPayload('blocked', { configPath: '/cfg', pid: 1, timestamp: 't' });
+    expect(bound.configPath).toBe('/cfg');
+    expect(bound.pid).toBe(1);
+    expect(bound.payload).toBe('blocked');
+  });
+});

--- a/src/defence/iron-dome/enforcement-binding.ts
+++ b/src/defence/iron-dome/enforcement-binding.ts
@@ -1,0 +1,227 @@
+/**
+ * #224 — bind every enforcement record to a plane, a host, a hook and an intent.
+ *
+ * Audit rows that cannot say which plane produced them, which gateway they
+ * came from, or which intent they name cannot feed an acceptance contract or
+ * an FP rate. This is the one source of those fields. Writers (Claude hook,
+ * OpenClaw interceptor, conversation hooks) stamp; they do not invent a
+ * second schema.
+ *
+ * `actionKey` is NOT the approval hash. Approvals stay exact-command
+ * (`hashToolCall`) so approving `rm -rf /tmp/a` cannot release `/tmp/b`.
+ * The action key collapses path *classes* and volatile args so Veronica's
+ * FP denominator is distinct intents, not records.
+ */
+import { randomBytes, randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { mkdirSecure } from '../../setup/state-permissions.js';
+import { extractPath, extractUrl, normaliseToolName } from './tool-action-guard.js';
+
+export const REQUIRED_BINDING_FIELDS = [
+  'plane',
+  'gatewayInstanceId',
+  'hookName',
+  'pluginId',
+  'nonce',
+  'seq',
+  'actionKey',
+] as const;
+
+export type BindingField = (typeof REQUIRED_BINDING_FIELDS)[number];
+
+export type EnforcementPlane = 'action_guard' | 'conversation_firewall';
+
+const PLANES = new Set<string>(['action_guard', 'conversation_firewall']);
+
+export interface EnforcementBinding {
+  plane: EnforcementPlane;
+  gatewayInstanceId: string;
+  hookName: string;
+  pluginId: string;
+  nonce: string;
+  seq: number;
+  actionKey: string;
+}
+
+export interface BindingContext {
+  plane: EnforcementPlane;
+  hookName: string;
+  pluginId: string;
+  home?: string;
+  gatewayPid?: number;
+  tool?: string;
+  args?: Record<string, unknown>;
+  /** Override when the caller already knows the intent (conversation rows). */
+  actionKey?: string;
+}
+
+export function hasRequiredBinding(entry: unknown): boolean {
+  if (!entry || typeof entry !== 'object') return false;
+  const rec = entry as Record<string, unknown>;
+  if (!PLANES.has(String(rec.plane ?? ''))) return false;
+  for (const field of REQUIRED_BINDING_FIELDS) {
+    if (field === 'seq') {
+      if (typeof rec.seq !== 'number' || !Number.isInteger(rec.seq) || rec.seq < 1) return false;
+      continue;
+    }
+    const v = rec[field];
+    if (typeof v !== 'string' || v.length === 0) return false;
+  }
+  if (!/^[0-9a-f]{32}$/.test(String(rec.nonce))) return false;
+  return true;
+}
+
+export function attachEnforcementBinding<T extends Record<string, unknown>>(
+  entry: T,
+  ctx: BindingContext,
+): T & EnforcementBinding {
+  const home = ctx.home ?? homedir();
+  const instance = resolveInstanceId(home);
+  const gatewayInstanceId = ctx.gatewayPid
+    ? `${instance}:gw:${ctx.gatewayPid}`
+    : `${instance}:${ctx.plane === 'conversation_firewall' ? 'conversation' : ctx.hookName}`;
+  const actionKey = ctx.actionKey
+    ?? (ctx.tool ? actionKeyForToolCall(ctx.tool, ctx.args ?? {}) : `${ctx.plane}:${ctx.hookName}`);
+  const binding: EnforcementBinding = {
+    plane: ctx.plane,
+    gatewayInstanceId,
+    hookName: ctx.hookName,
+    pluginId: ctx.pluginId,
+    nonce: randomBytes(16).toString('hex'),
+    seq: nextAuditSeq(home),
+    actionKey,
+  };
+  return { ...entry, ...binding };
+}
+
+export function actionKeyForToolCall(tool: string, args: Record<string, unknown>): string {
+  const command = commandFromArgs(args);
+  if (command) return shapeCommand(command);
+  const path = extractPath(args);
+  if (path) return `${normaliseToolName(tool)}:${pathClass(path)}`;
+  const url = extractUrl(args);
+  if (url) return `${normaliseToolName(tool)}:${urlClass(url)}`;
+  return normaliseToolName(tool);
+}
+
+function commandFromArgs(args: Record<string, unknown>): string {
+  // Narrower than extractCommand: `code`/`input` are payload on many tools
+  // and must not become the intent key.
+  for (const key of ['command', 'cmd', 'script'] as const) {
+    const v = args[key];
+    if (typeof v === 'string' && v.trim()) return v;
+  }
+  return '';
+}
+
+function tokenize(cmd: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let quote: string | null = null;
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i];
+    if (quote) {
+      if (c === quote) quote = null;
+      else cur += c;
+      continue;
+    }
+    if (c === '"' || c === "'") { quote = c; continue; }
+    if (c === ' ' || c === '\t' || c === '\n') {
+      if (cur) { out.push(cur); cur = ''; }
+      continue;
+    }
+    cur += c;
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+function shapeCommand(cmd: string): string {
+  const tokens = tokenize(cmd);
+  const out: string[] = [];
+  let seenKill = false;
+  for (const raw of tokens) {
+    if (!raw) continue;
+    if (/^kill(?:all)?$/.test(raw)) { seenKill = true; out.push(raw); continue; }
+    if (raw.startsWith('-')) { out.push(raw); continue; }
+    if (seenKill && /^[0-9]+$/.test(raw)) { out.push('<pid>'); continue; }
+    out.push(classifyPositional(raw));
+  }
+  return out.join(' ');
+}
+
+function classifyPositional(tok: string): string {
+  if (looksLikeAbsPath(tok) || tok.startsWith('~/') || tok.startsWith('./') || tok.startsWith('../')) {
+    return pathClass(tok);
+  }
+  if (tok.includes('/') && /\.\w+$/.test(tok)) return pathClass(tok);
+  if (tok.includes('/')) return '<ref>';
+  if (/^[0-9a-f]{7,40}$/.test(tok)) return '<hash>';
+  return tok;
+}
+
+function looksLikeAbsPath(tok: string): boolean {
+  return tok.startsWith('/') || tok === '~';
+}
+
+export function pathClass(tok: string): string {
+  if (tok === '/' || tok === '/*' || tok === '/**') return '<root>';
+  if (tok === '~' || tok === '~/' || tok === '$HOME' || tok === '$HOME/') return '<home>';
+  if (/^\.[./]*$/.test(tok)) return '<cwd>';
+  if (/^(?:\/tmp|\/var\/tmp|\/private\/var\/folders)(?:\/|$)/i.test(tok)) return '<tmp>';
+  if (/^(?:~|\/Users\/|\/home\/)/.test(tok)) return '<home>';
+  if (/^\/(?:etc|usr|var|bin|sbin|opt|root|System|private\/etc)(?:\/|$)/.test(tok)) return '<sys>';
+  if (tok.startsWith('/')) return '<abs>';
+  return '<rel>';
+}
+
+function urlClass(url: string): string {
+  try {
+    const u = new URL(url);
+    return `<url:${u.protocol}//${u.hostname}>`;
+  } catch {
+    return '<url>';
+  }
+}
+
+export function resolveInstanceId(home: string = homedir()): string {
+  const dir = join(home, '.shieldcortex');
+  mkdirSecure(dir);
+  const file = join(dir, 'instance-id');
+  try {
+    if (existsSync(file)) {
+      const existing = readFileSync(file, 'utf8').trim();
+      if (/^[0-9a-f-]{36}$/i.test(existing)) return existing.toLowerCase();
+    }
+  } catch { /* mint a new one */ }
+  const id = randomUUID();
+  try { writeFileSync(file, `${id}\n`, { mode: 0o600 }); } catch { /* best-effort persist */ }
+  return id;
+}
+
+export function nextAuditSeq(home: string = homedir()): number {
+  const dir = join(home, '.shieldcortex', 'audit');
+  mkdirSecure(dir);
+  const file = join(dir, 'seq');
+  let n = 0;
+  try {
+    if (existsSync(file)) n = parseInt(readFileSync(file, 'utf8').trim(), 10) || 0;
+  } catch { n = 0; }
+  n += 1;
+  try { writeFileSync(file, `${n}\n`, { mode: 0o600 }); } catch { /* still return the next number */ }
+  return n;
+}
+
+export function bindRuntimeInspectPayload(
+  raw: unknown,
+  opts: { configPath: string; pid: number | null; timestamp: string },
+): Record<string, unknown> {
+  const stamp = { configPath: opts.configPath, pid: opts.pid, timestamp: opts.timestamp };
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return { ...(raw as Record<string, unknown>), ...stamp };
+  }
+  return { payload: raw, ...stamp };
+}

--- a/src/integrations/openclaw-runtime-inspect.ts
+++ b/src/integrations/openclaw-runtime-inspect.ts
@@ -1,0 +1,57 @@
+/**
+ * #224 — bind `openclaw plugins inspect --runtime --json` (or our stand-in)
+ * to the config path we actually read, the gateway pid, and a timestamp.
+ *
+ * The raw inspect payload is forgeable in both directions via
+ * OPENCLAW_CONFIG_PATH. Stamping the path, pid and time is what makes a
+ * payload about a host, not about any host.
+ */
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+
+import { bindRuntimeInspectPayload } from '../defence/iron-dome/enforcement-binding.js';
+import { defaultConfigPath } from './openclaw-config-validate.js';
+import { readRunningGatewayProcess } from './openclaw-gateway-process.js';
+
+export function openClawConfigPathForInspect(home: string = homedir()): string {
+  return defaultConfigPath(home);
+}
+
+export function buildBoundRuntimeInspect(opts: {
+  raw?: unknown;
+  home?: string;
+  pid?: number | null;
+  timestamp?: string;
+} = {}): Record<string, unknown> {
+  const home = opts.home ?? homedir();
+  const pid = opts.pid !== undefined ? opts.pid : (readRunningGatewayProcess(home)?.pid ?? process.pid);
+  return bindRuntimeInspectPayload(opts.raw ?? { source: 'shieldcortex' }, {
+    configPath: openClawConfigPathForInspect(home),
+    pid,
+    timestamp: opts.timestamp ?? new Date().toISOString(),
+  });
+}
+
+/** Best-effort: run OpenClaw's inspect if present, then bind. Never throws. */
+export function collectBoundRuntimeInspect(home: string = homedir()): Record<string, unknown> {
+  let raw: unknown = { source: 'shieldcortex', inspect: 'unavailable' };
+  try {
+    const r = spawnSync('openclaw', ['plugins', 'inspect', '--runtime', '--json'], {
+      encoding: 'utf8',
+      timeout: 8_000,
+      env: process.env,
+    });
+    if (r.status === 0 && r.stdout?.trim()) {
+      try { raw = JSON.parse(r.stdout); } catch { raw = { source: 'openclaw', stdout: r.stdout.slice(0, 2000) }; }
+    } else if (r.stderr) {
+      raw = { source: 'openclaw', error: r.stderr.slice(0, 500), status: r.status };
+    }
+  } catch (err) {
+    raw = { source: 'shieldcortex', inspect: 'unavailable', error: err instanceof Error ? err.message : String(err) };
+  }
+  return buildBoundRuntimeInspect({ raw, home });
+}
+
+export function printBoundRuntimeInspect(): void {
+  process.stdout.write(`${JSON.stringify(collectBoundRuntimeInspect(), null, 2)}\n`);
+}

--- a/src/setup/__tests__/skill-install-179.test.ts
+++ b/src/setup/__tests__/skill-install-179.test.ts
@@ -115,7 +115,7 @@ describe('#179 — the command the operator typed now exists', () => {
   it('the openclaw subcommand router carries a skill case and the usage names it', () => {
     const src = fs.readFileSync(path.join(repoRoot, 'src', 'setup', 'openclaw.ts'), 'utf-8');
     expect(src).toMatch(/case 'skill':/);
-    expect(src).toMatch(/openclaw <install\|uninstall\|status\|repair\|skill install>/);
+    expect(src).toMatch(/openclaw <install\|uninstall\|status\|repair\|inspect-runtime\|skill install>/);
   });
 
   it('update wires the resolved binary + acknowledge flag, and its skip names the install command', () => {

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -2226,6 +2226,11 @@ export async function handleOpenClawCommand(subcommand: string, extraArgs: strin
     case 'status':
       await openClawHookStatus();
       break;
+    case 'inspect-runtime': {
+      const { printBoundRuntimeInspect } = await import('../integrations/openclaw-runtime-inspect.js');
+      printBoundRuntimeInspect();
+      break;
+    }
     case 'repair':
       await repairOpenClawPlugin();
       break;
@@ -2246,7 +2251,7 @@ export async function handleOpenClawCommand(subcommand: string, extraArgs: strin
       break;
     }
     default:
-      console.log('Usage: shieldcortex openclaw <install|uninstall|status|repair|skill install>');
+      console.log('Usage: shieldcortex openclaw <install|uninstall|status|repair|inspect-runtime|skill install>');
       console.log('');
       console.log('Install options:');
       console.log('  --no-hooks              Skip hook installation (useful in Docker/CI)');


### PR DESCRIPTION
## Summary

Closes #224. Every enforcement audit record can now say **which plane, which host, which hook, and which intent** produced it. That unblocks Athena's acceptance contract and Veronica's FP benchmark (rate over distinct intents, not records).

## What landed

One source of truth: `attachEnforcementBinding` (`src/defence/iron-dome/enforcement-binding.ts`).

| Field | Role |
|---|---|
| `plane` | `action_guard` \| `conversation_firewall` |
| `gatewayInstanceId` | persisted install UUID + gateway pid when known |
| `hookName` | `before_tool_call` / `PreToolUse` / `llm_input` / … |
| `pluginId` | `shieldcortex-realtime` or `claude-code-hook` |
| `nonce` | per-record freshness |
| `seq` | durable monotonic counter (gap detection) |
| `actionKey` | intent class — **not** the approval hash |

`actionKey` collapses `description`/`timeout`, path classes (`/tmp/a` ≡ `/tmp/b`), and targeted PIDs. Approvals stay exact-command via `hashToolCall` so approving `rm -rf /tmp/a` cannot release `/tmp/b`.

Writers wired: OpenClaw interceptor (`bindAudit`), conversation `auditLog`, Claude PreToolUse hook (intent computed before redaction).

Also:
- `shieldcortex openclaw inspect-runtime` stamps `configPath`, `pid`, `timestamp` so `OPENCLAW_CONFIG_PATH` cannot forge a payload about a different host
- `replay-guard-corpus --fp-intents` prints the stop rate over distinct action keys

## Tests

- Schema test fails if any required field is dropped
- Property tests: same-intent collapses, different intents do not
- Interceptor + Claude hook deny rows carry the full binding
- 88 related tests green (binding, hook, interceptor, conversation-hardening)

## Harness

Transport still fail-open on audit write failure. Binding failure writes the unbound row rather than dropping the event or wedging the turn.