### PR TITLE
fix(setup): installer honesty leftovers (#214) and repair converge (#156)

### DIFF
--- a/src/__tests__/gateway-process-bound-evidence.test.ts
+++ b/src/__tests__/gateway-process-bound-evidence.test.ts
@@ -79,6 +79,28 @@ describe('parseRegistrationsSince — dated lines only, bounded below', () => {
     expect(parseRegistrationsSince(text, 0)).toHaveLength(0);
   });
 
+  it('#214 — attributes a journald unit[pid] so a CLI line is not the gateway', () => {
+    const iso = '2026-08-08T14:04:00.000Z';
+    const text = [
+      JSON.stringify({ time: iso, pid: 4242, message: '[shieldcortex] v4.47.32 registered (llm_input)' }),
+      `2026-08-08T14:04:01.000Z host shieldcortex[9999]: [shieldcortex] v4.50.0 registered (llm_input)`,
+      `2026-08-08T14:04:02.000Z host openclaw-gateway[4242]: [shieldcortex] v4.47.32 registered (llm_input)`,
+    ].join('\n');
+    const got = parseRegistrationsSince(text, Date.parse('2026-08-08T14:00:00.000Z'));
+    expect(got.map((s) => s.pid)).toEqual([4242, 9999, 4242]);
+    expect(got.map((s) => s.version)).toEqual(['4.47.32', '4.50.0', '4.47.32']);
+  });
+
+  it('#214 — running version ignores a registration whose pid is not the gateway', () => {
+    const iso = '2026-08-08T14:04:00.000Z';
+    const text = [
+      `${iso} host openclaw-gateway[111]: [shieldcortex] v4.47.32 registered (llm_input)`,
+      `${iso} host shieldcortex[999]: [shieldcortex] v4.50.0 registered (llm_input)`,
+    ].join('\n');
+    expect(parseRunningPluginVersionSince(text, Date.parse('2026-08-08T14:00:00.000Z'), 111)).toBe('4.47.32');
+    expect(parseRunningPluginVersionSince(text, Date.parse('2026-08-08T14:00:00.000Z'), 111)).not.toBe('4.50.0');
+  });
+
   it('findRegistrationSince returns null when the log dir is unreadable', () => {
     expect(findRegistrationSince(0, { logDir: '/definitely/not/a/dir' })).toBeNull();
   });

--- a/src/cli/__tests__/doctor-startup-intent-156.test.ts
+++ b/src/cli/__tests__/doctor-startup-intent-156.test.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { checkPluginStartupIntent, readPluginStartupIntent } from '../doctor.js';
+
+/**
+ * #156 — doctor/repair must statically see the aiquant silent-skip.
+ *
+ * A 2026.7.x gateway loads a plugin at boot only if the installed manifest
+ * says `activation.onStartup === true` or lists `hook` in
+ * `activation.onCapabilities`. A pre-fix copy on disk with onStartup:false
+ * is silently absent from every boot while doctor can still look green.
+ */
+
+let home: string;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-156-intent-'));
+});
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+function writeManifest(activation: Record<string, unknown>): string {
+  const dir = path.join(home, '.openclaw', 'extensions', 'shieldcortex-realtime');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'openclaw.plugin.json');
+  fs.writeFileSync(file, JSON.stringify({ id: 'shieldcortex-realtime', activation }, null, 2));
+  return file;
+}
+
+describe('#156 readPluginStartupIntent', () => {
+  it('reads onStartup and hook capability from the installed manifest', () => {
+    writeManifest({ onStartup: true, onCapabilities: ['hook'] });
+    const intent = readPluginStartupIntent(home);
+    expect(intent).toEqual({
+      onStartup: true,
+      hookCapability: true,
+      source: expect.stringContaining('openclaw.plugin.json'),
+    });
+  });
+
+  it('returns null when no installed manifest exists', () => {
+    expect(readPluginStartupIntent(home)).toBeNull();
+  });
+});
+
+describe('#156 doctor startup-intent check', () => {
+  it('fails a pre-fix manifest that declares onStartup:false and no hook capability', async () => {
+    writeManifest({ onStartup: false, hooks: ['llm_input'] });
+    const r = await checkPluginStartupIntent(home);
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/onStartup/i);
+    expect(r.fix).toMatch(/reinstall|repair/i);
+  });
+
+  it('passes the current manifest shape', async () => {
+    writeManifest({ onStartup: true, onCapabilities: ['hook'], hooks: ['llm_input'] });
+    const r = await checkPluginStartupIntent(home);
+    expect(r.status).toBe('pass');
+  });
+
+  it('is informational when no plugin is installed', async () => {
+    const r = await checkPluginStartupIntent(home);
+    expect(r.status).toBe('info');
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -35,7 +35,7 @@ import {
   evaluateEnforcementSupport,
   describeEnforcementSupport,
 } from '../integrations/openclaw-conversation-capability.js';
-import { parseRegistrationsSince } from '../integrations/openclaw-gateway-roster.js';
+import { parseRegistrationsSince, parseLogLinePid } from '../integrations/openclaw-gateway-roster.js';
 import { readRunningGatewayProcess } from '../integrations/openclaw-gateway-process.js';
 import { resolveSelfInstallDir } from '../setup/native-binding.js';
 import { getCanonicalSchema } from '../database/init.js';
@@ -3373,6 +3373,8 @@ export interface RunningPluginVersionDeps {
    * "running".
    */
   readGatewayProcessStartMs: () => number | null;
+  /** #214 — running gateway pid, so a CLI registration line is not quoted as the gateway. */
+  readGatewayPid?: () => number | null;
 }
 
 /**
@@ -3381,13 +3383,20 @@ export interface RunningPluginVersionDeps {
  * chronological (oldest → newest), so the final match is the current start's
  * registration. Returns null when no registration line is present.
  */
-export function parseRunningPluginVersion(journal: string): string | null {
+export function parseRunningPluginVersion(journal: string, gatewayPid?: number | null): string | null {
   // Matches "[shieldcortex] v4.47.8 registered (...)" including semver
   // pre-release/build suffixes. Global so we can walk to the final match.
   const re = /\[shieldcortex\]\s+v(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\s+registered/g;
   let match: RegExpExecArray | null;
   let last: string | null = null;
   while ((match = re.exec(journal)) !== null) {
+    if (gatewayPid != null) {
+      const lineStart = journal.lastIndexOf('\n', match.index) + 1;
+      const lineEnd = journal.indexOf('\n', match.index);
+      const line = journal.slice(lineStart, lineEnd < 0 ? journal.length : lineEnd);
+      const pid = parseLogLinePid(line);
+      if (pid != null && pid !== gatewayPid) continue;
+    }
     last = match[1];
   }
   return last;
@@ -3398,9 +3407,16 @@ export function parseRunningPluginVersion(journal: string): string | null {
  * count, and a line that cannot be dated cannot be called fresh. The unbounded
  * parser above remains for callers that genuinely want "newest ever".
  */
-export function parseRunningPluginVersionSince(journal: string, sinceMs: number): string | null {
+export function parseRunningPluginVersionSince(
+  journal: string,
+  sinceMs: number,
+  gatewayPid?: number | null,
+): string | null {
   const sightings = parseRegistrationsSince(journal, sinceMs);
-  return sightings.length > 0 ? sightings[sightings.length - 1].version : null;
+  const usable = gatewayPid == null
+    ? sightings
+    : sightings.filter((s) => s.pid == null || s.pid === gatewayPid);
+  return usable.length > 0 ? usable[usable.length - 1].version : null;
 }
 
 /**
@@ -3469,6 +3485,7 @@ export function realRunningPluginVersionDeps(home: string = os.homedir()): Runni
       return null;
     },
     readGatewayProcessStartMs: (): number | null => readRunningGatewayProcess(home)?.startedAtMs ?? null,
+    readGatewayPid: (): number | null => readRunningGatewayProcess(home)?.pid ?? null,
   };
 }
 
@@ -3514,9 +3531,10 @@ export async function checkOpenClawRunningPluginVersion(
     };
   }
 
+  const gatewayPid = deps.readGatewayPid?.() ?? null;
   const running = journal.preBounded
-    ? parseRunningPluginVersion(journal.text)
-    : parseRunningPluginVersionSince(journal.text, processStartMs);
+    ? parseRunningPluginVersion(journal.text, gatewayPid)
+    : parseRunningPluginVersionSince(journal.text, processStartMs, gatewayPid);
   if (!running) {
     const historic = journal.preBounded ? null : parseRunningPluginVersion(journal.text);
     return {
@@ -3547,6 +3565,65 @@ export async function checkOpenClawRunningPluginVersion(
       'Restart the OpenClaw gateway so it re-registers the on-disk plugin:\n' +
       `  ${gatewayRestartAdvice()}\n` +
       'Until then the live interceptor is the version shown as "running", not the one on disk.',
+  };
+}
+
+/**
+ * #156 — the aiquant silent-skip is a static property of the installed
+ * manifest. A 2026.7.x gateway will not load us at boot unless
+ * `activation.onStartup === true` or `activation.onCapabilities` lists `hook`.
+ */
+export function readPluginStartupIntent(home: string = os.homedir()): {
+  onStartup: boolean;
+  hookCapability: boolean;
+  source: string;
+} | null {
+  const candidates = [
+    path.join(home, '.openclaw', 'extensions', 'shieldcortex-realtime', 'openclaw.plugin.json'),
+  ];
+  for (const file of candidates) {
+    try {
+      if (!fs.existsSync(file)) continue;
+      const raw = JSON.parse(fs.readFileSync(file, 'utf-8')) as { activation?: { onStartup?: unknown; onCapabilities?: unknown } };
+      const act = raw.activation && typeof raw.activation === 'object' ? raw.activation : {};
+      const caps = Array.isArray(act.onCapabilities) ? act.onCapabilities : [];
+      return {
+        onStartup: act.onStartup === true,
+        hookCapability: caps.includes('hook'),
+        source: file,
+      };
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export async function checkPluginStartupIntent(home: string = os.homedir()): Promise<CheckResult> {
+  const label = 'OpenClaw plugin startup intent';
+  if (!fs.existsSync(path.join(home, '.openclaw'))) {
+    return { label, status: 'info', message: 'skipped (OpenClaw not detected)' };
+  }
+  const intent = readPluginStartupIntent(home);
+  if (!intent) {
+    return { label, status: 'info', message: 'skipped (no installed plugin manifest)' };
+  }
+  if (intent.onStartup && intent.hookCapability) {
+    return {
+      label,
+      status: 'pass',
+      message: `installed manifest declares onStartup + hook capability (${intent.source.replace(home, '~')})`,
+    };
+  }
+  return {
+    label,
+    status: 'fail',
+    message:
+      `installed plugin manifest will not load at gateway boot ` +
+      `(activation.onStartup=${intent.onStartup}, hook capability=${intent.hookCapability}) — ` +
+      `this is the aiquant silent-skip`,
+    fix:
+      'Reinstall the current plugin so the on-disk manifest has `activation.onStartup: true` and `onCapabilities: ["hook"]`: `shieldcortex repair` or `openclaw plugins install @drakon-systems/shieldcortex-realtime`.',
   };
 }
 
@@ -3882,6 +3959,7 @@ export async function runDoctor(
     checkOpenClawPluginLoadState,
     checkOpenClawConversationScanning,
     checkOpenClawRunningPluginVersion,
+    checkPluginStartupIntent,
     checkOpenClawPluginPackage,
     checkOpenClawDuplicateInstalls,
     checkOpenClawManagedPinDrift,

--- a/src/integrations/openclaw-gateway-roster.ts
+++ b/src/integrations/openclaw-gateway-roster.ts
@@ -57,6 +57,18 @@ function parseTimestamp(line: string): number | null {
   return Number.isFinite(ms) ? ms : null;
 }
 
+/** Journald `unit[pid]:` or a JSON `pid` field. Null when the line is anonymous. */
+export function parseLogLinePid(line: string): number | null {
+  try {
+    const obj = JSON.parse(line) as { pid?: unknown };
+    if (typeof obj.pid === 'number' && Number.isInteger(obj.pid) && obj.pid > 0) return obj.pid;
+  } catch { /* not JSON */ }
+  const m = /\b[\w.-]+\[(\d+)\]:/.exec(line);
+  if (!m) return null;
+  const pid = Number.parseInt(m[1], 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
 /**
  * Parse a single log line into a boot roster. PURE. Returns null when the line
  * is not a roster line.
@@ -198,6 +210,8 @@ const REGISTRATION_RE = /\[shieldcortex\]\s+v(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+
 export interface RegistrationSighting {
   version: string;
   atMs: number;
+  /** Process that emitted the line, when the log attributes one (#214). */
+  pid: number | null;
 }
 
 /**
@@ -212,7 +226,7 @@ export function parseRegistrationsSince(text: string, sinceMs: number): Registra
     if (!m) continue;
     const ts = parseTimestamp(line);
     if (ts == null || ts < sinceMs) continue;
-    out.push({ version: m[1], atMs: ts });
+    out.push({ version: m[1], atMs: ts, pid: parseLogLinePid(line) });
   }
   return out;
 }

--- a/src/setup/__tests__/installer-stanza-backup-214.test.ts
+++ b/src/setup/__tests__/installer-stanza-backup-214.test.ts
@@ -1,0 +1,135 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  installOpenClawHook,
+  openClawConfigPath,
+  snapshotOpenClawConfig,
+  __setNativePluginInstallForTest,
+} from '../openclaw.js';
+
+/**
+ * #214 leftovers — #213 restores a wiped stanza after install, but the
+ * installer still had no on-disk snapshot of the config it was about to let
+ * `openclaw plugins install` rewrite, and it deleted the extensions copy
+ * BEFORE that native install was known to succeed.
+ *
+ * Field shape (Case, aiquant, 8 Aug): native install exited 0, stanza gone,
+ * CLI said installed. The 13:57 `.bak` is why the box was recoverable at all.
+ */
+
+const PLUGIN = 'shieldcortex-realtime';
+
+let tempHome: string;
+let previousDocker: string | undefined;
+let previousExitCode: string | number | undefined;
+
+function configPath(): string {
+  return path.join(tempHome, '.openclaw', 'openclaw.json');
+}
+
+function writeConfig(cfg: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(configPath()), { recursive: true });
+  fs.writeFileSync(configPath(), JSON.stringify(cfg, null, 2) + '\n');
+}
+
+beforeEach(() => {
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-214-bak-'));
+  previousDocker = process.env.DOCKER;
+  process.env.DOCKER = 'false';
+  fs.mkdirSync(path.join(tempHome, '.openclaw'), { recursive: true });
+  previousExitCode = process.exitCode;
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(os, 'homedir').mockReturnValue(tempHome);
+  const resolved = openClawConfigPath();
+  if (!resolved.startsWith(tempHome + path.sep)) {
+    throw new Error(`REFUSING TO RUN: home redirect failed (${resolved})`);
+  }
+});
+
+afterEach(() => {
+  __setNativePluginInstallForTest(null);
+  if (previousDocker === undefined) delete process.env.DOCKER;
+  else process.env.DOCKER = previousDocker;
+  process.exitCode = previousExitCode;
+  jest.restoreAllMocks();
+  fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe('#214 pre-install snapshot of openclaw.json', () => {
+  it('writes a dated .sc-preinstall.bak that still holds the pre-wipe stanza', async () => {
+    writeConfig({
+      plugins: {
+        allow: ['codex', PLUGIN],
+        entries: {
+          codex: { enabled: true },
+          [PLUGIN]: { enabled: true, hooks: { allowConversationAccess: true } },
+        },
+      },
+    });
+    const before = fs.readFileSync(configPath(), 'utf-8');
+
+    __setNativePluginInstallForTest(() => {
+      // The field wipe: native install exits 0 and the stanza is gone.
+      writeConfig({ plugins: { allow: ['codex'], entries: { codex: { enabled: true } } } });
+      return 'native-package';
+    });
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    const backups = fs.readdirSync(path.join(tempHome, '.openclaw'))
+      .filter((n) => n.startsWith('openclaw.json.sc-preinstall.bak'));
+    expect(backups.length).toBe(1);
+    const snap = fs.readFileSync(path.join(tempHome, '.openclaw', backups[0]), 'utf-8');
+    expect(snap).toBe(before);
+    expect(JSON.parse(snap).plugins.allow).toContain(PLUGIN);
+  });
+
+  it('snapshotOpenClawConfig is a no-op when openclaw.json does not exist yet', () => {
+    const result = snapshotOpenClawConfig(tempHome);
+    expect(result).toBeNull();
+    const leftovers = fs.readdirSync(path.join(tempHome, '.openclaw'))
+      .filter((n) => n.includes('sc-preinstall'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('a native wipe is still restored (#213) and the backup is not the live file', async () => {
+    writeConfig({
+      plugins: {
+        allow: ['codex', PLUGIN],
+        entries: { codex: { enabled: true }, [PLUGIN]: { enabled: true } },
+      },
+    });
+    __setNativePluginInstallForTest(() => {
+      writeConfig({ plugins: { allow: ['codex'], entries: { codex: { enabled: true } } } });
+      return 'native-package';
+    });
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    const live = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(live.plugins.allow).toContain(PLUGIN);
+    expect(live.plugins.entries[PLUGIN].enabled).toBe(true);
+    expect(process.exitCode === 1).toBe(false);
+  });
+});
+
+describe('#214 native install must not destroy the extensions copy first', () => {
+  it('tryNativeOpenClawPluginInstall source does not rmSync the extensions copy before spawn', () => {
+    const src = fs.readFileSync(
+      path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'openclaw.ts'),
+      'utf-8',
+    );
+    const fn = src.slice(src.indexOf('function tryNativeOpenClawPluginInstall'), src.indexOf('function findExtensionsDir'));
+    const rmAt = fn.indexOf('rmSync');
+    const spawnAt = fn.indexOf('spawnSync');
+    expect(spawnAt).toBeGreaterThan(0);
+    // Deleting the working copy before we know native install succeeded is
+    // defect 3 in #214. A later rmSync (cleanup after success) is fine.
+    if (rmAt >= 0) expect(rmAt).toBeGreaterThan(spawnAt);
+  });
+});

--- a/src/setup/__tests__/installer-stanza-backup-214.test.ts
+++ b/src/setup/__tests__/installer-stanza-backup-214.test.ts
@@ -41,6 +41,7 @@ beforeEach(() => {
   process.env.DOCKER = 'false';
   fs.mkdirSync(path.join(tempHome, '.openclaw'), { recursive: true });
   previousExitCode = process.exitCode;
+  process.exitCode = undefined;
   jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
   jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -114,7 +115,9 @@ describe('#214 pre-install snapshot of openclaw.json', () => {
     const live = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
     expect(live.plugins.allow).toContain(PLUGIN);
     expect(live.plugins.entries[PLUGIN].enabled).toBe(true);
-    expect(process.exitCode === 1).toBe(false);
+    // Isolate from other suites that leave exitCode=1 on the worker
+    // (macos-test failed this assertion while the stanza was restored).
+    expect(process.exitCode).not.toBe(1);
   });
 });
 

--- a/src/setup/__tests__/installer-stanza-backup-214.test.ts
+++ b/src/setup/__tests__/installer-stanza-backup-214.test.ts
@@ -7,6 +7,7 @@ import {
   installOpenClawHook,
   openClawConfigPath,
   snapshotOpenClawConfig,
+  NATIVE_INSTALL_TIMEOUT_MS,
   __setNativePluginInstallForTest,
 } from '../openclaw.js';
 
@@ -118,6 +119,19 @@ describe('#214 pre-install snapshot of openclaw.json', () => {
     // Isolate from other suites that leave exitCode=1 on the worker
     // (macos-test failed this assertion while the stanza was restored).
     expect(process.exitCode).not.toBe(1);
+  });
+});
+
+describe('#214 native install timeout must not SIGTERM a mid-rewrite', () => {
+  it('gives OpenClaw at least two minutes — 30s is how aiquant lost the stanza', () => {
+    expect(NATIVE_INSTALL_TIMEOUT_MS).toBeGreaterThanOrEqual(120_000);
+    const src = fs.readFileSync(
+      path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'openclaw.ts'),
+      'utf-8',
+    );
+    const fn = src.slice(src.indexOf('function tryNativeOpenClawPluginInstall'), src.indexOf('function findExtensionsDir'));
+    expect(fn).toMatch(/timeout:\s*NATIVE_INSTALL_TIMEOUT_MS/);
+    expect(fn).not.toMatch(/timeout:\s*30000/);
   });
 });
 

--- a/src/setup/__tests__/repair-converges-156.test.ts
+++ b/src/setup/__tests__/repair-converges-156.test.ts
@@ -21,6 +21,8 @@
 import { describe, it, expect } from '@jest/globals';
 import { waitForGatewayReady } from '../gateway-readiness.js';
 import { resolveRepairConsent } from '../repair-consent.js';
+import { reconcileOpenClawPluginState, MAX_RECONCILE_PASSES } from '../openclaw-reconcile.js';
+import { reconcilePluginState, type ReconcileInput } from '../../integrations/openclaw-plugin-index.js';
 
 // ── 1. The race that produced the false FAILED ─────────────────────────────
 
@@ -121,5 +123,73 @@ describe('#156 — a human at a terminal has already consented', () => {
     // Non-TTY with no env is exactly the shape of an agent or cron run. It must
     // never restart the gateway it is itself running inside.
     expect(resolveRepairConsent({ env: bare, isTty: false }).restart).toBe(false);
+  });
+});
+
+// ── 3. Detect → remediate → verify until stable, not one pass ──────────────
+
+describe('#156 — repair converges instead of one-shot', () => {
+  const PLUGIN = 'shieldcortex-realtime';
+
+  function wiped(): ReconcileInput {
+    return {
+      pluginId: PLUGIN,
+      expectedVersion: '4.50.0',
+      config: { enabled: null, inAllow: false, readable: true, present: true },
+      installsJson: { version: '4.50.0', installPath: '/x' },
+      index: {
+        installRecords: { [PLUGIN]: { source: 'npm', version: '4.50.0', installPath: '/x' } },
+        plugins: [],
+        warning: null,
+      },
+      onDiskVersion: '4.50.0',
+      projectDirs: [],
+      liveRoster: [],
+    };
+  }
+
+  it('retries a restore that failed the first pass, then reports success', async () => {
+    expect(MAX_RECONCILE_PASSES).toBeGreaterThanOrEqual(2);
+    const input = wiped();
+    let restores = 0;
+    let enabled = false;
+    const result = await reconcileOpenClawPluginState({
+      home: '/tmp/sc-156-converge',
+      pluginId: PLUGIN,
+      expectedVersion: '4.50.0',
+      apply: true,
+      readState: () => {
+        const i: ReconcileInput = enabled
+          ? {
+            ...input,
+            config: { enabled: true, inAllow: true, readable: true, present: true },
+            index: { ...input.index!, plugins: [{ pluginId: PLUGIN, enabled: true }] },
+            liveRoster: [PLUGIN],
+          }
+          : input;
+        return { input: i, verdict: reconcilePluginState(i) };
+      },
+      restoreRegistration: () => {
+        restores += 1;
+        if (restores === 1) return { ok: false, detail: 'first write raced' };
+        enabled = true;
+        return { ok: true, detail: 'restored on retry' };
+      },
+      runCommand: () => ({ status: 0, output: 'ok' }),
+      reloadGateway: async () => ({ restarted: true, detail: 'reloaded' }),
+      waitForGateway: async () => ({ ready: true, waitedMs: 5 }),
+      selfCheck: async () => ({
+        ok: enabled,
+        rosterState: enabled ? 'present' : 'absent',
+        rosterProof: enabled,
+        canaryProof: enabled,
+        versionProof: true,
+        reasons: [enabled ? 'loaded' : 'not loaded'],
+      }) as never,
+    });
+    expect(restores).toBeGreaterThanOrEqual(2);
+    expect(result.ok).toBe(true);
+    expect(result.passes).toBeGreaterThanOrEqual(2);
+    expect(result.postVerdict?.state).toBe('healthy');
   });
 });

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -44,6 +44,9 @@ export interface StepResult {
   detail: string;
 }
 
+/** #156 — one extra detect→remediate pass when the first did not converge. */
+export const MAX_RECONCILE_PASSES = 2;
+
 export interface ReconcileExecResult {
   /** The state BEFORE remediation — what the plan was computed from. */
   verdict: ReconcileVerdict;
@@ -61,6 +64,8 @@ export interface ReconcileExecResult {
   selfCheck?: SelfCheckRunResult;
   ok: boolean;
   messages: string[];
+  /** How many detect→remediate passes ran (#156). */
+  passes?: number;
 }
 
 export interface ReconcileOptions {
@@ -102,6 +107,8 @@ export interface ReconcileOptions {
    * path and leave the re-read unproven.
    */
   readState?: () => { input: ReconcileInput; verdict: ReconcileVerdict };
+  /** Internal: which converge pass this is (1-based). */
+  pass?: number;
 }
 
 function defaultApply(): boolean {
@@ -388,7 +395,24 @@ export async function reconcileOpenClawPluginState(options: ReconcileOptions): P
     messages.push('reconciled: plugin confirmed loaded (roster) and enforcing (canary)');
   }
 
-  return { verdict, postVerdict, plan, applied: true, stepResults, selfCheck: selfCheckResult, ok, messages };
+  const pass = options.pass ?? 1;
+  if (!ok && postVerdict.severity !== 'ok' && pass < MAX_RECONCILE_PASSES) {
+    messages.push(`state still ${postVerdict.state} after pass ${pass} — running another detect→remediate pass (#156)`);
+    const retry = await reconcileOpenClawPluginState({ ...options, pass: pass + 1 });
+    return {
+      verdict,
+      postVerdict: retry.postVerdict ?? postVerdict,
+      plan: [...plan, ...retry.plan],
+      applied: true,
+      stepResults: [...stepResults, ...retry.stepResults],
+      selfCheck: retry.selfCheck ?? selfCheckResult,
+      ok: retry.ok,
+      messages: [...messages, ...retry.messages],
+      passes: retry.passes ?? pass + 1,
+    };
+  }
+
+  return { verdict, postVerdict, plan, applied: true, stepResults, selfCheck: selfCheckResult, ok, messages, passes: pass };
 }
 
 /**

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -835,6 +835,10 @@ export function snapshotOpenClawConfig(homeArg?: string): string | null {
   }
 }
 
+/** #214 — 30s SIGTERM'd `openclaw plugins install` mid-openclaw.json rewrite
+ *  on aiquant. Two minutes is still a bound, not a hang. */
+export const NATIVE_INSTALL_TIMEOUT_MS = 120_000;
+
 function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
   if (_nativePluginInstallForTest) return _nativePluginInstallForTest();
   if (process.env[OPENCLAW_SKIP_NATIVE_INSTALL_ENV] === '1') return null;
@@ -855,7 +859,7 @@ function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
     const result = spawnSync('openclaw', attempt.args, {
       env,
       encoding: 'utf-8',
-      timeout: 30000,
+      timeout: NATIVE_INSTALL_TIMEOUT_MS,
     });
 
     if (result.status === 0) {

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -811,21 +811,39 @@ export function __setNativePluginInstallForTest(fn: (() => PluginInstallMode | n
   _nativePluginInstallForTest = fn;
 }
 
+/**
+ * #214 — snapshot openclaw.json BEFORE any path that can let
+ * `openclaw plugins install` rewrite it. The 8 Aug wipe was recoverable
+ * only because Case had a 4-minute-old `.bak`. Restore stays merge-
+ * preserving (`verifyPluginRegistration`); this file is the forensic copy.
+ *
+ * Dated so a second install does not clobber the first snapshot.
+ * Returns the backup path, or null when there is nothing to copy.
+ */
+export function snapshotOpenClawConfig(homeArg?: string): string | null {
+  const configPath = homeArg
+    ? path.join(homeArg, '.openclaw', 'openclaw.json')
+    : openClawConfigPath();
+  if (!fs.existsSync(configPath)) return null;
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const dest = `${configPath}.sc-preinstall.bak-${ts}`;
+  try {
+    fs.copyFileSync(configPath, dest);
+    return dest;
+  } catch {
+    return null;
+  }
+}
+
 function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
   if (_nativePluginInstallForTest) return _nativePluginInstallForTest();
   if (process.env[OPENCLAW_SKIP_NATIVE_INSTALL_ENV] === '1') return null;
   if (!isOpenClawInstalled()) return null;
 
-  // Remove existing extensions copy so OpenClaw doesn't refuse with "plugin already exists"
-  const extDir = findExtensionsDir();
-  if (extDir) {
-    const existingDir = path.join(extDir, PLUGIN_DIR_NAME);
-    if (fs.existsSync(existingDir)) {
-      try {
-        fs.rmSync(existingDir, { recursive: true, force: true });
-      } catch { /* best-effort cleanup */ }
-    }
-  }
+  // #214 defect 3: do not destroy ~/.openclaw/extensions/shieldcortex-realtime
+  // before we know the native install succeeded. That copy is the rollback
+  // state. If OpenClaw refuses "plugin already exists", the --link attempt
+  // and the local-copy fallback still have something to work with.
 
   const env = { ...process.env, HOME: resolveUserHome() };
   const attempts: Array<{ args: string[]; label: string }> = [
@@ -1315,6 +1333,9 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
     console.log('Skipping hook installation (--no-hooks flag).');
     installed = hooksDirs.length; // pretend success so plugin install proceeds
   }
+
+  // #214: snapshot openclaw.json before any path that can rewrite it.
+  if (!options.noPlugins) snapshotOpenClawConfig();
 
   // Install the real-time plugin to the extensions directory
   const pluginInstallMode = installPlugin({


### PR DESCRIPTION
## Summary

Finishes the remaining #214 installer-honesty holes and the remaining #156 repair-converge holes. Does **not** close either issue until CI is green and you say so — but the listed spec items below are implemented.

## #214

| Gap | Status |
|---|---|
| Native exit 0 + stanza gone, CLI says installed | Already #213 `verifyPluginRegistration` |
| No pre-write backup | **This PR** — dated `openclaw.json.sc-preinstall.bak-*` |
| Extensions copy deleted before native success | **This PR** — no longer destroyed first |
| 30s `spawnSync` SIGTERM mid-rewrite | **This PR** — `NATIVE_INSTALL_TIMEOUT_MS = 120s` |
| Doctor quotes any `registered` line as the gateway | **This PR** — PID-attribute; ignore a line whose pid is not the gateway |

macos-test failed once because a prior suite left `process.exitCode=1`; the restore itself was fine. Isolated.

## #156

Wait-for-gateway after reload and TTY-as-consent were already on main.

| Gap | Status |
|---|---|
| Startup-intent check (aiquant silent skip) | **This PR** — doctor reads the installed manifest; `onStartup:false` + no hook capability is a FAIL |
| Re-verify after the restart repair recommended | Already `waitForGatewayReady` in reconcile |
| Converge loop | **This PR** — one extra detect→remediate pass (`MAX_RECONCILE_PASSES=2`) when the first leaves the host unconverged |
| Unverifiable listed as unverifiable | Already (readiness timeout / unobservable / canary not proven) |

## Tests

Backup + wipe-restore, timeout constant, source contract against pre-spawn delete, PID parse + running-version filter, startup-intent pass/fail/skip, converge retry after a raced first restore. Related #213/#226/#145/#150/#142 suites still green.

## Harness

Snapshot is best-effort. Restore stays merge-preserving. Repair still never restarts without the existing consent gates. A second converge pass is bounded at 2.