### PR TITLE
test(guard): precision corpus across all three planes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       # classifier), so it runs here on the Linux matrix, not the billed macOS
       # runner. Also covered by `npm test` below — this is the visible gate.
       - name: Guard precision gate (#182 — no Action Guard false positives)
-        run: npm run guard:precision
+        run: npm run guard:precision -- --planes
 
       - name: Test
         run: npm test

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -193,7 +193,7 @@ Protects what the agent *sees*. Runs the firewall over fetched web pages and too
 | Runtime | Hook | Package |
 |---------|------|---------|
 | OpenClaw | `before_tool_call` (typed-hook bus) + `llm_input` / `llm_output` | `@drakon-systems/shieldcortex-realtime` (npm) |
-| Hermes | `pre_tool_call` → REST `POST /api/v1/scan` | `plugins/hermes/shieldcortex/` (repo) |
+| Hermes | `pre_tool_call` → REST `POST /api/v1/action-guard` | `plugins/hermes/shieldcortex/` (repo) |
 
 Both integrations are **advisory-first** and **fail-open at the transport**: an unreachable or erroring guard never wedges the agent. That is a statement about the *plumbing*, not about every verdict — when the guard does run, the catastrophic action class hard-blocks and cannot be configured open (see Iron Dome above). Everything below that class is advisory by default.
 

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ cp -r plugins/hermes/shieldcortex ~/.hermes/plugins/shieldcortex
 hermes plugins enable shieldcortex
 ```
 
-It registers a **`pre_tool_call` gate**: before every Hermes tool execution it scans the tool + arguments through ShieldCortex's defence pipeline via the local REST API (`POST /api/v1/scan`).
+It registers a **`pre_tool_call` gate**: before every Hermes tool execution it asks Action Guard via the local REST API (`POST /api/v1/action-guard`) — the same `evaluateToolCall` verdict the Claude Code hook and OpenClaw interceptor already share.
 
 - 🛡️ **Advisory-first** — `enforce` is off by default; it logs what it *would* block. Set `SHIELDCORTEX_ENFORCE=1` to actively block.
 - 🪂 **Fail-open** — if the ShieldCortex API is unreachable, the gate never blocks. A down scanner must not wedge the agent; every fail-open is logged.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "test:watch": "node scripts/run-jest.mjs --watch",
     "test:coverage": "node scripts/run-jest.mjs --coverage",
     "test:dist": "node scripts/check-no-bare-require.mjs",
-    "guard:precision": "node scripts/run-jest.mjs src/__tests__/guard-precision-corpus.test.ts",
+    "guard:precision": "node scripts/run-guard-precision.mjs",
     "bench": "tsx benchmark/longmemeval/run.ts",
     "bench:smoke": "SHIELDCORTEX_SKIP_EMBEDDINGS=1 tsx benchmark/longmemeval/run.ts --quiet",
     "audit:security": "npm audit --audit-level=moderate",

--- a/plugins/hermes/shieldcortex/README.md
+++ b/plugins/hermes/shieldcortex/README.md
@@ -7,9 +7,11 @@ OpenClaw, so this is a Hermes-native plugin, not a shim.
 ## Phase 1 (this)
 
 `register(ctx)` registers a **`pre_tool_call`** gate. Before every Hermes tool
-execution it scans the tool + args through ShieldCortex (`POST /api/v1/scan`) and
-**hard-blocks** a BLOCK/QUARANTINE verdict by returning
-`{"action": "block", "message": …}` (Hermes honours first-block-wins).
+execution it asks Action Guard (`POST /api/v1/action-guard`, the same
+`evaluateToolCall` the Claude hook and OpenClaw interceptor run) and
+**hard-blocks** `block` / `require_approval` by returning
+`{"action": "block", "message": …}` (Hermes honours first-block-wins; it has
+no approval prompt).
 
 - **Enforce by default (v4.47.2).** The gate blocks out of the box. To watch what
   *would* be blocked without blocking (advisory / warn-only), opt out explicitly

--- a/plugins/hermes/shieldcortex/__init__.py
+++ b/plugins/hermes/shieldcortex/__init__.py
@@ -1,16 +1,17 @@
 """
 ShieldCortex — Hermes plugin.
 
-Routes Hermes tool calls through ShieldCortex's defence pipeline via the
+Routes Hermes tool calls through ShieldCortex's Action Guard via the
 `pre_tool_call` hook (Hermes' real, block-capable interceptor). The heavy logic
-lives in `sc_client` (REST call to `POST /api/v1/scan`) and `policy` (verdict →
-decision) and is unit-tested standalone; this module is thin glue around
-`register(ctx)`, the Hermes plugin entrypoint.
+lives in `sc_client` (REST call to `POST /api/v1/action-guard`) and `policy`
+(verdict → decision) and is unit-tested standalone; this module is thin glue
+around `register(ctx)`, the Hermes plugin entrypoint.
 
-Posture: ENFORCE by default (v4.47.2). The gate blocks BLOCK/QUARANTINE verdicts
-out of the box; set env `SHIELDCORTEX_ENFORCE=0` (or false/no/off/advisory) to
-drop back to advisory (warn-only). Fail-open on an unreachable scanner is
-unchanged — a down scanner never wedges the agent.
+Posture: ENFORCE by default (v4.47.2). The gate blocks Action Guard
+`block` / `require_approval` verdicts out of the box; set env
+`SHIELDCORTEX_ENFORCE=0` (or false/no/off/advisory) to drop `require_approval`
+back to advisory (warn-only). Catastrophic `block` still denies. Fail-open on
+an unreachable scanner is unchanged — a down scanner never wedges the agent.
 
 Phase 1 (this): pre_tool_call gate. Phase 2: transform_tool_result/terminal
 scrubbing, pre_llm_call recall context, pre_approval_request → Overseer Guard,
@@ -22,14 +23,20 @@ import os
 
 try:
     from .sc_client import (
-        scan, fallback_catastrophic_match, fallback_dangerous_match, fallback_surface,
+        evaluate_tool_call,
+        fallback_catastrophic_match,
+        fallback_dangerous_match,
+        fallback_surface,
     )
-    from .policy import tool_call_decision, resolve_enforce
+    from .policy import action_guard_decision, resolve_enforce
 except ImportError:  # pragma: no cover - standalone import
     from sc_client import (
-        scan, fallback_catastrophic_match, fallback_dangerous_match, fallback_surface,
+        evaluate_tool_call,
+        fallback_catastrophic_match,
+        fallback_dangerous_match,
+        fallback_surface,
     )
-    from policy import tool_call_decision, resolve_enforce
+    from policy import action_guard_decision, resolve_enforce
 
 log = logging.getLogger("shieldcortex.hermes")
 
@@ -80,25 +87,13 @@ def _enforce_default() -> bool:
     return resolve_enforce(os.environ.get("SHIELDCORTEX_ENFORCE"))
 
 
-def _tool_content(tool_name, args) -> str:
-    try:
-        return f"{tool_name}: {json.dumps(args, default=str, ensure_ascii=False)}"
-    except Exception:
-        return f"{tool_name}: {args!r}"
-
-
 def register(ctx):
     """Hermes plugin entrypoint — registers the pre_tool_call gate."""
     enforce = _enforce_default()
 
     def pre_tool_call(tool_name, args, task_id=None, **_kw):
-        content = _tool_content(tool_name, args)
-        verdict = scan(
-            content,
-            title=f"tool:{tool_name}",
-            source_type="tool",
-            source_id="hermes",
-        )
+        tool_args = args if isinstance(args, dict) else {}
+        verdict = evaluate_tool_call(tool_name, tool_args)
         # Issue #59/WS2: scanner unreachable no longer means blanket fail-open.
         # The dependency-free fallback scan (raw exec surface, not the JSON blob)
         # denies catastrophic shapes always and dangerous shapes when enforcing;
@@ -106,21 +101,18 @@ def register(ctx):
         fallback_blocked = False
         fallback_dangerous = False
         if not verdict.available:
-            surface = fallback_surface(args)
+            surface = fallback_surface(tool_args)
             fallback_blocked = fallback_catastrophic_match(surface)
             fallback_dangerous = fallback_dangerous_match(surface)
             denied = fallback_blocked or (fallback_dangerous and enforce)
             _audit_gate_degraded(tool_name, verdict.reason, denied)
-        # Observability: every decision leaves a log line so advisory mode is
-        # actually visible (a silent gate is indistinguishable from a no-op —
-        # see the missing-auth fail-open caught in the ATHENA dogfood).
         fallback_denies = fallback_blocked or (fallback_dangerous and enforce)
-        if verdict.blocked or fallback_denies:
+        if (verdict.available and verdict.decision != "allow") or fallback_denies:
             tier = "FALLBACK_BLOCK (catastrophic)" if fallback_blocked else (
-                "FALLBACK_BLOCK (dangerous)" if fallback_denies else verdict.result)
+                "FALLBACK_BLOCK (dangerous)" if fallback_denies else verdict.decision)
             log.warning(
                 "[shieldcortex] %s on tool %r: %s",
-                tier, tool_name, verdict.reason or verdict.threats,
+                tier, tool_name, verdict.reason or verdict.signals,
             )
         elif not verdict.available:
             log.warning(
@@ -132,9 +124,8 @@ def register(ctx):
                 verdict.reason,
             )
         else:
-            log.info("[shieldcortex] %s on tool %r", verdict.result, tool_name)
-        # None -> allow ; {"action":"block","message":...} -> block (first block wins)
-        return tool_call_decision(
+            log.info("[shieldcortex] %s on tool %r", verdict.decision, tool_name)
+        return action_guard_decision(
             verdict, enforce=enforce,
             fallback_blocked=fallback_blocked, fallback_dangerous=fallback_dangerous,
         )

--- a/plugins/hermes/shieldcortex/policy.py
+++ b/plugins/hermes/shieldcortex/policy.py
@@ -13,9 +13,9 @@ opt back into advisory without touching the fail-open behaviour.
 from __future__ import annotations
 
 try:
-    from .sc_client import Verdict  # as a Hermes package
+    from .sc_client import ActionGuardVerdict, Verdict  # as a Hermes package
 except ImportError:  # pragma: no cover - standalone (tests add the package dir to sys.path)
-    from sc_client import Verdict
+    from sc_client import ActionGuardVerdict, Verdict
 
 
 # v4.47.2: the gate ENFORCES by default. Only an explicit opt-out disables it —
@@ -82,3 +82,33 @@ def tool_call_decision(
         return None
     detail = verdict.reason or (", ".join(verdict.threats) if verdict.threats else "policy violation")
     return {"action": "block", "message": f"ShieldCortex blocked this action — {detail}"}
+
+
+def action_guard_decision(
+    verdict: ActionGuardVerdict,
+    *,
+    enforce: bool = True,
+    fallback_blocked: bool = False,
+    fallback_dangerous: bool = False,
+):
+    """Map an Action Guard verdict to a Hermes hook decision.
+
+    Hermes has no approval prompt. ``require_approval`` therefore becomes a
+    block when enforcing (same unattended fail-closed the OpenClaw interceptor
+    already applies). ``allow`` is None. Scanner-down uses the same fallback
+    contract as :func:`tool_call_decision`.
+    """
+    if not verdict.available:
+        return tool_call_decision(
+            Verdict("ERROR", [], verdict.reason, available=False),
+            enforce=enforce,
+            fallback_blocked=fallback_blocked,
+            fallback_dangerous=fallback_dangerous,
+        )
+    if verdict.decision == "block":
+        detail = verdict.reason or "policy violation"
+        return {"action": "block", "message": f"ShieldCortex blocked this action — {detail}"}
+    if verdict.decision == "require_approval" and enforce:
+        detail = verdict.reason or "requires approval"
+        return {"action": "block", "message": f"ShieldCortex blocked this action — {detail}"}
+    return None

--- a/plugins/hermes/shieldcortex/sc_client.py
+++ b/plugins/hermes/shieldcortex/sc_client.py
@@ -1,10 +1,11 @@
 """
 ShieldCortex defence client for the Hermes plugin.
 
-Calls ShieldCortex's local REST API (`POST /api/v1/scan`, the documented
-"Python via REST" surface) to run content through the defence pipeline and
-returns a normalised verdict. Hermes is Python; ShieldCortex is Node — REST is
-the clean cross-runtime boundary (no CLI text-scraping, no in-process bridge).
+Calls ShieldCortex's local REST API. Tool calls go through
+`POST /api/v1/action-guard` (the same `evaluateToolCall` the Claude hook and
+OpenClaw interceptor run). Content scanning stays on `POST /api/v1/scan`.
+Hermes is Python; ShieldCortex is Node — REST is the clean cross-runtime
+boundary (no CLI text-scraping, no in-process bridge).
 
 Auth: the API requires a Bearer token (the server writes it to
 `~/.shieldcortex/.api-token`, 0600). We read it from `SHIELDCORTEX_API_TOKEN`
@@ -167,6 +168,60 @@ def _post(url, body: bytes, timeout: float, opener, headers: dict):
     req = urllib.request.Request(url, data=body, headers=headers, method="POST")
     with opener(req, timeout=timeout) as resp:
         return json.loads(resp.read().decode("utf-8"))
+
+
+class ActionGuardVerdict:
+    """Normalised result of POST /api/v1/action-guard (evaluateToolCall)."""
+
+    __slots__ = ("decision", "signals", "reason", "available")
+
+    def __init__(self, decision: str, signals, reason: str, available: bool = True):
+        self.decision = (decision or "allow").lower()  # allow | require_approval | block
+        self.signals = list(signals or [])
+        self.reason = reason or ""
+        self.available = available
+
+    def __repr__(self) -> str:
+        return (
+            f"ActionGuardVerdict(decision={self.decision!r}, "
+            f"signals={self.signals!r}, available={self.available})"
+        )
+
+
+def evaluate_tool_call(
+    tool: str,
+    args: dict | None = None,
+    *,
+    base_url: str | None = None,
+    timeout: float = 4.0,
+    opener=urllib.request.urlopen,
+) -> ActionGuardVerdict:
+    """Ask ShieldCortex's Action Guard for a verdict. Never raises."""
+    base = (base_url or DEFAULT_BASE_URL).rstrip("/")
+    body = json.dumps(
+        {
+            "tool": tool,
+            "args": args if isinstance(args, dict) else {},
+            "source": {"type": "tool", "identifier": "hermes"},
+        }
+    ).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    token = _api_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        data = _post(f"{base}/api/v1/action-guard", body, timeout, opener, headers)
+    except Exception as exc:
+        return ActionGuardVerdict("allow", [], f"scanner unreachable: {exc}", available=False)
+
+    decision = str((data or {}).get("decision") or "allow").lower()
+    if decision not in ("allow", "require_approval", "block"):
+        decision = "allow"
+    signals = (data or {}).get("signals") or []
+    if not isinstance(signals, list):
+        signals = []
+    reason = (data or {}).get("reason") or ""
+    return ActionGuardVerdict(decision, signals, reason, available=True)
 
 
 def scan(

--- a/plugins/hermes/shieldcortex/tests/test_client_policy.py
+++ b/plugins/hermes/shieldcortex/tests/test_client_policy.py
@@ -13,8 +13,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from sc_client import Verdict, scan  # noqa: E402
-from policy import tool_call_decision, resolve_enforce  # noqa: E402
+from sc_client import ActionGuardVerdict, Verdict, evaluate_tool_call, scan  # noqa: E402
+from policy import action_guard_decision, resolve_enforce, tool_call_decision  # noqa: E402
 
 
 def fake_opener(response: dict | None, *, raises: Exception | None = None):
@@ -38,6 +38,59 @@ def capturing_opener(captured: dict, response: dict):
         yield io.BytesIO(json.dumps(response).encode("utf-8"))
 
     return _opener
+
+
+class TestActionGuardClient(unittest.TestCase):
+    def test_parses_evaluateToolCall_shape(self):
+        v = evaluate_tool_call(
+            "Bash",
+            {"command": "rm -rf /"},
+            opener=fake_opener({"decision": "block", "signals": ["recursive-force-delete"], "reason": "wipe"}),
+        )
+        self.assertEqual(v.decision, "block")
+        self.assertEqual(v.signals, ["recursive-force-delete"])
+        self.assertTrue(v.available)
+
+    def test_posts_to_action_guard_not_scan(self):
+        captured = {}
+
+        @contextmanager
+        def opener(req, timeout=None):
+            captured["url"] = req.full_url
+            yield io.BytesIO(json.dumps({"decision": "allow", "signals": []}).encode("utf-8"))
+
+        evaluate_tool_call("Bash", {"command": "git status"}, opener=opener)
+        self.assertTrue(captured["url"].endswith("/api/v1/action-guard"))
+
+    def test_unreachable_is_unavailable(self):
+        v = evaluate_tool_call("Bash", {"command": "ls"}, opener=fake_opener(None, raises=ConnectionRefusedError("down")))
+        self.assertFalse(v.available)
+
+
+class TestActionGuardPolicy(unittest.TestCase):
+    def test_block_always_blocks(self):
+        d = action_guard_decision(ActionGuardVerdict("block", ["x"], "wipe"), enforce=True)
+        self.assertEqual(d["action"], "block")
+
+    def test_require_approval_blocks_when_enforcing(self):
+        d = action_guard_decision(ActionGuardVerdict("require_approval", ["sudo"], "ask"), enforce=True)
+        self.assertEqual(d["action"], "block")
+
+    def test_require_approval_allows_in_advisory(self):
+        self.assertIsNone(
+            action_guard_decision(ActionGuardVerdict("require_approval", ["sudo"], "ask"), enforce=False)
+        )
+
+    def test_allow_is_none(self):
+        self.assertIsNone(action_guard_decision(ActionGuardVerdict("allow", [], ""), enforce=True))
+
+    def test_unavailable_plus_fallback_blocks(self):
+        d = action_guard_decision(
+            ActionGuardVerdict("allow", [], "down", available=False),
+            enforce=True,
+            fallback_blocked=True,
+        )
+        self.assertEqual(d["action"], "block")
 
 
 class TestScanClient(unittest.TestCase):

--- a/scripts/run-guard-precision.mjs
+++ b/scripts/run-guard-precision.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Action Guard precision gate (#182) plus optional three-plane parity.
+ *
+ *   npm run guard:precision           — core evaluateToolCall corpus
+ *   npm run guard:precision -- --planes
+ *       — same corpus, plus Claude hook / OpenClaw interceptor / Hermes
+ *         REST must return the same decision + signal set. Drift fails.
+ */
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const planes = process.argv.slice(2).includes('--planes');
+const files = ['src/__tests__/guard-precision-corpus.test.ts'];
+if (planes) files.push('src/__tests__/guard-precision-planes.test.ts');
+
+const child = spawn(process.execPath, ['scripts/run-jest.mjs', ...files], {
+  cwd: repo,
+  stdio: 'inherit',
+});
+child.on('exit', (code) => process.exit(code ?? 1));
+child.on('error', (err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/__tests__/guard-precision-planes.test.ts
+++ b/src/__tests__/guard-precision-planes.test.ts
@@ -1,0 +1,248 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import type { Request, Response } from 'express';
+import { evaluateToolCall } from '../defence/iron-dome/tool-action-guard.js';
+import {
+  GUARD_PRECISION_CORPUS,
+  type GuardCorpusEntry,
+} from '../defence/iron-dome/guard-precision-corpus.js';
+import { createInterceptor, DEFAULT_CONFIG } from '../../plugins/openclaw/interceptor.js';
+
+/**
+ * Phase B / PR 6 — precision corpus across all three planes.
+ *
+ * #182 already holds evaluateToolCall to 100% allow-on-SAFE / gate-on-DANGEROUS.
+ * A fleet with three different gates is three products. This file replays the
+ * same corpus through:
+ *   - core evaluateToolCall
+ *   - Claude pre-tool hook (stdin as PreToolUse delivers it)
+ *   - OpenClaw interceptor (before_tool_call payload)
+ *   - Hermes REST (POST /api/v1/action-guard — the only evaluateToolCall
+ *     surface the Python plugin can call)
+ * and fails the build on any decision or signal-set mismatch.
+ *
+ * The hook's audit writer redacts unknown signal names (SAFE_SIGNALS). The
+ * classifier verdict is recovered from the hook's permissionDecision, which
+ * is a 1:1 map of evaluateToolCall.decision. Signals are compared on the
+ * interceptor wrap and the Hermes REST body, which both see the raw verdict.
+ */
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const HOOK_PATH = path.join(REPO, 'scripts', 'pre-tool-hook.mjs');
+const DIST_GUARD = path.join(REPO, 'dist', 'defence', 'iron-dome', 'tool-action-guard.js');
+const HERMES_INIT = path.join(REPO, 'plugins', 'hermes', 'shieldcortex', '__init__.py');
+const HERMES_CLIENT = path.join(REPO, 'plugins', 'hermes', 'shieldcortex', 'sc_client.py');
+
+type PlaneDecision = 'allow' | 'require_approval' | 'block';
+interface PlaneVerdict {
+  decision: PlaneDecision;
+  signals: string[];
+}
+
+const okPipeline = () => ({
+  allowed: true,
+  firewall: { result: 'ALLOW' as const, reason: '', threatIndicators: [] as string[], anomalyScore: 0, blockedPatterns: [] as string[] },
+  trust: { score: 0.5 },
+  sensitivity: { level: 'INTERNAL' },
+  fragmentation: null,
+  auditId: 1,
+});
+
+function summarise(v: { decision: string; signals: string[] }): PlaneVerdict {
+  if (v.decision !== 'allow' && v.decision !== 'require_approval' && v.decision !== 'block') {
+    throw new Error(`unexpected decision ${v.decision}`);
+  }
+  return { decision: v.decision, signals: [...v.signals].sort() };
+}
+
+function sameSignals(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const as = [...a].sort();
+  const bs = [...b].sort();
+  return as.every((s, i) => s === bs[i]);
+}
+
+async function interceptorPlane(entry: GuardCorpusEntry): Promise<PlaneVerdict> {
+  let seen: { decision: string; signals: string[] } | undefined;
+  const interceptor = createInterceptor(
+    { ...DEFAULT_CONFIG, logger: { info: () => {}, warn: () => {} } } as never,
+    okPipeline as never,
+    {
+      evaluateToolCall: (tool, args, config, options) => {
+        const v = evaluateToolCall(tool, args, config as never, options);
+        seen = v;
+        return v;
+      },
+    },
+  );
+  try {
+    await interceptor.handleToolCall({ toolName: entry.tool, arguments: entry.args });
+  } catch {
+    // deny / unattended require_approval throw; the classifier verdict is `seen`.
+  }
+  if (!seen) throw new Error(`interceptor did not call evaluateToolCall for ${entry.args.command}`);
+  return summarise(seen);
+}
+
+function runHook(payload: unknown, env: NodeJS.ProcessEnv): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [HOOK_PATH], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => { stdout += String(c); });
+    child.stderr.on('data', (c) => { stderr += String(c); });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ stdout, stderr, code: code ?? 0 }));
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+async function hookPlane(entry: GuardCorpusEntry, homesRoot: string, distRoot: string): Promise<PlaneVerdict> {
+  // Fresh HOME per call. Sharing one tree across 160 hook processes lets
+  // pending-approval / session-guard state from an earlier row change a later
+  // verdict (observed: `npm install -g` flipped ask → deny).
+  const home = fs.mkdtempSync(path.join(homesRoot, 'h-'));
+
+  const { stdout, code } = await runHook(
+    {
+      session_id: 'planes-corpus',
+      cwd: '/tmp',
+      permission_mode: 'default',
+      hook_event_name: 'PreToolUse',
+      tool_name: entry.tool,
+      tool_input: entry.args,
+    },
+    {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      SHIELDCORTEX_DIST_ROOT: distRoot,
+      // Lease/DECISIONS store uses os.homedir() unless this is set — HOME
+      // alone still reads the operator's live leases (pid 30065 held `install`).
+      SHIELDCORTEX_CONFIG_DIR: path.join(home, '.shieldcortex'),
+    },
+  );
+  if (code !== 0) {
+    throw new Error(`hook exited ${code} for ${entry.args.command}`);
+  }
+
+  if (!stdout.trim()) {
+    return { decision: 'allow', signals: [] };
+  }
+  const parsed = JSON.parse(stdout) as {
+    hookSpecificOutput?: { permissionDecision?: string };
+  };
+  const pd = parsed.hookSpecificOutput?.permissionDecision;
+  let decision: PlaneDecision;
+  if (pd === 'deny') decision = 'block';
+  else if (pd === 'ask') decision = 'require_approval';
+  else {
+    throw new Error(`hook unexpected permissionDecision ${pd} for ${entry.args.command}`);
+  }
+
+  // Fallback path is not evaluateToolCall — that is a plane lie, not a match.
+  const auditDir = path.join(home, '.shieldcortex', 'audit');
+  if (fs.existsSync(auditDir)) {
+    const file = fs.readdirSync(auditDir).find((n) => /^realtime-.*\.jsonl$/.test(n));
+    if (file) {
+      const lines = fs.readFileSync(path.join(auditDir, file), 'utf8').trim().split('\n').filter(Boolean);
+      const last = lines.length > 0 ? JSON.parse(lines[lines.length - 1]) as { firewallResult?: string } : null;
+      if (last?.firewallResult === 'ACTION_GUARD_FALLBACK') {
+        throw new Error(`hook used fallback, not evaluateToolCall, for ${entry.args.command}`);
+      }
+    }
+  }
+  return { decision, signals: [] };
+}
+
+function mockRes(): { res: Response; body: () => Record<string, unknown> } {
+  let payload: Record<string, unknown> = {};
+  const json = (j: Record<string, unknown>) => { payload = j; };
+  const status = (_code: number) => ({ json: (j: Record<string, unknown>) => { payload = { status: _code, ...j }; } });
+  return { res: { status, json } as unknown as Response, body: () => payload };
+}
+
+async function hermesPlane(entry: GuardCorpusEntry): Promise<PlaneVerdict> {
+  const mod = await import('../api/visualization-server.js');
+  const handle = (mod as { handleV1ActionGuard?: (req: Request, res: Response) => void }).handleV1ActionGuard;
+  if (typeof handle !== 'function') {
+    throw new Error('POST /api/v1/action-guard is missing — Hermes has no evaluateToolCall surface');
+  }
+  const { res, body } = mockRes();
+  handle({ body: { tool: entry.tool, args: entry.args } } as Request, res);
+  const got = body();
+  if (typeof got.status === 'number' && got.status >= 400) {
+    throw new Error(`action-guard HTTP ${got.status} for ${entry.args.command}: ${JSON.stringify(got)}`);
+  }
+  if (got.decision !== 'allow' && got.decision !== 'require_approval' && got.decision !== 'block') {
+    throw new Error(`action-guard returned ${JSON.stringify(got.decision)} for ${entry.args.command}`);
+  }
+  const signals = Array.isArray(got.signals) ? got.signals.map(String) : [];
+  return summarise({ decision: got.decision, signals });
+}
+
+describe('three-plane precision — same evaluateToolCall verdict on every runtime', () => {
+  let homesRoot: string;
+
+  beforeAll(() => {
+    if (!fs.existsSync(DIST_GUARD)) {
+      throw new Error(`missing ${DIST_GUARD} — run npm run build:ts before the planes gate`);
+    }
+    homesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-planes-'));
+  });
+
+  afterAll(() => {
+    if (homesRoot) fs.rmSync(homesRoot, { recursive: true, force: true });
+  });
+
+  it('Hermes plugin calls Action Guard, not the content scanner, on pre_tool_call', () => {
+    const init = fs.readFileSync(HERMES_INIT, 'utf8');
+    const client = fs.readFileSync(HERMES_CLIENT, 'utf8');
+    expect(client).toMatch(/\/api\/v1\/action-guard/);
+    expect(init).toMatch(/evaluate_tool_call/);
+    expect(init).not.toMatch(/verdict = scan\(/);
+  });
+
+  it('0 decision mismatches and 0 signal-set mismatches across planes', async () => {
+    const mismatches: Array<Record<string, unknown>> = [];
+
+    for (const entry of GUARD_PRECISION_CORPUS) {
+      const core = summarise(evaluateToolCall(entry.tool, entry.args));
+      const interceptor = await interceptorPlane(entry);
+      const hook = await hookPlane(entry, homesRoot, path.join(REPO, 'dist'));
+      let hermes: PlaneVerdict | { error: string };
+      try {
+        hermes = await hermesPlane(entry);
+      } catch (err) {
+        hermes = { error: err instanceof Error ? err.message : String(err) };
+      }
+
+      const label = String(entry.args.command ?? JSON.stringify(entry.args));
+      if (interceptor.decision !== core.decision || !sameSignals(interceptor.signals, core.signals)) {
+        mismatches.push({ plane: 'openclaw-interceptor', command: label, core, interceptor });
+      }
+      if (hook.decision !== core.decision) {
+        mismatches.push({ plane: 'claude-code-hook', command: label, coreDecision: core.decision, hookDecision: hook.decision });
+      }
+      if ('error' in hermes) {
+        mismatches.push({ plane: 'hermes', command: label, core, error: hermes.error });
+      } else if (hermes.decision !== core.decision || !sameSignals(hermes.signals, core.signals)) {
+        mismatches.push({ plane: 'hermes', command: label, core, hermes });
+      }
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[planes] corpus=${GUARD_PRECISION_CORPUS.length} mismatches=${mismatches.length}`,
+    );
+    expect(mismatches).toEqual([]);
+  }, 180_000);
+});

--- a/src/api/__tests__/scan-route-source.test.ts
+++ b/src/api/__tests__/scan-route-source.test.ts
@@ -16,6 +16,7 @@ import { queryAuditLogs } from '../../defence/audit/queries.js';
 import {
   handleV1Scan,
   handleV1ScanBatch,
+  handleV1ActionGuard,
   normaliseDefenceSource,
   __test__,
 } from '../visualization-server.js';
@@ -162,6 +163,31 @@ describe('Fix #13 — /api/v1/scan source normalisation + tamper audit', () => {
 
       expect(rows.length).toBeGreaterThanOrEqual(1);
       expect(rows[0].source_type).toBe('api');
+    });
+  });
+
+  describe('handleV1ActionGuard (route handler)', () => {
+    it('returns the same decision + signals as evaluateToolCall', () => {
+      const { res, json } = createResponseMock();
+      handleV1ActionGuard(makeReq({ tool: 'Bash', args: { command: 'rm -rf /' } }), res);
+      expect(json).toHaveBeenCalledWith(expect.objectContaining({
+        decision: 'block',
+        signals: expect.arrayContaining(['recursive-force-delete']),
+      }));
+    });
+
+    it('rejects a missing tool', () => {
+      const { res, status, json } = createResponseMock();
+      handleV1ActionGuard(makeReq({ args: { command: 'ls' } }), res);
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'tool (string) is required' });
+    });
+
+    it('rejects a non-object args', () => {
+      const { res, status, json } = createResponseMock();
+      handleV1ActionGuard(makeReq({ tool: 'Bash', args: 'rm -rf /' }), res);
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'args must be an object' });
     });
   });
 });

--- a/src/api/visualization-server.ts
+++ b/src/api/visualization-server.ts
@@ -31,6 +31,7 @@ import { BrainWorker } from '../worker/brain-worker.js';
 import { isPaused, isKillSwitchActive, getKillSwitchMeta, activateKillSwitch, deactivateKillSwitch } from './control.js';
 import { getRunningVersion } from './version.js';
 import { runDefencePipeline } from '../defence/pipeline.js';
+import { evaluateToolCall } from '../defence/iron-dome/tool-action-guard.js';
 import { DEFAULT_DEFENCE_CONFIG } from '../defence/types.js';
 import type { DefenceSource, DefenceConfig } from '../defence/types.js';
 import { queryAgentOperations } from '../defence/audit/queries.js';
@@ -291,6 +292,41 @@ export function handleV1ScanBatch(req: Request, res: Response): void {
     });
 
     res.json({ results, total: results.length });
+  } catch (error) {
+    res.status(500).json({ error: (error as Error).message });
+  }
+}
+
+/**
+ * Handler for `POST /api/v1/action-guard`.
+ *
+ * The cross-runtime Action Guard surface. Hermes is Python; the classifier
+ * is Node. This is the evaluateToolCall equivalent of `/api/v1/scan` — tool
+ * name + args in, the same decision + signal set the Claude hook and OpenClaw
+ * interceptor already share. Content scanning stays on `/api/v1/scan`.
+ *
+ * Exported for unit tests.
+ */
+export function handleV1ActionGuard(req: Request, res: Response): void {
+  try {
+    const { tool, args } = req.body ?? {};
+    if (!tool || typeof tool !== 'string') {
+      res.status(400).json({ error: 'tool (string) is required' });
+      return;
+    }
+    if (args != null && (typeof args !== 'object' || Array.isArray(args))) {
+      res.status(400).json({ error: 'args must be an object' });
+      return;
+    }
+    const verdict = evaluateToolCall(tool, (args ?? {}) as Record<string, unknown>);
+    res.json({
+      decision: verdict.decision,
+      signals: verdict.signals,
+      severity: verdict.severity,
+      family: verdict.family,
+      action: verdict.action,
+      reason: verdict.reason,
+    });
   } catch (error) {
     res.status(500).json({ error: (error as Error).message });
   }
@@ -840,6 +876,7 @@ export function startVisualizationServer(dbPath?: string): void {
 
   app.post('/api/v1/scan', handleV1Scan);
   app.post('/api/v1/scan/batch', handleV1ScanBatch);
+  app.post('/api/v1/action-guard', handleV1ActionGuard);
 
   const brainWorker = new BrainWorker();
   registerIncidentRoutes(app);
@@ -1142,6 +1179,7 @@ export function startVisualizationServer(dbPath?: string): void {
 ║  Defence API:                                                ║
 ║    POST /api/v1/scan             - Scan content              ║
 ║    POST /api/v1/scan/batch       - Batch scan                ║
+║    POST /api/v1/action-guard     - Evaluate a tool call      ║
 ║    GET  /api/v1/audit            - Query audit logs          ║
 ║    GET  /api/v1/audit/stats      - Audit statistics          ║
 ║    GET  /api/v1/quarantine       - List quarantined items    ║


### PR DESCRIPTION
Phase B / item 6. `#182` already holds core `evaluateToolCall`. This PR fails the build if Claude, OpenClaw, or Hermes disagree with it.

## What changed

- `npm run guard:precision -- --planes` replays `GUARD_PRECISION_CORPUS` through:
  - core `evaluateToolCall`
  - Claude pre-tool hook (stdin as PreToolUse delivers it)
  - OpenClaw interceptor (`before_tool_call`)
  - Hermes `POST /api/v1/action-guard`
- Asserts identical `decision` + signal set. 163/163, 0 mismatches locally.
- Hermes `pre_tool_call` now calls Action Guard. It was `POST /api/v1/scan` (content pipeline) — a different product, so a SAFE command that looked like injection could block, and a DANGEROUS command the scanner missed could run.
- Content scan stays on `/api/v1/scan`. Scanner-down still uses the #59 fallback (transport fail-open, catastrophic fail-closed).
- Named CI step now runs `--planes`.

## Isolation note

Hook session leases live in `SHIELDCORTEX_CONFIG_DIR` / `os.homedir()`, and `os.homedir()` on macOS is the passwd home, not `$HOME`. The planes test sets `SHIELDCORTEX_CONFIG_DIR` so a live `install` lease on the operator box cannot flip `npm install -g` from ask to deny.

## Verify

```
npm run build:ts
npm run guard:precision -- --planes
python3 -m unittest plugins.hermes.shieldcortex.tests.test_client_policy
```

First six PRs from the 8/10 plan are now all up or merged. Isolation (Phase C) is the next stack, not mixed in here.