### PR TITLE
fix(trust): drop same-score identity spoof (#269 blocker)

### DIFF
--- a/src/__tests__/claims-proof.test.ts
+++ b/src/__tests__/claims-proof.test.ts
@@ -679,34 +679,44 @@ describe('F. Fleet isolation (cross-agent contamination)', () => {
     ).canRead).toBe(false);
   });
 
-  // The ACL grants RESTRICTED to the operator (`type: 'user'`), so the isolation
-  // is only as strong as the operator identity itself. A peer agent must not be
-  // able to simply CLAIM it: `user:approved` scores 0.9, the same as a `cli:*`
-  // caller, so the score-only ceiling clamp let it through verbatim. This walks
-  // the real MCP boundary — resolveToolSource, then the tool — because that is
-  // the composition an attacker actually has.
-  it('claim 13: agent B cannot BECOME the operator by declaring it', () => {
-    const secret = addMemory(
-      { title: 'jarvis deploy key 2', content: 'Sensitive material here.', category: 'note', project: PROJECT },
-      undefined,
-      JARVIS,
-    );
-    getDatabase().prepare(`UPDATE memories SET sensitivity_level = 'RESTRICTED' WHERE id = ?`).run(secret.id);
+  // Walks the real MCP composition: resolveToolSource, then the tool.
+  // Ceiling MUST be cli:mcp at 0.9 — the default agent:unknown (0.3) already
+  // score-clamps these claims and the test would pass for the wrong reason.
+  // `cli:openclaw-jarvis` is the MCP-reachable spoof (sourceParam allows cli).
+  it('claim 13: agent B cannot become the owner or the operator by declaring it', () => {
+    const savedEntrypoint = process.env.CLAUDE_CODE_ENTRYPOINT;
+    const savedAgentSource = process.env.SHIELDCORTEX_AGENT_SOURCE;
+    delete process.env.SHIELDCORTEX_AGENT_SOURCE;
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'claude';
+    try {
+      const ceiling = resolveToolSource(undefined, { toolName: 'get_memory', project: PROJECT, strict: false });
+      expect(ceiling.source).toEqual({ type: 'cli', identifier: 'mcp' });
 
-    for (const claim of [
-      { type: 'user', identifier: 'approved' },   // same score as cli — the bypass
-      { type: 'user', identifier: 'direct' },     // over-scores — already clamped
-      { type: 'user', identifier: 'michael' },
-    ] as DefenceSource[]) {
-      const resolved = resolveToolSource(claim, { toolName: 'get_memory', project: PROJECT, strict: false });
-      // The declaration never becomes an operator identity…
-      expect(resolved.source.type).not.toBe('user');
-      // …so the fetch that follows it is still a peer read, and is refused.
-      expect(executeGetMemory({ id: secret.id, source: resolved.source }).success).toBe(false);
+      const secret = addMemory(
+        { title: 'jarvis deploy key 2', content: 'Sensitive material here.', category: 'note', project: PROJECT },
+        undefined,
+        JARVIS,
+      );
+      getDatabase().prepare(`UPDATE memories SET sensitivity_level = 'RESTRICTED' WHERE id = ?`).run(secret.id);
+
+      for (const claim of [
+        { type: 'user', identifier: 'approved' },
+        { type: 'user', identifier: 'direct' },
+        { type: 'cli', identifier: 'openclaw-jarvis' },
+      ] as DefenceSource[]) {
+        const resolved = resolveToolSource(claim, { toolName: 'get_memory', project: PROJECT, strict: false });
+        expect(resolved.source).toEqual({ type: 'cli', identifier: 'mcp' });
+        expect(resolved.clamped).toBe(true);
+        expect(executeGetMemory({ id: secret.id, source: resolved.source }).success).toBe(false);
+      }
+
+      expect(executeGetMemory({ id: secret.id, source: JARVIS }).success).toBe(true);
+    } finally {
+      if (savedEntrypoint === undefined) delete process.env.CLAUDE_CODE_ENTRYPOINT;
+      else process.env.CLAUDE_CODE_ENTRYPOINT = savedEntrypoint;
+      if (savedAgentSource === undefined) delete process.env.SHIELDCORTEX_AGENT_SOURCE;
+      else process.env.SHIELDCORTEX_AGENT_SOURCE = savedAgentSource;
     }
-
-    // The owner is unaffected — it never needed to declare anything.
-    expect(executeGetMemory({ id: secret.id, source: JARVIS }).success).toBe(true);
   });
 
   it('claim 13: a web-sourced write by agent A does not surface in agent B\'s get_context', async () => {

--- a/src/__tests__/claims-proof.test.ts
+++ b/src/__tests__/claims-proof.test.ts
@@ -45,6 +45,7 @@ import { detectSkillThreats } from '../defence/skill-scanner/patterns.js';
 import { checkContradiction } from '../memory/contradiction.js';
 
 import { checkAccess, type AccessCheckMemory } from '../defence/trust/access-control.js';
+import { resolveToolSource } from '../defence/trust/resolve-tool-source.js';
 import { scoreSource } from '../defence/trust/source-scorer.js';
 import {
   redactRestrictedForDisplay,
@@ -676,6 +677,36 @@ describe('F. Fleet isolation (cross-agent contamination)', () => {
       EDITH,
       'read',
     ).canRead).toBe(false);
+  });
+
+  // The ACL grants RESTRICTED to the operator (`type: 'user'`), so the isolation
+  // is only as strong as the operator identity itself. A peer agent must not be
+  // able to simply CLAIM it: `user:approved` scores 0.9, the same as a `cli:*`
+  // caller, so the score-only ceiling clamp let it through verbatim. This walks
+  // the real MCP boundary — resolveToolSource, then the tool — because that is
+  // the composition an attacker actually has.
+  it('claim 13: agent B cannot BECOME the operator by declaring it', () => {
+    const secret = addMemory(
+      { title: 'jarvis deploy key 2', content: 'Sensitive material here.', category: 'note', project: PROJECT },
+      undefined,
+      JARVIS,
+    );
+    getDatabase().prepare(`UPDATE memories SET sensitivity_level = 'RESTRICTED' WHERE id = ?`).run(secret.id);
+
+    for (const claim of [
+      { type: 'user', identifier: 'approved' },   // same score as cli — the bypass
+      { type: 'user', identifier: 'direct' },     // over-scores — already clamped
+      { type: 'user', identifier: 'michael' },
+    ] as DefenceSource[]) {
+      const resolved = resolveToolSource(claim, { toolName: 'get_memory', project: PROJECT, strict: false });
+      // The declaration never becomes an operator identity…
+      expect(resolved.source.type).not.toBe('user');
+      // …so the fetch that follows it is still a peer read, and is refused.
+      expect(executeGetMemory({ id: secret.id, source: resolved.source }).success).toBe(false);
+    }
+
+    // The owner is unaffected — it never needed to declare anything.
+    expect(executeGetMemory({ id: secret.id, source: JARVIS }).success).toBe(true);
   });
 
   it('claim 13: a web-sourced write by agent A does not surface in agent B\'s get_context', async () => {

--- a/src/__tests__/threat-graph-attestation.test.ts
+++ b/src/__tests__/threat-graph-attestation.test.ts
@@ -99,6 +99,63 @@ describe('resolveToolSource return shape', () => {
   });
 });
 
+/**
+ * The OPERATOR identity is a privilege boundary, not a trust tier (#269).
+ *
+ * The clamp compares SCORES, so a same-score TYPE elevation slipped through:
+ * `user:approved` scores 0.9 in BASE_SCORES and a normal MCP caller infers as
+ * `cli:mcp`, also 0.9. Not greater — so the declaration was honoured verbatim
+ * and the caller became `type: 'user'`. Once #269 grants RESTRICTED reads to
+ * the operator, that one line is a full credential-isolation bypass: any peer
+ * agent could pass `source: {type:'user', identifier:'approved'}` to
+ * `get_memory`/`recall` and read another agent's secrets.
+ *
+ * `forget` already refuses a declared identity for exactly this reason ("the
+ * clamp only caps trust SCORE, not identity"), and ResolvedToolSource's own
+ * doc says attestation "must never be self-served". This enforces it at the
+ * one place whose job is hardening a declared source, so every consumer —
+ * not just the ACL — sees an operator identity only when the environment
+ * actually backs it.
+ */
+describe('#269 — the operator identity can never be self-declared', () => {
+  it('drops a same-score `user` claim the environment did not confirm', () => {
+    const resolved = resolveToolSource(
+      { type: 'user', identifier: 'approved' },
+      { toolName: 'get_memory', project: null, strict: false },
+    );
+    // The env here infers a non-user identity, so the claim must not survive.
+    expect(resolved.source.type).not.toBe('user');
+    expect(resolved.clamped).toBe(true);
+    // …and what is returned is now system-derived, so it IS attested.
+    expect(resolved.attested).toBe(true);
+  });
+
+  it('drops an over-scoring `user` claim too (unchanged clamp behaviour)', () => {
+    const resolved = resolveToolSource(
+      { type: 'user', identifier: 'direct' },
+      { toolName: 'recall', project: null, strict: false },
+    );
+    expect(resolved.source.type).not.toBe('user');
+    expect(resolved.clamped).toBe(true);
+  });
+
+  it('leaves a NON-operator self-declaration alone (only `user` is a boundary)', () => {
+    const resolved = resolveToolSource(
+      { type: 'file', identifier: 'import' },
+      { toolName: 'remember', project: null, strict: false },
+    );
+    expect(resolved.source.type).toBe('file');
+    expect(resolved.clamped).toBe(false);
+  });
+
+  it('honours a real operator environment (no declaration to second-guess)', () => {
+    const resolved = resolveToolSource(undefined, { toolName: 'recall', project: null });
+    // Whatever the env is, an undeclared identity is system-derived and attested.
+    expect(resolved.attested).toBe(true);
+    expect(resolved.clamped).toBe(false);
+  });
+});
+
 describe('pipeline → ledger plumbing', () => {
   const source: DefenceSource = { type: 'user', identifier: 'direct' };
 

--- a/src/__tests__/threat-graph-attestation.test.ts
+++ b/src/__tests__/threat-graph-attestation.test.ts
@@ -100,59 +100,100 @@ describe('resolveToolSource return shape', () => {
 });
 
 /**
- * The OPERATOR identity is a privilege boundary, not a trust tier (#269).
+ * Same-score identity is not self-declarable (#270).
  *
- * The clamp compares SCORES, so a same-score TYPE elevation slipped through:
- * `user:approved` scores 0.9 in BASE_SCORES and a normal MCP caller infers as
- * `cli:mcp`, also 0.9. Not greater — so the declaration was honoured verbatim
- * and the caller became `type: 'user'`. Once #269 grants RESTRICTED reads to
- * the operator, that one line is a full credential-isolation bypass: any peer
- * agent could pass `source: {type:'user', identifier:'approved'}` to
- * `get_memory`/`recall` and read another agent's secrets.
+ * The score clamp only rejects a declaration that OUTSCORES the env ceiling.
+ * A normal MCP process infers as `cli:mcp` (0.9). These claims are also 0.9,
+ * so the score clamp lets them through:
+ *   - `user:approved` (operator exception on the ACL)
+ *   - `cli:openclaw-jarvis` (owner of another agent's RESTRICTED row)
  *
- * `forget` already refuses a declared identity for exactly this reason ("the
- * clamp only caps trust SCORE, not identity"), and ResolvedToolSource's own
- * doc says attestation "must never be self-served". This enforces it at the
- * one place whose job is hardening a declared source, so every consumer —
- * not just the ACL — sees an operator identity only when the environment
- * actually backs it.
+ * Both are identity spoofs, not downgrades. Tests MUST pin the 0.9 ceiling
+ * via CLAUDE_CODE_ENTRYPOINT — without it the default `agent:unknown` (0.3)
+ * already score-clamps these claims and the suite goes green for the wrong
+ * reason. `forget` already refuses a declared identity for this reason.
  */
-describe('#269 — the operator identity can never be self-declared', () => {
-  it('drops a same-score `user` claim the environment did not confirm', () => {
+const IDENTITY_ENV_KEYS = [
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_AGENT_CONTEXT',
+  'CODEX_INTERNAL_ORIGINATOR_OVERRIDE',
+  'CODEX_THREAD_ID',
+  'CODEX_CI',
+  'SHIELDCORTEX_AGENT_SOURCE',
+] as const;
+
+describe('#270 — same-score identity is not self-declarable', () => {
+  const saved: Partial<Record<(typeof IDENTITY_ENV_KEYS)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    for (const key of IDENTITY_ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    // Any non-subagent entrypoint → inferSourceFromEnvironment returns cli:mcp (0.9).
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'claude';
+  });
+
+  afterEach(() => {
+    for (const key of IDENTITY_ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it('pins the 0.9 cli:mcp ceiling this suite is about', () => {
+    const resolved = resolveToolSource(undefined, { toolName: 'recall', project: null });
+    expect(resolved.source).toEqual({ type: 'cli', identifier: 'mcp' });
+    expect(resolved.attested).toBe(true);
+    expect(resolved.clamped).toBe(false);
+  });
+
+  it('drops user:approved at equal 0.9 (the score clamp would have honoured it)', () => {
     const resolved = resolveToolSource(
       { type: 'user', identifier: 'approved' },
       { toolName: 'get_memory', project: null, strict: false },
     );
-    // The env here infers a non-user identity, so the claim must not survive.
-    expect(resolved.source.type).not.toBe('user');
+    expect(resolved.source).toEqual({ type: 'cli', identifier: 'mcp' });
     expect(resolved.clamped).toBe(true);
-    // …and what is returned is now system-derived, so it IS attested.
     expect(resolved.attested).toBe(true);
   });
 
-  it('drops an over-scoring `user` claim too (unchanged clamp behaviour)', () => {
+  it('drops an over-scoring user:direct claim (unchanged score clamp)', () => {
     const resolved = resolveToolSource(
       { type: 'user', identifier: 'direct' },
       { toolName: 'recall', project: null, strict: false },
     );
-    expect(resolved.source.type).not.toBe('user');
+    expect(resolved.source).toEqual({ type: 'cli', identifier: 'mcp' });
     expect(resolved.clamped).toBe(true);
   });
 
-  it('leaves a NON-operator self-declaration alone (only `user` is a boundary)', () => {
+  it('drops cli:openclaw-jarvis at equal 0.9 (owner-identity spoof — MCP-reachable)', () => {
+    const resolved = resolveToolSource(
+      { type: 'cli', identifier: 'openclaw-jarvis' },
+      { toolName: 'get_memory', project: null, strict: false },
+    );
+    expect(resolved.source).toEqual({ type: 'cli', identifier: 'mcp' });
+    expect(resolved.clamped).toBe(true);
+    expect(resolved.attested).toBe(true);
+  });
+
+  it('keeps a genuine trust downgrade (file:import 0.4 < cli:mcp 0.9)', () => {
     const resolved = resolveToolSource(
       { type: 'file', identifier: 'import' },
       { toolName: 'remember', project: null, strict: false },
     );
-    expect(resolved.source.type).toBe('file');
+    expect(resolved.source).toEqual({ type: 'file', identifier: 'import' });
     expect(resolved.clamped).toBe(false);
   });
 
-  it('honours a real operator environment (no declaration to second-guess)', () => {
-    const resolved = resolveToolSource(undefined, { toolName: 'recall', project: null });
-    // Whatever the env is, an undeclared identity is system-derived and attested.
-    expect(resolved.attested).toBe(true);
+  it('honours a declaration the environment independently confirms', () => {
+    const resolved = resolveToolSource(
+      { type: 'cli', identifier: 'mcp' },
+      { toolName: 'recall', project: null, strict: false },
+    );
+    expect(resolved.source).toEqual({ type: 'cli', identifier: 'mcp' });
     expect(resolved.clamped).toBe(false);
+    expect(resolved.attested).toBe(true);
   });
 });
 

--- a/src/defence/trust/resolve-tool-source.ts
+++ b/src/defence/trust/resolve-tool-source.ts
@@ -78,15 +78,36 @@ export function resolveToolSource(
   options: ResolveToolSourceOptions,
 ): ResolvedToolSource {
   const clampResult = clampSourceToCeiling(declaredSource);
-  const { source, clamped, declaredScore, ceilingScore, detection } = clampResult;
+  const { declaredScore, ceilingScore, detection } = clampResult;
+  let { source, clamped } = clampResult;
   const strict = options.strict ?? getStrictSourceMode();
-  const attested = deriveAttested({
+  let attested = deriveAttested({
     declared: declaredSource,
     resolved: source,
     clamped,
     strict,
     envInferred: detection.source,
   });
+
+  // The OPERATOR identity is a privilege BOUNDARY, not just a trust tier (#269).
+  //
+  // clampSourceToCeiling compares SCORES, so a same-score TYPE elevation slipped
+  // through: `user:approved` scores 0.9 and a normal MCP caller infers as
+  // `cli:mcp`, also 0.9 — not greater, so the declaration was honoured verbatim
+  // and the caller became `type: 'user'`. Once the ACL grants RESTRICTED reads to
+  // the operator, that is a full credential-isolation bypass by one argument.
+  //
+  // `user` may therefore only come from the environment. An unattested claim to
+  // it is dropped to the env-inferred identity and audited as an elevation
+  // attempt — the same treatment an over-scoring claim already gets. This is the
+  // module whose job is hardening a declared source, so every consumer benefits,
+  // not only the ACL that happened to surface the hole.
+  const operatorClaimBlocked = !attested && source.type === 'user';
+  if (operatorClaimBlocked) {
+    source = detection.source;
+    clamped = true;
+    attested = true; // what we return is now system-derived
+  }
 
   if (clamped && declaredSource) {
     try {
@@ -107,7 +128,12 @@ export function resolveToolSource(
           `SOURCE_ELEVATION_BLOCKED: tool=${options.toolName}, ` +
           `declared=${declaredSource.type}:${declaredSource.identifier} (score=${declaredScore}), ` +
           `clamped=${source.type}:${source.identifier} (score=${ceilingScore}) ` +
-          `via ${detection.method} (confidence: ${detection.confidence})`,
+          `via ${detection.method} (confidence: ${detection.confidence})` +
+          // Without this an operator-identity block reads as a contradiction in
+          // the ledger: the scores are EQUAL, yet the claim was rejected.
+          (operatorClaimBlocked
+            ? ' — reason: operator identity is not self-declarable (type elevation at equal score)'
+            : ''),
         fragmentation_score: null,
         pipeline_duration_ms: null,
       });

--- a/src/defence/trust/resolve-tool-source.ts
+++ b/src/defence/trust/resolve-tool-source.ts
@@ -4,10 +4,12 @@
  * MCP callers can self-declare any source they like. This module:
  * 1. Always computes the environment-inferred trust ceiling first.
  * 2. Clamps any over-claimed declared source down to that ceiling.
- * 3. Writes a `SOURCE_ELEVATION_BLOCKED` row to defence_audit when a clamp
+ * 3. Drops a same-score identity that the environment did not confirm
+ *    (owner spoof / operator spoof). A genuine trust downgrade is kept.
+ * 4. Writes a `SOURCE_ELEVATION_BLOCKED` row to defence_audit when a clamp
  *    happens, so operators can spot prompt-injection trying to escalate
- *    its own trust.
- * 4. Writes a `SOURCE_MISSING` row when no source was declared, preserving
+ *    its own trust or wear another agent's name.
+ * 5. Writes a `SOURCE_MISSING` row when no source was declared, preserving
  *    the existing visibility into unconfigured callers.
  */
 
@@ -81,33 +83,31 @@ export function resolveToolSource(
   const { declaredScore, ceilingScore, detection } = clampResult;
   let { source, clamped } = clampResult;
   const strict = options.strict ?? getStrictSourceMode();
-  let attested = deriveAttested({
+
+  // Score clamp only rejects a declaration that OUTSCORES the ceiling.
+  // A same-score different identity is not a downgrade — it is spoofing
+  // (`user:approved` or `cli:openclaw-jarvis` against env `cli:mcp`, all 0.9).
+  // Genuine downgrades (file:import 0.4 < cli:mcp 0.9) stay honoured.
+  const env = detection.source;
+  const identitySpoof = !!(
+    declaredSource
+    && !clamped
+    && declaredScore !== null
+    && declaredScore === ceilingScore
+    && (declaredSource.type !== env.type || declaredSource.identifier !== env.identifier)
+  );
+  if (identitySpoof) {
+    source = env;
+    clamped = true;
+  }
+
+  const attested = deriveAttested({
     declared: declaredSource,
     resolved: source,
     clamped,
     strict,
-    envInferred: detection.source,
+    envInferred: env,
   });
-
-  // The OPERATOR identity is a privilege BOUNDARY, not just a trust tier (#269).
-  //
-  // clampSourceToCeiling compares SCORES, so a same-score TYPE elevation slipped
-  // through: `user:approved` scores 0.9 and a normal MCP caller infers as
-  // `cli:mcp`, also 0.9 — not greater, so the declaration was honoured verbatim
-  // and the caller became `type: 'user'`. Once the ACL grants RESTRICTED reads to
-  // the operator, that is a full credential-isolation bypass by one argument.
-  //
-  // `user` may therefore only come from the environment. An unattested claim to
-  // it is dropped to the env-inferred identity and audited as an elevation
-  // attempt — the same treatment an over-scoring claim already gets. This is the
-  // module whose job is hardening a declared source, so every consumer benefits,
-  // not only the ACL that happened to surface the hole.
-  const operatorClaimBlocked = !attested && source.type === 'user';
-  if (operatorClaimBlocked) {
-    source = detection.source;
-    clamped = true;
-    attested = true; // what we return is now system-derived
-  }
 
   if (clamped && declaredSource) {
     try {
@@ -129,10 +129,10 @@ export function resolveToolSource(
           `declared=${declaredSource.type}:${declaredSource.identifier} (score=${declaredScore}), ` +
           `clamped=${source.type}:${source.identifier} (score=${ceilingScore}) ` +
           `via ${detection.method} (confidence: ${detection.confidence})` +
-          // Without this an operator-identity block reads as a contradiction in
-          // the ledger: the scores are EQUAL, yet the claim was rejected.
-          (operatorClaimBlocked
-            ? ' — reason: operator identity is not self-declarable (type elevation at equal score)'
+          // Without this a same-score identity drop reads as a contradiction:
+          // the scores are EQUAL, yet the claim was rejected.
+          (identitySpoof
+            ? ' — reason: same-score identity is not self-declarable'
             : ''),
         fragmentation_score: null,
         pipeline_duration_ms: null,


### PR DESCRIPTION
Stacks on #269. Rewritten so the tests actually fire the 0.9 case and the **MCP-reachable** owner-spoof is closed.

## The hole

`clampSourceToCeiling` only rejects a declaration that **outscores** the env ceiling. A normal MCP process infers as `cli:mcp` (0.9). These claims are also 0.9, so the score clamp lets them through:

| Declaration | Reachable on MCP? | What it buys |
|---|---|---|
| `cli:openclaw-jarvis` | Yes (`sourceParam` allows `cli`) | `isOwner` on Jarvis's RESTRICTED row |
| `user:approved` | No (Zod rejects `type: user`) | operator exception on the ACL |

The first version of this PR only special-cased `type: user`. That is defence in depth, not the live bypass.

## The fix

In `resolveToolSource`: a **same-score different identity** is dropped to the env inference and audited as `SOURCE_ELEVATION_BLOCKED` (`same-score identity is not self-declarable`). Genuine downgrades (`file:import` 0.4 < `cli:mcp` 0.9) stay.

## Tests now pin the ceiling

Without `CLAUDE_CODE_ENTRYPOINT`, env is `agent:unknown` (0.3) and the score clamp already drops every 0.9 claim — the suite goes green for the wrong reason. These tests set the entrypoint so the ceiling is actually `cli:mcp` at 0.9, then assert:

- undeclared → `cli:mcp`
- `user:approved` → dropped to `cli:mcp`
- `cli:openclaw-jarvis` → dropped to `cli:mcp` (owner spoof)
- `file:import` → kept (downgrade)
- matching `cli:mcp` → kept and attested
- claim 13 walks resolve → `get_memory` for all three spoofs

## Verify

```
npm test -- threat-graph-attestation
npm test -- claims-proof -t 'claim 13'
npm test -- mcp-read-acl
```