### PR TITLE
fix(trust): drop tool_response inbound from shared-context bootstrap

### DIFF
--- a/src/__tests__/claims-proof.test.ts
+++ b/src/__tests__/claims-proof.test.ts
@@ -740,4 +740,26 @@ describe('F. Fleet isolation (cross-agent contamination)', () => {
     expect(jarvis.success).toBe(true);
     expect(jarvis.context ?? '').not.toContain(canary);
   });
+
+  it('claim 13: a tool_response write does not surface in get_context either', async () => {
+    const canary = 'JARVIS-TOOL-RESPONSE-POISON-CANARY';
+    // tool_response scores 0.5 (quarantine band), so addMemory would refuse
+    // the write. Stamp after a successful store — this claim tests the
+    // read-guard, not the write ACL.
+    const row = addMemory(
+      {
+        title: `scanner output ${canary}`,
+        content: `External tool dumped this into memory ${canary}.`,
+        category: 'note',
+        project: PROJECT,
+      },
+      undefined,
+      JARVIS,
+    );
+    getDatabase().prepare(`UPDATE memories SET source = 'tool_response:browser' WHERE id = ?`).run(row.id);
+
+    const edith = await executeGetContext({ project: PROJECT, format: 'raw', source: EDITH });
+    expect(edith.success).toBe(true);
+    expect(edith.context ?? '').not.toContain(canary);
+  });
 });

--- a/src/__tests__/threat-graph-attestation.test.ts
+++ b/src/__tests__/threat-graph-attestation.test.ts
@@ -177,6 +177,16 @@ describe('#270 — same-score identity is not self-declarable', () => {
     expect(resolved.attested).toBe(true);
   });
 
+  it('drops cli:openclaw-jarvis at equal 0.9 even when strictSourceMode attests the declaration', () => {
+    // strict attests consequences; it must not skip the identity-spoof gate.
+    const resolved = resolveToolSource(
+      { type: 'cli', identifier: 'openclaw-jarvis' },
+      { toolName: 'get_memory', project: null, strict: true },
+    );
+    expect(resolved.source).toEqual({ type: 'cli', identifier: 'mcp' });
+    expect(resolved.clamped).toBe(true);
+  });
+
   it('keeps a genuine trust downgrade (file:import 0.4 < cli:mcp 0.9)', () => {
     const resolved = resolveToolSource(
       { type: 'file', identifier: 'import' },

--- a/src/defence/__tests__/read-guard.test.ts
+++ b/src/defence/__tests__/read-guard.test.ts
@@ -113,6 +113,14 @@ describe('guardReadBySensitivity (shared-context bootstrap surfaces)', () => {
     ];
     expect(guardReadBySensitivity(rows).map((m) => m.id)).toEqual([3]);
   });
+
+  it('drops tool_response inbound rows (same class as web/email)', () => {
+    const rows = [
+      mem({ id: 1, source: 'tool_response:browser', sensitivityLevel: 'PUBLIC' }),
+      mem({ id: 2, source: 'cli:openclaw-jarvis', sensitivityLevel: 'INTERNAL' }),
+    ];
+    expect(guardReadBySensitivity(rows).map((m) => m.id)).toEqual([2]);
+  });
 });
 
 describe('guardReadMemory', () => {

--- a/src/defence/trust/read-guard.ts
+++ b/src/defence/trust/read-guard.ts
@@ -75,16 +75,26 @@ export function guardReadRows<T extends Record<string, unknown>>(
  * start_session, the memory:// resources, restore_context, detect_contradictions).
  *
  * These surfaces feed the prompt / a broadly-shared project summary, so they must
- * NEVER surface RESTRICTED, quarantined, or untrusted-inbound (`web:` / `email:`)
- * rows to ANYONE — matching the .mjs prompt hooks and SCOPE P4 (a web capture
- * written by agent A must not bootstrap agent B). Unlike the per-caller fetch
- * tools they do NOT apply the source-relative own-only tier, so a low-trust
- * subagent still receives INTERNAL project context. Credential isolation
- * without the availability blackout.
+ * NEVER surface RESTRICTED, quarantined, or untrusted-inbound
+ * (`web:` / `email:` / `tool_response:`) rows to ANYONE — matching the
+ * .mjs prompt hooks and SCOPE P4 (a capture written by agent A must not
+ * bootstrap agent B). `tool_response` is a first-class DefenceSource
+ * (score 0.5) for raw external tool output; a prefix denylist that omits
+ * it lets an inbound capture land in every agent's get_context.
+ * Unlike the per-caller fetch tools they do NOT apply the source-relative
+ * own-only tier, so a low-trust subagent still receives INTERNAL project
+ * context. Credential isolation without the availability blackout.
  */
+const UNTRUSTED_INBOUND_TYPES = new Set(['web', 'email', 'tool_response']);
+
 function isUntrustedInboundSource(source: string | null | undefined): boolean {
+  // Null/empty stays fail-open: many INTERNAL rows are still unstamped, and
+  // this surface must keep shared project context available. Fail-closed for
+  // unknown provenance is a separate change.
   if (!source) return false;
-  return source.startsWith('web:') || source.startsWith('email:');
+  const sep = source.indexOf(':');
+  const type = (sep === -1 ? source : source.slice(0, sep)).toLowerCase();
+  return UNTRUSTED_INBOUND_TYPES.has(type);
 }
 
 export function guardReadBySensitivity(memories: Memory[]): Memory[] {


### PR DESCRIPTION
Stacks on #269 (`feat/isolation-claims-f` @ `866a9f5`). #270 already merged into that branch.

## Problem

#269's shared-context denylist is `web:` / `email:` only. `tool_response` is a first-class DefenceSource (score 0.5) for raw external tool output — the same class `scanToolResponse` exists to handle — and still landed in `get_context` / `memory://` / `start_session`.

## Fix

`guardReadBySensitivity` now parses the stored source type (case-insensitive) and drops `tool_response` alongside `web`/`email`. Null/empty source stays fail-open (legacy unstamped INTERNAL).

Claim 13 sibling stamps `tool_response:browser` after a successful store because the write ACL quarantines trust 0.5. Also locks that `strictSourceMode` attestation cannot skip #270's same-score identity-spoof gate.

## Verify

```
npm test -- src/defence/__tests__/read-guard.test.ts \
  src/__tests__/threat-graph-attestation.test.ts \
  src/defence/__tests__/access-control.test.ts --no-coverage
npm run build:ts
```

50/50 + typecheck on this host. Independent read-only review: APPROVE, no blockers.

Does not merge to main. Land after #269.