### PR TITLE
docs(threat-graph): use a generic source-key example in user-facing text

### DIFF
--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -8,7 +8,7 @@ import type { EntityType, ExtractionResult } from './extract.js';
  * cross-table lookup.
  */
 export interface TripleProvenance {
-  /** Canonical source tuple of the writing memory (e.g. `agent:jarvis`). */
+  /** Canonical source tuple of the writing memory (e.g. `agent:build-bot`). */
   writerSource: string;
   /** Trust score at write time (raw — capping is applied on store). */
   writerTrust: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -991,7 +991,7 @@ ${bold}DOCS${reset}
     } else if (action === 'reset-source') {
       const key = process.argv[4];
       if (!key) {
-        console.error("Usage: shieldcortex threat-graph reset-source '<source-key>'  (e.g. 'agent:jarvis')");
+        console.error("Usage: shieldcortex threat-graph reset-source '<source-key>'  (e.g. 'agent:build-bot')");
         process.exit(1);
       }
       const { resetSourceRisk } = await import('./threat-graph/risk.js');

--- a/src/server.ts
+++ b/src/server.ts
@@ -768,7 +768,7 @@ but you can use this tool to check for new contradictions at any time.`,
     'Query the threat graph — the security event graph projected from the defence audit ledgers. Views: sources (per-source counters), source (one source with its triggered patterns + recent events), events (recent notable events), campaigns (coordinated-attack clusters), allowances (operator auto-release grants), conflicts (relation-channel disputes awaiting review). Responses are row- and byte-capped with an explicit truncated flag.',
     {
       view: z.enum(['sources', 'source', 'events', 'campaigns', 'allowances', 'conflicts']).describe('What to list'),
-      key: z.string().optional().describe("Source key for view 'source', e.g. 'agent:jarvis'"),
+      key: z.string().optional().describe("Source key for view 'source', e.g. 'agent:build-bot'"),
       project: z.string().optional().describe('Filter events by originating project'),
       since: z.string().optional().describe('ISO timestamp — only rows seen at/after this'),
       limit: z.number().optional().describe('Max rows (default 50, hard cap 200)'),

--- a/src/tools/threat-graph.ts
+++ b/src/tools/threat-graph.ts
@@ -11,7 +11,7 @@ import { listAllowances } from '../threat-graph/allowance.js';
 
 export interface ThreatGraphQueryArgs {
   view: 'sources' | 'source' | 'events' | 'campaigns' | 'allowances' | 'conflicts';
-  /** Node key for view 'source' (e.g. 'agent:jarvis'). */
+  /** Node key for view 'source' (e.g. 'agent:build-bot'). */
   key?: string;
   /** Filter events by originating project. */
   project?: string;


### PR DESCRIPTION
The published package used a fleet agent name as the canonical example of a source key, so every consumer saw internal naming as the documented shape. Verified against the published `shieldcortex@4.50.0` tarball before changing anything.

## What users were seeing

```js
// dist/server.js — the threat_graph MCP tool schema, read by every user's model
.describe("Source key for view 'source', e.g. 'agent:jarvis'")

// dist/index.js — the CLI usage line
"Usage: shieldcortex threat-graph reset-source '<source-key>'  (e.g. 'agent:jarvis')"
```

## Changed

All four now read `agent:build-bot`, which illustrates the `type:identifier` shape without naming anyone's infrastructure:

| file | surface |
|---|---|
| `src/server.ts` | `threat_graph` MCP tool schema — every user's model reads this when deciding how to call the tool |
| `src/index.ts` | `threat-graph reset-source` CLI usage line |
| `src/tools/threat-graph.ts` | JSDoc for the same `key` field — ships in the `.d.ts`, shows in a consumer's editor |
| `src/graph/resolve.ts` | JSDoc for `TripleProvenance.writerSource`, same |

The two JSDoc lines document the *same* fields as the two runtime strings, so fixing only the runtime side would have left an inconsistency in the published types.

No behaviour change — these are examples in descriptions and usage text, and nothing asserts on them (the `agent:jarvis` occurrences in tests are fixture *data*, untouched). Confirmed `agent:jarvis` no longer appears anywhere in `dist/`.

## Deliberately not touched

- **Incident-provenance comments** (`Hit live on Friday-Mac's backup cron…`, `Live incident (Edith, 2026-07-21): 79.6 MB DB…`). These are why several of those fixes are precise rather than guessed. Stripping them from the tarball would mean `removeComments`, which also drops the JSDoc consumers rely on — a real trade, not a free win. Left as a conscious call.
- `src/cortex/store.ts` — a trailing `//` comment that never reaches the `.d.ts`, so it is internal only.

## Verification

- `npm run build:ts` clean; `agent:jarvis` verified absent from `dist/`.
- Full suite: **438 suites / 5268 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
