### PR TITLE
docs: add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, colour, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologising to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behaviour include:
+
+* The use of sexualised language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the community leaders responsible for enforcement at
+<support@drakonsystems.com>. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behaviour deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behaviour was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behaviour. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behaviour.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behaviour, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to ShieldCortex
+
+Thanks for taking the time to contribute. ShieldCortex guards agent memory, so a bug
+here can quietly weaken someone else's security posture — we hold changes to a higher
+bar than the size of the diff usually suggests.
+
+## Ground Rules
+
+- **Security issues never go in a public issue.** Follow [SECURITY.md](SECURITY.md)
+  and email <security@drakonsystems.com> instead.
+- **Open an issue before a large change.** For anything beyond a bug fix or a docs
+  correction, describe the problem first so we can agree the approach before you
+  spend the effort.
+- **One concern per pull request.** A security fix should not carry a refactor along
+  with it; they need different levels of scrutiny.
+
+## Getting Set Up
+
+Node 20 or later is required (CI runs 20 and 22).
+
+```bash
+git clone https://github.com/Drakon-Systems-Ltd/ShieldCortex.git
+cd ShieldCortex
+npm ci
+npm run build:ts
+npm test
+```
+
+For iterating without a rebuild each time, `npm run dev` runs the entry point through
+`tsx`. The dashboard is a separate workspace: `cd dashboard && npm ci && npm run dev`.
+
+## Before You Open a Pull Request
+
+Run what CI runs, so the first failure you see is yours rather than the pipeline's:
+
+```bash
+npm run build:ts          # must compile clean
+npm test                  # Jest suite
+npm run test:dist         # no ESM-unsafe require() in dist
+npm run guard:precision -- --planes   # Action Guard false-positive gate
+```
+
+If you touched the dashboard, also `cd dashboard && npm run lint && npm run build`.
+
+A green suite is not the same as a working change. Run the real command against real
+input and read what it actually printed before you call it done — most regressions we
+have shipped passed their tests.
+
+## Pull Request Expectations
+
+- **Explain the failure, not just the fix.** Describe what breaks without your change
+  and how you reproduced it. A fix for an unreproduced fault is a guess.
+- **Include a regression test** that fails before your change and passes after. If you
+  cannot write one, say why in the PR description.
+- **Keep the diff the smallest one that fully solves the problem.** Opportunistic
+  tidying makes a security review much harder.
+- **Comments explain why, not what** — especially any non-obvious constraint that
+  would tempt a future reader to "simplify" the code back into a bug.
+- **Say what you did not do.** Parts you skipped, could not reach, or left unproven
+  belong in the description. Silence about a gap reads as coverage.
+
+## Areas That Need Extra Care
+
+- **The Action Guard** — over-blocking is as damaging as under-blocking. Any change to
+  its matching logic needs `npm run guard:precision` evidence in the PR.
+- **Memory and claim scoping** — cross-agent contamination is the failure mode we care
+  about most. Changes here need tests that prove isolation holds.
+- **The host environment** — ShieldCortex must never break the agent or gateway it is
+  installed into. Nothing in the install, repair, or hook paths may leave a host worse
+  off than it found it.
+
+## Reporting Bugs
+
+Include the ShieldCortex version (`shieldcortex --version`), Node version, operating
+system, the exact command you ran, and the full output. "It doesn't work" costs a
+round trip we could both skip.
+
+## Licence
+
+By contributing you agree that your contributions are licensed under the MIT Licence,
+the same terms that cover the rest of the project. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -931,6 +931,15 @@ The [cloud free tier](https://shieldcortex.ai/pricing) is included: 500 scans/mo
 
 **Enterprise** adds full cloud memory/graph replication, shared review, Replay, Verify, Device Doctor, key scopes, multi-device fleets, and self-hosted deployments — contact **sales@drakonsystems.com**.
 
+## 🤝 Contributing
+
+Bug reports and pull requests are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for
+setup, the checks CI runs, and what a good PR looks like. Participation is governed by
+our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Found a security vulnerability? Do **not** open a public issue — follow
+[SECURITY.md](SECURITY.md) and email **security@drakonsystems.com**.
+
 ---
 
 <p align="center">
@@ -938,7 +947,9 @@ The [cloud free tier](https://shieldcortex.ai/pricing) is included: 500 scans/mo
   <a href="https://shieldcortex.ai/docs">Documentation</a> ·
   <a href="https://www.npmjs.com/package/shieldcortex">npm</a> ·
   <a href="https://pypi.org/project/shieldcortex/">PyPI</a> ·
-  <a href="CHANGELOG.md">Changelog</a>
+  <a href="CHANGELOG.md">Changelog</a> ·
+  <a href="CONTRIBUTING.md">Contributing</a> ·
+  <a href="SECURITY.md">Security</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Snyk Advisor flags both files as missing on `shieldcortex`, which drags the community/health score down.

## What's here

- **CONTRIBUTING.md** — setup, and the checks CI actually runs (`build:ts`, `test`, `test:dist`, `guard:precision -- --planes`) so a contributor's first failure is their own rather than the pipeline's. Calls out the three areas needing extra review care: the Action Guard (over-blocking is as damaging as under-blocking), claim/memory scoping, and host safety.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1. Reports route to support@drakonsystems.com, which is verified live; a fresh `conduct@` alias would have bounced the way security@ did before 7 Aug.
- **README.md** — links both, plus SECURITY.md, which nothing in the README pointed at before.

Docs only, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)