### PR TITLE
feat(cli): shieldcortex enable/disable — the command doctor could not point at (#275)

### DIFF
--- a/src/__tests__/enable-disable-275.test.ts
+++ b/src/__tests__/enable-disable-275.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { mkdtempSync, rmSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * #275 — `shieldcortex enable|disable`.
+ *
+ * `doctor` used to prescribe a JSON key path (`actionGuard.notify.enabled: true`)
+ * with no command that could set it: `shieldcortex config` is cloud-only, so the
+ * only route was hand-editing `~/.shieldcortex/config.json`. That edit breaks the
+ * embedded `_sig` HMAC, so the next read reports "possible tampering detected"
+ * and forces `defenceMode: strict` — the tool's own remediation advice degraded
+ * the install.
+ *
+ * The contract pinned here:
+ *   1. Every toggle writes through the SIGNING writer, so a feature the operator
+ *      enabled never reads back as tampered. This is the whole point.
+ *   2. Unrelated settings survive (a config write must never wipe cloudApiKey).
+ *   3. An unknown feature fails loudly and names the real ones — no silent no-op.
+ *   4. Reading state never mutates the config.
+ */
+
+const originalConfigDir = process.env.SHIELDCORTEX_CONFIG_DIR;
+
+describe('#275 — enable/disable toggles', () => {
+  let tempDir: string;
+  let configDir: string;
+  let configFile: string;
+
+  beforeEach(() => {
+    jest.resetModules();
+    tempDir = mkdtempSync(join(tmpdir(), 'sc-toggles-'));
+    configDir = join(tempDir, '.shieldcortex');
+    mkdirSync(configDir, { recursive: true });
+    configFile = join(configDir, 'config.json');
+    process.env.SHIELDCORTEX_CONFIG_DIR = configDir;
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) delete process.env.SHIELDCORTEX_CONFIG_DIR;
+    else process.env.SHIELDCORTEX_CONFIG_DIR = originalConfigDir;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const readConfig = () => JSON.parse(readFileSync(configFile, 'utf8')) as Record<string, unknown>;
+
+  it('enabling a feature does NOT trip the integrity check (the #275 defect)', async () => {
+    const { setCloudConfig, isConfigTampered, clearCloudConfigCache, readRawConfig } =
+      await import('../cloud/config.js');
+    const { applyToggle } = await import('../cli/toggles.js');
+
+    // A legitimately-signed starting config, with a secret that must survive.
+    setCloudConfig({ cloudApiKey: 'sc_live_' + 'KEEPME', cloudEnabled: true });
+    expect(typeof readConfig()._sig).toBe('string');
+
+    const result = applyToggle('notify', true, { openclaw: true });
+    expect(result.ok).toBe(true);
+
+    // The value landed…
+    const guard = readRawConfig().actionGuard as Record<string, unknown>;
+    const notify = guard.notify as Record<string, unknown>;
+    expect(notify.enabled).toBe(true);
+    expect(notify.openclaw).toBe(true);
+
+    // …the file is still signed, and a FRESH read does not cry tampering.
+    expect(typeof readConfig()._sig).toBe('string');
+    clearCloudConfigCache();
+    readRawConfig();
+    expect(isConfigTampered()).toBe(false);
+  });
+
+  it('preserves unrelated settings — a toggle must never wipe the config', async () => {
+    const { setCloudConfig, getCloudConfig, clearCloudConfigCache } = await import('../cloud/config.js');
+    const { applyToggle } = await import('../cli/toggles.js');
+
+    setCloudConfig({ cloudApiKey: 'sc_live_' + 'KEEPME', cloudEnabled: true });
+    applyToggle('notify', true, { openclaw: true });
+
+    clearCloudConfigCache();
+    const cloud = getCloudConfig();
+    expect(cloud.cloudApiKey).toBe('sc_live_' + 'KEEPME');
+    expect(cloud.cloudEnabled).toBe(true);
+  });
+
+  it('disable turns the feature off without removing neighbouring keys', async () => {
+    const { readRawConfig, clearCloudConfigCache } = await import('../cloud/config.js');
+    const { applyToggle } = await import('../cli/toggles.js');
+
+    applyToggle('notify', true, { webhookUrl: 'https://ops.example/hook' });
+    applyToggle('notify', false, {});
+
+    clearCloudConfigCache();
+    const notify = (readRawConfig().actionGuard as Record<string, unknown>).notify as Record<string, unknown>;
+    expect(notify.enabled).toBe(false);
+    // The endpoint is retained so re-enabling does not require re-entering it.
+    expect(notify.webhookUrl).toBe('https://ops.example/hook');
+  });
+
+  it('rejects an unknown feature and names the real ones', async () => {
+    const { applyToggle, listToggles } = await import('../cli/toggles.js');
+    const result = applyToggle('nonsense', true, {});
+    expect(result.ok).toBe(false);
+    const ids = listToggles().map((t) => t.id);
+    expect(ids).toContain('notify');
+    for (const id of ids) expect(typeof id).toBe('string');
+    // The error has to be actionable — it must list what IS valid.
+    expect(ids.some((id) => result.message.includes(id))).toBe(true);
+  });
+
+  it('refuses a webhook URL that is not http(s) rather than storing a spoofed channel', async () => {
+    const { applyToggle } = await import('../cli/toggles.js');
+    const result = applyToggle('notify', true, { webhookUrl: 'javascript:alert(1)' });
+    expect(result.ok).toBe(false);
+  });
+
+  it('listing state never mutates the config', async () => {
+    const { listToggles } = await import('../cli/toggles.js');
+    writeFileSync(configFile, JSON.stringify({ deviceId: 'abc' }, null, 2) + '\n', { mode: 0o600 });
+    const before = readFileSync(configFile, 'utf8');
+    listToggles();
+    expect(readFileSync(configFile, 'utf8')).toBe(before);
+  });
+
+  it('every registered toggle reports a state and a one-line summary', async () => {
+    const { listToggles } = await import('../cli/toggles.js');
+    for (const t of listToggles()) {
+      expect(t.summary.length).toBeGreaterThan(0);
+      expect(['on', 'off', 'unknown']).toContain(t.state);
+    }
+  });
+});
+
+/**
+ * Pins EXISTING behaviour (config.ts:554 clears the flag on a legitimate write).
+ * Written while checking a claim in #275 that the flag was never cleared — it is,
+ * on any signed write; it is only stale after a HAND-heal outside the product.
+ * Kept as a regression test so the healing path cannot silently rot.
+ */
+describe('#275 — a signed write clears the tampered flag', () => {
+  let tempDir: string;
+  let configDir: string;
+
+  beforeEach(() => {
+    jest.resetModules();
+    tempDir = mkdtempSync(join(tmpdir(), 'sc-tamperflag-'));
+    configDir = join(tempDir, '.shieldcortex');
+    mkdirSync(configDir, { recursive: true });
+    process.env.SHIELDCORTEX_CONFIG_DIR = configDir;
+  });
+
+  afterEach(() => {
+    if (originalConfigDir === undefined) delete process.env.SHIELDCORTEX_CONFIG_DIR;
+    else process.env.SHIELDCORTEX_CONFIG_DIR = originalConfigDir;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('a healed config stops reporting tampered once the cache is cleared', async () => {
+    const { setCloudConfig, readRawConfig, isConfigTampered, clearCloudConfigCache } =
+      await import('../cloud/config.js');
+    const configFile = join(configDir, 'config.json');
+
+    setCloudConfig({ cloudEnabled: false });
+    // Hand-edit while keeping the now-stale `_sig` — the naive operator edit.
+    const bad = JSON.parse(readFileSync(configFile, 'utf8')) as Record<string, unknown>;
+    bad.somethingNew = true;
+    writeFileSync(configFile, JSON.stringify(bad, null, 2) + '\n', { mode: 0o600 });
+    clearCloudConfigCache();
+    readRawConfig();
+    expect(isConfigTampered()).toBe(true);
+
+    // Heal it the way the product does (a signed write), then clear the cache.
+    setCloudConfig({ cloudEnabled: false });
+    clearCloudConfigCache();
+    readRawConfig();
+    expect(isConfigTampered()).toBe(false);
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2162,9 +2162,13 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
             `Action Guard is enforcing with no notify channel (actionGuard.notify.webhookUrl unset` +
             `${notifyOn ? '' : ', notify.enabled is not true'}) — unattended denials stay in the ` +
             `audit log and session-guard index only. The #242 cron incidents were this shape.`,
+          // #275: a runnable command, not a config fragment. Hand-editing
+          // config.json invalidates its `_sig` and reads back as tampering, so
+          // the remediation has to be something the operator can actually run.
           fix:
-            'Set `actionGuard.notify.enabled: true` and `actionGuard.notify.webhookUrl` to an https endpoint ' +
-            '(or `notify.openclaw: true`) so a denied cron reaches a human. OpenClaw lastRunStatus is not ShieldCortex\'s to write.',
+            'Run `shieldcortex enable notify --openclaw` to route denials through the gateway you already have ' +
+            '(no endpoint needed), or `shieldcortex enable notify --webhook https://… --secret <key>` for a signed POST. ' +
+            'OpenClaw lastRunStatus is not ShieldCortex\'s to write.',
         });
       }
     }

--- a/src/cli/enable.ts
+++ b/src/cli/enable.ts
@@ -1,0 +1,73 @@
+/**
+ * `shieldcortex enable|disable [feature] [options]` (#275).
+ *
+ * The command `doctor` could not previously point at. With no feature named it
+ * prints the whole registry and each toggle's current state, so "what can I turn
+ * on, and what is on right now?" is one command rather than a config-file
+ * archaeology session.
+ *
+ * Writes go through the signing config writer (see toggles.ts) — an operator
+ * should never have to hand-edit `config.json`, because that trips the integrity
+ * check and silently forces strict mode.
+ */
+
+import { applyToggle, listToggles, type ToggleOptions } from './toggles.js';
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + ' '.repeat(n - s.length);
+}
+
+function printRegistry(): void {
+  const rows = listToggles();
+  const width = Math.max(...rows.map((r) => r.id.length));
+  console.log('\nShieldCortex features\n');
+  for (const r of rows) {
+    const mark = r.state === 'on' ? '●' : r.state === 'off' ? '○' : '?';
+    console.log(`  ${mark} ${pad(r.id, width)}  ${pad(r.state, 7)} ${r.summary}`);
+    if (r.detail) console.log(`    ${' '.repeat(width)}          ${r.detail}`);
+  }
+  console.log('\n  ● on   ○ off   ? unknown\n');
+  console.log('  shieldcortex enable <feature>     shieldcortex disable <feature>\n');
+  console.log('  Options: --openclaw | --webhook <url> [--secret <key>]   (notify)');
+  console.log('           --warn-only                                     (action-guard)\n');
+  console.log('  Settings live in ~/.shieldcortex/config.json — do not edit it by hand;');
+  console.log('  these commands re-sign it, a manual edit reads back as tampering.\n');
+}
+
+/** `--flag value` / `--flag` parsing, deliberately tiny — no dependency. */
+function parseOptions(args: string[]): ToggleOptions {
+  const opts: ToggleOptions = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--openclaw') opts.openclaw = true;
+    else if (a === '--no-openclaw') opts.openclaw = false;
+    else if (a === '--warn-only') opts.warnOnly = true;
+    else if (a === '--webhook') opts.webhookUrl = args[++i];
+    else if (a === '--secret') opts.webhookSecret = args[++i];
+  }
+  return opts;
+}
+
+export function handleToggleCommand(argv: string[], on: boolean): void {
+  const verb = on ? 'enable' : 'disable';
+  const feature = argv.find((a) => !a.startsWith('--'));
+
+  if (!feature) {
+    printRegistry();
+    return;
+  }
+
+  const result = applyToggle(feature, on, parseOptions(argv));
+  if (!result.ok) {
+    console.error(`✗ ${result.message}`);
+    console.error(`\n  Run \`shieldcortex ${verb}\` with no arguments to see every feature and its state.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`✓ ${result.message}`);
+  for (const note of result.notes) console.log(`  → ${note}`);
+
+  const after = listToggles().find((t) => t.id === feature);
+  if (after) console.log(`  now: ${after.state}${after.detail ? ` (${after.detail})` : ''}`);
+}

--- a/src/cli/toggles.ts
+++ b/src/cli/toggles.ts
@@ -1,0 +1,300 @@
+/**
+ * The feature-toggle registry behind `shieldcortex enable|disable` (#275).
+ *
+ * Before this, `doctor` prescribed config VALUES (`actionGuard.notify.enabled:
+ * true`) with no command that could set them — `shieldcortex config` is
+ * cloud-only. The only route left was hand-editing `~/.shieldcortex/config.json`,
+ * which invalidates the embedded `_sig` HMAC, so the next read reported
+ * "possible tampering detected" and forced `defenceMode: strict`. The tool's own
+ * remediation advice degraded the install.
+ *
+ * So the rule this module exists to enforce: **every toggle writes through the
+ * signing writer** (`mutateRawConfig`), never by hand. A feature the operator
+ * turned on must never read back as tampering.
+ *
+ * Adding a toggle: add a descriptor below. Keep `read` free of side effects —
+ * `listToggles()` is called by `doctor` and must never mutate the config.
+ */
+
+import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'node:fs';
+import { mutateRawConfig, readRawConfig } from '../cloud/config.js';
+import { openClawConfigPath } from '../setup/openclaw.js';
+
+export type ToggleState = 'on' | 'off' | 'unknown';
+
+export interface ToggleInfo {
+  id: string;
+  summary: string;
+  state: ToggleState;
+  /** Where the value lives — shown so an operator knows which file is authoritative. */
+  backing: 'shieldcortex' | 'openclaw';
+  /** Extra context for the current state (e.g. which channel is configured). */
+  detail?: string;
+}
+
+export interface ToggleOptions {
+  /** notify: deliver through the OpenClaw gateway's approval cards. */
+  openclaw?: boolean;
+  /** notify: deliver by signed webhook POST. */
+  webhookUrl?: string;
+  /** notify: HMAC key for the webhook body. */
+  webhookSecret?: string;
+  /** action-guard: opt down to warn-and-allow for the dangerous tier. */
+  warnOnly?: boolean;
+}
+
+export interface ToggleResult {
+  ok: boolean;
+  message: string;
+  /** Follow-up the operator still has to do (e.g. restart the gateway). */
+  notes: string[];
+}
+
+interface ToggleDescriptor {
+  id: string;
+  summary: string;
+  backing: 'shieldcortex' | 'openclaw';
+  read(): { state: ToggleState; detail?: string };
+  apply(on: boolean, opts: ToggleOptions): ToggleResult;
+}
+
+/** The `actionGuard` sub-object, created on demand. */
+function guardBlock(raw: Record<string, unknown>): Record<string, unknown> {
+  const existing = raw.actionGuard;
+  const block = existing && typeof existing === 'object' && !Array.isArray(existing)
+    ? (existing as Record<string, unknown>)
+    : {};
+  raw.actionGuard = block;
+  return block;
+}
+
+function subBlock(parent: Record<string, unknown>, key: string): Record<string, unknown> {
+  const existing = parent[key];
+  const block = existing && typeof existing === 'object' && !Array.isArray(existing)
+    ? (existing as Record<string, unknown>)
+    : {};
+  parent[key] = block;
+  return block;
+}
+
+function readGuard(): Record<string, unknown> {
+  const raw = readRawConfig();
+  const block = raw.actionGuard;
+  return block && typeof block === 'object' && !Array.isArray(block)
+    ? (block as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Same acceptance rule as notify-config.ts: only `http:`/`https:` is a channel.
+ * Anything else degrades to "no configured channel" rather than a spoofed one,
+ * so we refuse it at the door instead of storing it.
+ */
+function isAcceptableWebhook(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+const TOGGLES: ToggleDescriptor[] = [
+  {
+    id: 'notify',
+    summary: 'Send unattended Action Guard denials to a human (OpenClaw card or signed webhook)',
+    backing: 'shieldcortex',
+    read() {
+      const notify = readGuard().notify;
+      const block = notify && typeof notify === 'object' ? (notify as Record<string, unknown>) : {};
+      const channels = [
+        block.openclaw === true ? 'openclaw' : null,
+        typeof block.webhookUrl === 'string' && block.webhookUrl ? 'webhook' : null,
+      ].filter(Boolean);
+      return {
+        state: block.enabled === true ? 'on' : 'off',
+        detail: channels.length ? `channel: ${channels.join(' + ')}` : 'no channel configured',
+      };
+    },
+    apply(on, opts) {
+      if (on && opts.webhookUrl && !isAcceptableWebhook(opts.webhookUrl)) {
+        return {
+          ok: false,
+          notes: [],
+          message: `--webhook must be an http(s) URL (got "${opts.webhookUrl}"). A non-http scheme cannot be a notify channel.`,
+        };
+      }
+      // Enabling with no channel named is the #275 trap in reverse: the switch
+      // is on and nothing is reachable. Default to the gateway, which needs no
+      // endpoint and is what most installs already have wired.
+      const useOpenClaw = on && (opts.openclaw === true || (!opts.webhookUrl && opts.openclaw !== false));
+
+      mutateRawConfig((raw) => {
+        const notify = subBlock(guardBlock(raw), 'notify');
+        notify.enabled = on;
+        if (on) {
+          if (useOpenClaw) notify.openclaw = true;
+          if (opts.webhookUrl) notify.webhookUrl = opts.webhookUrl;
+          if (opts.webhookSecret) notify.webhookSecret = opts.webhookSecret;
+        }
+        // Disabling flips the master switch only — the endpoint is retained so
+        // re-enabling does not mean re-entering it.
+      });
+
+      if (!on) return { ok: true, notes: [], message: 'notify disabled — denials stay in the audit log only.' };
+
+      const notes: string[] = [];
+      if (useOpenClaw) notes.push('Delivering through the OpenClaw gateway — approvals appear on whatever channel it already reaches.');
+      if (opts.webhookUrl && !opts.webhookSecret) {
+        notes.push('No --secret given: this install can only send UNSIGNED POSTs. Any receiver worth pointing at should reject those.');
+      }
+      return { ok: true, notes, message: 'notify enabled.' };
+    },
+  },
+  {
+    id: 'action-guard',
+    summary: 'Gate dangerous tool calls before they run',
+    backing: 'shieldcortex',
+    read() {
+      const guard = readGuard();
+      if (guard.enabled === false) return { state: 'off', detail: 'tool calls are not gated' };
+      return {
+        state: 'on',
+        detail: guard.enforce === false ? 'warn-only (dangerous tier warns, does not block)' : 'enforcing',
+      };
+    },
+    apply(on, opts) {
+      mutateRawConfig((raw) => {
+        const guard = guardBlock(raw);
+        guard.enabled = on;
+        if (on) guard.enforce = opts.warnOnly !== true;
+      });
+      if (!on) {
+        return {
+          ok: true,
+          notes: ['Catastrophic operations are no longer blocked on this host.'],
+          message: 'action-guard disabled.',
+        };
+      }
+      return {
+        ok: true,
+        notes: opts.warnOnly === true
+          ? ['warn-only: the dangerous tier warns and allows. The catastrophic tier always blocks regardless.']
+          : [],
+        message: `action-guard enabled (${opts.warnOnly === true ? 'warn-only' : 'enforcing'}).`,
+      };
+    },
+  },
+  {
+    id: 'threat-graph',
+    summary: 'Project the audit ledgers into a per-source security event graph (advisory)',
+    backing: 'shieldcortex',
+    read() {
+      const block = readRawConfig().threatGraph;
+      const cfg = block && typeof block === 'object' ? (block as Record<string, unknown>) : {};
+      return { state: cfg.enabled === false ? 'off' : 'on', detail: 'advisory — changes no scan verdict' };
+    },
+    apply(on) {
+      mutateRawConfig((raw) => { subBlock(raw, 'threatGraph').enabled = on; });
+      return { ok: true, notes: [], message: `threat-graph ${on ? 'enabled' : 'disabled'}.` };
+    },
+  },
+  {
+    id: 'strict-source-mode',
+    summary: 'Harden consequences for unknown/self-declared callers',
+    backing: 'shieldcortex',
+    read() {
+      return {
+        state: readRawConfig().strictSourceMode === true ? 'on' : 'off',
+        detail: 'unknown sources score lower; sub-trust writes auto-quarantine',
+      };
+    },
+    apply(on) {
+      mutateRawConfig((raw) => { raw.strictSourceMode = on; });
+      return { ok: true, notes: [], message: `strict-source-mode ${on ? 'enabled' : 'disabled'}.` };
+    },
+  },
+  {
+    id: 'conversation-scanning',
+    summary: 'Let the gateway hand conversation content to ShieldCortex for scanning',
+    backing: 'openclaw',
+    read() {
+      try {
+        const path = openClawConfigPath();
+        if (!existsSync(path)) return { state: 'unknown', detail: 'no openclaw.json on this host' };
+        const cfg = JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+        const entry = ((cfg.plugins as Record<string, unknown> | undefined)?.entries as Record<string, unknown> | undefined)
+          ?.['shieldcortex-realtime'] as Record<string, unknown> | undefined;
+        if (!entry) return { state: 'unknown', detail: 'realtime plugin not registered' };
+        const hooks = entry.hooks as Record<string, unknown> | undefined;
+        return {
+          state: hooks?.allowConversationAccess === true ? 'on' : 'off',
+          detail: 'conversation content is sensitive — leaving this off is a valid choice',
+        };
+      } catch {
+        return { state: 'unknown', detail: 'openclaw.json unreadable' };
+      }
+    },
+    apply(on) {
+      const path = openClawConfigPath();
+      if (!existsSync(path)) {
+        return { ok: false, notes: [], message: `no openclaw.json at ${path} — nothing to change on this host.` };
+      }
+      let cfg: Record<string, unknown>;
+      try {
+        cfg = JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+      } catch {
+        // Same discipline as the config writer: never overwrite something we
+        // could not parse, or we destroy the operator's gateway settings.
+        return { ok: false, notes: [], message: `openclaw.json is unreadable — refusing to overwrite it. Fix ${path} and retry.` };
+      }
+      const plugins = subBlock(cfg, 'plugins');
+      const entries = subBlock(plugins, 'entries');
+      const entry = subBlock(entries, 'shieldcortex-realtime');
+      subBlock(entry, 'hooks').allowConversationAccess = on;
+
+      // The installer's own snapshot discipline (#214): back up before writing
+      // somebody else's config file.
+      const backup = `${path}.sc-toggle.bak`;
+      try { copyFileSync(path, backup); } catch { /* best-effort */ }
+      writeFileSync(path, JSON.stringify(cfg, null, 2) + '\n');
+
+      return {
+        ok: true,
+        notes: [
+          'Restart the OpenClaw gateway for this to take effect.',
+          `Previous config saved to ${backup}`,
+        ],
+        message: `conversation-scanning ${on ? 'enabled' : 'disabled'}.`,
+      };
+    },
+  },
+];
+
+export function listToggles(): ToggleInfo[] {
+  return TOGGLES.map((t) => {
+    let read: { state: ToggleState; detail?: string };
+    try {
+      read = t.read();
+    } catch {
+      read = { state: 'unknown', detail: 'could not be read' };
+    }
+    return { id: t.id, summary: t.summary, backing: t.backing, state: read.state, detail: read.detail };
+  });
+}
+
+export function applyToggle(id: string, on: boolean, opts: ToggleOptions): ToggleResult {
+  const toggle = TOGGLES.find((t) => t.id === id);
+  if (!toggle) {
+    return {
+      ok: false,
+      notes: [],
+      message: `unknown feature "${id}". Available: ${TOGGLES.map((t) => t.id).join(', ')}.`,
+    };
+  }
+  try {
+    return toggle.apply(on, opts);
+  } catch (err) {
+    return { ok: false, notes: [], message: `could not update "${id}": ${(err as Error).message}` };
+  }
+}

--- a/src/cloud/config.ts
+++ b/src/cloud/config.ts
@@ -576,7 +576,7 @@ function writeRawConfig(raw: Record<string, unknown>): void {
  * Returns true if the mutation was applied and persisted, false if it was
  * skipped because the config was unparseable (`onParseFail: 'skip'`).
  */
-function mutateRawConfig(
+export function mutateRawConfig(
   fn: (raw: Record<string, unknown>) => void,
   onParseFail: 'throw' | 'skip' = 'throw',
 ): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -788,6 +788,14 @@ ${bold}DOCS${reset}
     return;
   }
 
+  // Handle "enable"/"disable" (#275) — the feature toggles doctor points at.
+  // Bare `enable` lists every feature with its current state.
+  if (process.argv[2] === 'enable' || process.argv[2] === 'disable') {
+    const { handleToggleCommand } = await import('./cli/enable.js');
+    handleToggleCommand(process.argv.slice(3), process.argv[2] === 'enable');
+    return;
+  }
+
   // Handle "cloud" subcommand
   if (process.argv[2] === 'cloud') {
     const { handleCloudCommand } = await import('./cloud/cli.js');
@@ -1477,7 +1485,7 @@ ${bold}DOCS${reset}
   const knownCommands = new Set([
 
     'doctor', 'quickstart', 'setup', 'install', 'migrate', 'uninstall', 'hook', 'update', 'repair',
-    'openclaw', 'clawdbot', 'copilot', 'codex', 'service', 'config', 'status',
+    'openclaw', 'clawdbot', 'copilot', 'codex', 'service', 'config', 'status', 'enable', 'disable',
     'graph', 'license', 'licence', 'audit', 'mcp', 'iron-dome', 'scan', 'cloud', 'review-copilot',
     'scan-skill', 'scan-skills', 'dashboard', 'api', 'worker', 'stats', 'cortex', 'consolidate', 'xray', 'xray-preinstall',
     'memories', 'import-jsonl', 'remember', 'vacuum', 'compact', 'sessions', 'approve', 'deny', 'allowlist',

--- a/src/integrations/openclaw-conversation-access.ts
+++ b/src/integrations/openclaw-conversation-access.ts
@@ -83,7 +83,10 @@ export function readConversationAccess(home: string, pluginId: string): Conversa
  * plugin's startup line and the tests cannot drift apart.
  */
 export function conversationAccessFix(pluginId: string): string {
-  return `Add "hooks": { "allowConversationAccess": true } to plugins.entries["${pluginId}"] in ~/.openclaw/openclaw.json, then restart the gateway. Conversation content is sensitive — this is your call, and leaving it ungranted is a valid choice.`;
+  // #275: lead with the command. The equivalent hand-edit is still named,
+  // because an operator reviewing a consent decision deserves to see exactly
+  // which key it flips — but they should not have to hand-edit to apply it.
+  return `Run \`shieldcortex enable conversation-scanning\` (sets "hooks": { "allowConversationAccess": true } on plugins.entries["${pluginId}"] in ~/.openclaw/openclaw.json, and backs the file up first), then restart the gateway. Conversation content is sensitive — this is your call, and leaving it ungranted is a valid choice.`;
 }
 
 /**


### PR DESCRIPTION
Closes #275.

`doctor` prescribed config **values** with no command that could set them. `shieldcortex config` is cloud-only, so the only route left was hand-editing `~/.shieldcortex/config.json` — which invalidates the embedded `_sig`, so the next read reported *"possible tampering detected"* and forced `defenceMode: strict`. The tool's own remediation advice degraded the install. An operator who pasted the suggestion into a shell got:

```
$ actionGuard.notify.enabled: true
zsh: command not found: actionGuard.notify.enabled:
```

## The command

```
$ shieldcortex enable

ShieldCortex features

  ○ notify                 off     Send unattended Action Guard denials to a human (OpenClaw card or signed webhook)
                                   no channel configured
  ● action-guard           on      Gate dangerous tool calls before they run
                                   enforcing
  ● threat-graph           on      Project the audit ledgers into a per-source security event graph (advisory)
  ○ strict-source-mode     off     Harden consequences for unknown/self-declared callers
  ● conversation-scanning  on      Let the gateway hand conversation content to ShieldCortex for scanning

  ● on   ○ off   ? unknown
```

```
$ shieldcortex enable notify --openclaw
✓ notify enabled.
  → Delivering through the OpenClaw gateway — approvals appear on whatever channel it already reaches.
  now: on (channel: openclaw)
```

## What it does

- `shieldcortex enable|disable <feature>`; bare `enable` prints the registry with live state, so *"what can I turn on, and what is on now?"* is one command rather than config-file archaeology.
- **Every write goes through the signing writer** (`mutateRawConfig`, now exported). A feature the operator enabled never reads back as tampering — that invariant is the headline test.
- `notify` with no channel named **defaults to the gateway**: it needs no endpoint and most installs already have it wired, yet it was the least discoverable option because the old suggestion led with `webhookUrl`.
- Disabling **retains** a configured endpoint, so re-enabling is not a re-entry.
- A non-`http(s)` webhook is refused at the door rather than stored as a channel that silently degrades to none (matches `notify-config.ts`).
- `conversation-scanning` edits `openclaw.json`, so it **backs the file up first** (the installer's #214 snapshot discipline) and refuses to overwrite a file it could not parse (the config writer's discipline).
- `doctor` and the shared `conversationAccessFix` now emit **runnable commands** instead of JSON fragments, and the registry output states plainly: do not hand-edit `config.json`, these commands re-sign it.

Every config key in the registry was read off its consumer (`notify-config.ts`, `isThreatGraphEnabled`, `getStrictSourceMode`, the hook's `DEFAULT_ACTION_GUARD`) rather than assumed.

## Deliberately not changed

**The tamper verdict itself.** On an embedded-`_sig` mismatch there is no way to distinguish an operator edit from tampering, so it stays strict. The fix is removing the *need* to hand-edit, not softening the check.

**#275 defect 4 was withdrawn** ([comment](https://github.com/Drakon-Systems-Ltd/ShieldCortex/issues/275#issuecomment-5291094345)): I claimed `configTampered` was never cleared. It is — `config.ts:554`, on any legitimate write. It is only stale after a *hand*-heal outside the product, which is what made the workaround look broken when first tested in a single process. A regression test now pins that healing path rather than "fixing" a non-bug.

## Verification

- Headline test: enable a feature on a signed config → value lands, file still signed, fresh read reports `tampered: false`, and `cloudApiKey` survives.
- Also pinned: disable retains the endpoint; unknown feature fails loudly and names the valid ones; a `javascript:` webhook is rejected; `listToggles()` never mutates the config.
- End-to-end smoke through the real CLI handler: enable/disable/warn-only/unknown-exit-1 all correct.
- Full suite: **439 suites / 5276 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
