### PR TITLE
fix(config): signed CLI for Action Guard notify (#275)

### DIFF
--- a/src/__tests__/config-action-guard-notify-cli.test.ts
+++ b/src/__tests__/config-action-guard-notify-cli.test.ts
@@ -1,0 +1,138 @@
+/**
+ * #275 — `shieldcortex config --action-guard-notify-*` flags: the signed CLI
+ * path for setting the Action Guard notify channel. Before this, doctor's
+ * suggested fix was a bare key path ("set actionGuard.notify.enabled: true"),
+ * so operators hand-edited ~/.shieldcortex/config.json — which invalidated the
+ * embedded `_sig` HMAC and forced defenceMode strict. These flags write
+ * through mutateRawConfig/writeRawConfig, so the config is re-signed and the
+ * integrity check stays green.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { handleCloudConfig } from '../cloud/cli.js';
+import {
+  getActionGuardNotifyConfig,
+  setActionGuardNotifyConfig,
+  setReviewedScripts,
+  getConfigDir,
+  clearCloudConfigCache,
+  readRawConfig,
+  isConfigTampered,
+} from '../cloud/config.js';
+
+const configFile = () => path.join(getConfigDir(), 'config.json');
+const legacySigFile = () => path.join(getConfigDir(), '.config-sig');
+
+function resetConfigDir(): void {
+  fs.rmSync(configFile(), { force: true });
+  fs.rmSync(legacySigFile(), { force: true });
+  clearCloudConfigCache();
+}
+
+beforeEach(() => {
+  resetConfigDir();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  resetConfigDir();
+});
+
+describe('config --action-guard-notify-* flags (#275)', () => {
+  it('--action-guard-notify-openclaw enables notify via the OpenClaw approval channel', () => {
+    handleCloudConfig(['--action-guard-notify-openclaw']);
+    const cfg = getActionGuardNotifyConfig();
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.openclaw).toBe(true);
+  });
+
+  it('--action-guard-notify-webhook enables notify with the given https URL', () => {
+    handleCloudConfig(['--action-guard-notify-webhook', 'https://hooks.example.invalid/sc']);
+    const cfg = getActionGuardNotifyConfig();
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.webhookUrl).toBe('https://hooks.example.invalid/sc');
+  });
+
+  it('--action-guard-notify-disable turns notify off but keeps the channel config for re-enable', () => {
+    handleCloudConfig(['--action-guard-notify-webhook', 'https://hooks.example.invalid/sc']);
+    handleCloudConfig(['--action-guard-notify-disable']);
+    const cfg = getActionGuardNotifyConfig();
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.webhookUrl).toBe('https://hooks.example.invalid/sc');
+  });
+
+  it('rejects an http:// webhook URL and leaves the config untouched', () => {
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((): never => { throw new Error('exit'); }) as never);
+    expect(() =>
+      handleCloudConfig(['--action-guard-notify-webhook', 'http://hooks.example.invalid/sc']),
+    ).toThrow('exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const cfg = getActionGuardNotifyConfig();
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.webhookUrl).toBeUndefined();
+  });
+
+  it('rejects a non-URL webhook value', () => {
+    jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((): never => { throw new Error('exit'); }) as never);
+    expect(() =>
+      handleCloudConfig(['--action-guard-notify-webhook', 'not a url']),
+    ).toThrow('exit');
+    expect(getActionGuardNotifyConfig().enabled).toBe(false);
+  });
+
+  it('rejects a missing webhook value', () => {
+    jest
+      .spyOn(process, 'exit')
+      .mockImplementation(((): never => { throw new Error('exit'); }) as never);
+    expect(() => handleCloudConfig(['--action-guard-notify-webhook'])).toThrow('exit');
+    expect(getActionGuardNotifyConfig().enabled).toBe(false);
+  });
+
+  it('writes a SIGNED config: `_sig` is present and a fresh read does not trip the tamper flag', () => {
+    handleCloudConfig(['--action-guard-notify-openclaw']);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    expect(typeof onDisk._sig).toBe('string');
+    expect(onDisk._sig).toMatch(/^[0-9a-f]{64}$/);
+    clearCloudConfigCache();
+    const raw = readRawConfig();
+    expect(isConfigTampered()).toBe(false);
+    expect(raw.defenceMode).not.toBe('strict');
+  });
+
+  it('preserves sibling actionGuard keys and unrelated top-level keys on write', () => {
+    handleCloudConfig(['--mode', 'balanced']);
+    setReviewedScripts([{ hash: 'abc123' }]);
+    handleCloudConfig(['--action-guard-notify-webhook', 'https://hooks.example.invalid/sc']);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    expect(onDisk.defenceMode).toBe('balanced');
+    expect(onDisk.actionGuard.reviewedScripts).toEqual([{ hash: 'abc123' }]);
+    expect(onDisk.actionGuard.notify.enabled).toBe(true);
+    expect(onDisk.actionGuard.notify.webhookUrl).toBe('https://hooks.example.invalid/sc');
+  });
+
+  it('setActionGuardNotifyConfig rejects non-https URLs at the API layer too', () => {
+    expect(() => setActionGuardNotifyConfig({ webhookUrl: 'http://x.example/hook' })).toThrow(/https/);
+    expect(() => setActionGuardNotifyConfig({ webhookUrl: 'ftp://x.example/hook' })).toThrow(/https/);
+    expect(() => setActionGuardNotifyConfig({ webhookUrl: 'nonsense' })).toThrow(/https|URL/i);
+    expect(getActionGuardNotifyConfig().webhookUrl).toBeUndefined();
+  });
+
+  it('the same hand-edit the CLI replaces DOES trip the integrity check (why doctor must not recommend it)', () => {
+    handleCloudConfig(['--action-guard-notify-openclaw']);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    onDisk.actionGuard.notify.webhookUrl = 'https://hooks.example.invalid/hand-edited';
+    fs.writeFileSync(configFile(), JSON.stringify(onDisk, null, 2) + '\n');
+    clearCloudConfigCache();
+    const raw = readRawConfig();
+    expect(isConfigTampered()).toBe(true);
+    expect(raw.defenceMode).toBe('strict');
+  });
+});

--- a/src/cli/__tests__/doctor-action-guard.test.ts
+++ b/src/cli/__tests__/doctor-action-guard.test.ts
@@ -1,8 +1,14 @@
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
-import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { checkActionGuard, fixActionGuardConfig } from '../doctor.js';
+import { handleCloudConfig } from '../../cloud/cli.js';
+import {
+  getConfigDir,
+  clearCloudConfigCache,
+  readRawConfig,
+  isConfigTampered,
+} from '../../cloud/config.js';
 
 /**
  * Issue #94 — doctor had ZERO Action Guard check: its "Defence canary" probes
@@ -15,11 +21,20 @@ import { checkActionGuard, fixActionGuardConfig } from '../doctor.js';
  * wiring proof stays with the consent-gated live canary.
  */
 
-const configPath = () => path.join(os.homedir(), '.shieldcortex', 'config.json');
+// Same file the CLI setters and both runtime surfaces resolve — the jest
+// sandbox (scripts/jest-config-sandbox.mjs) points this at a per-worker dir,
+// so these tests never touch the developer's real ~/.shieldcortex.
+const configPath = () => path.join(getConfigDir(), 'config.json');
+const legacySigPath = () => path.join(getConfigDir(), '.config-sig');
 
 function writeConfig(cfg: Record<string, unknown>): void {
   fs.mkdirSync(path.dirname(configPath()), { recursive: true });
   fs.writeFileSync(configPath(), JSON.stringify(cfg, null, 2));
+  // A hand-written fixture is unsigned; a `.config-sig` left over from an
+  // earlier signed write would make it read as tampered. Drop it and the
+  // mtime cache so every fixture is adopted fresh.
+  fs.rmSync(legacySigPath(), { force: true });
+  clearCloudConfigCache();
 }
 
 let savedConfig: string | null = null;
@@ -34,6 +49,9 @@ afterEach(() => {
   } else {
     fs.writeFileSync(configPath(), savedConfig);
   }
+  fs.rmSync(legacySigPath(), { force: true });
+  clearCloudConfigCache();
+  jest.restoreAllMocks();
 });
 
 describe('doctor — Action Guard check (#94)', () => {
@@ -197,5 +215,114 @@ describe('doctor — Action Guard notify channel (#242)', () => {
     writeConfig({ actionGuard: { enforce: false } });
     const results = await checkActionGuard();
     expect(results.find((r) => /webhookUrl/i.test(r.message))).toBeUndefined();
+  });
+});
+
+/**
+ * #275 — the notify warn's Suggested fix must be a RUNNABLE command through the
+ * signed CLI path, not bare JSON key paths: operators who followed the old
+ * "set `actionGuard.notify.enabled: true`" prescription hand-edited
+ * config.json, invalidated the `_sig` HMAC, and got forced into strict mode.
+ */
+describe('doctor — Action Guard notify fix is a signed CLI command (#275)', () => {
+  const findNotifyWarn = async () => {
+    const results = await checkActionGuard();
+    return results.find((r) => r.status === 'warn' && /notify/.test(r.label));
+  };
+
+  it('prescribes `shieldcortex config` with a real flag, not bare key paths', async () => {
+    writeConfig({});
+    const warn = await findNotifyWarn();
+    expect(warn).toBeDefined();
+    expect(warn!.fix).toMatch(/shieldcortex config --action-guard-notify-(webhook|openclaw)/);
+    // The bare key-path prescription must no longer lead the fix.
+    expect(warn!.fix).not.toMatch(/Set `actionGuard\.notify/);
+  });
+
+  it('leads with the runnable command and never recommends hand-editing config.json', async () => {
+    writeConfig({});
+    const warn = await findNotifyWarn();
+    expect(warn).toBeDefined();
+    expect(warn!.fix!.startsWith('Run `shieldcortex config')).toBe(true);
+    // If config.json is mentioned at all it must be as a warning against
+    // editing it, never as an instruction: no sentence may open with an
+    // imperative Edit/Add/Set (the old fix began "Set `actionGuard...`").
+    expect(warn!.fix).not.toMatch(/(^|\.\s)(Edit|Add|Set)\b/);
+  });
+
+  it('warn clears when the OpenClaw channel is enabled via the CLI (signed write)', async () => {
+    fs.rmSync(configPath(), { force: true });
+    fs.rmSync(legacySigPath(), { force: true });
+    clearCloudConfigCache();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    handleCloudConfig(['--action-guard-notify-openclaw']);
+    const warn = await findNotifyWarn();
+    expect(warn).toBeUndefined();
+    const onDisk = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(typeof onDisk._sig).toBe('string');
+  });
+
+  it('warn clears when a webhook channel is set via the CLI (signed write)', async () => {
+    fs.rmSync(configPath(), { force: true });
+    fs.rmSync(legacySigPath(), { force: true });
+    clearCloudConfigCache();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    handleCloudConfig(['--action-guard-notify-webhook', 'https://hooks.example.invalid/sc']);
+    const warn = await findNotifyWarn();
+    expect(warn).toBeUndefined();
+    clearCloudConfigCache();
+    readRawConfig();
+    expect(isConfigTampered()).toBe(false);
+  });
+});
+
+/**
+ * #275 acceptance 7 — `doctor --fix-action-guard` used a bare fs.writeFileSync,
+ * so the migration it performed carried the OLD `_sig` (or none) and the fix
+ * itself tripped the integrity check into strict mode. The write must go
+ * through cloud/config's guarded mutate path, which re-signs.
+ */
+describe('doctor — fixActionGuardConfig re-signs the migrated config (#275)', () => {
+  it('migrated config carries a fresh `_sig` and reads back untampered', async () => {
+    writeConfig({ interceptor: { actionGuard: { enforce: false } } });
+    const fix = fixActionGuardConfig();
+    expect(fix.changed).toBe(true);
+
+    const after = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    expect(typeof after._sig).toBe('string');
+    expect(after._sig).toMatch(/^[0-9a-f]{64}$/);
+
+    clearCloudConfigCache();
+    const raw = readRawConfig();
+    expect(isConfigTampered()).toBe(false);
+    expect(raw.defenceMode).not.toBe('strict');
+
+    if (fix.backupPath) fs.rmSync(fix.backupPath, { force: true });
+  });
+
+  it('migration on an already-signed config stays untampered too', async () => {
+    // Build a SIGNED config containing the alias: sign a base config via the
+    // CLI path, then splice the alias in through another signed write is not
+    // possible (no setter writes `interceptor`), so adopt an unsigned fixture
+    // first read, then verify the migration write re-signs from there.
+    writeConfig({
+      actionGuard: { enforce: false },
+      interceptor: { enabled: true, actionGuard: { enforce: true, autoApprove: ['git_force_push'] } },
+    });
+    const fix = fixActionGuardConfig();
+    expect(fix.changed).toBe(true);
+
+    const after = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
+    // Merge semantics unchanged from #209: top-level wins, alias gap-fills.
+    expect(after.actionGuard).toEqual({ enforce: false, autoApprove: ['git_force_push'] });
+    expect(after.interceptor.actionGuard).toBeUndefined();
+    expect(after.interceptor.enabled).toBe(true);
+    expect(typeof after._sig).toBe('string');
+
+    clearCloudConfigCache();
+    readRawConfig();
+    expect(isConfigTampered()).toBe(false);
+
+    if (fix.backupPath) fs.rmSync(fix.backupPath, { force: true });
   });
 });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -56,6 +56,7 @@ import {
 // transport (cli-invoker.js) and the explainer (doctor-explainer.js) are
 // loaded with a runtime `import()` inside runDoctorAiSection() below, so a
 // plain `shieldcortex doctor` never touches either module.
+import { getConfigDir, readRawConfig, migrateInterceptorActionGuardAlias } from '../cloud/config.js';
 import { validateOpenClawConfig } from '../integrations/openclaw-config-validate.js';
 import type { OpenClawConfigVerdict, ValidateDeps } from '../integrations/openclaw-config-validate.js';
 import type { ModelInvoker } from '../defence/iron-dome/approval-judge.js';
@@ -2116,7 +2117,10 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
   //    evaluates posture warnings against the EFFECTIVE config with per-key
   //    provenance, and flags the alias itself so operators migrate off it.
   try {
-    const configPath = path.join(getShieldCortexDir(), 'config.json');
+    // getConfigDir (not getShieldCortexDir): the posture must be judged
+    // against the SAME file the `shieldcortex config` setters write and the
+    // runtime accessors read — including the SHIELDCORTEX_CONFIG_DIR override.
+    const configPath = path.join(getConfigDir(), 'config.json');
     const raw = fs.existsSync(configPath) ? JSON.parse(fs.readFileSync(configPath, 'utf-8')) : {};
     const isBlock = (v: unknown): v is Record<string, unknown> =>
       !!v && typeof v === 'object' && !Array.isArray(v);
@@ -2163,8 +2167,10 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
             `${notifyOn ? '' : ', notify.enabled is not true'}) — unattended denials stay in the ` +
             `audit log and session-guard index only. The #242 cron incidents were this shape.`,
           fix:
-            'Set `actionGuard.notify.enabled: true` and `actionGuard.notify.webhookUrl` to an https endpoint ' +
-            '(or `notify.openclaw: true`) so a denied cron reaches a human. OpenClaw lastRunStatus is not ShieldCortex\'s to write.',
+            'Run `shieldcortex config --action-guard-notify-webhook <https-url>` (or `shieldcortex config ' +
+            '--action-guard-notify-openclaw` for a native OpenClaw approval card) so a denied cron reaches a human. ' +
+            'The CLI writes a signed config — hand-editing config.json invalidates its integrity signature and ' +
+            'forces strict mode. OpenClaw lastRunStatus is not ShieldCortex\'s to write.',
         });
       }
     }
@@ -2210,9 +2216,9 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
  * Backs up config.json first and removes an emptied `interceptor` block.
  */
 export function fixActionGuardConfig(): { changed: boolean; backupPath?: string; message: string } {
-  const configPath = path.join(getShieldCortexDir(), 'config.json');
+  const configPath = path.join(getConfigDir(), 'config.json');
   if (!fs.existsSync(configPath)) return { changed: false, message: 'no config file — nothing to migrate' };
-  const raw = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  const raw = readRawConfig();
   const isBlock = (v: unknown): v is Record<string, unknown> =>
     !!v && typeof v === 'object' && !Array.isArray(v);
   const alias = isBlock(raw?.interceptor) && isBlock(raw.interceptor.actionGuard)
@@ -2223,10 +2229,11 @@ export function fixActionGuardConfig(): { changed: boolean; backupPath?: string;
   const backupPath = `${configPath}.bak-fix-209-${new Date().toISOString().replace(/[:.]/g, '-')}`;
   fs.copyFileSync(configPath, backupPath);
 
-  raw.actionGuard = { ...alias, ...(isBlock(raw.actionGuard) ? raw.actionGuard : {}) };
-  delete raw.interceptor.actionGuard;
-  if (Object.keys(raw.interceptor).length === 0) delete raw.interceptor;
-  fs.writeFileSync(configPath, JSON.stringify(raw, null, 2));
+  // The write goes through cloud/config's guarded mutate path (#275): the
+  // migrated file is re-signed with a fresh `_sig`. The previous bare
+  // fs.writeFileSync here carried the stale signature through, so running the
+  // fix ITSELF tripped the integrity check and forced strict mode.
+  migrateInterceptorActionGuardAlias();
   return {
     changed: true,
     backupPath,

--- a/src/cloud/cli.ts
+++ b/src/cloud/cli.ts
@@ -20,6 +20,8 @@ import {
   setToolResponseScanConfig,
   isRevokeBySourceEnabled,
   setRevokeBySourceEnabled,
+  getActionGuardNotifyConfig,
+  setActionGuardNotifyConfig,
   type DefenceMode,
 } from './config.js';
 import type { RankerEngine } from '../memory/types.js';
@@ -47,8 +49,13 @@ export function handleCloudConfig(args: string[]): void {
     const toolFirewall = getToolResponseScanConfig();
     const rankerOverridden = !!process.env.SHIELDCORTEX_RANKER;
     console.log('\nShieldCortex Configuration:');
+    const agNotify = getActionGuardNotifyConfig();
+    const agNotifyChannels = [agNotify.openclaw ? 'openclaw' : null, agNotify.webhookUrl ? 'webhook' : null]
+      .filter(Boolean)
+      .join(' + ');
     console.log(`  Defence Mode: ${mode}`);
     console.log(`  Tool-Output Firewall: ${toolFirewall.scanToolResponses ? toolFirewall.toolResponseMode : 'Off'}`);
+    console.log(`  Action Guard Notify: ${agNotify.enabled ? (agNotifyChannels || 'Enabled (no channel configured!)') : 'Off'}`);
     console.log(`  Revoke-by-source: ${isRevokeBySourceEnabled() ? 'Enabled (destructive)' : 'Disabled (default)'}`);
     console.log(`  Cloud Enabled:  ${config.cloudEnabled ? 'Yes' : 'No'}`);
     console.log(`  API Key:  ${config.cloudApiKey ? config.cloudApiKey.substring(0, 12) + '...' : 'Not set'}`);
@@ -284,6 +291,40 @@ export function handleCloudConfig(args: string[]): void {
     changed = true;
   }
 
+  // ── Action Guard notify channel (#275) ──
+  // The SIGNED path for what doctor's "enforcing with no notify channel" warn
+  // prescribes. Hand-editing config.json for these keys invalidates the `_sig`
+  // HMAC and forces defenceMode strict — these flags exist so nobody has to.
+
+  if (args.includes('--action-guard-notify-openclaw')) {
+    setActionGuardNotifyConfig({ enabled: true, openclaw: true });
+    console.log('Action Guard notify enabled via the OpenClaw approval channel — denials raise an approval card on your gateway\'s channel.');
+    changed = true;
+  }
+
+  const agNotifyWebhookIdx = args.indexOf('--action-guard-notify-webhook');
+  if (agNotifyWebhookIdx !== -1) {
+    const url = args[agNotifyWebhookIdx + 1];
+    if (!url || url.startsWith('--')) {
+      console.error('Missing value for --action-guard-notify-webhook. Provide an https:// URL, e.g. https://hooks.example.com/shieldcortex.');
+      process.exit(1);
+    }
+    try {
+      setActionGuardNotifyConfig({ enabled: true, webhookUrl: url });
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+    console.log(`Action Guard notify enabled via webhook: ${url.trim()}`);
+    changed = true;
+  }
+
+  if (args.includes('--action-guard-notify-disable')) {
+    setActionGuardNotifyConfig({ enabled: false });
+    console.log('Action Guard notify disabled — unattended denials will only reach the audit log and session-guard index.');
+    changed = true;
+  }
+
   if (args.includes('--allow-revoke-by-source')) {
     setRevokeBySourceEnabled(true);
     console.log('Revoke-by-source ENABLED. `forget --fromSource` can now bulk-delete a source\'s memories (trust-hierarchy ACL still applies). Disable again with --disallow-revoke-by-source when done.');
@@ -329,6 +370,9 @@ export function handleCloudConfig(args: string[]): void {
     console.log('  --tool-firewall-advisory  Log tool-output threats but deliver intact (default)');
     console.log('  --tool-firewall-off / --tool-firewall-on  Disable / enable tool-output scanning');
     console.log('  --allow-revoke-by-source / --disallow-revoke-by-source  Enable/disable destructive forget --fromSource (default: disabled)');
+    console.log('  --action-guard-notify-openclaw  Notify Action Guard denials via the native OpenClaw approval card');
+    console.log('  --action-guard-notify-webhook <https-url>  Notify Action Guard denials to an https webhook');
+    console.log('  --action-guard-notify-disable   Disable Action Guard denial notifications');
     console.log('  --restore-4.10-defaults  Restore pre-v4.11.0 defaults (recall on, strict interceptor, minimal preamble)');
     console.log('');
     console.log('LLM Verification:');

--- a/src/cloud/config.ts
+++ b/src/cloud/config.ts
@@ -649,6 +649,120 @@ export function setReviewedScripts(entries: Array<Record<string, unknown>>): voi
   });
 }
 
+// ── Action Guard notify channel (#275) ────────────────
+
+export interface ActionGuardNotifyConfig {
+  /** Master switch for the operator-notify transport (#143). Strict-true
+   *  semantics on read, mirroring notify-config.ts. */
+  enabled: boolean;
+  /** Deliver via the native OpenClaw approval card. */
+  openclaw: boolean;
+  /** Webhook channel target. Absent = no webhook channel configured. */
+  webhookUrl?: string;
+}
+
+const NOTIFY_WEBHOOK_URL_MAX_LENGTH = 2_048;
+
+/**
+ * Validate a webhook URL for the SIGNED setter path. Stricter than the
+ * runtime reader (notify-config.ts accepts http: for configs that predate
+ * this CLI): a URL being SET today must be https — a denial notification
+ * carries operational detail about what a cron just tried to run, and an
+ * http target hands that to the network in the clear. Throws with an
+ * operator-actionable message; never suggests hand-editing config.json.
+ */
+export function validateActionGuardNotifyWebhookUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    throw new Error('Invalid webhook URL: empty. Provide an https:// URL, e.g. https://hooks.example.com/shieldcortex.');
+  }
+  if (trimmed.length > NOTIFY_WEBHOOK_URL_MAX_LENGTH) {
+    throw new Error(`Invalid webhook URL: longer than ${NOTIFY_WEBHOOK_URL_MAX_LENGTH} characters.`);
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Invalid webhook URL: "${trimmed}" is not a URL. Provide an https:// URL, e.g. https://hooks.example.com/shieldcortex.`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Invalid webhook URL: scheme must be https (got ${parsed.protocol.replace(/:$/, '')}). Denial notifications must not travel in cleartext.`);
+  }
+  return trimmed;
+}
+
+/** Strict-true read of `actionGuard.notify`, same discipline as
+ *  normaliseNotifyConfig in notify-config.ts (which stays the runtime's
+ *  boundary — this reader only serves the CLI/status surface). */
+export function getActionGuardNotifyConfig(): ActionGuardNotifyConfig {
+  const guard = actionGuardBlock(readRawConfig());
+  const notify = guard.notify && typeof guard.notify === 'object' && !Array.isArray(guard.notify)
+    ? (guard.notify as Record<string, unknown>)
+    : {};
+  const cfg: ActionGuardNotifyConfig = {
+    enabled: notify.enabled === true,
+    openclaw: notify.openclaw === true,
+  };
+  if (typeof notify.webhookUrl === 'string' && notify.webhookUrl.trim()) {
+    cfg.webhookUrl = notify.webhookUrl.trim();
+  }
+  return cfg;
+}
+
+/**
+ * The SIGNED write path for `actionGuard.notify` (#275) — what the
+ * `shieldcortex config --action-guard-notify-*` flags call. Routed through
+ * mutateRawConfig so the `_sig` HMAC is recomputed and the tamper flag
+ * clears; the hand-edit this replaces invalidated the signature and forced
+ * defenceMode strict. Read-modify-write on the notify block: sub-keys not in
+ * `updates` (webhookSecret, timeoutMs, a parked webhookUrl during a disable)
+ * survive untouched.
+ */
+export function setActionGuardNotifyConfig(updates: Partial<ActionGuardNotifyConfig>): void {
+  const webhookUrl = updates.webhookUrl !== undefined
+    ? validateActionGuardNotifyWebhookUrl(updates.webhookUrl)
+    : undefined;
+  mutateRawConfig((raw) => {
+    const guard = actionGuardBlock(raw);
+    const notify = guard.notify && typeof guard.notify === 'object' && !Array.isArray(guard.notify)
+      ? (guard.notify as Record<string, unknown>)
+      : {};
+    if (updates.enabled !== undefined) notify.enabled = updates.enabled;
+    if (updates.openclaw !== undefined) notify.openclaw = updates.openclaw;
+    if (webhookUrl !== undefined) notify.webhookUrl = webhookUrl;
+    guard.notify = notify;
+    raw.actionGuard = guard;
+  });
+}
+
+/**
+ * `doctor --fix-action-guard`'s write path (#209 migration, #275 fix): merge
+ * the deprecated `interceptor.actionGuard` alias into the top-level block —
+ * top-level wins per key, the alias gap-fills, matching what both runtime
+ * surfaces already resolve — remove the alias, and drop an emptied
+ * `interceptor` block. Routed through mutateRawConfig so the migrated file is
+ * RE-SIGNED: doctor's previous bare fs.writeFileSync carried the stale `_sig`
+ * through, and the "fix" itself tripped the integrity check into strict mode.
+ * Returns true when an alias was found and migrated.
+ */
+export function migrateInterceptorActionGuardAlias(): boolean {
+  let changed = false;
+  mutateRawConfig((raw) => {
+    const interceptor = raw.interceptor && typeof raw.interceptor === 'object' && !Array.isArray(raw.interceptor)
+      ? (raw.interceptor as Record<string, unknown>)
+      : null;
+    const alias = interceptor && interceptor.actionGuard && typeof interceptor.actionGuard === 'object' && !Array.isArray(interceptor.actionGuard)
+      ? (interceptor.actionGuard as Record<string, unknown>)
+      : null;
+    if (!interceptor || !alias) return;
+    raw.actionGuard = { ...alias, ...actionGuardBlock(raw) };
+    delete interceptor.actionGuard;
+    if (Object.keys(interceptor).length === 0) delete raw.interceptor;
+    changed = true;
+  });
+  return changed;
+}
+
 // ── Cloud Iron Dome Cache ─────────────────────────────
 
 /**


### PR DESCRIPTION
## Why
#275: `doctor` prescribed bare `actionGuard.notify.*` key paths with no command. Operators hand-edited `~/.shieldcortex/config.json`, invalidated `_sig`, and got forced into `defenceMode: strict`.

## What
- Signed CLI path via `mutateRawConfig` / `writeRawConfig`:
  - `shieldcortex config --action-guard-notify-openclaw`
  - `shieldcortex config --action-guard-notify-webhook <https-url>`
  - `shieldcortex config --action-guard-notify-disable`
- HTTPS-only webhook validation on the setter path
- Doctor notify warn now leads with those runnable commands (not bare key paths)
- `doctor --fix-action-guard` migration also re-signs instead of bare `writeFileSync`

## Verify
- `npm run build:ts` clean
- Focused: **2 suites / 32 tests passed**
  - `config-action-guard-notify-cli.test.ts`
  - `doctor-action-guard.test.ts`

Closes #275