### PR TITLE
fix(install): surface OpenClaw config-invalid refusal (#251)

### DIFF
--- a/src/setup/__tests__/native-install-refusal-251.test.ts
+++ b/src/setup/__tests__/native-install-refusal-251.test.ts
@@ -322,6 +322,33 @@ describe('tryNativeOpenClawPluginInstall real spawn wiring (#251)', () => {
     const refusal = getLastNativePluginInstallRefusal();
     expect(refusal?.configInvalid).toBe(true);
     expect(refusal?.reason).toMatch(/config is invalid/i);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('hard-fails when extensions dir is unavailable after native refusal', async () => {
+    // Valid ~/.openclaw, but `extensions` is a FILE so mkdir/open fails and
+    // findExtensionsDir returns null — without tripping the earlier
+    // "OpenClaw not installed" hard exit.
+    const openclawDir = path.join(tempHome, '.openclaw');
+    fs.rmSync(openclawDir, { recursive: true, force: true });
+    fs.mkdirSync(openclawDir, { recursive: true });
+    fs.writeFileSync(path.join(openclawDir, 'extensions'), 'not-a-directory\n');
+    __setLastNativePluginInstallRefusalForTest({
+      reason: 'OpenClaw config is invalid',
+      detail: ['OpenClaw config is invalid'],
+      configInvalid: true,
+      truncated: false,
+      label: 'package install',
+    });
+    __setNativePluginInstallForTest(() => null);
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    const warnings = warnLines.join('\n');
+    expect(warnings).toMatch(/extensions directory unavailable|cannot fall back|Nothing was installed/i);
+    expect(process.exitCode).toBe(1);
+    expect(logLines.join('\n')).toMatch(/skipped after native install refused/i);
+    expect(logLines.join('\n')).not.toMatch(/Installed through native OpenClaw/);
   });
 });
 

--- a/src/setup/__tests__/native-install-refusal-251.test.ts
+++ b/src/setup/__tests__/native-install-refusal-251.test.ts
@@ -196,7 +196,7 @@ describe('install/repair surfaces native refusal (#251)', () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it('does not claim native-link success when load.paths already has the plugin but THIS run refused', async () => {
+  it('does not claim native-link success when load.paths already has the plugin but THIS run refused config-invalid', async () => {
     writeConfig({
       plugins: {
         allow: [PLUGIN],
@@ -217,12 +217,38 @@ describe('install/repair surfaces native refusal (#251)', () => {
 
     const warnings = warnLines.join('\n');
     expect(warnings).toMatch(/native plugin install refused/i);
-    expect(warnings).toMatch(/Not claiming native success|Pre-existing load\.paths/i);
+    expect(warnings).toMatch(/Not claiming native success|config is invalid/i);
     const summary = logLines.join('\n');
     expect(summary).not.toMatch(/Installed through native OpenClaw linked plugin records/);
     // Mode is skipped (not native-link); summary must say refused.
     expect(summary).toMatch(/skipped after native install refused/i);
     expect(process.exitCode).toBe(1);
+  });
+
+  it('keeps native-link when load.paths pre-exists and refusal is non-config-invalid (already exists)', async () => {
+    writeConfig({
+      plugins: {
+        allow: [PLUGIN],
+        load: { paths: [path.join(tempHome, '.openclaw', 'extensions', PLUGIN)] },
+        entries: { [PLUGIN]: { enabled: true } },
+      },
+    });
+    __setLastNativePluginInstallRefusalForTest({
+      reason: 'Error: plugin already exists',
+      detail: ['Error: plugin already exists'],
+      configInvalid: false,
+      truncated: false,
+      label: 'package install',
+    });
+    __setNativePluginInstallForTest(() => null);
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    const summary = logLines.join('\n');
+    expect(summary).toMatch(/Installed through native OpenClaw linked plugin records/);
+    expect(summary).not.toMatch(/skipped after native install refused/);
+    // Soft warning only — pre-existing registration is still valid.
+    expect(process.exitCode).not.toBe(1);
   });
 
   it('clears the refusal state when native install succeeds', async () => {

--- a/src/setup/__tests__/native-install-refusal-251.test.ts
+++ b/src/setup/__tests__/native-install-refusal-251.test.ts
@@ -19,6 +19,7 @@ import {
   openClawConfigPath,
   getLastNativePluginInstallRefusal,
   __setNativePluginInstallForTest,
+  __setNativeSpawnForTest,
   __setLastNativePluginInstallRefusalForTest,
   __clearLastNativePluginInstallRefusalForTest,
 } from '../openclaw.js';
@@ -82,6 +83,7 @@ beforeEach(() => {
 
 afterEach(() => {
   __setNativePluginInstallForTest(null);
+  __setNativeSpawnForTest(null);
   __clearLastNativePluginInstallRefusalForTest();
   if (previousDocker === undefined) delete process.env.DOCKER;
   else process.env.DOCKER = previousDocker;
@@ -188,6 +190,35 @@ describe('install/repair surfaces native refusal (#251)', () => {
     const summary = logLines.join('\n');
     expect(summary).toMatch(/skipped after native install refused/i);
     expect(summary).not.toMatch(/Installed through native OpenClaw/);
+    // #251: nothing installed after refusal is a hard failure, not exit-0 quiet.
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('does not claim native-link success when load.paths already has the plugin but THIS run refused', async () => {
+    writeConfig({
+      plugins: {
+        allow: [PLUGIN],
+        load: { paths: [path.join(tempHome, '.openclaw', 'extensions', PLUGIN)] },
+        entries: { [PLUGIN]: { enabled: true } },
+      },
+    });
+    __setLastNativePluginInstallRefusalForTest({
+      reason: 'OpenClaw config is invalid',
+      detail: ['OpenClaw config is invalid'],
+      configInvalid: true,
+      truncated: false,
+      label: 'package install',
+    });
+    __setNativePluginInstallForTest(() => null);
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    const warnings = warnLines.join('\n');
+    expect(warnings).toMatch(/native plugin install refused/i);
+    expect(warnings).toMatch(/Not claiming native success|Pre-existing load\.paths/i);
+    const summary = logLines.join('\n');
+    expect(summary).not.toMatch(/Installed through native OpenClaw linked plugin records/);
+    expect(process.exitCode).toBe(1);
   });
 
   it('clears the refusal state when native install succeeds', async () => {
@@ -215,6 +246,80 @@ describe('install/repair surfaces native refusal (#251)', () => {
   });
 });
 
+describe('tryNativeOpenClawPluginInstall real spawn wiring (#251)', () => {
+  it('classifies failed spawnSync output into lastNativePluginInstallRefusal without pre-seeding', async () => {
+    writeConfig({ plugins: { allow: [], entries: {} } });
+    // Do NOT seed refusal state. Drive the real tryNative path via spawn seam.
+    __setNativePluginInstallForTest(null);
+    __setNativeSpawnForTest((_cmd, _args) => ({
+      status: 1,
+      stdout: 'Audit, status, health, logs, tasks list/audit, and doctor commands still run with invalid config.\n',
+      stderr:
+        'OpenClaw config is invalid\n' +
+        'File: ~/.openclaw/openclaw.json\n' +
+        'Problem:\n' +
+        '  - plugins.entries.bogus-dangler: Invalid input\n' +
+        'Fix: openclaw doctor --fix\n',
+    }));
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    const refusal = getLastNativePluginInstallRefusal();
+    expect(refusal).not.toBeNull();
+    expect(refusal!.configInvalid).toBe(true);
+    expect(refusal!.reason).toMatch(/config is invalid/i);
+    expect(refusal!.reason).not.toMatch(/still run with invalid config/i);
+
+    const warnings = warnLines.join('\n');
+    expect(warnings).toMatch(/native plugin install refused/i);
+    expect(warnings).toMatch(/openclaw config validate/);
+    // Local fallback after real refusal is labelled, not plain native success.
+    expect(warnings).toMatch(/local fallback|not a native registration/i);
+    expect(logLines.join('\n')).not.toMatch(/Installed through native OpenClaw package records/);
+  });
+
+  it('accepts Buffer stdout/stderr from spawn (does not wipe diagnosis)', async () => {
+    writeConfig({ plugins: { allow: [], entries: {} } });
+    __setNativePluginInstallForTest(null);
+    __setNativeSpawnForTest(() => ({
+      status: 1,
+      stdout: Buffer.from('still run with invalid config\n'),
+      stderr: Buffer.from('OpenClaw config is invalid\n  × plugins.entries.bogus: bad\n'),
+    }));
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    const refusal = getLastNativePluginInstallRefusal();
+    expect(refusal?.configInvalid).toBe(true);
+    expect(refusal?.reason).toMatch(/config is invalid/i);
+  });
+
+  it('prefers config-invalid from the package attempt over later linked-attempt noise', async () => {
+    writeConfig({ plugins: { allow: [], entries: {} } });
+    __setNativePluginInstallForTest(null);
+    let calls = 0;
+    __setNativeSpawnForTest((_cmd, args) => {
+      calls += 1;
+      const joined = args.join(' ');
+      if (joined.includes('--link')) {
+        return { status: 1, stderr: 'Error: plugin already exists\n', stdout: '' };
+      }
+      return {
+        status: 1,
+        stderr: 'OpenClaw config is invalid\n  × plugins.entries.bogus: Invalid input\n',
+        stdout: '',
+      };
+    });
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    expect(calls).toBe(2);
+    const refusal = getLastNativePluginInstallRefusal();
+    expect(refusal?.configInvalid).toBe(true);
+    expect(refusal?.reason).toMatch(/config is invalid/i);
+  });
+});
+
 describe('#251 source contract — tryNativeOpenClawPluginInstall keeps child output', () => {
   it('classifies spawn output instead of bare-null discard', () => {
     const src = fs.readFileSync(
@@ -228,10 +333,10 @@ describe('#251 source contract — tryNativeOpenClawPluginInstall keeps child ou
     const fn = src.slice(start, end);
     expect(fn).toMatch(/classifyNativePluginInstallFailure/);
     expect(fn).toMatch(/lastNativePluginInstallRefusal/);
-    expect(fn).toMatch(/summariseCommandOutput|classifyNativePluginInstallFailure/);
+    expect(fn).toMatch(/spawnResultText/);
     // Must still not delete the extensions copy before spawn (#214).
     const rmAt = fn.indexOf('rmSync');
-    const spawnAt = fn.indexOf('spawnSync');
+    const spawnAt = fn.indexOf('spawn(') >= 0 ? fn.indexOf('spawn(') : fn.indexOf('spawnSync');
     expect(spawnAt).toBeGreaterThan(0);
     if (rmAt >= 0) expect(rmAt).toBeGreaterThan(spawnAt);
   });

--- a/src/setup/__tests__/native-install-refusal-251.test.ts
+++ b/src/setup/__tests__/native-install-refusal-251.test.ts
@@ -1,0 +1,238 @@
+/**
+ * #251 — install/repair must not swallow OpenClaw's config-invalid refusal.
+ *
+ * Before this fix, tryNativeOpenClawPluginInstall discarded every line of a
+ * failed `openclaw plugins install` and returned bare null. installPlugin then
+ * fell through to the local-copy path and printed plain success — so operators
+ * following doctor's `shieldcortex repair` advice never saw that OpenClaw had
+ * refused registration because the config was invalid.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import {
+  classifyNativePluginInstallFailure,
+  installOpenClawHook,
+  openClawConfigPath,
+  getLastNativePluginInstallRefusal,
+  __setNativePluginInstallForTest,
+  __setLastNativePluginInstallRefusalForTest,
+  __clearLastNativePluginInstallRefusalForTest,
+} from '../openclaw.js';
+
+const PLUGIN = 'shieldcortex-realtime';
+
+let tempHome: string;
+let tempPluginSource: string;
+let previousDocker: string | undefined;
+let previousPluginSource: string | undefined;
+let previousExitCode: string | number | undefined;
+let warnLines: string[];
+let logLines: string[];
+
+function configPath(): string {
+  return path.join(tempHome, '.openclaw', 'openclaw.json');
+}
+
+function writeConfig(cfg: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(configPath()), { recursive: true });
+  fs.writeFileSync(configPath(), JSON.stringify(cfg, null, 2) + '\n');
+}
+
+/** Minimal plugin source tree so the local-copy fallback can run. */
+function seedPluginSource(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-251-plugin-'));
+  for (const file of ['index.js', 'interceptor.js', 'intercept-ingest.js', 'openclaw.plugin.json']) {
+    const body = file === 'openclaw.plugin.json'
+      ? JSON.stringify({ id: PLUGIN, name: PLUGIN, version: '0.0.0-test' }, null, 2) + '\n'
+      : `// test stub ${file}\n`;
+    fs.writeFileSync(path.join(root, file), body);
+  }
+  return root;
+}
+
+beforeEach(() => {
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-251-home-'));
+  tempPluginSource = seedPluginSource();
+  previousDocker = process.env.DOCKER;
+  previousPluginSource = process.env.SHIELDCORTEX_PLUGIN_SOURCE;
+  process.env.DOCKER = 'false';
+  process.env.SHIELDCORTEX_PLUGIN_SOURCE = tempPluginSource;
+  previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  warnLines = [];
+  logLines = [];
+  jest.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logLines.push(args.map(String).join(' '));
+  });
+  jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+    warnLines.push(args.map(String).join(' '));
+  });
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(os, 'homedir').mockReturnValue(tempHome);
+  const resolved = openClawConfigPath();
+  if (!resolved.startsWith(tempHome + path.sep)) {
+    throw new Error(`REFUSING TO RUN: home redirect failed (${resolved})`);
+  }
+  __clearLastNativePluginInstallRefusalForTest();
+});
+
+afterEach(() => {
+  __setNativePluginInstallForTest(null);
+  __clearLastNativePluginInstallRefusalForTest();
+  if (previousDocker === undefined) delete process.env.DOCKER;
+  else process.env.DOCKER = previousDocker;
+  if (previousPluginSource === undefined) delete process.env.SHIELDCORTEX_PLUGIN_SOURCE;
+  else process.env.SHIELDCORTEX_PLUGIN_SOURCE = previousPluginSource;
+  process.exitCode = previousExitCode;
+  jest.restoreAllMocks();
+  fs.rmSync(tempHome, { recursive: true, force: true });
+  fs.rmSync(tempPluginSource, { recursive: true, force: true });
+});
+
+describe('classifyNativePluginInstallFailure (#251)', () => {
+  it('surfaces config-invalid as the reason and flags it', () => {
+    const refusal = classifyNativePluginInstallFailure(
+      'Audit, status, health, logs, tasks list/audit, and doctor commands still run with invalid config.\n',
+      'OpenClaw config is invalid\nFile: ~/.openclaw/openclaw.json\nProblem:\n  - plugins.entries.bogus-dangler: Invalid input\nFix: openclaw doctor --fix\n',
+      1,
+      { label: 'package install', home: tempHome },
+    );
+    expect(refusal.configInvalid).toBe(true);
+    expect(refusal.reason).toMatch(/config is invalid/i);
+    // Must not prefer the reassuring last line over the diagnosis.
+    expect(refusal.reason).not.toMatch(/still run with invalid config/i);
+    expect(refusal.label).toBe('package install');
+    // Operator-facing detail should still mention the offending key when present.
+    expect(refusal.detail.join('\n')).toMatch(/bogus-dangler|Invalid input|config is invalid/i);
+  });
+
+  it('does not mark a generic failure as config-invalid', () => {
+    const refusal = classifyNativePluginInstallFailure(
+      '',
+      'Error: plugin already exists\n',
+      1,
+      { label: 'linked install' },
+    );
+    expect(refusal.configInvalid).toBe(false);
+    expect(refusal.reason).toMatch(/already exists|Error/i);
+  });
+
+  it('falls back to exit status when there is no usable output', () => {
+    const refusal = classifyNativePluginInstallFailure('', '', 1, { label: 'package install' });
+    expect(refusal.configInvalid).toBe(false);
+    expect(refusal.reason).toMatch(/exited 1|no usable output/i);
+  });
+});
+
+describe('install/repair surfaces native refusal (#251)', () => {
+  it('warns with openclaw config validate when native install is refused for invalid config, even if local copy succeeds', async () => {
+    writeConfig({
+      plugins: {
+        allow: ['codex'],
+        entries: { codex: { enabled: true } },
+      },
+    });
+
+    __setLastNativePluginInstallRefusalForTest({
+      reason: 'OpenClaw config is invalid',
+      detail: [
+        'OpenClaw config is invalid',
+        'plugins.entries.bogus-dangler: Invalid input',
+      ],
+      configInvalid: true,
+      truncated: false,
+      label: 'package install',
+    });
+    __setNativePluginInstallForTest(() => null);
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    const warnings = warnLines.join('\n');
+    expect(warnings).toMatch(/native plugin install refused/i);
+    expect(warnings).toMatch(/OpenClaw config is invalid/i);
+    expect(warnings).toMatch(/openclaw config validate/);
+    // Local fallback must not read as a plain native success.
+    expect(warnings).toMatch(/local fallback|not a native registration/i);
+
+    const summary = logLines.join('\n');
+    // Must not claim native package/link install after a refusal.
+    expect(summary).not.toMatch(/Installed through native OpenClaw package records/);
+    expect(summary).not.toMatch(/Installed through native OpenClaw linked plugin records/);
+  });
+
+  it('does not report plain skip when native was refused and plugin source is missing', async () => {
+    // Remove the seeded plugin source so fallback cannot copy.
+    fs.rmSync(tempPluginSource, { recursive: true, force: true });
+    process.env.SHIELDCORTEX_PLUGIN_SOURCE = path.join(tempHome, 'missing-plugin-source');
+
+    writeConfig({ plugins: { allow: [], entries: {} } });
+    __setLastNativePluginInstallRefusalForTest({
+      reason: 'OpenClaw config is invalid',
+      detail: ['OpenClaw config is invalid'],
+      configInvalid: true,
+      truncated: false,
+      label: 'package install',
+    });
+    __setNativePluginInstallForTest(() => null);
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    const warnings = warnLines.join('\n');
+    expect(warnings).toMatch(/native plugin install refused/i);
+    expect(warnings).toMatch(/cannot fall back|Nothing was installed/i);
+
+    const summary = logLines.join('\n');
+    expect(summary).toMatch(/skipped after native install refused/i);
+    expect(summary).not.toMatch(/Installed through native OpenClaw/);
+  });
+
+  it('clears the refusal state when native install succeeds', async () => {
+    writeConfig({
+      plugins: {
+        allow: [PLUGIN],
+        entries: { [PLUGIN]: { enabled: true } },
+      },
+    });
+    __setLastNativePluginInstallRefusalForTest({
+      reason: 'stale',
+      detail: ['stale'],
+      configInvalid: true,
+      truncated: false,
+      label: 'package install',
+    });
+    __setNativePluginInstallForTest(() => 'native-package');
+
+    await installOpenClawHook({ noHooks: true, restartGateway: false });
+
+    expect(getLastNativePluginInstallRefusal()).toBeNull();
+    const summary = logLines.join('\n');
+    expect(summary).toMatch(/native OpenClaw package records/);
+    expect(warnLines.join('\n')).not.toMatch(/native plugin install refused/i);
+  });
+});
+
+describe('#251 source contract — tryNativeOpenClawPluginInstall keeps child output', () => {
+  it('classifies spawn output instead of bare-null discard', () => {
+    const src = fs.readFileSync(
+      path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'openclaw.ts'),
+      'utf-8',
+    );
+    const start = src.indexOf('function tryNativeOpenClawPluginInstall');
+    const end = src.indexOf('function findExtensionsDir');
+    expect(start).toBeGreaterThan(0);
+    expect(end).toBeGreaterThan(start);
+    const fn = src.slice(start, end);
+    expect(fn).toMatch(/classifyNativePluginInstallFailure/);
+    expect(fn).toMatch(/lastNativePluginInstallRefusal/);
+    expect(fn).toMatch(/summariseCommandOutput|classifyNativePluginInstallFailure/);
+    // Must still not delete the extensions copy before spawn (#214).
+    const rmAt = fn.indexOf('rmSync');
+    const spawnAt = fn.indexOf('spawnSync');
+    expect(spawnAt).toBeGreaterThan(0);
+    if (rmAt >= 0) expect(rmAt).toBeGreaterThan(spawnAt);
+  });
+});

--- a/src/setup/__tests__/native-install-refusal-251.test.ts
+++ b/src/setup/__tests__/native-install-refusal-251.test.ts
@@ -164,6 +164,8 @@ describe('install/repair surfaces native refusal (#251)', () => {
     // Must not claim native package/link install after a refusal.
     expect(summary).not.toMatch(/Installed through native OpenClaw package records/);
     expect(summary).not.toMatch(/Installed through native OpenClaw linked plugin records/);
+    // #251: config-invalid + local-copy is still hard-fail for scripts/CI.
+    expect(process.exitCode).toBe(1);
   });
 
   it('does not report plain skip when native was refused and plugin source is missing', async () => {
@@ -218,6 +220,8 @@ describe('install/repair surfaces native refusal (#251)', () => {
     expect(warnings).toMatch(/Not claiming native success|Pre-existing load\.paths/i);
     const summary = logLines.join('\n');
     expect(summary).not.toMatch(/Installed through native OpenClaw linked plugin records/);
+    // Mode is skipped (not native-link); summary must say refused.
+    expect(summary).toMatch(/skipped after native install refused/i);
     expect(process.exitCode).toBe(1);
   });
 
@@ -276,6 +280,7 @@ describe('tryNativeOpenClawPluginInstall real spawn wiring (#251)', () => {
     // Local fallback after real refusal is labelled, not plain native success.
     expect(warnings).toMatch(/local fallback|not a native registration/i);
     expect(logLines.join('\n')).not.toMatch(/Installed through native OpenClaw package records/);
+    expect(process.exitCode).toBe(1);
   });
 
   it('accepts Buffer stdout/stderr from spawn (does not wipe diagnosis)', async () => {

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -21,6 +21,7 @@ import {
   stripManagedPinsFromManifest,
   isRealtimePluginDisabledInConfig,
 } from '../integrations/openclaw-plugin-state.js';
+import { summariseCommandOutput } from '../integrations/child-output.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,10 +34,13 @@ const HOOK_SOURCE = path.resolve(__dirname, '..', '..', 'hooks', 'openclaw', HOO
 
 // Plugin compiled output in plugins/openclaw/dist/ relative to project root.
 // `SHIELDCORTEX_PLUGIN_SOURCE` overrides for hermetic tests so the install
-// path doesn't need a prior `npm run build`.
-const PLUGIN_SOURCE = process.env.SHIELDCORTEX_PLUGIN_SOURCE
-  ? path.resolve(process.env.SHIELDCORTEX_PLUGIN_SOURCE)
-  : path.resolve(__dirname, '..', '..', 'plugins', 'openclaw', 'dist');
+// path doesn't need a prior `npm run build`. Resolved at call time (not
+// module-load) so tests can redirect without reloading the module (#251).
+function resolvePluginSource(): string {
+  return process.env.SHIELDCORTEX_PLUGIN_SOURCE
+    ? path.resolve(process.env.SHIELDCORTEX_PLUGIN_SOURCE)
+    : path.resolve(__dirname, '..', '..', 'plugins', 'openclaw', 'dist');
+}
 const PLUGIN_PACKAGE_SOURCE = path.resolve(__dirname, '..', '..', 'plugins', 'openclaw');
 const PLUGIN_DIR_NAME = 'shieldcortex-realtime';
 const HOOK_FILES = ['HOOK.md', 'handler.ts', 'runtime.mjs'] as const;
@@ -839,8 +843,103 @@ export function snapshotOpenClawConfig(homeArg?: string): string | null {
  *  on aiquant. Two minutes is still a bound, not a hang. */
 export const NATIVE_INSTALL_TIMEOUT_MS = 120_000;
 
+/**
+ * #251 — what the native `openclaw plugins install` path last refused with.
+ * Kept module-scoped so installPlugin / the final "What was installed" block
+ * can still warn after falling back to a local copy. Cleared on native success
+ * or when native install is not attempted.
+ */
+export interface NativePluginInstallRefusal {
+  reason: string;
+  detail: string[];
+  configInvalid: boolean;
+  truncated: boolean;
+  /** Which attempt produced this refusal (package vs linked). */
+  label: string;
+}
+
+let lastNativePluginInstallRefusal: NativePluginInstallRefusal | null = null;
+
+/** Test/doctor seam: last native-install refusal, or null. */
+export function getLastNativePluginInstallRefusal(): NativePluginInstallRefusal | null {
+  return lastNativePluginInstallRefusal;
+}
+
+export function __clearLastNativePluginInstallRefusalForTest(): void {
+  lastNativePluginInstallRefusal = null;
+}
+
+/** Test seam: seed a native-install refusal that installPlugin will surface. */
+export function __setLastNativePluginInstallRefusalForTest(
+  refusal: NativePluginInstallRefusal | null,
+): void {
+  lastNativePluginInstallRefusal = refusal;
+}
+
+/**
+ * #251 — classify a failed `openclaw plugins install` spawn into an
+ * operator-facing reason. Reuses summariseCommandOutput so the cause is not
+ * the reassuring last line ("doctor still runs with invalid config") and so
+ * secrets in child output are redacted the same way as update/reconcile.
+ */
+export function classifyNativePluginInstallFailure(
+  stdout: string,
+  stderr: string,
+  status: number | null,
+  opts: { home?: string; label?: string } = {},
+): NativePluginInstallRefusal {
+  const streams = [stderr ?? '', stdout ?? ''];
+  const combined = streams.join('\n');
+  const configInvalid = /config is invalid/i.test(combined);
+  // Prefer the stream that carries the refusal signal (usually stderr).
+  const withSignal = streams.find((s) => s.trim() && /config is invalid|refus|denied|error|invalid|ENOENT|EACCES/i.test(s));
+  const chosen = withSignal ?? streams.find((s) => s.trim()) ?? '';
+  const summarised = summariseCommandOutput(chosen, {
+    maxLines: 4,
+    mode: 'failure',
+    neverEmpty: true,
+    // This IS a plugins subcommand — its [plugins] lines are the diagnosis.
+    dropPluginChatter: false,
+    home: opts.home,
+  });
+  const reason = summarised.lines[0]
+    ?? (status === null
+      ? 'openclaw plugins install failed with no exit code'
+      : `openclaw plugins install exited ${status} with no usable output`);
+  return {
+    reason,
+    detail: summarised.lines,
+    configInvalid,
+    truncated: summarised.truncated,
+    label: opts.label ?? 'native install',
+  };
+}
+
+function reportNativePluginInstallRefusal(refusal: NativePluginInstallRefusal): void {
+  console.warn(`  Warning: OpenClaw native plugin install refused (${refusal.label}) — ${refusal.reason}`);
+  for (const line of refusal.detail) {
+    if (line === refusal.reason) continue;
+    console.warn(`    ${line}`);
+  }
+  if (refusal.truncated) {
+    console.warn('    … (further OpenClaw output omitted)');
+  }
+  if (refusal.configInvalid) {
+    console.warn('  OpenClaw config is invalid — native install cannot register through OpenClaw until it validates.');
+    console.warn('  Fix: run `openclaw config validate`, repair the reported keys, then re-run `shieldcortex openclaw install` or `shieldcortex repair`.');
+  }
+}
+
 function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
-  if (_nativePluginInstallForTest) return _nativePluginInstallForTest();
+  // Test seam first: hermetic suites inject success/null without spawning.
+  // They may also seed lastNativePluginInstallRefusal via the helper below.
+  if (_nativePluginInstallForTest) {
+    const mode = _nativePluginInstallForTest();
+    if (mode) lastNativePluginInstallRefusal = null;
+    return mode;
+  }
+
+  lastNativePluginInstallRefusal = null;
   if (process.env[OPENCLAW_SKIP_NATIVE_INSTALL_ENV] === '1') return null;
   if (!isOpenClawInstalled()) return null;
 
@@ -855,6 +954,8 @@ function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
     { args: ['plugins', 'install', '--link', PLUGIN_PACKAGE_SOURCE], label: 'linked install' },
   ];
 
+  const refusals: NativePluginInstallRefusal[] = [];
+
   for (const attempt of attempts) {
     const result = spawnSync('openclaw', attempt.args, {
       env,
@@ -863,11 +964,27 @@ function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
     });
 
     if (result.status === 0) {
+      lastNativePluginInstallRefusal = null;
       console.log(`Installed real-time plugin via OpenClaw ${attempt.label}.`);
       return attempt.label === 'package install' ? 'native-package' : 'native-link';
     }
+
+    // #251: do not discard the child's reason. Bare `return null` after two
+    // failed attempts is how install/repair swallowed "OpenClaw config is
+    // invalid" while the copy fallback still printed plain success.
+    const refusal = classifyNativePluginInstallFailure(
+      typeof result.stdout === 'string' ? result.stdout : '',
+      typeof result.stderr === 'string' ? result.stderr : '',
+      typeof result.status === 'number' ? result.status : null,
+      { home: resolveUserHome(), label: attempt.label },
+    );
+    refusals.push(refusal);
   }
 
+  // Prefer a config-invalid refusal when any attempt produced one — that is
+  // the operator-actionable root cause, not "plugin already exists" noise.
+  lastNativePluginInstallRefusal =
+    refusals.find((r) => r.configInvalid) ?? refusals[refusals.length - 1] ?? null;
   return null;
 }
 
@@ -954,6 +1071,12 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
     return nativeInstall;
   }
 
+  // #251: surface the native refusal BEFORE falling back. A silent fall-
+  // through made copy-path success look like OpenClaw accepted the install.
+  if (lastNativePluginInstallRefusal) {
+    reportNativePluginInstallRefusal(lastNativePluginInstallRefusal);
+  }
+
   // Native install (--link) registers via load.paths — skip the extensions
   // copy to avoid duplicate plugin ID warnings.
   if (isPluginInLoadPaths()) {
@@ -961,8 +1084,17 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
     return 'native-link';
   }
 
-  if (!fs.existsSync(PLUGIN_SOURCE)) {
-    console.warn('  Warning: Plugin source not found, skipping plugin install');
+  const pluginSource = resolvePluginSource();
+  if (!fs.existsSync(pluginSource)) {
+    // #251: when native install was refused (e.g. invalid OpenClaw config) and
+    // the local plugin source is also missing, this is not a quiet skip — the
+    // operator has neither a native registration nor a fallback copy.
+    if (lastNativePluginInstallRefusal) {
+      console.warn('  Warning: Plugin source not found — cannot fall back to a local copy after native install refused.');
+      console.warn('  Nothing was installed. Fix the OpenClaw config (if invalid), rebuild (`npm run build`), then retry.');
+    } else {
+      console.warn('  Warning: Plugin source not found, skipping plugin install');
+    }
     return 'skipped';
   }
 
@@ -975,12 +1107,12 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
 
     const requiredFiles = ['index.js', 'interceptor.js', 'intercept-ingest.js', 'openclaw.plugin.json'];
     for (const file of requiredFiles) {
-      const src = path.join(PLUGIN_SOURCE, file);
+      const src = path.join(pluginSource, file);
       const dest = path.join(destDir, file);
       if (fs.existsSync(src)) {
         fs.copyFileSync(src, dest);
       } else {
-        console.warn(`  Warning: ${file} not found in plugin source (${PLUGIN_SOURCE})`);
+        console.warn(`  Warning: ${file} not found in plugin source (${pluginSource})`);
         if (file === 'openclaw.plugin.json') {
           console.warn('  OpenClaw will fail to load the plugin without this manifest.');
           console.warn('  This is a build issue — try rebuilding with: npm run build');
@@ -1413,8 +1545,25 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
     } else if (pluginInstallMode === 'untrusted-local-copy') {
       console.log('    Installed as a local fallback, but trust pinning failed.');
     }
+    // #251: local-copy success after a native refusal is NOT a plain success —
+    // OpenClaw itself still rejected the install (often invalid config).
+    const nativeRefusal = getLastNativePluginInstallRefusal();
+    if (
+      nativeRefusal
+      && (pluginInstallMode === 'trusted-local-copy' || pluginInstallMode === 'untrusted-local-copy')
+    ) {
+      console.warn('    Note: native OpenClaw install was refused — this is a local fallback, not a native registration.');
+      if (nativeRefusal.configInvalid) {
+        console.warn('    OpenClaw config is still invalid; run `openclaw config validate` before relying on native plugin management.');
+      }
+    }
   } else {
-    console.log('  • shieldcortex-realtime plugin: skipped');
+    const nativeRefusal = getLastNativePluginInstallRefusal();
+    if (nativeRefusal) {
+      console.log('  • shieldcortex-realtime plugin: skipped after native install refused (see warnings above)');
+    } else {
+      console.log('  • shieldcortex-realtime plugin: skipped');
+    }
   }
   console.log('');
   console.log('Native OpenClaw install is also supported:');

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -816,6 +816,26 @@ export function __setNativePluginInstallForTest(fn: (() => PluginInstallMode | n
 }
 
 /**
+ * #251 test seam — inject spawnSync results into the REAL tryNative path so
+ * classification/refusal wiring is exercised without a live openclaw binary.
+ * Signature mirrors the subset of spawnSync we read (status/stdout/stderr).
+ */
+type NativeSpawnResult = {
+  status: number | null;
+  stdout?: string | Buffer | null;
+  stderr?: string | Buffer | null;
+};
+type NativeSpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: { env?: NodeJS.ProcessEnv; encoding?: BufferEncoding; timeout?: number },
+) => NativeSpawnResult;
+let _nativeSpawnForTest: NativeSpawnFn | null = null;
+export function __setNativeSpawnForTest(fn: NativeSpawnFn | null): void {
+  _nativeSpawnForTest = fn;
+}
+
+/**
  * #214 — snapshot openclaw.json BEFORE any path that can let
  * `openclaw plugins install` rewrite it. The 8 Aug wipe was recoverable
  * only because Case had a 4-minute-old `.bak`. Restore stays merge-
@@ -930,6 +950,12 @@ function reportNativePluginInstallRefusal(refusal: NativePluginInstallRefusal): 
   }
 }
 
+function spawnResultText(value: string | Buffer | null | undefined): string {
+  if (typeof value === 'string') return value;
+  if (Buffer.isBuffer(value)) return value.toString('utf-8');
+  return '';
+}
+
 function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
   // Test seam first: hermetic suites inject success/null without spawning.
   // They may also seed lastNativePluginInstallRefusal via the helper below.
@@ -941,7 +967,7 @@ function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
 
   lastNativePluginInstallRefusal = null;
   if (process.env[OPENCLAW_SKIP_NATIVE_INSTALL_ENV] === '1') return null;
-  if (!isOpenClawInstalled()) return null;
+  if (!isOpenClawInstalled() && !_nativeSpawnForTest) return null;
 
   // #214 defect 3: do not destroy ~/.openclaw/extensions/shieldcortex-realtime
   // before we know the native install succeeded. That copy is the rollback
@@ -955,9 +981,11 @@ function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
   ];
 
   const refusals: NativePluginInstallRefusal[] = [];
+  const spawn = _nativeSpawnForTest ?? ((command, args, options) =>
+    spawnSync(command, args as string[], options));
 
   for (const attempt of attempts) {
-    const result = spawnSync('openclaw', attempt.args, {
+    const result = spawn('openclaw', attempt.args, {
       env,
       encoding: 'utf-8',
       timeout: NATIVE_INSTALL_TIMEOUT_MS,
@@ -973,8 +1001,8 @@ function tryNativeOpenClawPluginInstall(): PluginInstallMode | null {
     // failed attempts is how install/repair swallowed "OpenClaw config is
     // invalid" while the copy fallback still printed plain success.
     const refusal = classifyNativePluginInstallFailure(
-      typeof result.stdout === 'string' ? result.stdout : '',
-      typeof result.stderr === 'string' ? result.stderr : '',
+      spawnResultText(result.stdout),
+      spawnResultText(result.stderr),
       typeof result.status === 'number' ? result.status : null,
       { home: resolveUserHome(), label: attempt.label },
     );
@@ -1079,8 +1107,24 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
 
   // Native install (--link) registers via load.paths — skip the extensions
   // copy to avoid duplicate plugin ID warnings.
+  //
+  // #251: if THIS run's native install was refused, a pre-existing load.paths
+  // entry is NOT "Installed through native OpenClaw linked plugin records" for
+  // this run. Returning bare 'native-link' here was the silent-success hole
+  // both independent reviewers flagged. Keep the skip (no duplicate copy), but
+  // surface that registration is pre-existing and the live attempt failed.
   if (isPluginInLoadPaths()) {
-    console.log('Plugin already registered via load.paths, skipping extensions copy.');
+    if (lastNativePluginInstallRefusal) {
+      console.warn(
+        '  Note: plugin is already on plugins.load.paths from a previous install — ' +
+        'this run\'s native OpenClaw install still refused (see above). Not claiming native success.',
+      );
+      if (lastNativePluginInstallRefusal.configInvalid) {
+        process.exitCode = 1;
+      }
+    } else {
+      console.log('Plugin already registered via load.paths, skipping extensions copy.');
+    }
     return 'native-link';
   }
 
@@ -1092,6 +1136,7 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
     if (lastNativePluginInstallRefusal) {
       console.warn('  Warning: Plugin source not found — cannot fall back to a local copy after native install refused.');
       console.warn('  Nothing was installed. Fix the OpenClaw config (if invalid), rebuild (`npm run build`), then retry.');
+      process.exitCode = 1;
     } else {
       console.warn('  Warning: Plugin source not found, skipping plugin install');
     }
@@ -1536,10 +1581,17 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
   }
   if (pluginInstallMode !== 'skipped') {
     console.log('  • shieldcortex-realtime plugin (real-time LLM input scanning + optional output extraction)');
+    const nativeRefusal = getLastNativePluginInstallRefusal();
     if (pluginInstallMode === 'native-package') {
       console.log('    Installed through native OpenClaw package records.');
     } else if (pluginInstallMode === 'native-link') {
-      console.log('    Installed through native OpenClaw linked plugin records.');
+      // #251: native-link is also returned for pre-existing load.paths after a
+      // refused attempt — never claim "installed through native …" then.
+      if (nativeRefusal) {
+        console.warn('    Pre-existing load.paths registration only — this run\'s native OpenClaw install was refused (not a native success).');
+      } else {
+        console.log('    Installed through native OpenClaw linked plugin records.');
+      }
     } else if (pluginInstallMode === 'trusted-local-copy') {
       console.log('    Installed as a local fallback and trusted via plugins.allow.');
     } else if (pluginInstallMode === 'untrusted-local-copy') {
@@ -1547,7 +1599,6 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
     }
     // #251: local-copy success after a native refusal is NOT a plain success —
     // OpenClaw itself still rejected the install (often invalid config).
-    const nativeRefusal = getLastNativePluginInstallRefusal();
     if (
       nativeRefusal
       && (pluginInstallMode === 'trusted-local-copy' || pluginInstallMode === 'untrusted-local-copy')

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -1026,11 +1026,26 @@ function findExtensionsDir(): string | null {
   const home = resolveUserHome();
   const openclawDir = path.join(home, '.openclaw');
   if (!fs.existsSync(openclawDir)) return null;
+  // ~/.openclaw must be a directory — a file there means we cannot host extensions.
+  try {
+    if (!fs.statSync(openclawDir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
 
   const extensionsDir = path.join(openclawDir, 'extensions');
   if (!fs.existsSync(extensionsDir)) {
     try {
       fs.mkdirSync(extensionsDir, { recursive: true });
+    } catch {
+      return null;
+    }
+  } else {
+    // #251: if `extensions` exists as a plain file, existsSync is true and the
+    // old code returned that path — copy then failed in catch. Treat non-dir
+    // as unavailable so the refusal hard-fail branch can fire cleanly.
+    try {
+      if (!fs.statSync(extensionsDir).isDirectory()) return null;
     } catch {
       return null;
     }
@@ -1108,23 +1123,29 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
   // Native install (--link) registers via load.paths — skip the extensions
   // copy to avoid duplicate plugin ID warnings.
   //
-  // #251: if THIS run's native install was refused, a pre-existing load.paths
-  // entry is NOT a native success for this run. Returning bare 'native-link'
-  // lied to every caller/doctor that trusts PluginInstallMode. Keep the skip
-  // (no duplicate copy), surface the pre-existing registration, hard-fail on
-  // config-invalid, and return 'skipped' so the mode is not a native success.
+  // #251: config-invalid refusal means OpenClaw will not honour native
+  // management — do not report bare 'native-link' success for THIS run, and
+  // hard-fail. Non-config-invalid refusals (e.g. "plugin already exists") with
+  // a pre-existing load.paths entry are still a valid native-link registration;
+  // warn about the refused attempt but keep the mode honest.
   if (isPluginInLoadPaths()) {
-    if (lastNativePluginInstallRefusal) {
+    if (lastNativePluginInstallRefusal?.configInvalid) {
       console.warn(
         '  Note: plugin is already on plugins.load.paths from a previous install — ' +
-        'this run\'s native OpenClaw install still refused (see above). Not claiming native success.',
+        'this run\'s native OpenClaw install still refused because the config is invalid. ' +
+        'Not claiming native success.',
       );
-      if (lastNativePluginInstallRefusal.configInvalid) {
-        process.exitCode = 1;
-      }
+      process.exitCode = 1;
       return 'skipped';
     }
-    console.log('Plugin already registered via load.paths, skipping extensions copy.');
+    if (lastNativePluginInstallRefusal) {
+      console.warn(
+        `  Note: native OpenClaw install attempt refused (${lastNativePluginInstallRefusal.reason}) — ` +
+        'keeping pre-existing load.paths registration (native-link).',
+      );
+    } else {
+      console.log('Plugin already registered via load.paths, skipping extensions copy.');
+    }
     return 'native-link';
   }
 

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -1144,7 +1144,16 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
   }
 
   const extensionsDir = findExtensionsDir();
-  if (!extensionsDir) return 'skipped';
+  if (!extensionsDir) {
+    // #251 sibling of missing-source: native refused, then no writable
+    // ~/.openclaw/extensions — must not return quiet skipped/exit 0.
+    if (lastNativePluginInstallRefusal) {
+      console.warn('  Warning: OpenClaw extensions directory unavailable — cannot fall back to a local copy after native install refused.');
+      console.warn('  Nothing was installed. Ensure ~/.openclaw exists and is writable, then retry.');
+      process.exitCode = 1;
+    }
+    return 'skipped';
+  }
 
   const destDir = path.join(extensionsDir, PLUGIN_DIR_NAME);
   try {
@@ -1247,6 +1256,11 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
       console.warn(`  Skipped plugin install (permission denied on ${destDir})`);
     } else {
       console.warn(`  Warning: Could not install plugin: ${(err as Error).message}`);
+    }
+    // #251: copy/register throw after a native refusal must not quiet-succeed.
+    if (lastNativePluginInstallRefusal) {
+      console.warn('  Nothing was installed via local fallback after native install refused.');
+      process.exitCode = 1;
     }
     return 'skipped';
   }

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -1109,10 +1109,10 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
   // copy to avoid duplicate plugin ID warnings.
   //
   // #251: if THIS run's native install was refused, a pre-existing load.paths
-  // entry is NOT "Installed through native OpenClaw linked plugin records" for
-  // this run. Returning bare 'native-link' here was the silent-success hole
-  // both independent reviewers flagged. Keep the skip (no duplicate copy), but
-  // surface that registration is pre-existing and the live attempt failed.
+  // entry is NOT a native success for this run. Returning bare 'native-link'
+  // lied to every caller/doctor that trusts PluginInstallMode. Keep the skip
+  // (no duplicate copy), surface the pre-existing registration, hard-fail on
+  // config-invalid, and return 'skipped' so the mode is not a native success.
   if (isPluginInLoadPaths()) {
     if (lastNativePluginInstallRefusal) {
       console.warn(
@@ -1122,9 +1122,9 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
       if (lastNativePluginInstallRefusal.configInvalid) {
         process.exitCode = 1;
       }
-    } else {
-      console.log('Plugin already registered via load.paths, skipping extensions copy.');
+      return 'skipped';
     }
+    console.log('Plugin already registered via load.paths, skipping extensions copy.');
     return 'native-link';
   }
 
@@ -1225,10 +1225,20 @@ function installPlugin(options: { noPlugins?: boolean; grantConversationAccess?:
       // once by installOpenClawHook, after the registration verify, for every
       // non-skipped install mode. See reportConversationAccessState.
       console.log(`Installed real-time plugin to ${destDir}`);
+      // #251: local-copy after a config-invalid native refusal is still a
+      // degraded outcome for scripts/CI — OpenClaw itself refused. Soft-success
+      // (exit 0) was the original silent shape; hard-fail the process so repair
+      // does not look green while the config is still broken.
+      if (lastNativePluginInstallRefusal?.configInvalid) {
+        process.exitCode = 1;
+      }
       return 'trusted-local-copy';
     } else {
       console.warn('  Warning: Could not register plugin in OpenClaw config');
       console.log(`Installed real-time plugin to ${destDir}`);
+      if (lastNativePluginInstallRefusal?.configInvalid) {
+        process.exitCode = 1;
+      }
       return 'untrusted-local-copy';
     }
   } catch (err) {
@@ -1585,13 +1595,7 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
     if (pluginInstallMode === 'native-package') {
       console.log('    Installed through native OpenClaw package records.');
     } else if (pluginInstallMode === 'native-link') {
-      // #251: native-link is also returned for pre-existing load.paths after a
-      // refused attempt — never claim "installed through native …" then.
-      if (nativeRefusal) {
-        console.warn('    Pre-existing load.paths registration only — this run\'s native OpenClaw install was refused (not a native success).');
-      } else {
-        console.log('    Installed through native OpenClaw linked plugin records.');
-      }
+      console.log('    Installed through native OpenClaw linked plugin records.');
     } else if (pluginInstallMode === 'trusted-local-copy') {
       console.log('    Installed as a local fallback and trusted via plugins.allow.');
     } else if (pluginInstallMode === 'untrusted-local-copy') {
@@ -1612,6 +1616,10 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
     const nativeRefusal = getLastNativePluginInstallRefusal();
     if (nativeRefusal) {
       console.log('  • shieldcortex-realtime plugin: skipped after native install refused (see warnings above)');
+      if (nativeRefusal.configInvalid && isPluginInLoadPaths()) {
+        // load.paths pre-existed; mode is skipped but files may still be present.
+        console.warn('    Pre-existing load.paths registration only — this run\'s native OpenClaw install was refused (not a native success).');
+      }
     } else {
       console.log('  • shieldcortex-realtime plugin: skipped');
     }


### PR DESCRIPTION
## Why
#251: `tryNativeOpenClawPluginInstall` discarded every line of a failed `openclaw plugins install` and returned bare `null`. install/repair then fell through to local-copy and printed plain success — same swallow #221 fixed on doctor/update.

## What
- Classify native spawn failures with `summariseCommandOutput` (redacted, front-ranked)
- Prefer config-invalid as the operator-facing root cause
- Warn with `openclaw config validate` before fallback
- Local-copy after native refusal is labelled as fallback, not native success
- Missing plugin source after refusal is no longer a quiet skip
- Resolve `SHIELDCORTEX_PLUGIN_SOURCE` at call time so missing-source is testable/real

## Verify
- `npm run build:ts` clean
- Focused: **4 suites / 28 tests passed**
  - `native-install-refusal-251.test.ts`
  - `installer-stanza-backup-214.test.ts`
  - `native-install-consent-226.test.ts`
  - `openclaw-install-mode-contract.test.ts`

Closes #251