### PR TITLE
fix(hooks): record prompt-recall telemetry before early exits (#253)

### DIFF
--- a/scripts/prompt-recall-hook.mjs
+++ b/scripts/prompt-recall-hook.mjs
@@ -360,6 +360,43 @@ function formatRecallContext(memories) {
   return lines.join('\n');
 }
 
+// ==================== TELEMETRY (#253) ====================
+
+/**
+ * Record a prompt-recall invocation BEFORE any early exit.
+ *
+ * Issue #253: seven process.exit(0) paths sat above the only
+ * recordHookInvocation call, so "fires but extracts nothing" was
+ * indistinguishable from "never fires" — the exact ambiguity this
+ * table was built to remove. Call this on every terminal path
+ * (including zero-yield gates) with memoriesExtracted: 0 and a
+ * short notes reason. Best-effort; never throws; never blocks exit.
+ */
+function recordPromptRecallTelemetry({
+  startedAt,
+  memoriesExtracted = 0,
+  notes = null,
+  dbPath = null,
+} = {}) {
+  const path = dbPath || getDbPath();
+  if (!path || !existsSync(path)) return;
+  let tdb = null;
+  try {
+    tdb = new Database(path, { timeout: 1000 });
+    recordHookInvocation(tdb, {
+      hookName: 'prompt-recall',
+      exitCode: 0,
+      durationMs: typeof startedAt === 'number' ? Date.now() - startedAt : null,
+      memoriesExtracted,
+      notes,
+    });
+  } catch {
+    // Telemetry must never block the user prompt.
+  } finally {
+    try { if (tdb) tdb.close(); } catch { /* ignore */ }
+  }
+}
+
 // ==================== MAIN ====================
 
 let input = '';
@@ -370,6 +407,7 @@ process.stdin.on('readable', () => {
 });
 
 process.stdin.on('end', async () => {
+  const startedAt = Date.now();
   try {
     const config = loadConfig();
     const hookData = JSON.parse(input || '{}');
@@ -411,6 +449,8 @@ process.stdin.on('end', async () => {
     }
 
     if (config.proactiveRecall !== true) {
+      // #253: fired, gated off — not "never ran".
+      recordPromptRecallTelemetry({ startedAt, notes: 'gated:proactiveRecall-disabled' });
       process.exit(0);
     }
 
@@ -421,20 +461,25 @@ process.stdin.on('end', async () => {
     const prompt = sanitisePromptForRecall(rawPrompt);
 
     if (prompt.length < MIN_PROMPT_LENGTH) {
+      recordPromptRecallTelemetry({ startedAt, notes: 'gated:prompt-too-short' });
       process.exit(0);
     }
 
     if (/^(yes|no|ok|sure|do it|go|send it|y|n|yep|nope)\s*[.!?]?\s*$/i.test(prompt.trim())) {
+      recordPromptRecallTelemetry({ startedAt, notes: 'gated:trivial-prompt' });
       process.exit(0);
     }
 
     const project = deriveProjectKey(cwd);
     if (!project) {
+      recordPromptRecallTelemetry({ startedAt, notes: 'gated:no-project-key' });
       process.exit(0);
     }
 
     const dbPath = getDbPath();
     if (!existsSync(dbPath)) {
+      // No DB file → cannot write telemetry either; still not a silent
+      // "never fired" once a DB exists on later runs. notes unused here.
       process.exit(0);
     }
 
@@ -488,6 +533,14 @@ process.stdin.on('end', async () => {
           relevanceDrops,
         });
       }
+      // #253: zero-yield recall MUST leave a hook_invocations row.
+      // This is the Veronica empty-store case — fires, injects nothing.
+      recordPromptRecallTelemetry({
+        startedAt,
+        memoriesExtracted: 0,
+        notes: fullSet.length > 0 ? 'zero-yield:filtered-empty' : 'zero-yield:no-candidates',
+        dbPath,
+      });
       process.exit(0);
     }
 
@@ -516,6 +569,12 @@ process.stdin.on('end', async () => {
           dedupHashes,
           context: null,
           relevanceDrops,
+        });
+        recordPromptRecallTelemetry({
+          startedAt,
+          memoriesExtracted: 0,
+          notes: 'zero-yield:dedup-suppressed',
+          dbPath,
         });
         process.exit(0);
       }
@@ -565,19 +624,32 @@ process.stdin.on('end', async () => {
     try {
       const writeDb = new Database(dbPath, { timeout: 1000 });
       const ids = memories.map(m => m.id);
-      const placeholders = ids.map(() => '?').join(',');
-      writeDb.prepare(`
-        UPDATE memories SET access_count = access_count + 1, last_accessed = datetime('now')
-        WHERE id IN (${placeholders})
-      `).run(...ids);
-      // Phase 0 measurement: record the recall injection in hook_invocations
-      // (reusing the connection we already opened). This is the cumulative
-      // "is the store actually read into prompts?" signal — fires = recalls
-      // that injected ≥1, memories_extracted = count injected. Best-effort.
-      recordHookInvocation(writeDb, { hookName: 'prompt-recall', memoriesExtracted: memories.length });
+      if (ids.length > 0) {
+        const placeholders = ids.map(() => '?').join(',');
+        writeDb.prepare(`
+          UPDATE memories SET access_count = access_count + 1, last_accessed = datetime('now')
+          WHERE id IN (${placeholders})
+        `).run(...ids);
+      }
+      // #253: record EVERY terminal path, including zero-yield after
+      // recall-defence emptied the set. memories_extracted = injected count;
+      // notes distinguish success from zero-yield so status is not a lie.
+      recordHookInvocation(writeDb, {
+        hookName: 'prompt-recall',
+        exitCode: 0,
+        durationMs: Date.now() - startedAt,
+        memoriesExtracted: memories.length,
+        notes: memories.length > 0 ? 'injected' : 'zero-yield:defence-empty',
+      });
       writeDb.close();
     } catch {
-      // Non-critical — don't block on access count update
+      // Non-critical — don't block on access count update / telemetry
+      recordPromptRecallTelemetry({
+        startedAt,
+        memoriesExtracted: memories.length,
+        notes: memories.length > 0 ? 'injected' : 'zero-yield:defence-empty',
+        dbPath,
+      });
     }
 
     const output = {
@@ -606,6 +678,12 @@ process.stdin.on('end', async () => {
     process.exit(0);
   } catch (error) {
     console.error(`[shieldcortex] Proactive recall error: ${error.message}`);
+    // #253: errors are still firings — record when a DB is available.
+    recordPromptRecallTelemetry({
+      startedAt,
+      memoriesExtracted: 0,
+      notes: `error:${error?.message ?? 'unknown'}`.slice(0, 200),
+    });
     process.exit(0);
   }
 });

--- a/scripts/prompt-recall-hook.mjs
+++ b/scripts/prompt-recall-hook.mjs
@@ -408,6 +408,9 @@ process.stdin.on('readable', () => {
 
 process.stdin.on('end', async () => {
   const startedAt = Date.now();
+  // #253: handler-level so a post-success throw cannot double-insert via
+  // the outer catch after the primary reinforce/telemetry block already wrote.
+  let invocationRecorded = false;
   try {
     const config = loadConfig();
     const hookData = JSON.parse(input || '{}');
@@ -623,7 +626,6 @@ process.stdin.on('end', async () => {
     // Reinforce access counts (fire-and-forget in a writable connection)
     // #253: record success/zero-yield once. close() lives in finally so a
     // close throw cannot re-enter the catch and double-insert telemetry.
-    let recorded = false;
     try {
       const writeDb = new Database(dbPath, { timeout: 1000 });
       try {
@@ -644,20 +646,21 @@ process.stdin.on('end', async () => {
           memoriesExtracted: memories.length,
           notes: memories.length > 0 ? 'injected' : 'zero-yield:defence-empty',
         });
-        recorded = true;
+        invocationRecorded = true;
       } finally {
         try { writeDb.close(); } catch { /* ignore close errors */ }
       }
     } catch {
       // Non-critical — don't block on access count update / telemetry
     }
-    if (!recorded) {
+    if (!invocationRecorded) {
       recordPromptRecallTelemetry({
         startedAt,
         memoriesExtracted: memories.length,
         notes: memories.length > 0 ? 'injected' : 'zero-yield:defence-empty',
         dbPath,
       });
+      invocationRecorded = true;
     }
 
     const output = {
@@ -686,12 +689,15 @@ process.stdin.on('end', async () => {
     process.exit(0);
   } catch (error) {
     console.error(`[shieldcortex] Proactive recall error: ${error.message}`);
-    // #253: errors are still firings — record when a DB is available.
-    recordPromptRecallTelemetry({
-      startedAt,
-      memoriesExtracted: 0,
-      notes: `error:${error?.message ?? 'unknown'}`.slice(0, 200),
-    });
+    // #253: errors are still firings — record when a DB is available,
+    // but only if this invocation has not already written a row.
+    if (!invocationRecorded) {
+      recordPromptRecallTelemetry({
+        startedAt,
+        memoriesExtracted: 0,
+        notes: `error:${error?.message ?? 'unknown'}`.slice(0, 200),
+      });
+    }
     process.exit(0);
   }
 });

--- a/scripts/prompt-recall-hook.mjs
+++ b/scripts/prompt-recall-hook.mjs
@@ -621,29 +621,37 @@ process.stdin.on('end', async () => {
     }
 
     // Reinforce access counts (fire-and-forget in a writable connection)
+    // #253: record success/zero-yield once. close() lives in finally so a
+    // close throw cannot re-enter the catch and double-insert telemetry.
+    let recorded = false;
     try {
       const writeDb = new Database(dbPath, { timeout: 1000 });
-      const ids = memories.map(m => m.id);
-      if (ids.length > 0) {
-        const placeholders = ids.map(() => '?').join(',');
-        writeDb.prepare(`
-          UPDATE memories SET access_count = access_count + 1, last_accessed = datetime('now')
-          WHERE id IN (${placeholders})
-        `).run(...ids);
+      try {
+        const ids = memories.map(m => m.id);
+        if (ids.length > 0) {
+          const placeholders = ids.map(() => '?').join(',');
+          writeDb.prepare(`
+            UPDATE memories SET access_count = access_count + 1, last_accessed = datetime('now')
+            WHERE id IN (${placeholders})
+          `).run(...ids);
+        }
+        // memories_extracted = injected count; notes distinguish success
+        // from zero-yield so status is not a lie.
+        recordHookInvocation(writeDb, {
+          hookName: 'prompt-recall',
+          exitCode: 0,
+          durationMs: Date.now() - startedAt,
+          memoriesExtracted: memories.length,
+          notes: memories.length > 0 ? 'injected' : 'zero-yield:defence-empty',
+        });
+        recorded = true;
+      } finally {
+        try { writeDb.close(); } catch { /* ignore close errors */ }
       }
-      // #253: record EVERY terminal path, including zero-yield after
-      // recall-defence emptied the set. memories_extracted = injected count;
-      // notes distinguish success from zero-yield so status is not a lie.
-      recordHookInvocation(writeDb, {
-        hookName: 'prompt-recall',
-        exitCode: 0,
-        durationMs: Date.now() - startedAt,
-        memoriesExtracted: memories.length,
-        notes: memories.length > 0 ? 'injected' : 'zero-yield:defence-empty',
-      });
-      writeDb.close();
     } catch {
       // Non-critical — don't block on access count update / telemetry
+    }
+    if (!recorded) {
       recordPromptRecallTelemetry({
         startedAt,
         memoriesExtracted: memories.length,

--- a/src/__tests__/prompt-recall-telemetry-253.test.ts
+++ b/src/__tests__/prompt-recall-telemetry-253.test.ts
@@ -94,11 +94,10 @@ describe('prompt-recall telemetry before early exits (#253)', () => {
     runHook({ home, prompt: 'how do I deploy the production service safely today' });
 
     const rows = readInvocations(dbPath);
-    expect(rows.length).toBeGreaterThanOrEqual(1);
-    const last = rows[rows.length - 1];
-    expect(last.hook_name).toBe('prompt-recall');
-    expect(last.memories_extracted).toBe(0);
-    expect(last.notes).toMatch(/zero-yield:no-candidates/);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].hook_name).toBe('prompt-recall');
+    expect(rows[0].memories_extracted).toBe(0);
+    expect(rows[0].notes).toBe('zero-yield:no-candidates');
   });
 
   it('records gated:proactiveRecall-disabled when recall is off', () => {
@@ -109,9 +108,9 @@ describe('prompt-recall telemetry before early exits (#253)', () => {
     runHook({ home, prompt: 'how do I deploy the production service safely today' });
 
     const rows = readInvocations(dbPath);
-    expect(rows.length).toBeGreaterThanOrEqual(1);
-    expect(rows[rows.length - 1].notes).toMatch(/gated:proactiveRecall-disabled/);
-    expect(rows[rows.length - 1].memories_extracted).toBe(0);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].notes).toBe('gated:proactiveRecall-disabled');
+    expect(rows[0].memories_extracted).toBe(0);
   });
 
   it('records gated:trivial-prompt for yes/no acknowledgements', () => {
@@ -121,17 +120,17 @@ describe('prompt-recall telemetry before early exits (#253)', () => {
     runHook({ home, prompt: 'send it.' });
 
     const rows = readInvocations(dbPath);
-    expect(rows.length).toBeGreaterThanOrEqual(1);
-    expect(rows[rows.length - 1].notes).toMatch(/gated:trivial-prompt/);
-    expect(rows[rows.length - 1].memories_extracted).toBe(0);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].notes).toBe('gated:trivial-prompt');
+    expect(rows[0].memories_extracted).toBe(0);
   });
 
   it('records gated:prompt-too-short for tiny prompts', () => {
     runHook({ home, prompt: 'hi' });
 
     const rows = readInvocations(dbPath);
-    expect(rows.length).toBeGreaterThanOrEqual(1);
-    expect(rows[rows.length - 1].notes).toMatch(/gated:prompt-too-short/);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].notes).toBe('gated:prompt-too-short');
   });
 
   it('records injected count when a memory is actually recalled', () => {
@@ -154,36 +153,55 @@ describe('prompt-recall telemetry before early exits (#253)', () => {
     });
 
     const rows = readInvocations(dbPath);
-    expect(rows.length).toBeGreaterThanOrEqual(1);
-    const last = rows[rows.length - 1];
-    expect(last.hook_name).toBe('prompt-recall');
-    // Either injected ≥1 or zero-yield after defence/filter — never missing.
-    expect(last.notes).toMatch(/injected|zero-yield/);
-    if (last.notes === 'injected') {
-      expect(last.memories_extracted).toBeGreaterThanOrEqual(1);
-    }
+    // Exactly one row — catches double-record regressions.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].hook_name).toBe('prompt-recall');
+    // Hard-require real injection (reviewers flagged soft injected|zero-yield).
+    expect(rows[0].notes).toBe('injected');
+    expect(rows[0].memories_extracted).toBeGreaterThanOrEqual(1);
   });
 
-  it('source contract: every process.exit(0) after the capture block has a telemetry call nearby', () => {
+  it('records gated:no-project-key when no project can be derived', () => {
+    // cwd with no usable basename and no SHIELDCORTEX_PROJECT_KEY.
+    // Use '/' — deriveProjectKey typically cannot produce a key from root.
+    runHook({ home, prompt: 'how do I deploy the production service safely today', cwd: '/' });
+
+    const rows = readInvocations(dbPath);
+    // Either no-project-key, or some hosts derive a key from env/cwd fallback.
+    // If a key WAS derived, we still must have exactly one telemetry row.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].hook_name).toBe('prompt-recall');
+    expect(rows[0].memories_extracted).toBe(0);
+  });
+
+  it('source contract: early exits that can write telemetry are instrumented', () => {
     const src = readFileSync(HOOK, 'utf8');
-    // The helper must exist.
     expect(src).toMatch(/function recordPromptRecallTelemetry/);
-    // Zero-yield paths must call it (the Veronica bug).
     expect(src).toMatch(/zero-yield:no-candidates/);
     expect(src).toMatch(/zero-yield:dedup-suppressed/);
+    expect(src).toMatch(/zero-yield:filtered-empty/);
     expect(src).toMatch(/gated:proactiveRecall-disabled/);
     expect(src).toMatch(/gated:trivial-prompt/);
-    // Count process.exit(0) after capture block vs telemetry sites.
-    // Crude but catches a future exit that forgets the record call:
-    // every early-exit gate we know about must appear as a notes reason
-    // OR be the missing-db path (cannot write).
-    const exitCount = (src.match(/process\.exit\(0\)/g) || []).length;
-    expect(exitCount).toBeGreaterThanOrEqual(7);
-    // recordHookInvocation / recordPromptRecallTelemetry must appear more
-    // than the single success-path call that existed before #253.
-    const recordSites =
-      (src.match(/recordPromptRecallTelemetry\(/g) || []).length +
-      (src.match(/recordHookInvocation\(/g) || []).length;
-    expect(recordSites).toBeGreaterThanOrEqual(6);
+    expect(src).toMatch(/gated:prompt-too-short/);
+    expect(src).toMatch(/gated:no-project-key/);
+    // Success path must not double-record via close-in-try.
+    expect(src).toMatch(/let recorded = false/);
+    expect(src).toMatch(/if \(!recorded\)/);
+
+    // Pair each known gate/zero-yield notes reason with a preceding record*
+    // call in the same function body region (string presence is the floor;
+    // behavioral tests above are the real lock).
+    const requiredNotes = [
+      'gated:proactiveRecall-disabled',
+      'gated:prompt-too-short',
+      'gated:trivial-prompt',
+      'gated:no-project-key',
+      'zero-yield:no-candidates',
+      'zero-yield:dedup-suppressed',
+      'injected',
+    ];
+    for (const note of requiredNotes) {
+      expect(src).toContain(note);
+    }
   });
 });

--- a/src/__tests__/prompt-recall-telemetry-253.test.ts
+++ b/src/__tests__/prompt-recall-telemetry-253.test.ts
@@ -184,9 +184,9 @@ describe('prompt-recall telemetry before early exits (#253)', () => {
     expect(src).toMatch(/gated:trivial-prompt/);
     expect(src).toMatch(/gated:prompt-too-short/);
     expect(src).toMatch(/gated:no-project-key/);
-    // Success path must not double-record via close-in-try.
-    expect(src).toMatch(/let recorded = false/);
-    expect(src).toMatch(/if \(!recorded\)/);
+    // Success path must not double-record via close-in-try or outer catch.
+    expect(src).toMatch(/let invocationRecorded = false/);
+    expect(src).toMatch(/if \(!invocationRecorded\)/);
 
     // Pair each known gate/zero-yield notes reason with a preceding record*
     // call in the same function body region (string presence is the floor;

--- a/src/__tests__/prompt-recall-telemetry-253.test.ts
+++ b/src/__tests__/prompt-recall-telemetry-253.test.ts
@@ -1,0 +1,189 @@
+/**
+ * #253 — prompt-recall must record hook_invocations BEFORE early exits.
+ *
+ * The table was built so status can show "fires but extracts nothing".
+ * Seven process.exit(0) paths sat above the only recordHookInvocation
+ * call, so an empty store (or any gate) looked like "never fires".
+ *
+ * Proof: spawn the real hook against a temp DB and assert a
+ * hook_invocations row lands on zero-yield / gated paths.
+ */
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { execFileSync } from 'node:child_process';
+import Database from 'better-sqlite3';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const HOOK = join(repoRoot, 'scripts', 'prompt-recall-hook.mjs');
+
+function runHook({ home, prompt, cwd = '/tmp/recall-253', sessionId = 'sess-253', envExtra = {} }: {
+  home: string;
+  prompt: string;
+  cwd?: string;
+  sessionId?: string | null;
+  envExtra?: Record<string, string>;
+}): void {
+  const input = JSON.stringify({
+    prompt,
+    cwd,
+    session_id: sessionId,
+  });
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    ...envExtra,
+  };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('SHIELDCORTEX_') && !(key in envExtra)) {
+      delete env[key];
+    }
+  }
+  try {
+    execFileSync('node', [HOOK], {
+      input,
+      env: env as NodeJS.ProcessEnv,
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    // Hook always exits 0; DB assertions are the contract.
+  }
+}
+
+function readInvocations(dbPath: string): Array<{
+  hook_name: string;
+  memories_extracted: number | null;
+  notes: string | null;
+}> {
+  const db = new Database(dbPath, { readonly: true });
+  const rows = db.prepare(
+    `SELECT hook_name, memories_extracted, notes FROM hook_invocations ORDER BY id`,
+  ).all() as Array<{ hook_name: string; memories_extracted: number | null; notes: string | null }>;
+  db.close();
+  return rows;
+}
+
+describe('prompt-recall telemetry before early exits (#253)', () => {
+  let home: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'sc-253-'));
+    mkdirSync(join(home, '.shieldcortex'), { recursive: true });
+    writeFileSync(
+      join(home, '.shieldcortex', 'config.json'),
+      JSON.stringify({ proactiveRecall: true, captureEvents: false }),
+    );
+    dbPath = join(home, '.shieldcortex', 'memories.db');
+    const schema = readFileSync(join(repoRoot, 'src', 'database', 'schema.sql'), 'utf8');
+    const db = new Database(dbPath);
+    db.exec(schema);
+    db.close();
+  });
+
+  afterEach(() => {
+    try { rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  it('records zero-yield:no-candidates when the store is empty (Veronica case)', () => {
+    // Empty memories table — the exact host-B failure mode.
+    runHook({ home, prompt: 'how do I deploy the production service safely today' });
+
+    const rows = readInvocations(dbPath);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    const last = rows[rows.length - 1];
+    expect(last.hook_name).toBe('prompt-recall');
+    expect(last.memories_extracted).toBe(0);
+    expect(last.notes).toMatch(/zero-yield:no-candidates/);
+  });
+
+  it('records gated:proactiveRecall-disabled when recall is off', () => {
+    writeFileSync(
+      join(home, '.shieldcortex', 'config.json'),
+      JSON.stringify({ proactiveRecall: false, captureEvents: false }),
+    );
+    runHook({ home, prompt: 'how do I deploy the production service safely today' });
+
+    const rows = readInvocations(dbPath);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[rows.length - 1].notes).toMatch(/gated:proactiveRecall-disabled/);
+    expect(rows[rows.length - 1].memories_extracted).toBe(0);
+  });
+
+  it('records gated:trivial-prompt for yes/no acknowledgements', () => {
+    // Must be ≥ MIN_PROMPT_LENGTH (8) so we reach the trivial gate, not
+    // the shorter prompt-too-short exit. "send it." is 8 chars and matches
+    // the trivial regex.
+    runHook({ home, prompt: 'send it.' });
+
+    const rows = readInvocations(dbPath);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[rows.length - 1].notes).toMatch(/gated:trivial-prompt/);
+    expect(rows[rows.length - 1].memories_extracted).toBe(0);
+  });
+
+  it('records gated:prompt-too-short for tiny prompts', () => {
+    runHook({ home, prompt: 'hi' });
+
+    const rows = readInvocations(dbPath);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[rows.length - 1].notes).toMatch(/gated:prompt-too-short/);
+  });
+
+  it('records injected count when a memory is actually recalled', () => {
+    const db = new Database(dbPath);
+    db.prepare(
+      `INSERT INTO memories (uuid, type, category, title, content, project, salience, trust_score, sensitivity_level, status)
+       VALUES (?, 'long_term', 'note', ?, ?, ?, 0.9, 1.0, 'INTERNAL', 'active')`,
+    ).run(
+      'uuid-253-benign',
+      'Deploy runbook',
+      'Deploy runbook: use the documented production deploy path for service rollout.',
+      'recall-253',
+    );
+    db.close();
+
+    runHook({
+      home,
+      prompt: 'how do I deploy the production service safely today',
+      cwd: '/tmp/recall-253',
+    });
+
+    const rows = readInvocations(dbPath);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    const last = rows[rows.length - 1];
+    expect(last.hook_name).toBe('prompt-recall');
+    // Either injected ≥1 or zero-yield after defence/filter — never missing.
+    expect(last.notes).toMatch(/injected|zero-yield/);
+    if (last.notes === 'injected') {
+      expect(last.memories_extracted).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('source contract: every process.exit(0) after the capture block has a telemetry call nearby', () => {
+    const src = readFileSync(HOOK, 'utf8');
+    // The helper must exist.
+    expect(src).toMatch(/function recordPromptRecallTelemetry/);
+    // Zero-yield paths must call it (the Veronica bug).
+    expect(src).toMatch(/zero-yield:no-candidates/);
+    expect(src).toMatch(/zero-yield:dedup-suppressed/);
+    expect(src).toMatch(/gated:proactiveRecall-disabled/);
+    expect(src).toMatch(/gated:trivial-prompt/);
+    // Count process.exit(0) after capture block vs telemetry sites.
+    // Crude but catches a future exit that forgets the record call:
+    // every early-exit gate we know about must appear as a notes reason
+    // OR be the missing-db path (cannot write).
+    const exitCount = (src.match(/process\.exit\(0\)/g) || []).length;
+    expect(exitCount).toBeGreaterThanOrEqual(7);
+    // recordHookInvocation / recordPromptRecallTelemetry must appear more
+    // than the single success-path call that existed before #253.
+    const recordSites =
+      (src.match(/recordPromptRecallTelemetry\(/g) || []).length +
+      (src.match(/recordHookInvocation\(/g) || []).length;
+    expect(recordSites).toBeGreaterThanOrEqual(6);
+  });
+});


### PR DESCRIPTION
## Why
#253 — `hook_invocations` was built so `shieldcortex status` can show **fires but extracts nothing**. Seven `process.exit(0)` paths in `prompt-recall-hook.mjs` sat **above** the only `recordHookInvocation` call, so empty-store hosts (Veronica) looked offline while the hook ran on every prompt.

## Fix
- Add `recordPromptRecallTelemetry()` and call it **before every early exit** that can still reach a DB
- Zero-yield paths (`no-candidates`, `filtered-empty`, `dedup-suppressed`, defence-empty) write `memories_extracted: 0` + notes
- Gated paths (`proactiveRecall-disabled`, `prompt-too-short`, `trivial-prompt`, `no-project-key`) also leave a row
- Success path still records injected count with `notes: injected`
- Missing DB cannot write telemetry (no sink) — unchanged physical limit
- #214-style: telemetry is best-effort and never blocks the user prompt

## Tests
- New `src/__tests__/prompt-recall-telemetry-253.test.ts` (real hook subprocess)
- Related: `hook-yield`, `recall-defence-integration`

## Loop
write → test → observe → update until spec met. Dual independent review (SOL Pro + Grok Heavy) follows on the PR head.

Closes #253