### PR TITLE
fix(cred): bound hex patterns and drop stale Firebase FCM (#205)

### DIFF
--- a/src/defence/__tests__/credential-entropy-padding.test.ts
+++ b/src/defence/__tests__/credential-entropy-padding.test.ts
@@ -89,25 +89,37 @@ describe('#257 — entropy detector silently bypassed by low-entropy padding', (
     expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
   });
 
-  it('a pure hex filler prefix that pattern-matches as an Azure key cannot suppress entropy redaction', () => {
-    // Regression for the second-order #257 bypass: the generic hex/Azure
-    // pattern used to claim only the low-entropy filler prefix. The later
-    // entropy token overlapped that range and was skipped, so the real unknown
-    // secret suffix survived in supposedly redacted output.
+  it('a pure hex filler prefix cannot suppress entropy redaction (#205: Azure no longer claims nested hex)', () => {
+    // Pre-#205: bare [a-f0-9]{32} claimed a 32-hex substring of the 40-hex
+    // filler; entropy then skipped the overlapping token and the secret
+    // suffix leaked. Post-#205 Azure is hex-bounded so it does NOT match
+    // inside a longer hex run — entropy alone must still catch the secret.
     const padded = 'a'.repeat(40) + UNKNOWN_SHAPE_SECRET;
     const result = scanForCredentials(padded);
     expect(result.leaked).toBe(true);
-    expect(result.findings.some((f) => f.provider === 'azure')).toBe(true);
+    expect(result.findings.some((f) => f.provider === 'azure')).toBe(false);
     expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
     expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
   });
 
-  it('the same pattern-overlap fix covers a 32-char hex filler prefix', () => {
+  it('a 32-char hex filler glued to a secret is still fully redacted by entropy', () => {
+    // 32 hex + secret starting with hex letter is ONE contiguous hex-ish run
+    // under Azure's bounded rule (lookahead fails). Entropy must cover it.
     const padded = 'f'.repeat(32) + UNKNOWN_SHAPE_SECRET;
     const result = scanForCredentials(padded);
     expect(result.leaked).toBe(true);
     expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
     expect(leaksRawSecret(padded, UNKNOWN_SHAPE_SECRET)).toBe(false);
+  });
+
+  it('a standalone 32-hex Azure-shaped token still matches Azure; adjacent unknown secret still redacts', () => {
+    // Space separates so Azure can match the bounded 32-hex token.
+    const azureKey = 'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+    const content = `${azureKey} ${UNKNOWN_SHAPE_SECRET}`;
+    const result = scanForCredentials(content);
+    expect(result.findings.some((f) => f.provider === 'azure')).toBe(true);
+    expect(result.findings.some((f) => f.type === 'high_entropy')).toBe(true);
+    expect(leaksRawSecret(content, UNKNOWN_SHAPE_SECRET)).toBe(false);
   });
 
   it('padding alone, with no secret attached, is NOT promoted to a finding', () => {

--- a/src/defence/__tests__/credential-leak.test.ts
+++ b/src/defence/__tests__/credential-leak.test.ts
@@ -191,11 +191,13 @@ describe('Credential Leak Detection', () => {
   });
 
   describe('Firebase FCM Keys', () => {
-    it('should detect valid Firebase FCM server keys', () => {
+    // #205: legacy FCM AAAA… server keys were decommissioned mid-2024.
+    // Pattern removed — pure FP surface (base64 zero-runs). Do not re-add
+    // without a current documented key format.
+    it('does not flag legacy AAAA FCM-shaped strings as firebase credentials', () => {
       const key = 'AAAA' + 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef01234567';
       const result = scanForCredentials(`FCM_KEY=${key}`);
-      expect(result.leaked).toBe(true);
-      expect(result.findings.some(f => f.provider === 'firebase')).toBe(true);
+      expect(result.findings.some(f => f.provider === 'firebase')).toBe(false);
     });
 
     it('should not trigger on "AAAA" alone or short strings', () => {

--- a/src/defence/__tests__/credential-precision-205.test.ts
+++ b/src/defence/__tests__/credential-precision-205.test.ts
@@ -80,11 +80,32 @@ describe('#205 credential pattern precision', () => {
       expect(result.findings.some((f) => f.type === 'env_secret')).toBe(true);
     });
 
-    it('isDocumentationPlaceholder covers the named issue examples', () => {
+    it.each([
+      // Dual-review FN cases: denylist must NOT swallow these.
+      ['API_KEY=my-secret-prod-a1b2c3d4'],
+      ['TOKEN=the-key-ops-7f3a9c'],
+      ['SECRET=Spring-Change-2024-rollout'],
+      ['PASSWORD=must-replace-oncall-91'],
+      ['API_TOKEN=todo-later-but-real-Xk9mQ2'],
+      ['DB_PASSWORD=set-the-db-password-now-8f'],
+    ])('STILL flags non-template env value: %s', (line) => {
+      const result = scanForCredentials(line);
+      expect(result.findings.some((f) => f.type === 'env_secret')).toBe(true);
+    });
+
+    it('isDocumentationPlaceholder covers the named issue examples only', () => {
       expect(isDocumentationPlaceholder('your-api-key-here')).toBe(true);
       expect(isDocumentationPlaceholder('replace-with-your-token')).toBe(true);
       expect(isDocumentationPlaceholder('changeme_in_production')).toBe(true);
       expect(isDocumentationPlaceholder('Kp9Wm2Qx7Lr4Nt8Vy1Zb5Fh6Jd')).toBe(false);
+      expect(isDocumentationPlaceholder('my-secret-prod-a1b2c3d4')).toBe(false);
+      expect(isDocumentationPlaceholder('Spring-Change-2024-rollout')).toBe(false);
+      expect(isDocumentationPlaceholder('must-replace-oncall-91')).toBe(false);
+    });
+
+    it('does not apply placeholder denylist to connection strings containing example hosts', () => {
+      const result = scanForCredentials('redis://default:s3cr3tPassw0rd99@redis.example.com:6379');
+      expect(result.findings.some((f) => f.provider === 'redis')).toBe(true);
     });
   });
 

--- a/src/defence/__tests__/credential-precision-205.test.ts
+++ b/src/defence/__tests__/credential-precision-205.test.ts
@@ -1,0 +1,104 @@
+/**
+ * #205 — credential pattern precision: word boundaries + placeholder denylist.
+ *
+ * Defects measured on main before this fix:
+ * - Azure bare 32-hex fired inside SHA-256 (twice) and on empty-file MD5
+ * - Firebase AAAA… matched base64 zero-runs at 0.90 (credential class dead)
+ * - ENV_SECRET matched documentation placeholders
+ *
+ * Gate: stop-count moves only in the directions the change explains.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { scanForCredentials, isDocumentationPlaceholder } from '../credential-leak/index.js';
+import { isWellKnownNonSecret } from '../credential-leak/entropy.js';
+
+// Fabricated — not a real secret.
+const STANDALONE_32_HEX = 'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const SHA256_EMPTY = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+const MD5_EMPTY = 'd41d8cd98f00b204e9800998ecf8427e';
+const SHA256_TEST = '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08';
+
+describe('#205 credential pattern precision', () => {
+  describe('Azure 32-hex boundaries', () => {
+    it('does NOT fire Azure inside a SHA-256 digest (no nested 32-hex hits)', () => {
+      const result = scanForCredentials(`checksum ${SHA256_EMPTY}`);
+      const azure = result.findings.filter((f) => f.provider === 'azure');
+      expect(azure).toHaveLength(0);
+    });
+
+    it('does NOT fire Azure twice inside a non-empty SHA-256', () => {
+      const result = scanForCredentials(`sha256:${SHA256_TEST}`);
+      const azure = result.findings.filter((f) => f.provider === 'azure');
+      expect(azure).toHaveLength(0);
+    });
+
+    it('does NOT flag the well-known empty-file MD5', () => {
+      const result = scanForCredentials(`md5 ${MD5_EMPTY}`);
+      const azure = result.findings.filter((f) => f.provider === 'azure');
+      expect(azure).toHaveLength(0);
+      expect(isWellKnownNonSecret(MD5_EMPTY)).toBe(true);
+    });
+
+    it('STILL matches a standalone 32-hex token (bounded, not nested)', () => {
+      const result = scanForCredentials(`Ocp-Apim-Subscription-Key: ${STANDALONE_32_HEX}`);
+      // Low confidence (0.35) medium — may be warned not blocked; presence is the contract.
+      expect(result.findings.some((f) => f.provider === 'azure')).toBe(true);
+    });
+
+    it('does not match 32-hex as a substring of 33+ hex', () => {
+      const longer = STANDALONE_32_HEX + 'ab';
+      const result = scanForCredentials(`token ${longer}`);
+      expect(result.findings.some((f) => f.provider === 'azure')).toBe(false);
+    });
+  });
+
+  describe('Firebase AAAA removal', () => {
+    it('does not flag AAAA+base64-looking runs as firebase', () => {
+      const key = 'AAAA' + 'A'.repeat(40);
+      const result = scanForCredentials(`FCM=${key}`);
+      expect(result.findings.some((f) => f.provider === 'firebase')).toBe(false);
+    });
+  });
+
+  describe('documentation placeholder denylist', () => {
+    it.each([
+      ['API_KEY=your-api-key-here'],
+      ['TOKEN: replace-with-your-token'],
+      ['DB_PASSWORD=changeme_in_production'],
+      ['SECRET=changeme'],
+      ['API_TOKEN=<your-token>'],
+      ['PASSWORD=password'],
+    ])('does not flag placeholder assignment: %s', (line) => {
+      const result = scanForCredentials(line);
+      const env = result.findings.filter((f) => f.type === 'env_secret');
+      expect(env).toHaveLength(0);
+    });
+
+    it('STILL flags a real-looking env secret assignment', () => {
+      // High-entropy-ish value, not placeholder language.
+      const result = scanForCredentials('API_KEY=Kp9Wm2Qx7Lr4Nt8Vy1Zb5Fh6Jd');
+      expect(result.findings.some((f) => f.type === 'env_secret')).toBe(true);
+    });
+
+    it('isDocumentationPlaceholder covers the named issue examples', () => {
+      expect(isDocumentationPlaceholder('your-api-key-here')).toBe(true);
+      expect(isDocumentationPlaceholder('replace-with-your-token')).toBe(true);
+      expect(isDocumentationPlaceholder('changeme_in_production')).toBe(true);
+      expect(isDocumentationPlaceholder('Kp9Wm2Qx7Lr4Nt8Vy1Zb5Fh6Jd')).toBe(false);
+    });
+  });
+
+  describe('Mailgun token boundaries', () => {
+    it('does not match key-32alnum inside a longer identifier', () => {
+      const embedded = 'prefixkey-' + 'a'.repeat(32) + 'suffix';
+      const result = scanForCredentials(embedded);
+      expect(result.findings.some((f) => f.provider === 'mailgun')).toBe(false);
+    });
+
+    it('still matches a bare key- + 32 alnum token', () => {
+      const key = 'key-' + 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
+      const result = scanForCredentials(`mailgun ${key}`);
+      expect(result.findings.some((f) => f.provider === 'mailgun')).toBe(true);
+    });
+  });
+});

--- a/src/defence/credential-leak/entropy.ts
+++ b/src/defence/credential-leak/entropy.ts
@@ -234,6 +234,12 @@ export function isWellKnownNonSecret(token: string): boolean {
   // Abbreviated git SHA (7–12 hex, the `git rev-parse --short` range).
   if (/^[0-9a-f]{7,12}$/i.test(t)) return true;
 
+  // #205: well-known empty-content digests. The empty-file MD5 is exactly
+  // 32 hex, so Azure's bounded 32-hex rule would still fire without this.
+  // Only the canonical empty digests — not arbitrary 32-hex.
+  if (/^d41d8cd98f00b204e9800998ecf8427e$/i.test(t)) return true; // MD5("")
+  if (/^e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855$/i.test(t)) return true; // SHA-256("")
+
   return false;
 }
 

--- a/src/defence/credential-leak/index.ts
+++ b/src/defence/credential-leak/index.ts
@@ -89,6 +89,70 @@ function isAllowlisted(value: string, allowlist: string[]): boolean {
 }
 
 /**
+ * #205 — documentation / template placeholders are not secrets.
+ *
+ * ENV_SECRET patterns match `API_KEY=…` assignments at 0.82–0.85 confidence.
+ * Without a denylist they fire on every README (`your-api-key-here`,
+ * `changeme_in_production`, `replace-with-your-token`). Conservative:
+ * only obvious placeholder language, not real-looking random values.
+ */
+export function isDocumentationPlaceholder(value: string): boolean {
+  const v = value.trim().toLowerCase();
+  if (!v) return true;
+
+  // Exact common placeholders
+  const exact = new Set([
+    'changeme',
+    'change_me',
+    'changeme!',
+    'password',
+    'secret',
+    'secret123',
+    'password123',
+    'admin',
+    'root',
+    'todo',
+    'fixme',
+    'fix_me',
+    'example',
+    'sample',
+    'dummy',
+    'placeholder',
+    'redacted',
+    'xxx',
+    'xxxx',
+    'xxxxxxxx',
+    '<password>',
+    '<secret>',
+    '<token>',
+    '<api_key>',
+    'your_password',
+    'your_secret',
+    'your_token',
+    'your_api_key',
+    'insert_here',
+    'insert-here',
+  ]);
+  if (exact.has(v)) return true;
+
+  // Phrase-shaped placeholders
+  if (/^(your|my|the)[-_ ]?(api[-_ ]?key|secret|token|password|passwd|key)\b/.test(v)) return true;
+  if (/\b(your|my)[-_ ]?(api[-_ ]?key|secret|token|password)\b/.test(v)) return true;
+  if (/\b(replace|insert|put|enter|set)[-_ ]?(with[-_ ]?)?(your|a|the)[-_ ]?/.test(v)) return true;
+  // changeme / change_me anywhere in a short value (changeme_in_production)
+  if (/(^|[^a-z])change[-_]?me([^a-z]|$)/.test(v) && v.length < 48) return true;
+  if (/\b(change|replace)[-_]?(me)?\b/.test(v) && v.length < 40) return true;
+  if (/\b(example|sample|dummy|placeholder|redacted|todo|fixme)\b/.test(v) && v.length < 48) return true;
+  if (/^(x{4,}|\*{4,}|\.{4,}|-{4,}|_{4,})$/i.test(value.trim())) return true;
+  if (/^<.*>$/.test(value.trim())) return true;
+  if (/^(xxx+|yyy+|zzz+|abc+|test|testing|asdf|qwerty)([0-9!@._-]*)?$/i.test(v)) return true;
+  // *_in_production / *_here / *_todo style template tails
+  if (/_(in_production|here|todo|example|sample|placeholder)$/.test(v) && v.length < 48) return true;
+
+  return false;
+}
+
+/**
  * Expand a match span to the full contiguous identifier token it sits in, then
  * test it against the well-known-non-secret allowlist (git SHA / UUID).
  *
@@ -152,6 +216,11 @@ export function scanForCredentials(
       // Skip allowlisted values
       if (isAllowlisted(secretValue, cfg.allowlist)) continue;
 
+      // #205: documentation placeholders are not secrets.
+      // Only for env-style assignment CAPTURES — never for full connection
+      // strings / API keys (those can contain the word "example" in a host).
+      if (pattern.type === 'env_secret' && isDocumentationPlaceholder(secretValue)) continue;
+
       // Skip if this range is already covered by a higher-priority pattern
       const start = match.index;
       const end = start + fullMatch.length;
@@ -159,7 +228,7 @@ export function scanForCredentials(
 
       // Skip well-known PUBLIC identifiers (git SHA / UUID). Generic hex rules
       // match a substring of these, so expand to the full token before testing
-      // (Phase 17 A5).
+      // (Phase 17 A5 / #205 empty digests).
       if (matchIsWellKnownNonSecret(content, start, end)) continue;
 
       const action = actionForSeverity(pattern.severity, cfg);

--- a/src/defence/credential-leak/index.ts
+++ b/src/defence/credential-leak/index.ts
@@ -93,14 +93,19 @@ function isAllowlisted(value: string, allowlist: string[]): boolean {
  *
  * ENV_SECRET patterns match `API_KEY=…` assignments at 0.82–0.85 confidence.
  * Without a denylist they fire on every README (`your-api-key-here`,
- * `changeme_in_production`, `replace-with-your-token`). Conservative:
- * only obvious placeholder language, not real-looking random values.
+ * `changeme_in_production`, `replace-with-your-token`).
+ *
+ * Conservative on purpose (dual-review #280): only obvious template language.
+ * Do NOT match bare words like "change"/"replace"/"set" inside real values
+ * (`Spring-Change-2024`, `my-secret-prod-7f3a`). Prefer exacts + anchored
+ * phrase shapes with length caps.
  */
 export function isDocumentationPlaceholder(value: string): boolean {
-  const v = value.trim().toLowerCase();
+  const raw = value.trim();
+  const v = raw.toLowerCase();
   if (!v) return true;
 
-  // Exact common placeholders
+  // Exact common placeholders (whole value)
   const exact = new Set([
     'changeme',
     'change_me',
@@ -130,24 +135,56 @@ export function isDocumentationPlaceholder(value: string): boolean {
     'your_secret',
     'your_token',
     'your_api_key',
+    'your-api-key',
+    'your-api-key-here',
+    'your_api_key_here',
     'insert_here',
     'insert-here',
+    'replace-with-your-token',
+    'replace_with_your_token',
+    'replace-with-your-secret',
+    'replace_with_your_secret',
+    'replace-with-your-password',
+    'changeme_in_production',
+    'change_me_in_production',
+    'changeme-in-production',
   ]);
   if (exact.has(v)) return true;
 
-  // Phrase-shaped placeholders
-  if (/^(your|my|the)[-_ ]?(api[-_ ]?key|secret|token|password|passwd|key)\b/.test(v)) return true;
-  if (/\b(your|my)[-_ ]?(api[-_ ]?key|secret|token|password)\b/.test(v)) return true;
-  if (/\b(replace|insert|put|enter|set)[-_ ]?(with[-_ ]?)?(your|a|the)[-_ ]?/.test(v)) return true;
-  // changeme / change_me anywhere in a short value (changeme_in_production)
-  if (/(^|[^a-z])change[-_]?me([^a-z]|$)/.test(v) && v.length < 48) return true;
-  if (/\b(change|replace)[-_]?(me)?\b/.test(v) && v.length < 40) return true;
-  if (/\b(example|sample|dummy|placeholder|redacted|todo|fixme)\b/.test(v) && v.length < 48) return true;
-  if (/^(x{4,}|\*{4,}|\.{4,}|-{4,}|_{4,})$/i.test(value.trim())) return true;
-  if (/^<.*>$/.test(value.trim())) return true;
-  if (/^(xxx+|yyy+|zzz+|abc+|test|testing|asdf|qwerty)([0-9!@._-]*)?$/i.test(v)) return true;
-  // *_in_production / *_here / *_todo style template tails
-  if (/_(in_production|here|todo|example|sample|placeholder)$/.test(v) && v.length < 48) return true;
+  // Angle-bracket template tokens: <your-token>, <API_KEY>
+  if (/^<[^>]{1,40}>$/.test(raw)) return true;
+
+  // Pure mask runs
+  if (/^(x{4,}|\*{4,}|\.{4,}|-{4,}|_{4,})$/i.test(raw)) return true;
+  if (/^(xxx+|yyy+|zzz+|asdf|qwerty)([0-9!@._-]*)?$/i.test(v)) return true;
+
+  // Anchored "your/my … key/secret/token/password" whole-value templates.
+  // Requires a template tail (here|example|placeholder|xxx|sample) OR ends
+  // exactly at the credential noun — not "my-secret-prod-abc123".
+  if (
+    /^(your|my)[-_ ]+(api[-_ ]?key|secret|token|password|passwd|key)([-_ ]+(here|example|sample|placeholder|xxx+))?$/i.test(v)
+  ) {
+    return true;
+  }
+
+  // Anchored "replace/insert … with your …" whole-value templates only.
+  if (
+    v.length < 48
+    && /^(replace|insert)[-_ ]+(with[-_ ]+)?(your|my|a|the)[-_ ]+(api[-_ ]?key|secret|token|password|key|value)([-_ ]*(here)?)?$/.test(v)
+  ) {
+    return true;
+  }
+
+  // changeme / change_me as a PREFIX of a short template (changeme_in_production)
+  if (/^change[-_]?me([-_].{0,24})?$/.test(v) && v.length < 40) return true;
+
+  // *_in_production / *_here when the stem is a known placeholder word
+  if (
+    /^(change[-_]?me|password|secret|token|api[-_]?key|example|sample|dummy|placeholder|todo|fixme)[-_](in[-_]production|here|example|sample|placeholder|todo)$/.test(v)
+    && v.length < 48
+  ) {
+    return true;
+  }
 
   return false;
 }

--- a/src/defence/credential-leak/patterns.ts
+++ b/src/defence/credential-leak/patterns.ts
@@ -264,13 +264,17 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     confidence: 0.97,
   },
   // Mailgun
+  //
+  // #205: historically `key-` + 32 alnum. Bound the whole token so we do not
+  // match inside longer identifiers. Confidence kept modest — current Mailgun
+  // docs no longer clearly advertise this prefix; treat as best-effort.
   {
     name: 'Mailgun API Key',
     type: 'api_key',
     provider: 'mailgun',
-    regex: /key-[A-Za-z0-9]{32}/g,
+    regex: /(?<![A-Za-z0-9_-])key-[A-Za-z0-9]{32}(?![A-Za-z0-9_-])/g,
     severity: 'critical',
-    confidence: 0.85,
+    confidence: 0.80,
   },
   // npm
   {
@@ -319,16 +323,11 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     severity: 'critical',
     confidence: 0.97,
   },
-  // Firebase Cloud Messaging
-  {
-    name: 'Firebase Cloud Messaging Key',
-    type: 'api_key',
-    provider: 'firebase',
-    regex: /AAAA[A-Za-z0-9_-]{40,}/g,
-    severity: 'critical',
-    confidence: 0.90,
-    minLength: 44,
-  },
+  // Firebase Cloud Messaging — REMOVED (#205).
+  // Legacy FCM server keys (AAAA…) were decommissioned mid-2024. The bare
+  // AAAA[A-Za-z0-9_-]{40,} pattern matched base64 zero-runs and other
+  // non-secrets at 0.90 confidence with zero remaining true-positive class.
+  // Do not re-add without a current, documented key format.
   // HashiCorp Vault
   {
     name: 'HashiCorp Vault Token',
@@ -339,11 +338,16 @@ export const API_KEY_PATTERNS: CredentialPattern[] = [
     confidence: 0.96,
   },
   // Azure Subscription Key
+  //
+  // #205: bare `[a-f0-9]{32}` matched *inside* longer hex (SHA-256 twice,
+  // nested digests). Bound to a full 32-hex token — no leading/trailing hex.
+  // Confidence stays low; known public digests (empty MD5) are allowlisted
+  // in isWellKnownNonSecret / the scanner path.
   {
     name: 'Azure Subscription Key',
     type: 'api_key',
     provider: 'azure',
-    regex: /[a-f0-9]{32}/g,
+    regex: /(?<![A-Fa-f0-9])[a-f0-9]{32}(?![A-Fa-f0-9])/g,
     severity: 'medium',
     confidence: 0.35,
     minLength: 32,


### PR DESCRIPTION
## Why
#205 — credential patterns had no word/hex boundaries. Azure bare 32-hex fired **inside SHA-256** (twice) and on the empty-file MD5. Same audit: Firebase `AAAA…` is dead credential class (pure FP), ENV_SECRET matched README placeholders, Mailgun `key-` was unbound.

## Fix
- **Azure:** `(?<![A-Fa-f0-9])[a-f0-9]{32}(?![A-Fa-f0-9])` — full-token only
- **Empty digests:** MD5(\"\") / SHA-256(\"\") allowlisted in `isWellKnownNonSecret`
- **Firebase AAAA FCM:** removed (decommissioned mid-2024)
- **ENV placeholders:** `isDocumentationPlaceholder` denylist on env_secret captures only (hosts like `example.com` in connection strings stay matched)
- **Mailgun:** token-bounded; confidence 0.80
- **#257 tests:** updated so entropy still redacts when Azure no longer claims nested hex

## A/B direction (named signals)
| Signal | Direction |
|---|---|
| Azure inside SHA-256 / longer hex | stop ↓ |
| Empty MD5 | stop ↓ |
| Firebase AAAA zero-runs | stop ↓ |
| README placeholders | stop ↓ |
| Standalone 32-hex Azure / real env secrets / Mailgun bare key- | stop stays |

## Tests
- New `credential-precision-205.test.ts`
- Updated `credential-leak` Firebase expectations
- Updated `credential-entropy-padding` for bounded Azure
- Focused suite: **5 suites / 163 tests**

## Loop
write → test → observe → update. Dual independent review (SOL Pro + Grok Heavy) on PR head.

Closes #205