### PR TITLE
fix(doctor): attribute hot-reload load to gateway PID (#216)

### DIFF
--- a/src/__tests__/hot-reload-pid-load-216.test.ts
+++ b/src/__tests__/hot-reload-pid-load-216.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../integrations/openclaw-gateway-roster.js';
 import {
   reconcilePluginState,
+  classifyLiveLoadEvidence,
   type ReconcileInput,
 } from '../integrations/openclaw-plugin-index.js';
 import { evaluateSelfCheck } from '../setup/openclaw-selfcheck.js';
@@ -173,6 +174,121 @@ describe('#216 self-check — gateway-PID registration grants roster proof', () 
     });
     expect(v.rosterState).toBe('unproven');
     expect(v.rosterProof).toBe(false);
+  });
+});
+
+describe('#216 classifyLiveLoadEvidence — production decision tree (pure)', () => {
+  const pluginId = PLUGIN;
+  const gw = (atMs: number) => ({ atMs, pid: GW_PID, version: '4.47.32' });
+  const cli = (atMs: number) => ({ atMs, pid: CLI_PID, version: '4.50.0' });
+  const anon = (atMs: number) => ({ atMs, pid: null, version: '4.47.32' });
+
+  it('boot roster hit ⇒ boot-roster evidence, no registration scan needed', () => {
+    const r = classifyLiveLoadEvidence({
+      pluginId,
+      liveRoster: [PLUGIN, 'telegram'],
+      gatewayPid: GW_PID,
+      bootAtMs: 100,
+      processStartedAtMs: 50,
+      findGatewayReg: () => {
+        throw new Error('must not scan');
+      },
+      findAnyReg: () => {
+        throw new Error('must not scan');
+      },
+    });
+    expect(r.liveLoadEvidence).toBe('boot-roster');
+    expect(r.registrationSeenAfterBoot).toBe(false);
+  });
+
+  it('boot-miss + gateway-PID reg (bootAtMs bound only; processStartedAtMs null) ⇒ gateway-pid-registration', () => {
+    // SOL dual-review blocker: must not require processStartedAtMs.
+    const r = classifyLiveLoadEvidence({
+      pluginId,
+      liveRoster: ['telegram'],
+      gatewayPid: GW_PID,
+      bootAtMs: 100,
+      processStartedAtMs: null,
+      findGatewayReg: (since, pid) => {
+        expect(since).toBe(100);
+        expect(pid).toBe(GW_PID);
+        return gw(150);
+      },
+      findAnyReg: () => cli(160),
+    });
+    expect(r.liveLoadEvidence).toBe('gateway-pid-registration');
+    expect(r.liveRoster).toContain(PLUGIN);
+    expect(r.registrationSeenAfterBoot).toBe(false);
+  });
+
+  it('boot-miss + gateway-PID reg (processStartedAtMs bound only; bootAtMs null) ⇒ gateway-pid-registration', () => {
+    const r = classifyLiveLoadEvidence({
+      pluginId,
+      liveRoster: null,
+      gatewayPid: GW_PID,
+      bootAtMs: null,
+      processStartedAtMs: 200,
+      findGatewayReg: (since) => {
+        expect(since).toBe(200);
+        return gw(250);
+      },
+      findAnyReg: () => {
+        throw new Error('no boot ⇒ no #142 path');
+      },
+    });
+    expect(r.liveLoadEvidence).toBe('gateway-pid-registration');
+    expect(r.liveRoster).toEqual([PLUGIN]);
+  });
+
+  it('#142 preserved when processStartedAtMs is null: CLI/anon reg still marks registrationSeenAfterBoot', () => {
+    const r = classifyLiveLoadEvidence({
+      pluginId,
+      liveRoster: ['telegram'],
+      gatewayPid: GW_PID,
+      bootAtMs: 100,
+      processStartedAtMs: null,
+      findGatewayReg: () => null,
+      findAnyReg: (since) => {
+        expect(since).toBe(100);
+        return anon(120);
+      },
+    });
+    expect(r.liveLoadEvidence).toBeNull();
+    expect(r.registrationSeenAfterBoot).toBe(true);
+    expect(r.liveRoster).not.toContain(PLUGIN);
+  });
+
+  it('CLI-PID reg alone never grants gateway-pid-registration', () => {
+    const r = classifyLiveLoadEvidence({
+      pluginId,
+      liveRoster: ['telegram'],
+      gatewayPid: GW_PID,
+      bootAtMs: 100,
+      processStartedAtMs: 50,
+      findGatewayReg: () => null,
+      findAnyReg: () => cli(150),
+    });
+    expect(r.liveLoadEvidence).toBeNull();
+    expect(r.registrationSeenAfterBoot).toBe(true);
+  });
+
+  it('invalid gatewayPid does not call findGatewayReg; #142 still works', () => {
+    let gwCalls = 0;
+    const r = classifyLiveLoadEvidence({
+      pluginId,
+      liveRoster: ['telegram'],
+      gatewayPid: 0,
+      bootAtMs: 100,
+      processStartedAtMs: 50,
+      findGatewayReg: () => {
+        gwCalls++;
+        return gw(150);
+      },
+      findAnyReg: () => anon(120),
+    });
+    expect(gwCalls).toBe(0);
+    expect(r.liveLoadEvidence).toBeNull();
+    expect(r.registrationSeenAfterBoot).toBe(true);
   });
 });
 

--- a/src/__tests__/hot-reload-pid-load-216.test.ts
+++ b/src/__tests__/hot-reload-pid-load-216.test.ts
@@ -1,0 +1,202 @@
+/**
+ * #216 — doctor plugin-loaded must attribute hot-reload registrations to the
+ * running gateway PID.
+ *
+ * Case #213: after stanza restore the plugin hot-reloaded into the running
+ * gateway (registration line PID-attributable), but doctor only read the boot
+ * roster snapshot → false absent. Conversely a previous-boot roster line must
+ * never mask a currently-dead plugin (already bounded by process start).
+ *
+ * Contract:
+ * - gateway-PID registration after boot ⇒ loaded / healthy
+ * - CLI-PID or anonymous registration after boot ⇒ still load-unproven (#142)
+ * - no registration + absent from boot ⇒ enabled-not-loaded
+ */
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  findGatewayAttributedRegistrationSince,
+  parseRegistrationsSince,
+} from '../integrations/openclaw-gateway-roster.js';
+import {
+  reconcilePluginState,
+  type ReconcileInput,
+} from '../integrations/openclaw-plugin-index.js';
+import { evaluateSelfCheck } from '../setup/openclaw-selfcheck.js';
+import { renderPluginLoadVerdict } from '../cli/doctor.js';
+
+const PLUGIN = 'shieldcortex-realtime';
+const GW_PID = 4242;
+const CLI_PID = 9999;
+
+const base: ReconcileInput = {
+  pluginId: PLUGIN,
+  expectedVersion: '4.47.23',
+  config: { enabled: true, inAllow: true },
+  installsJson: null,
+  index: {
+    installRecords: { [PLUGIN]: { source: 'npm', version: '4.47.23' } },
+    plugins: [{ pluginId: PLUGIN, enabled: true }],
+    warning: null,
+  },
+  onDiskVersion: '4.47.23',
+  projectDirs: [],
+  liveRoster: ['telegram'], // boot snapshot missed us
+};
+
+function regLine(iso: string, version: string, pid: number | null): string {
+  if (pid == null) {
+    return JSON.stringify({
+      time: iso,
+      message: `[shieldcortex] v${version} registered (llm_input + before_tool_call)`,
+    });
+  }
+  return JSON.stringify({
+    time: iso,
+    pid,
+    message: `[shieldcortex] v${version} registered (llm_input + before_tool_call)`,
+  });
+}
+
+describe('#216 findGatewayAttributedRegistrationSince', () => {
+  it('returns only sightings whose pid matches the gateway', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-216-log-'));
+    try {
+      const text = [
+        regLine('2026-08-08T14:04:00.000Z', '4.47.32', CLI_PID),
+        regLine('2026-08-08T14:04:33.000Z', '4.47.32', GW_PID),
+      ].join('\n');
+      fs.writeFileSync(path.join(dir, 'openclaw-2026-08-08.log'), text);
+      const since = Date.parse('2026-08-08T14:00:00.000Z');
+      const got = findGatewayAttributedRegistrationSince(since, GW_PID, { logDir: dir });
+      expect(got).not.toBeNull();
+      expect(got!.pid).toBe(GW_PID);
+      expect(got!.version).toBe('4.47.32');
+      expect(findGatewayAttributedRegistrationSince(since, CLI_PID, { logDir: dir })!.pid).toBe(CLI_PID);
+      // Unknown pid → null
+      expect(findGatewayAttributedRegistrationSince(since, 1, { logDir: dir })).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores anonymous (no pid) registration lines — those stay #142-ambiguous', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-216-anon-'));
+    try {
+      fs.writeFileSync(
+        path.join(dir, 'openclaw-x.log'),
+        regLine('2026-08-08T14:04:33.000Z', '4.47.32', null),
+      );
+      const since = Date.parse('2026-08-08T14:00:00.000Z');
+      expect(findGatewayAttributedRegistrationSince(since, GW_PID, { logDir: dir })).toBeNull();
+      // parseRegistrationsStill sees it for the ambiguous path
+      expect(parseRegistrationsSince(fs.readFileSync(path.join(dir, 'openclaw-x.log'), 'utf8'), since)).toHaveLength(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('#216 reconciler — gateway-PID hot-reload is live load', () => {
+  it('boot-miss + gateway-PID registration ⇒ healthy (not enabled-not-loaded)', () => {
+    const v = reconcilePluginState({
+      ...base,
+      liveRoster: ['telegram'],
+      liveLoadEvidence: 'gateway-pid-registration',
+      registrationSeenAfterBoot: false,
+    });
+    expect(v.state).toBe('healthy');
+    expect(v.loadedInLiveRoster).toBe(true);
+    expect(v.reasons.join(' ')).toMatch(/RUNNING gateway PID after boot|hot-reload/i);
+  });
+
+  it('boot-miss + CLI/anonymous registration only ⇒ still load-unproven (#142)', () => {
+    const v = reconcilePluginState({
+      ...base,
+      liveRoster: ['telegram'],
+      registrationSeenAfterBoot: true,
+      liveLoadEvidence: null,
+    });
+    expect(v.state).toBe('load-unproven');
+    expect(v.severity).toBe('warn');
+  });
+
+  it('boot-miss + no registration ⇒ enabled-not-loaded fail', () => {
+    const v = reconcilePluginState({
+      ...base,
+      liveRoster: ['telegram'],
+      registrationSeenAfterBoot: false,
+      liveLoadEvidence: null,
+    });
+    expect(v.state).toBe('enabled-not-loaded');
+    expect(v.severity).toBe('fail');
+  });
+
+  it('promoting plugin id into liveRoster (gather path) also yields healthy', () => {
+    const v = reconcilePluginState({
+      ...base,
+      liveRoster: ['telegram', PLUGIN],
+      liveLoadEvidence: 'gateway-pid-registration',
+    });
+    expect(v.state).toBe('healthy');
+    expect(v.loadedInLiveRoster).toBe(true);
+  });
+});
+
+describe('#216 self-check — gateway-PID registration grants roster proof', () => {
+  const canaryPassed = { ran: true, denied: true, auditEntryFound: true };
+
+  it('boot-miss + gateway-PID reg ⇒ loaded + rosterProof', () => {
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: null,
+      liveRoster: ['telegram'],
+      registrationSeenAfterBoot: false,
+      gatewayPidRegistrationSeenAfterBoot: true,
+      canary: canaryPassed,
+    });
+    expect(v.rosterState).toBe('loaded');
+    expect(v.rosterProof).toBe(true);
+    expect(v.reasons.join(' ')).toMatch(/RUNNING gateway PID after boot|hot-reload/i);
+  });
+
+  it('boot-miss + CLI-only reg still unproven (does not grant proof)', () => {
+    const v = evaluateSelfCheck({
+      pluginId: PLUGIN,
+      index: null,
+      liveRoster: ['telegram'],
+      registrationSeenAfterBoot: true,
+      gatewayPidRegistrationSeenAfterBoot: false,
+      canary: canaryPassed,
+    });
+    expect(v.rosterState).toBe('unproven');
+    expect(v.rosterProof).toBe(false);
+  });
+});
+
+describe('#216 doctor render — names hot-reload evidence', () => {
+  it('healthy + hot-reload reason → gateway-PID message', () => {
+    const verdict = reconcilePluginState({
+      ...base,
+      liveRoster: ['telegram', PLUGIN],
+      liveLoadEvidence: 'gateway-pid-registration',
+    });
+    const r = renderPluginLoadVerdict(verdict);
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/gateway-PID registration after boot|hot-reload/i);
+  });
+
+  it('healthy + boot roster only → classic roster-confirmed message', () => {
+    const verdict = reconcilePluginState({
+      ...base,
+      liveRoster: [PLUGIN, 'telegram'],
+      liveLoadEvidence: 'boot-roster',
+    });
+    const r = renderPluginLoadVerdict(verdict);
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/roster-confirmed/i);
+    expect(r.message).not.toMatch(/hot-reload/i);
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3298,15 +3298,24 @@ export function renderPluginLoadVerdict(verdict: ReconcileVerdict): CheckResult 
       // from roster presence alone (#74 attempt #3 was roster-present-but-not-
       // enforcing). Say "loaded (roster-confirmed)"; point at repair's canary. (#74 finding 6)
       //
+      // #216: when the reconciler proved load via a gateway-PID-attributed
+      // post-boot registration (hot-reload), say so — the boot snapshot alone
+      // would have been a false absent.
+      //
       // "Loaded" does not mean "scanning conversations" either — that gap is
       // owned by `checkOpenClawPluginLoadState`, which downgrades this tick when
       // the conversation-access grant is missing (#226), and reported in full by
       // `checkOpenClawConversationScanning` (#225/#230). This renderer is pure:
       // it reads the verdict and nothing off disk.
+      const hotReload =
+        Array.isArray(verdict.reasons) &&
+        verdict.reasons.some((r) => /RUNNING gateway PID after boot|hot-reload/i.test(r));
       return {
         label,
         status: 'pass',
-        message: `realtime plugin loaded (roster-confirmed, v${version}); enforcement not probed here — prove it live with: ${LIVE_CANARY_COMMAND}`,
+        message: hotReload
+          ? `realtime plugin loaded (gateway-PID registration after boot / hot-reload, v${version}); enforcement not probed here — prove it live with: ${LIVE_CANARY_COMMAND}`
+          : `realtime plugin loaded (roster-confirmed, v${version}); enforcement not probed here — prove it live with: ${LIVE_CANARY_COMMAND}`,
       };
     }
     default: {

--- a/src/integrations/openclaw-gateway-roster.ts
+++ b/src/integrations/openclaw-gateway-roster.ts
@@ -266,3 +266,49 @@ export function findRegistrationSince(
   }
   return newest;
 }
+
+/**
+ * #216 — newest registration at/after `sinceMs` whose log line is attributed
+ * to `gatewayPid`.
+ *
+ * A post-boot `[shieldcortex] v… registered` line is only LIVE LOAD proof when
+ * the emitting process is the running gateway. CLI / repair / doctor processes
+ * write identical message text into the shared log; without PID attribution
+ * those lines must stay AMBIGUOUS (`load-unproven`), never "loaded".
+ *
+ * Null means "no gateway-attributed dated sighting" — not "not registered".
+ */
+export function findGatewayAttributedRegistrationSince(
+  sinceMs: number,
+  gatewayPid: number,
+  options: ReadBootRosterOptions = {},
+): RegistrationSighting | null {
+  if (!Number.isInteger(gatewayPid) || gatewayPid <= 0) return null;
+
+  const logDir = options.logDir ?? DEFAULT_LOG_DIR;
+  const readDir = options.readDir ?? ((d: string) => fs.readdirSync(d));
+  const readFile = options.readFile ?? ((f: string) => fs.readFileSync(f, 'utf-8'));
+
+  let names: string[];
+  try {
+    names = readDir(logDir);
+  } catch {
+    return null;
+  }
+
+  let newest: RegistrationSighting | null = null;
+  for (const name of names) {
+    if (!name.startsWith('openclaw-') || !name.endsWith('.log')) continue;
+    let text: string;
+    try {
+      text = readFile(path.join(logDir, name));
+    } catch {
+      continue;
+    }
+    for (const sighting of parseRegistrationsSince(text, sinceMs)) {
+      if (sighting.pid !== gatewayPid) continue;
+      if (!newest || sighting.atMs > newest.atMs) newest = sighting;
+    }
+  }
+  return newest;
+}

--- a/src/integrations/openclaw-plugin-index.ts
+++ b/src/integrations/openclaw-plugin-index.ts
@@ -755,6 +755,21 @@ export interface GatherOptions {
    * `http server listening` boot line). Returns null when it cannot be proven.
    */
   readLiveRoster?: () => string[] | null;
+  /**
+   * #216 test seam — gateway-PID-attributed registration since a bound.
+   * Production defaults to {@link findGatewayAttributedRegistrationSince}.
+   */
+  findGatewayAttributedRegistration?: (
+    sinceMs: number,
+    gatewayPid: number,
+  ) => { atMs: number; pid: number | null; version: string } | null;
+  /**
+   * #142 test seam — any dated registration since a bound (CLI/anonymous
+   * inclusive). Production defaults to {@link findRegistrationSince}.
+   */
+  findAnyRegistrationSince?: (
+    sinceMs: number,
+  ) => { atMs: number; pid: number | null; version: string } | null;
 }
 
 /**
@@ -848,6 +863,10 @@ export function gatherReconcileInput(home: string, options: GatherOptions): Reco
   // #216: a post-boot registration attributed to the RUNNING gateway PID is
   // live-load proof (hot-reload after stanza restore). CLI-attributed or
   // anonymous registration lines stay ambiguous (`registrationSeenAfterBoot`).
+  //
+  // Dual-review #281: #142 and #216 must NOT both require processStartedAtMs.
+  // - #216 needs gatewayPid + a lower bound (bootAtMs ?? processStartedAtMs)
+  // - #142 only needs bootAtMs (a post-snapshot ambiguous sighting)
   let bootAtMs: number | null = null;
   let gatewayPid: number | null = null;
   let processStartedAtMs: number | null = null;
@@ -864,30 +883,27 @@ export function gatherReconcileInput(home: string, options: GatherOptions): Reco
       return boot?.plugins ?? null;
     });
   let liveRoster = readRoster();
-  let liveLoadEvidence: 'boot-roster' | 'gateway-pid-registration' | null =
-    liveRoster != null && liveRoster.includes(pluginId) ? 'boot-roster' : null;
-  let registrationSeenAfterBoot = false;
-
-  if (
-    process.env.JEST_WORKER_ID === undefined &&
-    liveLoadEvidence == null &&
-    gatewayPid != null &&
-    processStartedAtMs != null
-  ) {
-    // Prefer the boot snapshot timestamp when we have one (post-snapshot race);
-    // otherwise bound by process start so a hot-reload after a missing boot
-    // line can still prove load for the CURRENT process.
-    const sinceMs = bootAtMs ?? processStartedAtMs;
-    const gatewayReg = findGatewayAttributedRegistrationSince(sinceMs, gatewayPid);
-    if (gatewayReg) {
-      liveLoadEvidence = 'gateway-pid-registration';
-      if (liveRoster == null) liveRoster = [pluginId];
-      else if (!liveRoster.includes(pluginId)) liveRoster = [...liveRoster, pluginId];
-    } else if (liveRoster != null && !liveRoster.includes(pluginId) && bootAtMs != null) {
-      // Ambiguous sighting only — CLI/anonymous lines must not convict or acquit.
-      registrationSeenAfterBoot = findRegistrationSince(bootAtMs) != null;
-    }
-  }
+  const classified = classifyLiveLoadEvidence({
+    pluginId,
+    liveRoster,
+    gatewayPid,
+    bootAtMs,
+    processStartedAtMs,
+    // Production reads real logs; tests inject via options below when present.
+    findGatewayReg:
+      options.findGatewayAttributedRegistration ??
+      ((sinceMs, pid) =>
+        process.env.JEST_WORKER_ID !== undefined
+          ? null
+          : findGatewayAttributedRegistrationSince(sinceMs, pid)),
+    findAnyReg:
+      options.findAnyRegistrationSince ??
+      ((sinceMs) =>
+        process.env.JEST_WORKER_ID !== undefined ? null : findRegistrationSince(sinceMs)),
+  });
+  liveRoster = classified.liveRoster;
+  const liveLoadEvidence = classified.liveLoadEvidence;
+  const registrationSeenAfterBoot = classified.registrationSeenAfterBoot;
 
   return {
     pluginId,
@@ -905,6 +921,68 @@ export function gatherReconcileInput(home: string, options: GatherOptions): Reco
     registrationSeenAfterBoot,
     liveLoadEvidence,
   };
+}
+
+/**
+ * #216/#142 pure classifier for post-boot live-load evidence.
+ *
+ * Extracted so Jest can exercise the production decision tree without touching
+ * real /tmp/openclaw logs (dual-review #281 blocker).
+ */
+export function classifyLiveLoadEvidence(input: {
+  pluginId: string;
+  liveRoster: string[] | null;
+  gatewayPid: number | null;
+  bootAtMs: number | null;
+  processStartedAtMs: number | null;
+  findGatewayReg: (sinceMs: number, gatewayPid: number) => { atMs: number; pid: number | null; version: string } | null;
+  findAnyReg: (sinceMs: number) => { atMs: number; pid: number | null; version: string } | null;
+}): {
+  liveRoster: string[] | null;
+  liveLoadEvidence: 'boot-roster' | 'gateway-pid-registration' | null;
+  registrationSeenAfterBoot: boolean;
+} {
+  let liveRoster = input.liveRoster;
+  let liveLoadEvidence: 'boot-roster' | 'gateway-pid-registration' | null =
+    liveRoster != null && liveRoster.includes(input.pluginId) ? 'boot-roster' : null;
+  let registrationSeenAfterBoot = false;
+
+  if (liveLoadEvidence != null) {
+    return { liveRoster, liveLoadEvidence, registrationSeenAfterBoot };
+  }
+
+  // #216 lower bound: prefer boot snapshot time, else process start. Either
+  // alone is enough — do not require both (SOL dual-review #281).
+  const sinceMs =
+    input.bootAtMs != null
+      ? input.bootAtMs
+      : input.processStartedAtMs != null
+        ? input.processStartedAtMs
+        : null;
+
+  if (
+    sinceMs != null &&
+    input.gatewayPid != null &&
+    Number.isInteger(input.gatewayPid) &&
+    input.gatewayPid > 0
+  ) {
+    const gatewayReg = input.findGatewayReg(sinceMs, input.gatewayPid);
+    if (gatewayReg) {
+      liveLoadEvidence = 'gateway-pid-registration';
+      if (liveRoster == null) liveRoster = [input.pluginId];
+      else if (!liveRoster.includes(input.pluginId)) liveRoster = [...liveRoster, input.pluginId];
+      return { liveRoster, liveLoadEvidence, registrationSeenAfterBoot: false };
+    }
+  }
+
+  // #142: ambiguous post-snapshot registration only needs bootAtMs.
+  // Independent of processStartedAtMs — a missing start bound must not turn
+  // a race into a confident enabled-not-loaded fail.
+  if (liveRoster != null && !liveRoster.includes(input.pluginId) && input.bootAtMs != null) {
+    registrationSeenAfterBoot = input.findAnyReg(input.bootAtMs) != null;
+  }
+
+  return { liveRoster, liveLoadEvidence, registrationSeenAfterBoot };
 }
 
 /** Extract the `~/.openclaw/npm/projects/<name>` directory name from any path

--- a/src/integrations/openclaw-plugin-index.ts
+++ b/src/integrations/openclaw-plugin-index.ts
@@ -7,7 +7,11 @@ import {
   readInstalledRealtimePluginVersion,
   resolveLocalExtensionInstall,
 } from './openclaw-plugin-state.js';
-import { readLatestBootRoster, findRegistrationSince } from './openclaw-gateway-roster.js';
+import {
+  readLatestBootRoster,
+  findRegistrationSince,
+  findGatewayAttributedRegistrationSince,
+} from './openclaw-gateway-roster.js';
 import { readRunningGatewayProcess } from './openclaw-gateway-process.js';
 
 /**
@@ -149,8 +153,20 @@ export interface ReconcileInput {
    * (#142). The snapshot races registration (169 ms margin observed live), so
    * absence-from-snapshot plus a later sighting is ambiguous — CLI processes
    * write identical lines — and must not convict the host as UNPROTECTED.
+   *
+   * #216: this flag is ONLY for ambiguous (non-gateway-PID) sightings. A
+   * registration whose log PID matches the running gateway is live-load proof
+   * and is folded into `liveRoster` / `liveLoadEvidence` instead.
    */
   registrationSeenAfterBoot?: boolean;
+  /**
+   * #216 — how `loadedInLiveRoster === true` was proven for this gather.
+   * - `boot-roster`: named on the current process boot line
+   * - `gateway-pid-registration`: post-boot/hot-reload registration attributed
+   *   to the running gateway PID (Case #213 / issue #216)
+   * - omitted/null: not proven loaded via live evidence
+   */
+  liveLoadEvidence?: 'boot-roster' | 'gateway-pid-registration' | null;
 }
 
 export type PluginLoadState =
@@ -256,8 +272,16 @@ export function reconcilePluginState(input: ReconcileInput): ReconcileVerdict {
   );
 
   // #103: the live gateway roster overrides the install index. Null = unread.
+  // #216: gather may also prove load via a gateway-PID-attributed registration
+  // (hot-reload / post-boot), which is represented either by promoting the
+  // plugin id into `liveRoster` or by `liveLoadEvidence`.
   const liveRoster = input.liveRoster ?? null;
-  const loadedInLiveRoster = liveRoster == null ? null : liveRoster.includes(pluginId);
+  const loadedInLiveRoster =
+    liveRoster == null
+      ? input.liveLoadEvidence === 'gateway-pid-registration'
+        ? true
+        : null
+      : liveRoster.includes(pluginId) || input.liveLoadEvidence === 'gateway-pid-registration';
 
   const installsJsonVersion = input.installsJson?.version ?? null;
   const indexVersion = indexRecord?.version ?? indexRecord?.resolvedVersion ?? null;
@@ -506,9 +530,12 @@ export function reconcilePluginState(input: ReconcileInput): ReconcileVerdict {
 
   // Say exactly which evidence we have. Claiming "loaded in roster" off the
   // install index alone is what made #103 a false positive.
+  // #216: distinguish boot-snapshot proof from PID-attributed hot-reload proof.
   reasons.push(
     loadedInLiveRoster === true
-      ? 'enabled, present on the running gateway boot roster, versions agree at the expected build'
+      ? input.liveLoadEvidence === 'gateway-pid-registration'
+        ? 'enabled, registration attributed to the RUNNING gateway PID after boot (hot-reload / post-boot load), versions agree at the expected build'
+        : 'enabled, present on the running gateway boot roster, versions agree at the expected build'
       : 'enabled and installed, versions agree at the expected build — but the running gateway boot roster could NOT be read, so the plugin is not proven loaded',
   );
   return { ...base, state: 'healthy', severity: 'ok', recommendedAction: 'none', reasons };
@@ -817,24 +844,51 @@ export function gatherReconcileInput(home: string, options: GatherOptions): Reco
   // #142/#150: bound the boot line by the RUNNING gateway's process start
   // (from OpenClaw's boot-lifecycle table). A line from a previous process, or
   // one we cannot bound, yields null — "cannot prove", never a stale answer.
+  //
+  // #216: a post-boot registration attributed to the RUNNING gateway PID is
+  // live-load proof (hot-reload after stanza restore). CLI-attributed or
+  // anonymous registration lines stay ambiguous (`registrationSeenAfterBoot`).
   let bootAtMs: number | null = null;
+  let gatewayPid: number | null = null;
+  let processStartedAtMs: number | null = null;
   const readRoster =
     options.readLiveRoster ??
     (() => {
       if (process.env.JEST_WORKER_ID !== undefined) return null;
       const proc = readRunningGatewayProcess(home);
       if (!proc) return null;
+      gatewayPid = proc.pid;
+      processStartedAtMs = proc.startedAtMs;
       const boot = readLatestBootRoster({ processStartedAtMs: proc.startedAtMs });
       bootAtMs = boot?.atMs ?? null;
       return boot?.plugins ?? null;
     });
-  const liveRoster = readRoster();
-  const registrationSeenAfterBoot =
-    liveRoster != null &&
-    !liveRoster.includes(pluginId) &&
+  let liveRoster = readRoster();
+  let liveLoadEvidence: 'boot-roster' | 'gateway-pid-registration' | null =
+    liveRoster != null && liveRoster.includes(pluginId) ? 'boot-roster' : null;
+  let registrationSeenAfterBoot = false;
+
+  if (
     process.env.JEST_WORKER_ID === undefined &&
-    bootAtMs != null &&
-    findRegistrationSince(bootAtMs) != null;
+    liveLoadEvidence == null &&
+    gatewayPid != null &&
+    processStartedAtMs != null
+  ) {
+    // Prefer the boot snapshot timestamp when we have one (post-snapshot race);
+    // otherwise bound by process start so a hot-reload after a missing boot
+    // line can still prove load for the CURRENT process.
+    const sinceMs = bootAtMs ?? processStartedAtMs;
+    const gatewayReg = findGatewayAttributedRegistrationSince(sinceMs, gatewayPid);
+    if (gatewayReg) {
+      liveLoadEvidence = 'gateway-pid-registration';
+      if (liveRoster == null) liveRoster = [pluginId];
+      else if (!liveRoster.includes(pluginId)) liveRoster = [...liveRoster, pluginId];
+    } else if (liveRoster != null && !liveRoster.includes(pluginId) && bootAtMs != null) {
+      // Ambiguous sighting only — CLI/anonymous lines must not convict or acquit.
+      registrationSeenAfterBoot = findRegistrationSince(bootAtMs) != null;
+    }
+  }
+
   return {
     pluginId,
     expectedVersion: options.expectedVersion,
@@ -849,6 +903,7 @@ export function gatherReconcileInput(home: string, options: GatherOptions): Reco
     projectDirs: scanProjectDirs(home, pluginId),
     liveRoster,
     registrationSeenAfterBoot,
+    liveLoadEvidence,
   };
 }
 

--- a/src/setup/openclaw-selfcheck.ts
+++ b/src/setup/openclaw-selfcheck.ts
@@ -6,6 +6,7 @@ import semver from 'semver';
 import {
   readPluginInstallIndex,
   REALTIME_PLUGIN_ID,
+  classifyLiveLoadEvidence,
   type PluginIndexRow,
 } from '../integrations/openclaw-plugin-index.js';
 import {
@@ -254,9 +255,24 @@ export interface RunSelfCheckOptions {
   /**
    * Injectable post-boot registration sighting (defaults to scanning the
    * gateway logs for a `[shieldcortex] … registered` line newer than the boot
-   * roster snapshot, #142). Only consulted when the roster omits the plugin.
+   * roster snapshot, #142). Only consulted when the roster omits the plugin
+   * AND no gateway-PID load proof is present.
    */
   readRegistrationSeenAfterBoot?: () => boolean;
+  /**
+   * #216 test seam — gateway-PID-attributed registration (defaults to
+   * {@link findGatewayAttributedRegistrationSince}).
+   */
+  findGatewayAttributedRegistration?: (
+    sinceMs: number,
+    gatewayPid: number,
+  ) => { atMs: number; pid: number | null; version: string } | null;
+  /**
+   * #142 test seam — any dated registration since a bound.
+   */
+  findAnyRegistrationSince?: (
+    sinceMs: number,
+  ) => { atMs: number; pid: number | null; version: string } | null;
   /** Injectable live enforcement probe (defaults to the guarded real probe). */
   canaryProbe?: (home: string, pluginId: string) => Promise<CanaryResult>;
 }
@@ -304,41 +320,45 @@ export async function runPluginSelfCheck(
       latestBoot = readLatestBootRoster({ processStartedAtMs: proc.startedAtMs });
       return latestBoot?.plugins ?? null;
     });
-  // Ambiguous post-boot registration (CLI/anonymous). #216 gateway-PID proof
-  // is collected separately and grants loaded.
-  const readRegistration =
-    options.readRegistrationSeenAfterBoot ??
-    (() => {
-      if (process.env.JEST_WORKER_ID !== undefined) return false;
-      if (latestBoot?.atMs == null) return false;
-      // Only count as ambiguous if we do NOT already have a gateway-PID match.
-      if (gatewayPid != null) {
-        const gw = findGatewayAttributedRegistrationSince(latestBoot.atMs, gatewayPid);
-        if (gw) return false;
-      }
-      return findRegistrationSince(latestBoot.atMs) != null;
-    });
   const probe = options.canaryProbe ?? defaultCanaryProbe;
 
   const index = readIndex(home);
-  const liveRoster = readRoster();
-  let gatewayPidRegistrationSeenAfterBoot = false;
+  let liveRoster = readRoster();
+  // #216/#142: ONE decision tree with gatherReconcileInput (dual-review #281).
+  // Do not re-implement processStartedAtMs coupling here.
+  const classified = classifyLiveLoadEvidence({
+    pluginId,
+    liveRoster,
+    gatewayPid,
+    bootAtMs: latestBoot?.atMs ?? null,
+    processStartedAtMs,
+    findGatewayReg:
+      options.findGatewayAttributedRegistration ??
+      ((sinceMs, pid) =>
+        process.env.JEST_WORKER_ID !== undefined
+          ? null
+          : findGatewayAttributedRegistrationSince(sinceMs, pid)),
+    findAnyReg:
+      options.findAnyRegistrationSince ??
+      ((sinceMs) =>
+        process.env.JEST_WORKER_ID !== undefined
+          ? null
+          : findRegistrationSince(sinceMs)),
+  });
+  // When tests inject readRegistrationSeenAfterBoot, honour it for the
+  // ambiguous path only — never override a gateway-PID load proof.
+  let registrationSeenAfterBoot = classified.registrationSeenAfterBoot;
+  let gatewayPidRegistrationSeenAfterBoot =
+    classified.liveLoadEvidence === 'gateway-pid-registration';
   if (
-    process.env.JEST_WORKER_ID === undefined &&
-    gatewayPid != null &&
-    processStartedAtMs != null &&
-    !(liveRoster?.includes(pluginId))
-  ) {
-    const sinceMs = latestBoot?.atMs ?? processStartedAtMs;
-    gatewayPidRegistrationSeenAfterBoot =
-      findGatewayAttributedRegistrationSince(sinceMs, gatewayPid) != null;
-  }
-  const registrationSeenAfterBoot =
+    options.readRegistrationSeenAfterBoot &&
     !gatewayPidRegistrationSeenAfterBoot &&
-    liveRoster != null &&
-    !liveRoster.includes(pluginId)
-      ? readRegistration()
-      : false;
+    classified.liveLoadEvidence !== 'boot-roster'
+  ) {
+    registrationSeenAfterBoot = options.readRegistrationSeenAfterBoot();
+  }
+  liveRoster = classified.liveRoster;
+
   const onDiskVersion = options.expectedVersion ? readOnDisk(home) : null;
   const canary = await probe(home, pluginId);
   const verdict = evaluateSelfCheck({

--- a/src/setup/openclaw-selfcheck.ts
+++ b/src/setup/openclaw-selfcheck.ts
@@ -12,7 +12,7 @@ import {
   readInstalledRealtimePluginVersion,
   resolveRealtimePluginInstallPath,
 } from '../integrations/openclaw-plugin-state.js';
-import { readLatestBootRoster, findRegistrationSince, type BootRoster } from '../integrations/openclaw-gateway-roster.js';
+import { readLatestBootRoster, findRegistrationSince, findGatewayAttributedRegistrationSince, type BootRoster } from '../integrations/openclaw-gateway-roster.js';
 import { readRunningGatewayProcess } from '../integrations/openclaw-gateway-process.js';
 import { resolveRepairConsent } from './repair-consent.js';
 import { evaluateToolCall } from '../defence/iron-dome/tool-action-guard.js';
@@ -111,9 +111,19 @@ export interface SelfCheckInput {
    * (#142). Registration races the snapshot (169 ms margin observed live) and
    * also happens mid-life, so absence-from-snapshot plus a later sighting is
    * AMBIGUOUS — CLI processes write identical lines — and must yield
-   * `unproven`, never `absent`. It never grants `loaded`; the canary does.
+   * `unproven`, never `absent`. It never grants `loaded` by itself.
+   *
+   * #216: gateway-PID-attributed registration is NOT this flag — that is
+   * `gatewayPidRegistrationSeenAfterBoot` / live-load proof.
    */
   registrationSeenAfterBoot?: boolean;
+  /**
+   * #216 — a post-boot registration line attributed to the RUNNING gateway
+   * PID. Unlike CLI-ambiguous `registrationSeenAfterBoot`, this IS live-load
+   * proof (hot-reload after stanza restore). Grants `loaded` when the boot
+   * snapshot omitted the plugin.
+   */
+  gatewayPidRegistrationSeenAfterBoot?: boolean;
   /** The build the flow expects to be enforcing; enables the version proof. */
   expectedVersion?: string;
   /** Ground-truth on-disk version, for the version proof. */
@@ -147,8 +157,14 @@ export function evaluateSelfCheck(input: SelfCheckInput): SelfCheckVerdict {
 
   let rosterState: RosterProofState;
   if (liveRoster == null) {
-    rosterState = 'unproven';
+    // #216: gateway-PID registration can still prove load when the boot line
+    // itself was unreadable (log wiped after hot-reload).
+    rosterState = input.gatewayPidRegistrationSeenAfterBoot === true ? 'loaded' : 'unproven';
   } else if (liveRoster.includes(pluginId)) {
+    rosterState = 'loaded';
+  } else if (input.gatewayPidRegistrationSeenAfterBoot === true) {
+    // #216: Case #213 shape — boot snapshot missed the plugin, but the running
+    // gateway process itself later emitted the registration line.
     rosterState = 'loaded';
   } else if (input.registrationSeenAfterBoot === true) {
     // #142: the boot line is a snapshot and registration races it. A sighting
@@ -161,7 +177,13 @@ export function evaluateSelfCheck(input: SelfCheckInput): SelfCheckVerdict {
   const rosterProof = rosterState === 'loaded';
 
   if (rosterState === 'loaded') {
-    reasons.push('roster proof: plugin named on the RUNNING gateway boot roster — actually loaded, not merely installed');
+    if (input.gatewayPidRegistrationSeenAfterBoot === true && !(liveRoster?.includes(pluginId))) {
+      reasons.push(
+        'roster proof: plugin registration attributed to the RUNNING gateway PID after boot — live load proven (hot-reload / post-boot), not merely installed',
+      );
+    } else {
+      reasons.push('roster proof: plugin named on the RUNNING gateway boot roster — actually loaded, not merely installed');
+    }
   } else if (rosterState === 'absent') {
     reasons.push('roster proof FAILED: plugin ABSENT from the RUNNING gateway boot roster — interceptor not loaded, host unprotected while status reports ON');
     if (enabledInIndex) {
@@ -269,31 +291,54 @@ export async function runPluginSelfCheck(
   // previous process, or one we cannot bound, yields null — "cannot prove",
   // never a stale answer wearing a fresh badge.
   let latestBoot: BootRoster | null | undefined;
+  let gatewayPid: number | null = null;
+  let processStartedAtMs: number | null = null;
   const readRoster =
     options.readLiveRoster ??
     (() => {
       if (process.env.JEST_WORKER_ID !== undefined) return null;
       const proc = readRunningGatewayProcess(home);
       if (!proc) return null;
+      gatewayPid = proc.pid;
+      processStartedAtMs = proc.startedAtMs;
       latestBoot = readLatestBootRoster({ processStartedAtMs: proc.startedAtMs });
       return latestBoot?.plugins ?? null;
     });
-  // Only meaningful when the bounded boot line exists yet omits the plugin:
-  // a registration sighted after that snapshot means the snapshot cannot
-  // convict (#142's 169 ms race), though it also cannot acquit.
+  // Ambiguous post-boot registration (CLI/anonymous). #216 gateway-PID proof
+  // is collected separately and grants loaded.
   const readRegistration =
     options.readRegistrationSeenAfterBoot ??
     (() => {
       if (process.env.JEST_WORKER_ID !== undefined) return false;
       if (latestBoot?.atMs == null) return false;
+      // Only count as ambiguous if we do NOT already have a gateway-PID match.
+      if (gatewayPid != null) {
+        const gw = findGatewayAttributedRegistrationSince(latestBoot.atMs, gatewayPid);
+        if (gw) return false;
+      }
       return findRegistrationSince(latestBoot.atMs) != null;
     });
   const probe = options.canaryProbe ?? defaultCanaryProbe;
 
   const index = readIndex(home);
   const liveRoster = readRoster();
+  let gatewayPidRegistrationSeenAfterBoot = false;
+  if (
+    process.env.JEST_WORKER_ID === undefined &&
+    gatewayPid != null &&
+    processStartedAtMs != null &&
+    !(liveRoster?.includes(pluginId))
+  ) {
+    const sinceMs = latestBoot?.atMs ?? processStartedAtMs;
+    gatewayPidRegistrationSeenAfterBoot =
+      findGatewayAttributedRegistrationSince(sinceMs, gatewayPid) != null;
+  }
   const registrationSeenAfterBoot =
-    liveRoster != null && !liveRoster.includes(pluginId) ? readRegistration() : false;
+    !gatewayPidRegistrationSeenAfterBoot &&
+    liveRoster != null &&
+    !liveRoster.includes(pluginId)
+      ? readRegistration()
+      : false;
   const onDiskVersion = options.expectedVersion ? readOnDisk(home) : null;
   const canary = await probe(home, pluginId);
   const verdict = evaluateSelfCheck({
@@ -301,6 +346,7 @@ export async function runPluginSelfCheck(
     index,
     liveRoster,
     registrationSeenAfterBoot,
+    gatewayPidRegistrationSeenAfterBoot,
     canary,
     expectedVersion: options.expectedVersion,
     onDiskVersion,

--- a/src/setup/openclaw-selfcheck.ts
+++ b/src/setup/openclaw-selfcheck.ts
@@ -178,7 +178,10 @@ export function evaluateSelfCheck(input: SelfCheckInput): SelfCheckVerdict {
   const rosterProof = rosterState === 'loaded';
 
   if (rosterState === 'loaded') {
-    if (input.gatewayPidRegistrationSeenAfterBoot === true && !(liveRoster?.includes(pluginId))) {
+    // Prefer the true evidence source. gather/selfcheck may promote pluginId
+    // into liveRoster after a gateway-PID hit (#216 dual-review nit) — still
+    // say hot-reload when that is how we proved load.
+    if (input.gatewayPidRegistrationSeenAfterBoot === true) {
       reasons.push(
         'roster proof: plugin registration attributed to the RUNNING gateway PID after boot — live load proven (hot-reload / post-boot), not merely installed',
       );


### PR DESCRIPTION
## Why
#216 (Case #213 secondary): after stanza restore the plugin **hot-reloaded** into the running gateway (registration line PID-attributable), but doctor's \"plugin loaded\" check only read the **boot roster snapshot** → false absent. A previous-boot roster line must also never mask a currently-dead plugin (already process-start bounded).

## Fix
- **`findGatewayAttributedRegistrationSince(sinceMs, gatewayPid)`** — only registration lines whose log PID equals the running gateway count as live-load proof
- **Gather / selfcheck:** if boot snapshot misses the plugin but a gateway-PID registration exists after boot (or process start), treat as **loaded** (`liveLoadEvidence: gateway-pid-registration`)
- **CLI / anonymous** post-boot registration stays **#142 load-unproven** (never grants loaded, never convicts)
- **Doctor healthy render** names hot-reload / gateway-PID evidence vs classic boot roster-confirmed

## Tests
New `src/__tests__/hot-reload-pid-load-216.test.ts` + existing #142/#150/#74 suites  
**Local:** build clean · **4 suites / 41 tests**

## Loop
write → test → observe → update. Dual independent review (SOL Pro + Grok Heavy) on PR head.

Also: **#252 verified fixed on main** (ambient `@huggingface/transformers` stub; `tsc` exit 0 without the optional package) and closed with evidence.

Closes #216