### PR TITLE
fix(trust): host-attested stamp for agent identity (#283)

### DIFF
--- a/src/__tests__/threat-graph-attestation.test.ts
+++ b/src/__tests__/threat-graph-attestation.test.ts
@@ -187,13 +187,19 @@ describe('#270 — same-score identity is not self-declarable', () => {
     expect(resolved.clamped).toBe(true);
   });
 
-  it('keeps a genuine trust downgrade (file:import 0.4 < cli:mcp 0.9)', () => {
+  it('rewrites a genuine trust downgrade off the host ACL key (#283)', () => {
+    // file:import 0.4 < cli:mcp 0.9 is still a legitimate downgrade (not
+    // clamped). #283 additionally rewrites the stored identity so ownership
+    // cannot wear host file:import. Score must not rise (file:unattested
+    // would score 0.6) — falls back to agent:unattested @ 0.3.
     const resolved = resolveToolSource(
       { type: 'file', identifier: 'import' },
       { toolName: 'remember', project: null, strict: false },
     );
-    expect(resolved.source).toEqual({ type: 'file', identifier: 'import' });
     expect(resolved.clamped).toBe(false);
+    expect(resolved.attested).toBe(false);
+    expect(resolved.source.identifier.startsWith('unattested>')).toBe(true);
+    expect(resolved.source).toEqual({ type: 'agent', identifier: 'unattested>import' });
   });
 
   it('honours a declaration the environment independently confirms', () => {

--- a/src/defence/__tests__/agent-inbound-stamp-283.test.ts
+++ b/src/defence/__tests__/agent-inbound-stamp-283.test.ts
@@ -1,0 +1,238 @@
+/**
+ * #283 — agent: is a self-applied trust label; inbound stamp must come from
+ * the arrival path.
+ *
+ * Acceptance (issue body + CASE criteria):
+ * 1. Inbound bit is minted at ingestion from the arrival path, not source.type
+ * 2. Stored where tool/env/declaration writers cannot overwrite it
+ * 3. Three reproduction rows fail closed (or host-attested by that stamp)
+ * 4. Guards that exempted `agent` read the stamp, not the self-declared type
+ * 5. checkAccess ownership uses the same host-attested stamp (not bare
+ *    `${type}:${identifier}` equality against a writer-chosen id)
+ * 6. Unattested below-ceiling declarations cannot own host-attested rows
+ *    (thread ResolvedToolSource.attested; cover four default cli:* 0.9 rows)
+ * 7. No writer-chosen bare identity reaches trust 0.5 on the env path
+ */
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { checkAccess } from '../trust/access-control.js';
+import { resolveToolSource, rewriteUnattestedSource, deriveAttested } from '../trust/resolve-tool-source.js';
+import { inferSourceFromEnvironment, bindIntegratorOverrideSource } from '../trust/env-detector.js';
+import { scoreSource, isUntrustedInboundSourceString, isUntrustedInboundType } from '../trust/source-scorer.js';
+import { guardReadBySensitivity } from '../trust/read-guard.js';
+import type { DefenceSource } from '../types.js';
+import type { Memory } from '../../memory/types.js';
+
+const ENV_KEYS = [
+  'SHIELDCORTEX_AGENT_SOURCE',
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_AGENT_CONTEXT',
+  'CODEX_INTERNAL_ORIGINATOR_OVERRIDE',
+  'CODEX_THREAD_ID',
+  'CODEX_CI',
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+
+function clearEnv(): void {
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+}
+
+function restoreEnv(): void {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+}
+
+function mem(source: string, id = 1): { id: number; source: string; sensitivity_level: string } {
+  return { id, source, sensitivity_level: 'INTERNAL' };
+}
+
+function memoryRow(source: string, id = 1): Memory {
+  return {
+    id,
+    title: 't',
+    content: 'c',
+    source,
+    sensitivityLevel: 'INTERNAL',
+    trustScore: 0.5,
+    status: 'active',
+    project: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    metadata: {},
+  } as Memory;
+}
+
+afterEach(() => {
+  restoreEnv();
+});
+
+describe('#283 — env below-cap claims are stamped without raising trust', () => {
+  it('SHIELDCORTEX_AGENT_SOURCE=browser → agent:env-claim>browser @ 0.3', () => {
+    clearEnv();
+    process.env.SHIELDCORTEX_AGENT_SOURCE = 'browser';
+    const inferred = inferSourceFromEnvironment();
+    expect(inferred.source).toEqual({ type: 'agent', identifier: 'env-claim>browser' });
+    expect(scoreSource(inferred.source).score).toBe(0.3);
+  });
+
+  it('SHIELDCORTEX_AGENT_SOURCE=agent:browser → agent:env-claim>browser @ 0.3', () => {
+    clearEnv();
+    process.env.SHIELDCORTEX_AGENT_SOURCE = 'agent:browser';
+    const inferred = inferSourceFromEnvironment();
+    expect(inferred.source).toEqual({ type: 'agent', identifier: 'env-claim>browser' });
+    expect(scoreSource(inferred.source).score).toBe(0.3);
+  });
+
+  it('at-cap agent:cron stays env-override (0.5) and does not raise', () => {
+    clearEnv();
+    process.env.SHIELDCORTEX_AGENT_SOURCE = 'agent:cron';
+    const inferred = inferSourceFromEnvironment();
+    expect(inferred.source).toEqual({ type: 'agent', identifier: 'env-override>cron' });
+    expect(scoreSource(inferred.source).score).toBe(0.5);
+  });
+
+  it('no writer-chosen bare identity reaches trust 0.5 on the env path', () => {
+    clearEnv();
+    // Below-cap bare names
+    for (const claim of ['browser', 'agent:browser', 'agent:some-agent', 'agent:agent-spawned']) {
+      const bound = claim.includes(':')
+        ? bindIntegratorOverrideSource(claim.split(':')[0], claim.split(':').slice(1).join(':'))
+        : bindIntegratorOverrideSource('agent', claim);
+      const score = scoreSource(bound).score;
+      expect(score).toBeLessThan(0.5);
+      // Must not collide with host-attested bare agent:browser / agent:cron keys
+      expect(`${bound.type}:${bound.identifier}`).not.toMatch(/^agent:(browser|cron|agent-spawned)$/);
+    }
+    // At-cap is stamped env-override>, not bare
+    const cron = bindIntegratorOverrideSource('agent', 'cron');
+    expect(cron.identifier.startsWith('env-override>')).toBe(true);
+    expect(scoreSource(cron).score).toBe(0.5);
+  });
+});
+
+describe('#283 — unattested below-ceiling declarations rewrite on resolve', () => {
+  const declared: DefenceSource = { type: 'agent', identifier: 'browser' };
+
+  const highCeilings: Array<{ env: Record<string, string>; label: string }> = [
+    { label: 'claude-cli', env: { CLAUDE_CODE_ENTRYPOINT: 'cli' } },
+    { label: 'claude-vscode', env: { CLAUDE_CODE_ENTRYPOINT: 'vscode' } },
+    { label: 'codex-cli', env: { CODEX_THREAD_ID: 'thread-1' } },
+    { label: 'codex-vscode', env: { CODEX_INTERNAL_ORIGINATOR_OVERRIDE: 'codex_vscode' } },
+  ];
+
+  it.each(highCeilings)('$label: declared agent:browser rewrites + attested=false', ({ env }) => {
+    clearEnv();
+    Object.assign(process.env, env);
+    const resolved = resolveToolSource(declared, { toolName: 'get_context', project: null, strict: false });
+    expect(resolved.attested).toBe(false);
+    expect(resolved.clamped).toBe(false);
+    expect(resolved.source).toEqual({ type: 'agent', identifier: 'unattested>browser' });
+    expect(scoreSource(resolved.source).score).toBe(0.3);
+    // Must not own host-attested agent:browser
+    const policy = checkAccess(
+      mem('agent:browser'),
+      resolved.source,
+      'read',
+      { attested: resolved.attested },
+    );
+    expect(policy.canRead).toBe(false);
+    expect(policy.reason).not.toMatch(/Owner access/);
+  });
+
+  it('low-ceiling env still clamps same-score spoof (attested via clamp)', () => {
+    clearEnv();
+    // no recognised vars → agent:unknown 0.3; declared agent:browser 0.3 is same-score spoof
+    const resolved = resolveToolSource(declared, { toolName: 'get_context', project: null, strict: false });
+    expect(resolved.clamped).toBe(true);
+    expect(resolved.attested).toBe(true);
+    expect(resolved.source).toEqual({ type: 'agent', identifier: 'unknown' });
+    expect(
+      checkAccess(mem('agent:browser'), resolved.source, 'read', { attested: true }).canRead,
+    ).toBe(false);
+  });
+});
+
+describe('#283 — checkAccess ownership requires attestation', () => {
+  const hostRow = mem('agent:browser');
+  const bare: DefenceSource = { type: 'agent', identifier: 'browser' };
+
+  it('unattested bare agent:browser does NOT own host agent:browser INTERNAL', () => {
+    const policy = checkAccess(hostRow, bare, 'read', { attested: false });
+    expect(policy.canRead).toBe(false);
+    expect(policy.reason).toMatch(/Unattested|Insufficient trust/i);
+  });
+
+  it('attested host agent:browser DOES own its own INTERNAL row', () => {
+    const policy = checkAccess(hostRow, bare, 'read', { attested: true });
+    expect(policy.canRead).toBe(true);
+    expect(policy.reason).toBe('Owner access');
+  });
+
+  it('rewritten env-claim identity does not own host row', () => {
+    const claim: DefenceSource = { type: 'agent', identifier: 'env-claim>browser' };
+    expect(scoreSource(claim).score).toBe(0.3);
+    const policy = checkAccess(hostRow, claim, 'read', { attested: true });
+    expect(policy.canRead).toBe(false);
+  });
+
+  it('delete/revoke stay closed at 0.3 even if string matched (attested false)', () => {
+    expect(checkAccess(hostRow, bare, 'delete', { attested: false }).canDelete).toBe(false);
+    expect(checkAccess(hostRow, bare, 'revoke', { attested: false }).canDelete).toBe(false);
+    // Even attested at 0.3 cannot delete (need ≥0.5)
+    expect(checkAccess(hostRow, bare, 'delete', { attested: true }).canDelete).toBe(false);
+  });
+
+  it('default attested=true preserves legacy host-derived callers', () => {
+    expect(checkAccess(hostRow, bare, 'read').canRead).toBe(true);
+  });
+});
+
+describe('#283 — inbound bootstrap reads the stamp, not type alone', () => {
+  it('host-attested agent:browser stays inbound-exempt (availability)', () => {
+    expect(isUntrustedInboundSourceString('agent:browser')).toBe(false);
+    expect(isUntrustedInboundType('agent')).toBe(false);
+  });
+
+  it('claim-stamped agent rows are untrusted inbound', () => {
+    expect(isUntrustedInboundSourceString('agent:env-claim>browser')).toBe(true);
+    expect(isUntrustedInboundSourceString('agent:env-override>cron')).toBe(true);
+    expect(isUntrustedInboundSourceString('agent:unattested>browser')).toBe(true);
+  });
+
+  it('guardReadBySensitivity drops stamped agent rows, keeps host agent', () => {
+    const rows = [
+      memoryRow('agent:browser', 1),
+      memoryRow('agent:env-claim>browser', 2),
+      memoryRow('agent:unattested>browser', 3),
+      memoryRow('agent:env-override>cron', 4),
+      memoryRow('tool_response:fetch', 5),
+    ];
+    const kept = guardReadBySensitivity(rows).map((m) => m.id);
+    expect(kept).toEqual([1]); // only host-attested agent
+  });
+});
+
+describe('#283 — pure helpers', () => {
+  it('rewriteUnattestedSource is idempotent on stamps', () => {
+    const a = rewriteUnattestedSource({ type: 'agent', identifier: 'browser' });
+    expect(a.identifier).toBe('unattested>browser');
+    expect(rewriteUnattestedSource(a)).toEqual(a);
+  });
+
+  it('deriveAttested is false for unclamped below-ceiling declaration', () => {
+    expect(
+      deriveAttested({
+        declared: { type: 'agent', identifier: 'browser' },
+        resolved: { type: 'agent', identifier: 'browser' },
+        clamped: false,
+        strict: false,
+        envInferred: { type: 'cli', identifier: 'mcp' },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/defence/__tests__/agent-inbound-stamp-283.test.ts
+++ b/src/defence/__tests__/agent-inbound-stamp-283.test.ts
@@ -224,6 +224,12 @@ describe('#283 — pure helpers', () => {
     expect(rewriteUnattestedSource(a)).toEqual(a);
   });
 
+  it('rewriteUnattestedSource strips writer-supplied env-override pin', () => {
+    const a = rewriteUnattestedSource({ type: 'agent', identifier: 'env-override>browser' });
+    expect(a).toEqual({ type: 'agent', identifier: 'unattested>browser' });
+    expect(scoreSource(a).score).toBe(0.3);
+  });
+
   it('deriveAttested is false for unclamped below-ceiling declaration', () => {
     expect(
       deriveAttested({
@@ -234,5 +240,56 @@ describe('#283 — pure helpers', () => {
         envInferred: { type: 'cli', identifier: 'mcp' },
       }),
     ).toBe(false);
+  });
+});
+
+describe('#283 dual-review blockers', () => {
+  const declared: DefenceSource = { type: 'agent', identifier: 'browser' };
+
+  it('strict:true still rewrites unconfirmed declaration and does not own host row', () => {
+    clearEnv();
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const resolved = resolveToolSource(declared, {
+      toolName: 'get_context',
+      project: null,
+      strict: true,
+    });
+    expect(resolved.source).toEqual({ type: 'agent', identifier: 'unattested>browser' });
+    expect(resolved.attested).toBe(false);
+    expect(scoreSource(resolved.source).score).toBe(0.3);
+    expect(
+      checkAccess(mem('agent:browser'), resolved.source, 'read', { attested: resolved.attested }).canRead,
+    ).toBe(false);
+  });
+
+  it('declared env-override> stamp cannot keep 0.5 pin under cli ceiling', () => {
+    clearEnv();
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const smuggled: DefenceSource = { type: 'agent', identifier: 'env-override>browser' };
+    const resolved = resolveToolSource(smuggled, {
+      toolName: 'recall',
+      project: null,
+      strict: false,
+    });
+    expect(resolved.source.identifier.startsWith('unattested>')).toBe(true);
+    expect(scoreSource(resolved.source).score).toBe(0.3);
+    expect(resolved.attested).toBe(false);
+    // Must not gain shared read via 0.5 pin
+    expect(scoreSource(resolved.source).score).toBeLessThan(0.5);
+  });
+
+  it('env-confirmed declaration stays bare and attested', () => {
+    clearEnv();
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'subagent';
+    // env infers agent:agent-spawned; declare the same
+    const same: DefenceSource = { type: 'agent', identifier: 'agent-spawned' };
+    const resolved = resolveToolSource(same, {
+      toolName: 'recall',
+      project: null,
+      strict: false,
+    });
+    expect(resolved.source).toEqual(same);
+    expect(resolved.attested).toBe(true);
+    expect(resolved.clamped).toBe(false);
   });
 });

--- a/src/defence/__tests__/env-detector.test.ts
+++ b/src/defence/__tests__/env-detector.test.ts
@@ -9,7 +9,7 @@ import {
   clampSourceToCeiling,
   bindIntegratorOverrideSource,
 } from '../trust/env-detector.js';
-import { scoreSource, isUntrustedInboundType } from '../trust/source-scorer.js';
+import { scoreSource, isUntrustedInboundType, isUntrustedInboundSourceString } from '../trust/source-scorer.js';
 import { guardReadBySensitivity } from '../trust/read-guard.js';
 import type { DefenceSource } from '../types.js';
 import type { Memory } from '../../memory/types.js';
@@ -88,14 +88,17 @@ describe('Environment-Based Source Inference', () => {
       process.env.SHIELDCORTEX_AGENT_SOURCE = 'some-agent';
       const result = inferSourceFromEnvironment();
       expect(result.source.type).toBe('agent'); // defaults to agent
-      expect(result.source.identifier).toBe('some-agent');
+      // #283: below-cap bare tokens are env-claim stamped so they cannot wear
+      // a host-attested agent:<name> ACL key.
+      expect(result.source.identifier).toBe('env-claim>some-agent');
+      expect(scoreSource(result.source).score).toBe(0.3);
     });
 
     it('should prioritise SHIELDCORTEX_AGENT_SOURCE over CLAUDE_CODE_ENTRYPOINT', () => {
       process.env.SHIELDCORTEX_AGENT_SOURCE = 'agent:custom-tool';
       process.env.CLAUDE_CODE_ENTRYPOINT = 'subagent';
       const result = inferSourceFromEnvironment();
-      expect(result.source).toEqual({ type: 'agent', identifier: 'custom-tool' });
+      expect(result.source).toEqual({ type: 'agent', identifier: 'env-claim>custom-tool' });
     });
 
     it('refuses operator and CLI types on the integrator override — they cannot become the ceiling', () => {
@@ -131,10 +134,12 @@ describe('Environment-Based Source Inference', () => {
       }
     });
 
-    it('keeps already-low override identities (no wrap, no raise)', () => {
+    it('stamps already-low override agent identities without raising trust (#283)', () => {
       process.env.SHIELDCORTEX_AGENT_SOURCE = 'agent:some-agent';
       const inferred = inferSourceFromEnvironment();
-      expect(inferred.source).toEqual({ type: 'agent', identifier: 'some-agent' });
+      // Wrap is required so checkAccess cannot treat the claim as host agent:some-agent.
+      // Score must stay 0.3 (env-claim pin), never rise to env-override 0.5.
+      expect(inferred.source).toEqual({ type: 'agent', identifier: 'env-claim>some-agent' });
       expect(scoreSource(inferred.source).score).toBe(0.3);
     });
 
@@ -177,8 +182,11 @@ describe('Environment-Based Source Inference', () => {
     it('keeps a bare token (no type prefix) as agent — documented integrator form', () => {
       process.env.SHIELDCORTEX_AGENT_SOURCE = 'some-agent';
       const inferred = inferSourceFromEnvironment();
-      expect(inferred.source).toEqual({ type: 'agent', identifier: 'some-agent' });
+      // #283: type stays agent, identifier is claim-stamped. Type-only inbound
+      // helper still sees agent as exempt; full-source helper does not.
+      expect(inferred.source).toEqual({ type: 'agent', identifier: 'env-claim>some-agent' });
       expect(isUntrustedInboundType(inferred.source.type)).toBe(false);
+      expect(isUntrustedInboundSourceString(`${inferred.source.type}:${inferred.source.identifier}`)).toBe(true);
       expect(scoreSource(inferred.source).score).toBe(0.3);
     });
 
@@ -432,7 +440,7 @@ describe('Environment-Based Source Inference', () => {
       expect(entry.project).toBe('test-project');
     });
 
-    it('honours declared sources that score at or below the env ceiling', () => {
+    it('rewrites unattested declared sources that score at or below the env ceiling (#283)', () => {
       process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
       const declared = { type: 'agent' as const, identifier: 'user-spawned>task-1' };
 
@@ -442,10 +450,14 @@ describe('Environment-Based Source Inference', () => {
         strict: false,
       });
 
-      expect(resolved.source).toEqual(declared);
-      // An accepted self-declaration is honoured but not attested.
+      // Below-ceiling declarations are still accepted as a downgrade, but the
+      // stored identity is rewritten so ownership cannot wear a host ACL key.
+      expect(resolved.source).toEqual({ type: 'agent', identifier: 'unattested>user-spawned>task-1' });
       expect(resolved.attested).toBe(false);
-      expect(logAudit).not.toHaveBeenCalled();
+      expect(scoreSource(resolved.source).score).toBeLessThanOrEqual(scoreSource(declared).score);
+      expect(logAudit).toHaveBeenCalled();
+      const entry = logAudit.mock.calls[0][0] as { reason: string };
+      expect(entry.reason).toContain('SOURCE_UNATTESTED_REWRITTEN');
     });
 
     it('writes a SOURCE_MISSING audit row when no source is declared', () => {

--- a/src/defence/trust/access-control.ts
+++ b/src/defence/trust/access-control.ts
@@ -6,9 +6,15 @@
  *   Trust 0.5–0.7 → Read own + non-restricted, write quarantine, delete own
  *   Trust < 0.5  → Read own only, write quarantine, delete none
  *
- * RESTRICTED is owner (trust ≥ 0.7) or `user` (human operator). A peer
- * high-trust cli/agent is not the operator — credential isolation holds
+ * RESTRICTED is owner (trust ≥ 0.7) and attested, or `user` (human operator).
+ * A peer high-trust cli/agent is not the operator — credential isolation holds
  * across agents (SCOPE P4).
+ *
+ * #283: ownership is decided by the host-attested identity key. An unattested
+ * caller never matches a stored row as owner, even if the writer-chosen
+ * type:identifier string collides. Callers that already went through
+ * resolveToolSource have rewritten unattested keys; the `attested` option is
+ * the second belt for any path that still holds a bare DefenceSource.
  */
 
 import type { DefenceSource } from '../types.js';
@@ -29,9 +35,16 @@ export interface AccessCheckMemory {
   sensitivity_level?: string | null;
 }
 
-/**
- * Check whether a source has access to a memory for a given operation.
- */
+export interface AccessCheckOptions {
+  /**
+   * #283 — from ResolvedToolSource.attested. When false, the caller is not
+   * host-attested and cannot be treated as owner of any stored row. Deliberately
+   * NOT a field on DefenceSource (caller-suppliable). Default true preserves
+   * legacy internal callers that already hold host-derived identities.
+   */
+  attested?: boolean;
+}
+
 /** Parse a stored "type:identifier" source string back into a DefenceSource. */
 function parseStoredSource(stored: string): DefenceSource {
   const i = stored.indexOf(':');
@@ -39,15 +52,24 @@ function parseStoredSource(stored: string): DefenceSource {
   return { type: stored.slice(0, i) as DefenceSource['type'], identifier: stored.slice(i + 1) };
 }
 
+/**
+ * Check whether a source has access to a memory for a given operation.
+ *
+ * @param options.attested — pass ResolvedToolSource.attested from the resolve
+ *   path. `false` denies ownership (read own / delete own / revoke own).
+ */
 export function checkAccess(
   memory: AccessCheckMemory,
   source: DefenceSource,
   operation: 'read' | 'write' | 'delete' | 'revoke',
+  options?: AccessCheckOptions,
 ): AccessPolicy {
   const trust = scoreSource(source).score;
   const memorySource = memory.source || '__system:unattributed';
   const callerKey = `${source.type}:${source.identifier}`;
-  const isOwner = memorySource === callerKey;
+  // #283: unattested callers never own. Host-attested equality still required.
+  const attested = options?.attested !== false;
+  const isOwner = attested && memorySource === callerKey;
   const isRestricted = memory.sensitivity_level === 'RESTRICTED';
 
   if (operation === 'read') {
@@ -68,7 +90,7 @@ export function checkAccess(
       return deny('RESTRICTED is isolated across agents');
     }
 
-    // Owner always reads own
+    // Owner always reads own (attested identity only — #283)
     if (isOwner) {
       return allow('Owner access');
     }
@@ -83,7 +105,11 @@ export function checkAccess(
       return allow('Shared read access');
     }
 
-    // Low trust: own only (already checked above)
+    // Low trust: own only (already checked above). Unattested low-trust that
+    // string-matched a host row used to fall through as owner — that door is shut.
+    if (!attested && memorySource === callerKey) {
+      return deny('Unattested identity cannot claim ownership');
+    }
     return deny('Insufficient trust for shared memories (need ≥0.5)');
   }
 

--- a/src/defence/trust/agent-scorer.ts
+++ b/src/defence/trust/agent-scorer.ts
@@ -24,7 +24,12 @@ export const DEFAULT_AGENT_CONFIG: AgentTrustConfig = {
     'user-spawned': 0.9,
     'user-approved': 0.85,
     'cron': 0.5,
+    // Integrator / declaration stamps (#273 / #283). env-override is the
+    // at-cap pin (0.5). Below-cap claims must NOT use that pin — it would
+    // raise 0.3 → 0.5. env-claim / unattested stay at the low-trust floor.
     'env-override': 0.5,
+    'env-claim': 0.3,
+    'unattested': 0.3,
     'agent-spawned': 0.3,
     'web': 0.2,
   },
@@ -47,11 +52,11 @@ export function scoreAgent(
   // Circuit breaker: block agents beyond max depth
   if (depth > config.maxDepth) return 0;
 
-  // Integrator env claims may keep a unique identifier for ACL, but they
-  // cannot ride parent-tier trust. Pin at the origin score (0.5) with no
-  // further decay — the cap is a ceiling, not a forced downgrade below it.
-  if (origin === 'env-override') {
-    return config.originScores['env-override'] ?? 0.5;
+  // Claim stamps (#273 / #283) keep a unique identifier for ACL legibility
+  // but cannot ride parent-tier trust or depth decay. Pin at the origin
+  // score — the stamp is a ceiling/floor marker, not a hierarchy root.
+  if (origin === 'env-override' || origin === 'env-claim' || origin === 'unattested') {
+    return config.originScores[origin] ?? (origin === 'env-override' ? 0.5 : 0.3);
   }
 
   const baseScore = config.originScores[origin] ?? 0.3;

--- a/src/defence/trust/env-detector.ts
+++ b/src/defence/trust/env-detector.ts
@@ -55,6 +55,24 @@ function withOverrideOrigin(identifier: string): string {
 }
 
 /**
+ * #283 — below-cap integrator claims must not collide with a host-attested
+ * `${type}:${identifier}` ACL key, and must not raise trust. `env-override>`
+ * pins at 0.5 (the cap); below-cap uses `env-claim>` pinned at 0.3.
+ */
+const ENV_CLAIM_ORIGIN = 'env-claim';
+
+function withEnvClaimOrigin(identifier: string): string {
+  if (
+    identifier.startsWith(`${ENV_CLAIM_ORIGIN}>`)
+    || identifier.startsWith(`${ENV_OVERRIDE_ORIGIN}>`)
+    || identifier.startsWith('unattested>')
+  ) {
+    return identifier;
+  }
+  return `${ENV_CLAIM_ORIGIN}>${identifier}`;
+}
+
+/**
  * Bind a SHIELDCORTEX_AGENT_SOURCE claim to an identity scoreSource will
  * actually honour at ≤ ENV_OVERRIDE_SCORE_CAP. Pipeline / store / ACL all
  * re-score from type+identifier, so a ceiling-number-only clamp would leave
@@ -97,6 +115,13 @@ export function bindIntegratorOverrideSource(
   const score = scoreSource(candidate).score;
 
   if (score < ENV_OVERRIDE_SCORE_CAP) {
+    // #283: bare below-cap agent claims used to keep `agent:browser` verbatim,
+    // so checkAccess treated them as OWNER of host-attested agent:browser rows
+    // and guardReadBySensitivity treated type=agent as inbound-exempt. Stamp
+    // without raising score (env-claim → 0.3, never env-override → 0.5).
+    if (sourceType === 'agent') {
+      return { type: 'agent', identifier: withEnvClaimOrigin(identifier) };
+    }
     return candidate;
   }
   if (score === ENV_OVERRIDE_SCORE_CAP) {

--- a/src/defence/trust/env-detector.ts
+++ b/src/defence/trust/env-detector.ts
@@ -58,14 +58,20 @@ function withOverrideOrigin(identifier: string): string {
  * #283 — below-cap integrator claims must not collide with a host-attested
  * `${type}:${identifier}` ACL key, and must not raise trust. `env-override>`
  * pins at 0.5 (the cap); below-cap uses `env-claim>` pinned at 0.3.
+ *
+ * Stamps **agent** below-cap claims (the inbound-exempt type). Other below-cap
+ * types (email/web) stay bare — they are already inbound-blocked by type and
+ * do not inherit the agent ownership exemption. At-cap non-agent claims still
+ * get env-override> so they cannot wear host tool_response:/agent:cron keys.
  */
 const ENV_CLAIM_ORIGIN = 'env-claim';
 
 function withEnvClaimOrigin(identifier: string): string {
+  const lower = identifier.toLowerCase();
   if (
-    identifier.startsWith(`${ENV_CLAIM_ORIGIN}>`)
-    || identifier.startsWith(`${ENV_OVERRIDE_ORIGIN}>`)
-    || identifier.startsWith('unattested>')
+    lower.startsWith(`${ENV_CLAIM_ORIGIN}>`)
+    || lower.startsWith(`${ENV_OVERRIDE_ORIGIN}>`)
+    || lower.startsWith('unattested>')
   ) {
     return identifier;
   }

--- a/src/defence/trust/read-guard.ts
+++ b/src/defence/trust/read-guard.ts
@@ -128,9 +128,10 @@ export function guardContextSummary(summary: ContextSummary): ContextSummary {
 export function guardReadMemory(
   memory: Memory | null | undefined,
   source: DefenceSource | undefined,
+  options?: { attested?: boolean },
 ): Memory | null {
   if (!memory) return null;
-  return guardReadMemories([memory], source)[0] ?? null;
+  return guardReadMemories([memory], source, options)[0] ?? null;
 }
 
 /**

--- a/src/defence/trust/read-guard.ts
+++ b/src/defence/trust/read-guard.ts
@@ -21,13 +21,16 @@
 
 import { checkAccess } from './access-control.js';
 import { redactContent } from '../sensitivity/redaction.js';
-import { isUntrustedInboundType } from './source-scorer.js';
+import { isUntrustedInboundSourceString } from './source-scorer.js';
 import type { DefenceSource } from '../types.js';
 import type { Memory, ContextSummary } from '../../memory/types.js';
 
 /**
  * Core read decision, shared by the camelCase (Memory) and snake_case (raw row)
  * guards so the policy lives in exactly one place.
+ *
+ * #283: `attested` threads ResolvedToolSource.attested into ownership. When
+ * omitted, checkAccess defaults to attested=true (legacy host-derived callers).
  */
 function callerCanRead(
   id: number,
@@ -35,21 +38,30 @@ function callerCanRead(
   sensitivityLevel: string | null,
   trustScore: number,
   source: DefenceSource | undefined,
+  attested?: boolean,
 ): boolean {
   // Quarantined memories are never surfaced through a normal read.
   if (trustScore === 0) return false;
   // Without a caller identity we cannot make a source-relative decision;
   // surface everything else (the server resolves a source in practice).
   if (!source) return true;
-  return checkAccess({ id, source: storedSource, sensitivity_level: sensitivityLevel }, source, 'read').canRead;
+  return checkAccess(
+    { id, source: storedSource, sensitivity_level: sensitivityLevel },
+    source,
+    'read',
+    attested === undefined ? undefined : { attested },
+  ).canRead;
 }
 
 /** Filter recalled memories (camelCase Memory) to those the caller may read. */
 export function guardReadMemories(
   memories: Memory[],
   source: DefenceSource | undefined,
+  options?: { attested?: boolean },
 ): Memory[] {
-  return memories.filter((m) => callerCanRead(m.id, m.source, m.sensitivityLevel, m.trustScore, source));
+  return memories.filter((m) =>
+    callerCanRead(m.id, m.source, m.sensitivityLevel, m.trustScore, source, options?.attested),
+  );
 }
 
 /**
@@ -59,6 +71,7 @@ export function guardReadMemories(
 export function guardReadRows<T extends Record<string, unknown>>(
   rows: T[],
   source: DefenceSource | undefined,
+  options?: { attested?: boolean },
 ): T[] {
   return rows.filter((r) =>
     callerCanRead(
@@ -67,6 +80,7 @@ export function guardReadRows<T extends Record<string, unknown>>(
       (r.sensitivity_level as string | null) ?? null,
       Number(r.trust_score ?? 1),
       source,
+      options?.attested,
     ),
   );
 }
@@ -78,22 +92,17 @@ export function guardReadRows<T extends Record<string, unknown>>(
  * These surfaces feed the prompt / a broadly-shared project summary, so they must
  * NEVER surface RESTRICTED, quarantined, or untrusted-inbound rows to ANYONE —
  * matching the .mjs prompt hooks. Untrusted-inbound is derived from TYPE_SCORES
- * (anything below UNTRUSTED_INBOUND_FLOOR) with `agent` explicitly exempted.
- * That exemption is the availability half: a low-trust subagent still receives
- * INTERNAL project context. This function does not block cross-agent
- * contamination of agent-typed rows; that is checkAccess / own-only on the
- * per-caller fetch path. Parse the stored type rather than prefix-matching so
- * `webx:…` cannot sneak past a `web:` startsWith check, and future types under
- * the floor are covered by construction.
+ * plus #283 claim-stamp detection on the identifier (env-claim / unattested /
+ * env-override agent rows are inbound even though type=agent). Host-attested
+ * agent rows stay exempt so a real low-trust subagent still receives INTERNAL
+ * project context. Cross-agent contamination of agent-typed rows remains
+ * checkAccess / own-only on the per-caller fetch path.
  */
 function isUntrustedInboundSource(source: string | null | undefined): boolean {
   // Null/empty stays fail-open: many INTERNAL rows are still unstamped, and
   // this surface must keep shared project context available. Fail-closed for
   // unknown provenance is a separate change.
-  if (!source) return false;
-  const sep = source.indexOf(':');
-  const type = (sep === -1 ? source : source.slice(0, sep)).toLowerCase();
-  return isUntrustedInboundType(type);
+  return isUntrustedInboundSourceString(source);
 }
 
 export function guardReadBySensitivity(memories: Memory[]): Memory[] {

--- a/src/defence/trust/resolve-tool-source.ts
+++ b/src/defence/trust/resolve-tool-source.ts
@@ -5,18 +5,25 @@
  * 1. Always computes the environment-inferred trust ceiling first.
  * 2. Clamps any over-claimed declared source down to that ceiling.
  * 3. Drops a same-score identity that the environment did not confirm
- *    (owner spoof / operator spoof). A genuine trust downgrade is kept.
+ *    (owner spoof / operator spoof). A genuine trust downgrade is kept
+ *    only after the unattested rewrite (#283) so it cannot wear a host
+ *    ACL key.
  * 4. Writes a `SOURCE_ELEVATION_BLOCKED` row to defence_audit when a clamp
  *    happens, so operators can spot prompt-injection trying to escalate
  *    its own trust or wear another agent's name.
  * 5. Writes a `SOURCE_MISSING` row when no source was declared, preserving
  *    the existing visibility into unconfigured callers.
+ * 6. #283: rewrites unattested below-ceiling declarations onto a stamped
+ *    identifier (`unattested>…`) so stored source + checkAccess ownership
+ *    keys cannot equal a host-attested `${type}:${identifier}` row. Does
+ *    not raise score (unattested pin is 0.3, never env-override 0.5).
  */
 
 import type { DefenceSource } from '../types.js';
 import { clampSourceToCeiling } from './env-detector.js';
 import { logAudit } from '../audit/logger.js';
 import { getStrictSourceMode } from '../../cloud/config.js';
+import { scoreSource } from './source-scorer.js';
 
 export interface ResolveToolSourceOptions {
   /** Tool name (e.g. 'remember', 'recall') — recorded in the audit reason. */
@@ -68,6 +75,32 @@ export function deriveAttested(input: {
   return false;
 }
 
+/** Already-stamped claim identifiers must not be double-wrapped. */
+function isClaimStamp(identifier: string): boolean {
+  return (
+    identifier.startsWith('env-override>')
+    || identifier.startsWith('env-claim>')
+    || identifier.startsWith('unattested>')
+    || identifier.startsWith('unrecognised>')
+  );
+}
+
+/**
+ * #283 — rewrite an unattested resolved identity so the stored source string
+ * (and therefore the checkAccess ownership key) cannot equal a host-attested
+ * `${type}:${identifier}` row. Score must not rise: agent stamps pin at 0.3
+ * via `unattested`.
+ *
+ * Exported for unit tests.
+ */
+export function rewriteUnattestedSource(source: DefenceSource): DefenceSource {
+  if (isClaimStamp(source.identifier)) return source;
+  // Stamp identifier on every unattested type so ownership cannot collide
+  // with a host-attested row of the same type:id. Agent is the dangerous
+  // inbound-exemption case; other types still need ACL-key separation.
+  return { type: source.type, identifier: `unattested>${source.identifier}` };
+}
+
 /**
  * Resolve the effective source for an MCP tool call.
  *
@@ -87,7 +120,7 @@ export function resolveToolSource(
   // Score clamp only rejects a declaration that OUTSCORES the ceiling.
   // A same-score different identity is not a downgrade — it is spoofing
   // (`user:approved` or `cli:openclaw-jarvis` against env `cli:mcp`, all 0.9).
-  // Genuine downgrades (file:import 0.4 < cli:mcp 0.9) stay honoured.
+  // Genuine downgrades stay honoured only after the unattested rewrite below.
   const env = detection.source;
   const identitySpoof = !!(
     declaredSource
@@ -108,6 +141,46 @@ export function resolveToolSource(
     strict,
     envInferred: env,
   });
+
+  // #283: unattested below-ceiling declarations (the default cli:* 0.9 path
+  // honouring agent:browser 0.3) used to keep the bare identity. Rewrite the
+  // stored source so ownership and inbound guards cannot treat it as host-
+  // attested. Do this BEFORE returns so the resolved source is final.
+  if (declaredSource && !attested && !clamped) {
+    const beforeScore = scoreSource(source).score;
+    const rewritten = rewriteUnattestedSource(source);
+    const afterScore = scoreSource(rewritten).score;
+    // Score must not rise (env-override pin would). Defensive floor.
+    source = afterScore > beforeScore + 1e-9
+      ? { type: 'agent', identifier: `unattested>${declaredSource.identifier}` }
+      : rewritten;
+    if (`${source.type}:${source.identifier}` !== `${declaredSource.type}:${declaredSource.identifier}`) {
+      try {
+        logAudit({
+          memory_id: null,
+          project: options.project,
+          timestamp: new Date().toISOString(),
+          source_type: source.type,
+          source_identifier: source.identifier,
+          trust_score: scoreSource(source).score,
+          sensitivity_level: 'PUBLIC',
+          firewall_result: 'ALLOW',
+          operation: null,
+          anomaly_score: 0,
+          threat_indicators: JSON.stringify(['identity_unattested']),
+          blocked_patterns: '[]',
+          reason:
+            `SOURCE_UNATTESTED_REWRITTEN: tool=${options.toolName}, ` +
+            `declared=${declaredSource.type}:${declaredSource.identifier} (score=${declaredScore}), ` +
+            `rewritten=${source.type}:${source.identifier} — reason: environment did not confirm identity`,
+          fragmentation_score: null,
+          pipeline_duration_ms: null,
+        });
+      } catch {
+        // Audit logging must never break tool execution.
+      }
+    }
+  }
 
   if (clamped && declaredSource) {
     try {

--- a/src/defence/trust/resolve-tool-source.ts
+++ b/src/defence/trust/resolve-tool-source.ts
@@ -13,10 +13,13 @@
  *    its own trust or wear another agent's name.
  * 5. Writes a `SOURCE_MISSING` row when no source was declared, preserving
  *    the existing visibility into unconfigured callers.
- * 6. #283: rewrites unattested below-ceiling declarations onto a stamped
- *    identifier (`unattested>…`) so stored source + checkAccess ownership
- *    keys cannot equal a host-attested `${type}:${identifier}` row. Does
- *    not raise score (unattested pin is 0.3, never env-override 0.5).
+ * 6. #283: rewrites any declaration the environment did not confirm onto a
+ *    stamped identifier (`unattested>…`) so stored source + checkAccess
+ *    ownership keys cannot equal a host-attested `${type}:${identifier}`
+ *    row. Runs even under strictSourceMode (strict must not re-open spoof).
+ *    Does not raise score (unattested pin is 0.3, never env-override 0.5).
+ *    Writer-supplied claim stamps are stripped before rewrite so they cannot
+ *    smuggle a 0.5 env-override pin.
  */
 
 import type { DefenceSource } from '../types.js';
@@ -42,6 +45,9 @@ export interface ResolvedToolSource {
    * confirms) or the deployment runs strictSourceMode. Deliberately NOT a
    * field on DefenceSource — that type is caller-suppliable through the
    * scan-only/SDK surfaces, and attestation must never be self-served.
+   *
+   * #283: after an unattested rewrite the bit is forced false — strict mode
+   * must not mark a rewritten claim as host-attested owner material.
    */
   attested: boolean;
   clamped: boolean;
@@ -75,30 +81,41 @@ export function deriveAttested(input: {
   return false;
 }
 
-/** Already-stamped claim identifiers must not be double-wrapped. */
-function isClaimStamp(identifier: string): boolean {
-  return (
-    identifier.startsWith('env-override>')
-    || identifier.startsWith('env-claim>')
-    || identifier.startsWith('unattested>')
-    || identifier.startsWith('unrecognised>')
-  );
+const CLAIM_STAMP_PREFIXES = ['env-override>', 'env-claim>', 'unattested>', 'unrecognised>'] as const;
+
+/** Strip a leading claim stamp (case-insensitive) so writers cannot smuggle pins. */
+export function stripClaimStamp(identifier: string): string {
+  const lower = identifier.toLowerCase();
+  for (const p of CLAIM_STAMP_PREFIXES) {
+    if (lower.startsWith(p)) return identifier.slice(p.length);
+  }
+  return identifier;
+}
+
+function sameIdentity(a: DefenceSource, b: DefenceSource): boolean {
+  return a.type === b.type && a.identifier === b.identifier;
 }
 
 /**
- * #283 — rewrite an unattested resolved identity so the stored source string
- * (and therefore the checkAccess ownership key) cannot equal a host-attested
- * `${type}:${identifier}` row. Score must not rise: agent stamps pin at 0.3
- * via `unattested`.
+ * #283 — rewrite a declaration the environment did not confirm so the stored
+ * source string (and checkAccess ownership key) cannot equal a host-attested
+ * `${type}:${identifier}` row. Strips any writer-supplied claim stamp first
+ * (a declared `env-override>…` must not retain the 0.5 pin). Score must not
+ * rise: agent stamps pin at 0.3 via `unattested`.
  *
  * Exported for unit tests.
  */
 export function rewriteUnattestedSource(source: DefenceSource): DefenceSource {
-  if (isClaimStamp(source.identifier)) return source;
-  // Stamp identifier on every unattested type so ownership cannot collide
-  // with a host-attested row of the same type:id. Agent is the dangerous
-  // inbound-exemption case; other types still need ACL-key separation.
-  return { type: source.type, identifier: `unattested>${source.identifier}` };
+  const bareId = stripClaimStamp(source.identifier) || source.identifier;
+  const candidate: DefenceSource = { type: source.type, identifier: `unattested>${bareId}` };
+  const before = scoreSource({ type: source.type, identifier: bareId }).score;
+  const after = scoreSource(candidate).score;
+  // Never raise trust. file:import (0.4) → file:unattested would score as
+  // generic file 0.6 — fall back to agent:unattested at 0.3.
+  if (after > before + 1e-9) {
+    return { type: 'agent', identifier: `unattested>${bareId}` };
+  }
+  return candidate;
 }
 
 /**
@@ -116,45 +133,41 @@ export function resolveToolSource(
   const { declaredScore, ceilingScore, detection } = clampResult;
   let { source, clamped } = clampResult;
   const strict = options.strict ?? getStrictSourceMode();
+  const env = detection.source;
 
   // Score clamp only rejects a declaration that OUTSCORES the ceiling.
-  // A same-score different identity is not a downgrade — it is spoofing
-  // (`user:approved` or `cli:openclaw-jarvis` against env `cli:mcp`, all 0.9).
-  // Genuine downgrades stay honoured only after the unattested rewrite below.
-  const env = detection.source;
+  // A same-score different identity is not a downgrade — it is spoofing.
   const identitySpoof = !!(
     declaredSource
     && !clamped
     && declaredScore !== null
     && declaredScore === ceilingScore
-    && (declaredSource.type !== env.type || declaredSource.identifier !== env.identifier)
+    && !sameIdentity(declaredSource, env)
   );
   if (identitySpoof) {
     source = env;
     clamped = true;
   }
 
-  const attested = deriveAttested({
-    declared: declaredSource,
-    resolved: source,
-    clamped,
-    strict,
-    envInferred: env,
-  });
+  // #283: environment confirmation is the only thing that keeps a bare
+  // declared identity. strictSourceMode must NOT skip this rewrite — it only
+  // affects consequence posture, not "did the host confirm this name".
+  const envConfirmed = !declaredSource
+    || clamped
+    || sameIdentity(declaredSource, env);
 
-  // #283: unattested below-ceiling declarations (the default cli:* 0.9 path
-  // honouring agent:browser 0.3) used to keep the bare identity. Rewrite the
-  // stored source so ownership and inbound guards cannot treat it as host-
-  // attested. Do this BEFORE returns so the resolved source is final.
-  if (declaredSource && !attested && !clamped) {
+  let rewritten = false;
+  if (declaredSource && !envConfirmed) {
+    const beforeKey = `${source.type}:${source.identifier}`;
     const beforeScore = scoreSource(source).score;
-    const rewritten = rewriteUnattestedSource(source);
-    const afterScore = scoreSource(rewritten).score;
-    // Score must not rise (env-override pin would). Defensive floor.
-    source = afterScore > beforeScore + 1e-9
-      ? { type: 'agent', identifier: `unattested>${declaredSource.identifier}` }
-      : rewritten;
-    if (`${source.type}:${source.identifier}` !== `${declaredSource.type}:${declaredSource.identifier}`) {
+    source = rewriteUnattestedSource(source);
+    // Extra belt if rewrite somehow elevated.
+    if (scoreSource(source).score > beforeScore + 1e-9) {
+      source = { type: 'agent', identifier: `unattested>${stripClaimStamp(declaredSource.identifier)}` };
+    }
+    rewritten = `${source.type}:${source.identifier}` !== beforeKey
+      || source.identifier.startsWith('unattested>');
+    if (rewritten) {
       try {
         logAudit({
           memory_id: null,
@@ -182,6 +195,18 @@ export function resolveToolSource(
     }
   }
 
+  // Attestation: rewritten claims are never host-attested, even under strict.
+  let attested = deriveAttested({
+    declared: declaredSource,
+    resolved: source,
+    clamped,
+    strict,
+    envInferred: env,
+  });
+  if (rewritten || (declaredSource && !envConfirmed)) {
+    attested = false;
+  }
+
   if (clamped && declaredSource) {
     try {
       logAudit({
@@ -193,7 +218,7 @@ export function resolveToolSource(
         trust_score: ceilingScore,
         sensitivity_level: 'PUBLIC',
         firewall_result: 'BLOCK',
-        operation: null, // source-resolution meta-event, not a memory read/write/delete
+        operation: null,
         anomaly_score: 0,
         threat_indicators: JSON.stringify(['privilege_escalation']),
         blocked_patterns: '[]',
@@ -202,8 +227,6 @@ export function resolveToolSource(
           `declared=${declaredSource.type}:${declaredSource.identifier} (score=${declaredScore}), ` +
           `clamped=${source.type}:${source.identifier} (score=${ceilingScore}) ` +
           `via ${detection.method} (confidence: ${detection.confidence})` +
-          // Without this a same-score identity drop reads as a contradiction:
-          // the scores are EQUAL, yet the claim was rejected.
           (identitySpoof
             ? ' — reason: same-score identity is not self-declarable'
             : ''),
@@ -216,8 +239,6 @@ export function resolveToolSource(
     return { source, attested, clamped };
   }
 
-  // No declared source — inferred from environment. Preserve the existing
-  // SOURCE_MISSING visibility so operators see unconfigured callers.
   if (!declaredSource) {
     try {
       logAudit({
@@ -226,12 +247,10 @@ export function resolveToolSource(
         timestamp: new Date().toISOString(),
         source_type: source.type,
         source_identifier: source.identifier,
-        // Record the inferred trust, not a dummy zero. This path can grant
-        // cli:mcp at 0.9; logging 0 made the one high-trust grant look empty.
         trust_score: ceilingScore,
         sensitivity_level: 'PUBLIC',
         firewall_result: 'ALLOW',
-        operation: null, // source-resolution meta-event, not a memory read/write/delete
+        operation: null,
         anomaly_score: 0,
         threat_indicators: '[]',
         blocked_patterns: '[]',

--- a/src/defence/trust/source-scorer.ts
+++ b/src/defence/trust/source-scorer.ts
@@ -36,25 +36,55 @@ export const TYPE_SCORES: Record<DefenceSource['type'], number> = {
  * adjustments, not a bootstrap denylist — this helper is type-level so a
  * restore still hydrates the session.
  *
- * `agent` scores 0.5, identical to `tool_response`. It is exempted on
- * purpose: guardReadBySensitivity promises INTERNAL project context to a
- * low-trust subagent (credential isolation without the availability
- * blackout). This function therefore does NOT implement "a capture written
- * by agent A must not bootstrap agent B" — that is checkAccess / own-only
- * on the per-caller fetch path.
+ * `agent` used to be blanket-exempt so a low-trust subagent still received
+ * INTERNAL project context. That exemption is now **identifier-shaped**
+ * (#283): only host-attested agent rows (no claim stamp) stay exempt.
+ * Writer-chosen / env-claim / unattested stamps are inbound-untrusted so
+ * they cannot bootstrap via get_context. Cross-agent contamination of
+ * host-attested agent rows remains checkAccess / own-only on the
+ * per-caller fetch path.
  */
 export const UNTRUSTED_INBOUND_FLOOR = 0.6;
 
-export const UNTRUSTED_INBOUND_EXEMPT_TYPES: ReadonlySet<DefenceSource['type']> = new Set(['agent']);
+/** Claim stamps that mean "writer/env declared this, host did not". */
+const CLAIM_STAMP_PREFIXES = ['env-override>', 'env-claim>', 'unattested>', 'unrecognised>'] as const;
 
-export function isUntrustedInboundType(type: string): boolean {
+export function isClaimStampedIdentifier(identifier: string): boolean {
+  const id = identifier.toLowerCase();
+  return CLAIM_STAMP_PREFIXES.some((p) => id.startsWith(p));
+}
+
+/**
+ * True when a stored `type:identifier` (or bare type) is untrusted inbound
+ * for shared-context bootstrap. Prefer this over {@link isUntrustedInboundType}
+ * when the full source string is available — type-only cannot see #283 stamps.
+ */
+export function isUntrustedInboundSourceString(source: string | null | undefined): boolean {
+  if (!source) return false;
+  const sep = source.indexOf(':');
+  const type = (sep === -1 ? source : source.slice(0, sep)).toLowerCase();
+  const identifier = sep === -1 ? '' : source.slice(sep + 1);
+  return isUntrustedInbound(type, identifier);
+}
+
+export function isUntrustedInbound(type: string, identifier = ''): boolean {
   const normalised = type.toLowerCase();
-  if ((UNTRUSTED_INBOUND_EXEMPT_TYPES as ReadonlySet<string>).has(normalised)) {
-    return false;
-  }
   const score = TYPE_SCORES[normalised as DefenceSource['type']];
+  // Unknown types are untrusted.
   if (score === undefined) return true;
+  // Agent is exempt ONLY when host-attested (no claim stamp). A stamped
+  // agent row is a self-applied or integrator label — treat as inbound.
+  if (normalised === 'agent') {
+    return isClaimStampedIdentifier(identifier);
+  }
   return score < UNTRUSTED_INBOUND_FLOOR;
+}
+
+/** @deprecated Prefer {@link isUntrustedInbound} with identifier when available. */
+export function isUntrustedInboundType(type: string): boolean {
+  // Type-only path: agent without identifier is treated as potentially
+  // host-attested (legacy callers). New code must pass the identifier.
+  return isUntrustedInbound(type, '');
 }
 
 const HIERARCHY_DISPLAY = [

--- a/src/memory/search-recall.ts
+++ b/src/memory/search-recall.ts
@@ -69,6 +69,7 @@ async function searchMemoriesInternal(
   config: MemoryConfig,
   source: DefenceSource | undefined,
   execution: SearchExecutionOptions,
+  acl?: { attested?: boolean },
 ): Promise<SearchResult[]> {
   if (++searchCount % 100 === 0) {
     pruneActivationCache();
@@ -309,6 +310,7 @@ async function searchMemoriesInternal(
         { id: result.memory.id, source: row?.source as string | null, sensitivity_level: row?.sensitivity_level as string | null },
         source,
         'read',
+        acl,
       );
       if (!policy.canRead) {
         logAccessDenial(result.memory.id, source, policy.reason);
@@ -543,22 +545,24 @@ export async function searchMemories(
   options: SearchOptions,
   config: MemoryConfig = DEFAULT_CONFIG,
   source?: DefenceSource,
+  acl?: { attested?: boolean },
 ): Promise<SearchResult[]> {
   return searchMemoriesInternal(options, config, source, {
     enableSideEffects: true,
     includeExplanation: false,
-  });
+  }, acl);
 }
 
 export async function searchMemoriesExplained(
   options: SearchOptions,
   config: MemoryConfig = DEFAULT_CONFIG,
   source?: DefenceSource,
+  acl?: { attested?: boolean },
 ): Promise<SearchResult[]> {
   return searchMemoriesInternal(options, config, source, {
     enableSideEffects: false,
     includeExplanation: true,
-  });
+  }, acl);
 }
 
 /**

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -383,6 +383,7 @@ export function logAllowedDelete(
 function filterRowsByAccess(
   rows: Record<string, unknown>[],
   source: DefenceSource,
+  options?: { attested?: boolean },
 ): Record<string, unknown>[] {
   return rows.filter(row => {
     const policy = checkAccess(
@@ -393,6 +394,7 @@ function filterRowsByAccess(
       },
       source,
       'read',
+      options,
     );
     if (!policy.canRead) {
       logAccessDenial(row.id as number, source, policy.reason);
@@ -792,7 +794,7 @@ export function addMemory(
 /**
  * Get a memory by ID
  */
-export function getMemoryById(id: number, source?: DefenceSource): Memory | null {
+export function getMemoryById(id: number, source?: DefenceSource, options?: { attested?: boolean }): Memory | null {
   const db = getDatabase();
   const row = db.prepare('SELECT * FROM memories WHERE id = ?').get(id) as Record<string, unknown> | undefined;
   if (!row) return null;
@@ -803,6 +805,7 @@ export function getMemoryById(id: number, source?: DefenceSource): Memory | null
       { id: row.id as number, source: row.source as string | null, sensitivity_level: row.sensitivity_level as string | null },
       source,
       'read',
+      options,
     );
     if (!policy.canRead) {
       logAccessDenial(id, source, policy.reason);
@@ -1241,10 +1244,11 @@ export function mergeMemories(
 export function deleteMemory(
   id: number,
   source?: DefenceSource,
-  opts?: { mode?: 'delete' | 'revoke' },
+  opts?: { mode?: 'delete' | 'revoke'; attested?: boolean },
 ): boolean {
   const db = getDatabase();
   const aclOp = opts?.mode ?? 'delete';
+  const aclOpts = opts?.attested === undefined ? undefined : { attested: opts.attested };
 
   // ACCESS CONTROL: Check delete permission. mode 'revoke' uses the
   // trust-hierarchy rule (own OR outrank); 'delete' (default) stays own-only.
@@ -1255,6 +1259,7 @@ export function deleteMemory(
         { id: row.id as number, source: row.source as string | null, sensitivity_level: row.sensitivity_level as string | null },
         source,
         aclOp,
+        aclOpts,
       );
       if (!policy.canDelete) {
         logAccessDenial(id, source, policy.reason, aclOp);
@@ -1368,6 +1373,7 @@ export function getRecentMemories(
   project?: string,
   source?: DefenceSource,
   filters?: MemoryListFilters,
+  acl?: { attested?: boolean },
 ): Memory[] {
   const db = getDatabase();
   const { clause, params } = buildMemoryFilterClause(project, filters);
@@ -1377,7 +1383,7 @@ export function getRecentMemories(
   params.push(source ? limit * 2 : limit); // over-fetch when access-filtering
 
   let rows = db.prepare(sql).all(...params) as Record<string, unknown>[];
-  if (source) rows = filterRowsByAccess(rows, source);
+  if (source) rows = filterRowsByAccess(rows, source, acl);
   return rows.slice(0, limit).map(rowToMemory);
 }
 
@@ -1407,6 +1413,7 @@ export function getHighPriorityMemories(
   project?: string,
   source?: DefenceSource,
   filters?: MemoryListFilters,
+  acl?: { attested?: boolean },
 ): Memory[] {
   const db = getDatabase();
   // Phase 1b: gate + order on EFFECTIVE salience (the decaying score), not raw
@@ -1433,7 +1440,7 @@ export function getHighPriorityMemories(
   params.push(source ? limit * 2 : limit);
 
   let rows = db.prepare(sql).all(...params) as Record<string, unknown>[];
-  if (source) rows = filterRowsByAccess(rows, source);
+  if (source) rows = filterRowsByAccess(rows, source, acl);
   return rows.slice(0, limit).map(rowToMemory);
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,30 +136,20 @@ export function withResponseScan(toolName: string, handler: (...args: any[]) => 
 }
 
 /**
- * Resolve source for an MCP tool call.
- *
- * Delegates to the env-ceiling clamp helper, which:
- * - Drops any caller-declared source that claims higher trust than the
- *   runtime environment justifies (writes SOURCE_ELEVATION_BLOCKED to audit).
- * - Falls back to env-inferred source when none was declared (writes
- *   SOURCE_MISSING to audit for operator visibility).
- */
-function resolveToolSource(declaredSource: DefenceSource | undefined, toolName: string): DefenceSource {
-  return resolveToolSourceImpl(declaredSource, {
-    toolName,
-    project: getActiveProject(),
-  }).source;
-}
-
-/**
- * Full resolution including attestation — used by write paths that record
- * source_attested on the audit ledger (threat-graph Phase B).
+ * Resolve source for an MCP tool call — always returns full ResolvedToolSource
+ * (source + attested + clamped). #283: callers must thread `attested` into
+ * checkAccess / guardRead*; discarding it reopens ownership spoof.
  */
 function resolveToolSourceFull(declaredSource: DefenceSource | undefined, toolName: string) {
   return resolveToolSourceImpl(declaredSource, {
     toolName,
     project: getActiveProject(),
   });
+}
+
+/** Source-only helper for paths that truly need only the identity string. */
+function resolveToolSource(declaredSource: DefenceSource | undefined, toolName: string): DefenceSource {
+  return resolveToolSourceFull(declaredSource, toolName).source;
 }
 
 /**
@@ -325,8 +315,8 @@ Modes: search (query-based), recent (by time), important (by salience)`,
     },
     { title: 'Search Memories', readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     withKillSwitchGuard('memory_read', withResponseScan('recall', async (args) => {
-      const source = resolveToolSource(args.source as DefenceSource | undefined, 'recall');
-      const result = await executeRecall({ ...args, source });
+      const resolved = resolveToolSourceFull(args.source as DefenceSource | undefined, 'recall');
+      const result = await executeRecall({ ...args, source: resolved.source, sourceAttested: resolved.attested });
       return {
         content: [{ type: 'text', text: formatRecallResult(result, true) }],
       };
@@ -387,8 +377,8 @@ Returns: architecture decisions, patterns, pending items, recent activity.`,
     },
     { title: 'Get Project Context', readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     withKillSwitchGuard('memory_read', withResponseScan('get_context', async (args) => {
-      const source = resolveToolSource(args.source as DefenceSource | undefined, 'get_context');
-      const result = await executeGetContext({ ...args, source });
+      const resolved = resolveToolSourceFull(args.source as DefenceSource | undefined, 'get_context');
+      const result = await executeGetContext({ ...args, source: resolved.source, sourceAttested: resolved.attested });
       return {
         content: [{
           type: 'text',
@@ -518,8 +508,8 @@ Returns: architecture decisions, patterns, pending items, recent activity.`,
     },
     { title: 'Get Memory by ID', readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     withKillSwitchGuard('memory_read', withResponseScan('get_memory', async (args) => {
-      const source = resolveToolSource(args.source as DefenceSource | undefined, 'get_memory');
-      const result = executeGetMemory({ ...args, source });
+      const resolved = resolveToolSourceFull(args.source as DefenceSource | undefined, 'get_memory');
+      const result = executeGetMemory({ ...args, source: resolved.source, sourceAttested: resolved.attested });
       return {
         content: [{
           type: 'text',
@@ -539,8 +529,8 @@ Returns: architecture decisions, patterns, pending items, recent activity.`,
     },
     { title: 'Export Memories', readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     withKillSwitchGuard('memory_read', withResponseScan('export_memories', async (args) => {
-      const source = resolveToolSource(args.source as DefenceSource | undefined, 'export_memories');
-      const result = executeExport({ ...args, source });
+      const resolved = resolveToolSourceFull(args.source as DefenceSource | undefined, 'export_memories');
+      const result = executeExport({ ...args, source: resolved.source, sourceAttested: resolved.attested });
       return {
         content: [{
           type: 'text',
@@ -600,8 +590,8 @@ Returns: architecture decisions, patterns, pending items, recent activity.`,
     },
     { title: 'Get Related Memories', readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     withKillSwitchGuard('memory_read', withResponseScan('get_related', async (args) => {
-      const source = resolveToolSource(args.source as DefenceSource | undefined, 'get_related');
-      const result = executeGetRelated({ id: args.id, source });
+      const resolved = resolveToolSourceFull(args.source as DefenceSource | undefined, 'get_related');
+      const result = executeGetRelated({ id: args.id, source: resolved.source, sourceAttested: resolved.attested });
       if (!result.success) {
         return { content: [{ type: 'text', text: `Error: ${result.error}` }], isError: true };
       }

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -351,7 +351,7 @@ export const exportSchema = z.object({
   project: z.string().optional().describe('Export only memories for this project'),
 });
 
-export function executeExport(input: { project?: string; source?: DefenceSource }): {
+export function executeExport(input: { project?: string; source?: DefenceSource; sourceAttested?: boolean }): {
   success: boolean;
   data?: string;
   count?: number;

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -41,7 +41,10 @@ export const recallSchema = z.object({
   source: sourceSchema,
 });
 
-export type RecallInput = z.infer<typeof recallSchema>;
+export type RecallInput = z.infer<typeof recallSchema> & {
+  /** INTERNAL — from resolveToolSourceFull.attested; never caller-supplied. */
+  sourceAttested?: boolean;
+};
 
 /**
  * Execute the recall tool
@@ -59,16 +62,18 @@ export async function executeRecall(input: RecallInput): Promise<{
     const projectFilter = resolvedProject ?? undefined;
 
     const source = input.source as DefenceSource | undefined;
+    const sourceAttested = input.sourceAttested;
+    const aclOpts = sourceAttested === undefined ? undefined : { attested: sourceAttested };
     let memories: Memory[] = [];
     let contradictions: Map<number, { memoryId: number; title: string; score: number }[]> | undefined;
 
     switch (input.mode) {
       case 'recent':
-        memories = getRecentMemories(input.limit, projectFilter, source);
+        memories = getRecentMemories(input.limit, projectFilter, source, undefined, aclOpts);
         break;
 
       case 'important':
-        memories = getHighPriorityMemories(input.limit, projectFilter, source);
+        memories = getHighPriorityMemories(input.limit, projectFilter, source, undefined, aclOpts);
         break;
 
       case 'search':
@@ -83,7 +88,7 @@ export async function executeRecall(input: RecallInput): Promise<{
           limit: input.limit,
           includeDecayed: input.includeDecayed,
           includeGlobal: input.includeGlobal,
-        }, undefined, source);
+        }, undefined, source, aclOpts);
         memories = results.map(r => r.memory);
 
         // If FTS5 returned few results, try embedding fallback for additional matches
@@ -124,7 +129,7 @@ export async function executeRecall(input: RecallInput): Promise<{
     // isolation / own-only for low trust). Belt-and-braces — the recent/important
     // store helpers + search already apply access control, but this keeps every
     // recall mode uniform and never reinforces a row the caller can't see.
-    memories = guardReadMemories(memories, source);
+    memories = guardReadMemories(memories, source, aclOpts);
 
     // Access each memory to reinforce it
     memories = memories.map(m => accessMemory(m.id, undefined, source) || m);
@@ -219,7 +224,7 @@ export const getMemorySchema = z.object({
   source: sourceSchema,
 });
 
-export function executeGetMemory(input: { id: number; source?: DefenceSource }): {
+export function executeGetMemory(input: { id: number; source?: DefenceSource; sourceAttested?: boolean }): {
   success: boolean;
   memory?: Memory;
   error?: string;
@@ -228,7 +233,7 @@ export function executeGetMemory(input: { id: number; source?: DefenceSource }):
     const memory = accessMemory(input.id, undefined, input.source);
     // Read ACL: a caller that may not read this memory gets a not-found, never
     // the content (don't reveal existence of RESTRICTED / other-source rows).
-    const allowed = guardReadMemory(memory, input.source);
+    const allowed = guardReadMemory(memory, input.source, input.sourceAttested === undefined ? undefined : { attested: input.sourceAttested });
     if (!allowed) {
       const error = new MemoryNotFoundError(input.id);
       return {
@@ -252,7 +257,7 @@ export function executeGetMemory(input: { id: number; source?: DefenceSource }):
  * Related links can cross trust/sensitivity boundaries, so the same read ACL
  * applies: a caller only sees related memories it is permitted to read.
  */
-export function executeGetRelated(input: { id: number; source?: DefenceSource }): {
+export function executeGetRelated(input: { id: number; source?: DefenceSource; sourceAttested?: boolean }): {
   success: boolean;
   related?: ReturnType<typeof getRelatedMemories>;
   error?: string;
@@ -260,7 +265,7 @@ export function executeGetRelated(input: { id: number; source?: DefenceSource })
   try {
     const related = getRelatedMemories(input.id);
     const allowedIds = new Set(
-      guardReadMemories(related.map((r) => r.memory), input.source).map((m) => m.id),
+      guardReadMemories(related.map((r) => r.memory), input.source, input.sourceAttested === undefined ? undefined : { attested: input.sourceAttested }).map((m) => m.id),
     );
     if (input.source && allowedIds.size > 0) {
       logAllowedRead(input.source, 'get_related', [...allowedIds]);


### PR DESCRIPTION
## Why
#283 (security): `agent:` was a self-applied trust label. After #273 closed env elevation, three residual rows still reached `get_context` / owned host INTERNAL rows:

1. `SHIELDCORTEX_AGENT_SOURCE=browser` → bare `agent:browser` 0.3 OWNER
2. `SHIELDCORTEX_AGENT_SOURCE=agent:cron` → type still inbound-exempt (identifier already stamped)
3. Declared `{agent,browser}` under default `cli:*` 0.9 ceilings → silent unclamped OWNER

## Design lock (from issue)
Rewrite the stored source string + thread `ResolvedToolSource.attested` into ownership. No side-channel-only inbound bit. Do not raise below-cap scores via `env-override>`.

## Fix
- **env below-cap agent claims** → `agent:env-claim>…` @ **0.3** (ACL-safe, no raise)
- **unattested below-ceiling declarations** → `*:unattested>…` rewrite + audit `SOURCE_UNATTESTED_REWRITTEN`
- **checkAccess** ownership requires `attested !== false`
- **guardReadBySensitivity** uses full source string — claim-stamped agent is inbound; host-attested bare agent stays available
- Covers four default high ceilings: Claude CLI, Claude IDE, Codex CLI, Codex VS Code

## Tests
`agent-inbound-stamp-283.test.ts` + updated env-detector expectations.
**Local:** build clean · **4 suites / 94 tests**

## Loop
write → test → observe → update. Dual independent review (SOL Pro + Grok Heavy) on PR head.

Closes #283