### PR TITLE
fix(trust): a self-declared identity may not own another's memories (#283)

### DIFF
--- a/src/__tests__/threat-graph-attestation.test.ts
+++ b/src/__tests__/threat-graph-attestation.test.ts
@@ -192,8 +192,13 @@ describe('#270 — same-score identity is not self-declarable', () => {
       { type: 'file', identifier: 'import' },
       { toolName: 'remember', project: null, strict: false },
     );
-    expect(resolved.source).toEqual({ type: 'file', identifier: 'import' });
+    // The downgrade stands — type, name and 0.4 trust are all preserved — but
+    // #283 keys it as self-declared: the env inferred `cli:mcp`, never
+    // `file:import`, so this identity may not own the real `file:import`'s rows.
+    expect(resolved.source.type).toBe('file');
+    expect(resolved.source.identifier).toBe('unattested>import');
     expect(resolved.clamped).toBe(false);
+    expect(resolved.envConfirmed).toBe(false);
   });
 
   it('honours a declaration the environment independently confirms', () => {

--- a/src/defence/__tests__/attestation-stamp.test.ts
+++ b/src/defence/__tests__/attestation-stamp.test.ts
@@ -1,0 +1,272 @@
+/**
+ * #283 — a self-declared identity may not wear a host-attested identity's name.
+ *
+ * The ceiling clamp (#273) asks "does this claim OUTSCORE the environment". A
+ * DOWNGRADE does not, so on a default `cli:*` 0.9 deployment a declared
+ * `hook:session-end` (0.8) was honoured verbatim, silently, with no
+ * `SOURCE_ELEVATION_BLOCKED` row — and then owned the real hook's rows, because
+ * `checkAccess` keys ownership on `${type}:${identifier}` string equality and
+ * that string was writer-chosen.
+ *
+ * The question ownership needs is not "is this claim too high" but "did the
+ * ENVIRONMENT confirm this identity". Where it did not, the identity keeps its
+ * declared type and score and is keyed into a separate namespace.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve as resolvePath } from 'node:path';
+
+import {
+  UNATTESTED_ORIGIN,
+  applyOwnershipStamp,
+  isUnattestedIdentifier,
+  isUnattestedSourceKey,
+  stampUnattestedIdentifier,
+  stripUnattestedStamp,
+} from '../trust/attestation-stamp.js';
+import { resolveToolSource, deriveEnvConfirmed } from '../trust/resolve-tool-source.js';
+import { checkAccess } from '../trust/access-control.js';
+import { scoreSource } from '../trust/source-scorer.js';
+import { scoreAgent, getAgentDepth, buildAgentHierarchy } from '../trust/agent-scorer.js';
+import type { DefenceSource } from '../types.js';
+
+const ENV_KEYS = [
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_AGENT_CONTEXT',
+  'CODEX_THREAD_ID',
+  'CODEX_CI',
+  'CODEX_INTERNAL_ORIGINATOR_OVERRIDE',
+  'SHIELDCORTEX_AGENT_SOURCE',
+  'SHIELDCORTEX_STRICT_SOURCE',
+];
+
+/** The four env shapes that give a default deployment a `cli:*` 0.9 ceiling. */
+const CLI_HOSTS: Array<[string, Record<string, string>]> = [
+  ['CLAUDE_CODE_ENTRYPOINT=cli', { CLAUDE_CODE_ENTRYPOINT: 'cli' }],
+  ['CLAUDE_CODE_ENTRYPOINT=vscode', { CLAUDE_CODE_ENTRYPOINT: 'vscode' }],
+  ['CODEX_THREAD_ID=t1', { CODEX_THREAD_ID: 't1' }],
+  [
+    'CODEX_INTERNAL_ORIGINATOR_OVERRIDE=codex_vscode',
+    { CODEX_INTERNAL_ORIGINATOR_OVERRIDE: 'codex_vscode' },
+  ],
+];
+
+/** Below-ceiling declarations: none of these is an over-claim under `cli:*` 0.9. */
+const BELOW_CEILING: Array<[DefenceSource, number]> = [
+  [{ type: 'hook', identifier: 'session-end' }, 0.8],
+  [{ type: 'api', identifier: 'ingest' }, 0.7],
+  [{ type: 'file', identifier: 'notes' }, 0.6],
+  [{ type: 'agent', identifier: 'browser' }, 0.3],
+];
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe('#283 ownership stamp — primitives', () => {
+  it('is idempotent, so a caller cannot escape stamping by pre-stamping itself', () => {
+    const once = stampUnattestedIdentifier('session-end');
+    expect(once).toBe(`${UNATTESTED_ORIGIN}>session-end`);
+    expect(stampUnattestedIdentifier(once)).toBe(once);
+    expect(stampUnattestedIdentifier(stampUnattestedIdentifier(once))).toBe(once);
+  });
+
+  it('round-trips: strip undoes stamp, and strip is a no-op on bare identifiers', () => {
+    expect(stripUnattestedStamp(stampUnattestedIdentifier('a>b'))).toBe('a>b');
+    expect(stripUnattestedStamp('a>b')).toBe('a>b');
+    expect(isUnattestedIdentifier('a>b')).toBe(false);
+  });
+
+  it('cannot collide with a host-attested key: an attested identifier is never stamped', () => {
+    // The stamp sits at the FRONT of the identifier, and `applyOwnershipStamp`
+    // is the only writer of it — so a confirmed identity can never carry it.
+    const attested = applyOwnershipStamp({ type: 'hook', identifier: 'session-end' }, true);
+    const declared = applyOwnershipStamp({ type: 'hook', identifier: 'session-end' }, false);
+    expect(attested.identifier).toBe('session-end');
+    expect(declared.identifier).toBe(`${UNATTESTED_ORIGIN}>session-end`);
+    expect(`${attested.type}:${attested.identifier}`)
+      .not.toBe(`${declared.type}:${declared.identifier}`);
+  });
+
+  it('returns the same object when the environment confirmed the identity', () => {
+    const source: DefenceSource = { type: 'hook', identifier: 'session-end' };
+    expect(applyOwnershipStamp(source, true)).toBe(source);
+  });
+
+  it('recognises a stamped STORED source string', () => {
+    expect(isUnattestedSourceKey(`hook:${UNATTESTED_ORIGIN}>session-end`)).toBe(true);
+    expect(isUnattestedSourceKey('hook:session-end')).toBe(false);
+    expect(isUnattestedSourceKey('no-separator')).toBe(false);
+  });
+});
+
+describe('#283 ownership stamp — never raises a score', () => {
+  it.each(BELOW_CEILING)('keeps %j at its declared score when stamped', (declared, expected) => {
+    const bare = scoreSource(declared).score;
+    const stamped = scoreSource(applyOwnershipStamp(declared, false)).score;
+    expect(bare).toBe(expected);
+    expect(stamped).toBe(expected);
+  });
+
+  it('bars a self-declared identity from claiming a privileged agent ORIGIN', () => {
+    // `env-override`/`cron`/`user-spawned` all mean "the host or the integrator's
+    // environment said so". A writer-chosen string claiming to be one of them is
+    // the exact claim under audit — it gets the unprivileged default instead.
+    // This is the one place the stamp moves a score, and it only ever lowers it.
+    for (const origin of ['env-override', 'cron', 'user-spawned']) {
+      const privileged = scoreAgent(origin);
+      const selfDeclared = scoreAgent(stampUnattestedIdentifier(origin));
+      expect(selfDeclared).toBeLessThan(privileged);
+      expect(selfDeclared).toBe(0.3);
+    }
+    expect(scoreAgent(stampUnattestedIdentifier('env-override>user-spawned'))).toBeLessThan(0.5);
+  });
+
+  it('does not read the stamp as a hierarchy rung', () => {
+    expect(getAgentDepth(stampUnattestedIdentifier('user-spawned>task-1')))
+      .toBe(getAgentDepth('user-spawned>task-1'));
+    expect(scoreAgent(stampUnattestedIdentifier('agent-spawned>x')))
+      .toBe(scoreAgent('agent-spawned>x'));
+  });
+
+  it('shows the stamp in the hierarchy display with the scores the ACL uses', () => {
+    const lines = buildAgentHierarchy(stampUnattestedIdentifier('user-spawned>task-1'));
+    expect(lines[0]).toContain(UNATTESTED_ORIGIN);
+    expect(lines.join('\n')).toContain('trust=0.300');
+  });
+});
+
+describe('#283 deriveEnvConfirmed', () => {
+  const env: DefenceSource = { type: 'cli', identifier: 'claude-code' };
+
+  it('confirms when nothing was declared', () => {
+    expect(deriveEnvConfirmed({ declared: undefined, clamped: false, envInferred: env })).toBe(true);
+  });
+
+  it('confirms when the over-claim was clamped to the env identity', () => {
+    expect(deriveEnvConfirmed({
+      declared: { type: 'user', identifier: 'direct' }, clamped: true, envInferred: env,
+    })).toBe(true);
+  });
+
+  it('confirms when the declaration is exactly what the environment produced', () => {
+    expect(deriveEnvConfirmed({ declared: { ...env }, clamped: false, envInferred: env })).toBe(true);
+  });
+
+  it('does NOT confirm a below-ceiling declaration the environment never produced', () => {
+    expect(deriveEnvConfirmed({
+      declared: { type: 'hook', identifier: 'session-end' }, clamped: false, envInferred: env,
+    })).toBe(false);
+  });
+
+  it('does not confuse a matching identifier under a different type', () => {
+    expect(deriveEnvConfirmed({
+      declared: { type: 'agent', identifier: 'claude-code' }, clamped: false, envInferred: env,
+    })).toBe(false);
+  });
+});
+
+describe('#283 resolveToolSource on the four cli:* 0.9 hosts', () => {
+  it.each(CLI_HOSTS)('stamps every below-ceiling declaration on %s', (_label, hostEnv) => {
+    for (const [declared] of BELOW_CEILING) {
+      Object.assign(process.env, hostEnv);
+      const r = resolveToolSource(declared, { toolName: 'recall', project: null, strict: false });
+      expect(r.clamped).toBe(false); // a downgrade is not an over-claim
+      expect(r.envConfirmed).toBe(false);
+      expect(r.source.type).toBe(declared.type); // the declaration is still honoured
+      expect(isUnattestedIdentifier(r.source.identifier)).toBe(true);
+      expect(stripUnattestedStamp(r.source.identifier)).toBe(declared.identifier);
+      for (const k of ENV_KEYS) delete process.env[k];
+    }
+  });
+
+  it('leaves an env-confirmed identity unstamped', () => {
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource(undefined, { toolName: 'recall', project: null, strict: false });
+    expect(r.envConfirmed).toBe(true);
+    expect(isUnattestedIdentifier(r.source.identifier)).toBe(false);
+  });
+
+  it('stamps under strictSourceMode too — the hardened posture must not carry the hole', () => {
+    // `attested` folds in strict mode; ownership deliberately does not.
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource({ type: 'hook', identifier: 'session-end' },
+      { toolName: 'recall', project: null, strict: true });
+    expect(r.envConfirmed).toBe(false);
+    expect(isUnattestedIdentifier(r.source.identifier)).toBe(true);
+  });
+});
+
+describe('#283 ACL — a declared identity owns only what it wrote itself', () => {
+  it.each(CLI_HOSTS)('denies cross-identity ownership on %s', (_label, hostEnv) => {
+    for (const [declared] of BELOW_CEILING) {
+      Object.assign(process.env, hostEnv);
+      const r = resolveToolSource(declared, { toolName: 'recall', project: null, strict: false });
+
+      // A row written by the REAL, host-attested holder of the declared name.
+      const victimKey = `${declared.type}:${declared.identifier}`;
+      const victimRestricted = { id: 1, source: victimKey, sensitivity_level: 'RESTRICTED' };
+
+      expect(checkAccess(victimRestricted, r.source, 'read').canRead).toBe(false);
+      expect(checkAccess(victimRestricted, r.source, 'delete').canDelete).toBe(false);
+      expect(checkAccess({ id: 2, source: victimKey }, r.source, 'revoke').canDelete).toBe(false);
+
+      // ...but it still owns its OWN writes, keyed to the stamped identity.
+      // (RESTRICTED own-read additionally needs trust ≥0.7, which is the
+      // pre-existing gate and not what this issue changed — see below.)
+      const ownKey = `${r.source.type}:${r.source.identifier}`;
+      expect(checkAccess({ id: 3, source: ownKey, sensitivity_level: 'INTERNAL' }, r.source, 'read').canRead)
+        .toBe(true);
+
+      for (const k of ENV_KEYS) delete process.env[k];
+    }
+  });
+
+  it('a stamped identity at trust ≥0.7 still reads its OWN RESTRICTED rows', () => {
+    // The stamp namespaces ownership; it does not demote the identity. A
+    // declared `hook:session-end` keeps 0.8 and therefore keeps owner access to
+    // the rows it wrote itself — only the real hook's rows moved out of reach.
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource({ type: 'hook', identifier: 'session-end' },
+      { toolName: 'recall', project: null, strict: false });
+    const ownKey = `${r.source.type}:${r.source.identifier}`;
+    expect(scoreSource(r.source).score).toBe(0.8);
+    expect(checkAccess({ id: 1, source: ownKey, sensitivity_level: 'RESTRICTED' }, r.source, 'read').canRead)
+      .toBe(true);
+  });
+
+  it('the host-attested holder still owns its own rows', () => {
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource(undefined, { toolName: 'recall', project: null, strict: false });
+    const ownKey = `${r.source.type}:${r.source.identifier}`;
+    expect(checkAccess({ id: 1, source: ownKey, sensitivity_level: 'RESTRICTED' }, r.source, 'read').canRead)
+      .toBe(true);
+  });
+});
+
+describe('#283 destructive floor', () => {
+  it('keeps hierarchy revoke off the wire: forget derives its identity from the environment', () => {
+    // `forget`/revoke-by-source is the only route to cross-identity deletion, and
+    // it is safe ONLY because it ignores the declared `source` param. A declared
+    // `hook:session-end` scores 0.8 — enough to outrank a real 0.3 agent — so if
+    // this handler ever starts honouring `args.source`, #283 becomes destructive.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const server = readFileSync(resolvePath(here, '../../server.ts'), 'utf8');
+    const forgetHandler = server.slice(server.indexOf("withKillSwitchGuard('memory_write'"));
+    expect(forgetHandler).toContain('inferSourceFromEnvironment().source');
+    expect(forgetHandler.slice(0, forgetHandler.indexOf('executeForget')))
+      .not.toMatch(/source\s*=\s*args\.source/);
+  });
+});

--- a/src/defence/__tests__/env-detector.test.ts
+++ b/src/defence/__tests__/env-detector.test.ts
@@ -442,10 +442,36 @@ describe('Environment-Based Source Inference', () => {
         strict: false,
       });
 
-      expect(resolved.source).toEqual(declared);
+      // The declaration is honoured — same type, same name, same trust score —
+      // but #283: the environment never produced this identity, so it is keyed
+      // into its own ownership namespace. Without the stamp this exact case
+      // (a below-ceiling declaration, so the clamp never fires) read the
+      // host-attested `agent:user-spawned>task-1`'s rows as OWNER.
+      expect(resolved.source.type).toBe(declared.type);
+      expect(resolved.source.identifier).toBe(`unattested>${declared.identifier}`);
+      // The stamp never RAISES a score. Here it lowers one, deliberately and in
+      // the only case it does: `user-spawned` is an ORIGIN, and an origin means
+      // "the host or the integrator's environment said so". A writer-chosen
+      // string claiming that origin is exactly the claim under audit, so it
+      // scores as an unconfirmed agent (0.3) decayed one rung — 0.21, not 0.63.
+      // Same rule keeps a declared `agent:env-override>…` off the 0.5 pin, i.e.
+      // below the trust≥0.5 delete floor.
+      expect(scoreSource(declared).score).toBe(0.63);
+      expect(scoreSource(resolved.source).score).toBe(0.21);
       // An accepted self-declaration is honoured but not attested.
       expect(resolved.attested).toBe(false);
-      expect(logAudit).not.toHaveBeenCalled();
+      expect(resolved.envConfirmed).toBe(false);
+      // ...and it is no longer the quietest path in the resolver: a
+      // self-declared identity now leaves a SOURCE_UNATTESTED row (ALLOW — the
+      // declaration stands, only its ownership is namespaced).
+      expect(logAudit).toHaveBeenCalledTimes(1);
+      const row = logAudit.mock.calls[0][0] as {
+        firewall_result: string;
+        reason: string;
+      };
+      expect(row.firewall_result).toBe('ALLOW');
+      expect(row.reason).toContain('SOURCE_UNATTESTED');
+      expect(row.reason).toContain('declared=agent:user-spawned>task-1');
     });
 
     it('writes a SOURCE_MISSING audit row when no source is declared', () => {

--- a/src/defence/trust/agent-scorer.ts
+++ b/src/defence/trust/agent-scorer.ts
@@ -8,7 +8,20 @@
  *   "cron"                            → base trust 0.5
  *   "agent-spawned"                   → base trust 0.3
  *   "env-override>…"                  → pinned 0.5 (integrator env claim)
+ *   "unattested>…"                    → self-declared; scores off the bare
+ *                                       identifier but may not claim a
+ *                                       privileged origin (see attestation-stamp)
  */
+
+import {
+  UNATTESTED_ORIGIN,
+  isUnattestedIdentifier,
+  stampUnattestedIdentifier,
+  stripUnattestedStamp,
+} from './attestation-stamp.js';
+
+/** Base trust for an origin the environment did not confirm — the `?? 0.3` default. */
+const UNPRIVILEGED_ORIGIN_SCORE = 0.3;
 
 export interface AgentTrustConfig {
   /** Base trust scores by spawn origin (first segment of identifier) */
@@ -40,7 +53,14 @@ export function scoreAgent(
   identifier: string,
   config: AgentTrustConfig = DEFAULT_AGENT_CONFIG,
 ): number {
-  const parts = identifier.split('>');
+  // An identity the environment did not confirm scores off its BARE identifier,
+  // so the stamp never changes the number — except that it may not claim a
+  // privileged origin. `env-override`/`cron`/`user-spawned` all mean "the host
+  // or the integrator's env said so"; a writer-chosen string saying it is one of
+  // them is exactly the claim under audit, and gets the unprivileged default.
+  const selfDeclared = isUnattestedIdentifier(identifier);
+  const bare = stripUnattestedStamp(identifier);
+  const parts = bare.split('>');
   const origin = parts[0];
   const depth = parts.length - 1;
 
@@ -50,11 +70,11 @@ export function scoreAgent(
   // Integrator env claims may keep a unique identifier for ACL, but they
   // cannot ride parent-tier trust. Pin at the origin score (0.5) with no
   // further decay — the cap is a ceiling, not a forced downgrade below it.
-  if (origin === 'env-override') {
+  if (origin === 'env-override' && !selfDeclared) {
     return config.originScores['env-override'] ?? 0.5;
   }
 
-  const baseScore = config.originScores[origin] ?? 0.3;
+  const baseScore = selfDeclared ? UNPRIVILEGED_ORIGIN_SCORE : (config.originScores[origin] ?? 0.3);
   return Math.round(baseScore * Math.pow(config.decayFactor, depth) * 1000) / 1000;
 }
 
@@ -62,7 +82,9 @@ export function scoreAgent(
  * Get the depth of an agent in its hierarchy (0 = parent).
  */
 export function getAgentDepth(identifier: string): number {
-  return identifier.split('>').length - 1;
+  // The stamp is an attestation marker, not a hierarchy level — a stamped
+  // identity must not read as one rung deeper than the name it declared.
+  return stripUnattestedStamp(identifier).split('>').length - 1;
 }
 
 /**
@@ -72,12 +94,18 @@ export function buildAgentHierarchy(
   identifier: string,
   config: AgentTrustConfig = DEFAULT_AGENT_CONFIG,
 ): string[] {
-  const parts = identifier.split('>');
+  const selfDeclared = isUnattestedIdentifier(identifier);
+  const parts = stripUnattestedStamp(identifier).split('>');
   const hierarchy: string[] = [];
 
+  if (selfDeclared) {
+    hierarchy.push(`${UNATTESTED_ORIGIN}> (self-declared — environment did not confirm)`);
+  }
   for (let i = 0; i < parts.length; i++) {
     const path = parts.slice(0, i + 1).join('>');
-    const score = scoreAgent(path, config);
+    // Score each rung through the stamp so the displayed numbers are the ones
+    // the ACL actually uses, not the unstamped identity's.
+    const score = scoreAgent(selfDeclared ? stampUnattestedIdentifier(path) : path, config);
     hierarchy.push(`${'  '.repeat(i)}${parts[i]} (trust=${score.toFixed(3)})`);
   }
 

--- a/src/defence/trust/attestation-stamp.ts
+++ b/src/defence/trust/attestation-stamp.ts
@@ -1,0 +1,82 @@
+/**
+ * Ownership keying for self-declared identities.
+ *
+ * `checkAccess` decides ownership by string equality on `${type}:${identifier}`.
+ * That key is the ONLY thing standing between a caller and another identity's
+ * memories — it gates owner-read of RESTRICTED rows, `delete`, and the `revoke`
+ * own-cleanup branch. Until this module, the key was built from whatever the
+ * caller declared, so a below-ceiling declaration wore a peer's name for free:
+ * on a default `cli:*` 0.9 deployment a declared `hook:session-end` (0.8) is not
+ * an over-claim, is honoured verbatim, and then reads the real hook's RESTRICTED
+ * rows as OWNER.
+ *
+ * The clamp cannot catch this — it asks "does the claim outscore the
+ * environment", and a genuine downgrade does not. The question ownership needs
+ * is different: "did the environment CONFIRM this identity". Where the answer is
+ * no, the identity keeps its declared type and score but is keyed into a
+ * separate namespace, so it can only ever own what it wrote itself.
+ *
+ * Properties this stamp must hold (all covered in attestation-stamp.test.ts):
+ * - it NEVER raises a score — `scoreSource` strips it before scoring, with one
+ *   deliberate exception below;
+ * - it can never collide with a host-attested `${type}:${identifier}` key, because
+ *   an attested identifier is by construction unstamped and the stamp sits at the
+ *   front of the identifier;
+ * - it is idempotent, so re-resolving an already-stamped identity is stable and a
+ *   caller cannot escape stamping by pre-stamping its own declaration;
+ * - a stamped identifier cannot claim a privileged agent ORIGIN (`env-override>`,
+ *   `cron`, `user-spawned`, …). Those origins mean "the host or the integrator's
+ *   environment said so"; a self-declared string saying it is one of them earns
+ *   the unprivileged default instead. This is the one place the stamp changes a
+ *   score, and it only ever lowers it.
+ */
+
+import type { DefenceSource } from '../types.js';
+
+/**
+ * Origin token marking an identity the environment did not confirm.
+ *
+ * Shares the `>` hierarchy separator with `env-override>` on purpose: agent
+ * identifiers already read as `origin>path`, so a stamped identifier stays
+ * legible in the audit ledger and in `source_risk` node keys.
+ */
+export const UNATTESTED_ORIGIN = 'unattested';
+
+const UNATTESTED_PREFIX = `${UNATTESTED_ORIGIN}>`;
+
+/** True when this identifier carries the unattested stamp. */
+export function isUnattestedIdentifier(identifier: string): boolean {
+  return identifier.startsWith(UNATTESTED_PREFIX);
+}
+
+/** Remove the stamp (no-op when absent). Scoring works off the bare identifier. */
+export function stripUnattestedStamp(identifier: string): string {
+  return isUnattestedIdentifier(identifier)
+    ? identifier.slice(UNATTESTED_PREFIX.length)
+    : identifier;
+}
+
+/** Stamp an identifier as unattested, idempotently. */
+export function stampUnattestedIdentifier(identifier: string): string {
+  return isUnattestedIdentifier(identifier) ? identifier : `${UNATTESTED_PREFIX}${identifier}`;
+}
+
+/**
+ * Apply the ownership stamp to a resolved source.
+ *
+ * Fed ONCE, at `resolveToolSource` — the single point where a declaration meets
+ * the environment. Everything downstream (the stored `source` string, the
+ * `checkAccess` caller key, the threat-graph `sourceKey`) is derived from the
+ * returned source, so `read`, `delete` and `revoke` cannot drift apart.
+ */
+export function applyOwnershipStamp(source: DefenceSource, envConfirmed: boolean): DefenceSource {
+  if (envConfirmed) return source;
+  const identifier = stampUnattestedIdentifier(source.identifier);
+  return identifier === source.identifier ? source : { ...source, identifier };
+}
+
+/** True when a stored `source` string was written by an unconfirmed identity. */
+export function isUnattestedSourceKey(storedSource: string): boolean {
+  const sep = storedSource.indexOf(':');
+  return sep !== -1 && isUnattestedIdentifier(storedSource.slice(sep + 1));
+}

--- a/src/defence/trust/index.ts
+++ b/src/defence/trust/index.ts
@@ -4,8 +4,16 @@ export { scoreAgent, getAgentDepth, buildAgentHierarchy } from './agent-scorer.j
 export { checkAccess } from './access-control.js';
 export { inferSourceFromEnvironment, resolveSource, clampSourceToCeiling } from './env-detector.js';
 export type { CeilingClampResult } from './env-detector.js';
-export { resolveToolSource } from './resolve-tool-source.js';
-export type { ResolveToolSourceOptions } from './resolve-tool-source.js';
+export { resolveToolSource, deriveAttested, deriveEnvConfirmed } from './resolve-tool-source.js';
+export type { ResolveToolSourceOptions, ResolvedToolSource } from './resolve-tool-source.js';
+export {
+  UNATTESTED_ORIGIN,
+  applyOwnershipStamp,
+  isUnattestedIdentifier,
+  isUnattestedSourceKey,
+  stampUnattestedIdentifier,
+  stripUnattestedStamp,
+} from './attestation-stamp.js';
 export type { AccessPolicy, AccessCheckMemory } from './access-control.js';
 export type { AgentTrustConfig } from './agent-scorer.js';
 export type { EnvDetectionResult } from './env-detector.js';

--- a/src/defence/trust/resolve-tool-source.ts
+++ b/src/defence/trust/resolve-tool-source.ts
@@ -11,9 +11,17 @@
  *    its own trust or wear another agent's name.
  * 5. Writes a `SOURCE_MISSING` row when no source was declared, preserving
  *    the existing visibility into unconfigured callers.
+ * 6. Stamps any identity the environment did not confirm, so `checkAccess`
+ *    cannot mistake a declaration for the host-attested identity of the same
+ *    name, and writes a `SOURCE_UNATTESTED` row for it. The clamp only asks
+ *    whether a claim OUTSCORES the environment; a below-ceiling claim
+ *    (`hook:session-end` at 0.8 under a `cli:*` 0.9 ceiling) is not an
+ *    over-claim, yet it wore the real hook's name for free. See
+ *    ./attestation-stamp.ts.
  */
 
 import type { DefenceSource } from '../types.js';
+import { applyOwnershipStamp } from './attestation-stamp.js';
 import { clampSourceToCeiling } from './env-detector.js';
 import { logAudit } from '../audit/logger.js';
 import { getStrictSourceMode } from '../../cloud/config.js';
@@ -28,6 +36,11 @@ export interface ResolveToolSourceOptions {
 }
 
 export interface ResolvedToolSource {
+  /**
+   * The identity the rest of the pipeline uses. Carries the ownership stamp when
+   * the environment did not confirm it, so the ACL cannot mistake a declaration
+   * for the host-attested identity of the same name.
+   */
   source: DefenceSource;
   /**
    * True when the resolved identity is SYSTEM-derived (no declaration, a
@@ -38,6 +51,18 @@ export interface ResolvedToolSource {
    */
   attested: boolean;
   clamped: boolean;
+  /**
+   * Did the ENVIRONMENT confirm this identity — the question ownership needs.
+   *
+   * Deliberately not the same predicate as `attested`. `attested` folds in
+   * strictSourceMode, which is an operator's opt-in to hardened CONSEQUENCES
+   * (risk accrual keyed on claimed identities); treating a declaration as
+   * confirmed is defensible there. It is not defensible for ownership: under
+   * strict mode a declared `hook:session-end` would otherwise own the real
+   * hook's RESTRICTED rows, i.e. the hardened posture would carry the hole the
+   * default one does. Ownership therefore asks only about the environment.
+   */
+  envConfirmed: boolean;
 }
 
 /**
@@ -66,6 +91,28 @@ export function deriveAttested(input: {
     return true;
   }
   return false;
+}
+
+/**
+ * Pure environment-confirmation derivation (exported for exhaustive testing).
+ *
+ * True when the resolved identity came FROM the host environment rather than
+ * from the caller: nothing declared, an over-claim we replaced with the
+ * env-inferred source, or a declaration the environment independently produced.
+ * Unlike `deriveAttested` this ignores strictSourceMode — see
+ * `ResolvedToolSource.envConfirmed`.
+ */
+export function deriveEnvConfirmed(input: {
+  declared: DefenceSource | undefined;
+  clamped: boolean;
+  envInferred: DefenceSource;
+}): boolean {
+  if (!input.declared) return true;
+  if (input.clamped) return true;
+  return (
+    input.declared.type === input.envInferred.type
+    && input.declared.identifier === input.envInferred.identifier
+  );
 }
 
 /**
@@ -108,6 +155,12 @@ export function resolveToolSource(
     strict,
     envInferred: env,
   });
+  const envConfirmed = deriveEnvConfirmed({ declared: declaredSource, clamped, envInferred: env });
+
+  // Fed ONCE, here. Everything downstream — the stored `source` string, the
+  // `checkAccess` caller key, the threat-graph node key — derives from this
+  // source, so read / delete / revoke cannot drift apart on ownership.
+  source = applyOwnershipStamp(source, envConfirmed);
 
   if (clamped && declaredSource) {
     try {
@@ -140,7 +193,46 @@ export function resolveToolSource(
     } catch {
       // Audit logging must never break tool execution.
     }
-    return { source, attested, clamped };
+    return { source, attested, clamped, envConfirmed };
+  }
+
+  // Declared, within the ceiling, but the environment never produced this
+  // identity. Previously the quietest path in the resolver: honoured verbatim,
+  // no audit row, and — before the ownership stamp — owning the host-attested
+  // rows of whatever name it declared. Record it so the ledger distinguishes a
+  // self-declared identity from a confirmed one.
+  if (declaredSource && !envConfirmed) {
+    try {
+      logAudit({
+        memory_id: null,
+        project: options.project,
+        timestamp: new Date().toISOString(),
+        source_type: source.type,
+        source_identifier: source.identifier,
+        // Non-null whenever a source was declared; the fallback only satisfies
+        // the type, it is unreachable inside this branch.
+        trust_score: declaredScore ?? ceilingScore,
+        sensitivity_level: 'PUBLIC',
+        // ALLOW, not BLOCK: the declaration is honoured (a downgrade is a
+        // legitimate feature). Only its ownership is namespaced.
+        firewall_result: 'ALLOW',
+        operation: null, // source-resolution meta-event, not a memory read/write/delete
+        anomaly_score: 0,
+        threat_indicators: '[]',
+        blocked_patterns: '[]',
+        reason:
+          `SOURCE_UNATTESTED: tool=${options.toolName}, ` +
+          `declared=${declaredSource.type}:${declaredSource.identifier} (score=${declaredScore}), ` +
+          `keyed=${source.type}:${source.identifier} — environment inferred ` +
+          `${env.type}:${env.identifier} via ${detection.method} ` +
+          `(confidence: ${detection.confidence}), so the declared identity owns only its own writes`,
+        fragmentation_score: null,
+        pipeline_duration_ms: null,
+      });
+    } catch {
+      // Audit logging must never break tool execution.
+    }
+    return { source, attested, clamped, envConfirmed };
   }
 
   // No declared source — inferred from environment. Preserve the existing
@@ -174,5 +266,5 @@ export function resolveToolSource(
     }
   }
 
-  return { source, attested, clamped };
+  return { source, attested, clamped, envConfirmed };
 }

--- a/src/defence/trust/source-scorer.ts
+++ b/src/defence/trust/source-scorer.ts
@@ -4,6 +4,7 @@
 
 import type { DefenceSource, TrustScore } from '../types.js';
 import { scoreAgent, buildAgentHierarchy } from './agent-scorer.js';
+import { stripUnattestedStamp } from './attestation-stamp.js';
 
 const BASE_SCORES: Record<string, number> = {
   'user:direct': 1.0,
@@ -71,9 +72,14 @@ const HIERARCHY_DISPLAY = [
 
 export function scoreSource(source: DefenceSource): TrustScore {
   const key = `${source.type}:${source.identifier}`;
+  // Score off the BARE identifier: the ownership stamp separates a self-declared
+  // identity from the host-attested one of the same name, and must not move the
+  // number in either direction. `agent` is the exception — see scoreAgent, where
+  // a stamped identifier is barred from claiming a privileged origin.
+  const bareKey = `${source.type}:${stripUnattestedStamp(source.identifier)}`;
 
   // Exact match overrides
-  const baseScore = BASE_SCORES[key];
+  const baseScore = BASE_SCORES[bareKey];
   if (baseScore !== undefined) {
     return { score: baseScore, source, hierarchy: [...HIERARCHY_DISPLAY, `>> ${key} = ${baseScore}`] };
   }


### PR DESCRIPTION
Closes #283.

`checkAccess` keys ownership on `${type}:${identifier}` string equality and that string was writer-chosen. The #273 clamp cannot catch it: the clamp asks whether a claim **outscores** the environment, and a **downgrade** does not. On the four default `cli:*` 0.9 hosts a declared `hook:session-end` (0.8) is not an over-claim, is honoured verbatim with **no** `SOURCE_ELEVATION_BLOCKED` row, and then owns the real hook's rows.

Ownership asks a different question: **did the environment confirm this identity.** Where it did not, the identity keeps its declared type and score and is keyed into a separate namespace (`unattested>` identifier stamp), applied **once** in `resolveToolSource` so the stored `source` string, the ACL caller key and the threat-graph node key cannot drift apart across read / delete / revoke.

## Matrix

Victim rows are keyed to the **bare** declared identity — i.e. the rows the host-attested holder of that name actually wrote. Harness: `tsx`, isolated `HOME`, `strict:false`. Identical on all four hosts (`CLAUDE_CODE_ENTRYPOINT=cli`, `=vscode`, `CODEX_THREAD_ID`, `CODEX_INTERNAL_ORIGINATOR_OVERRIDE=codex_vscode`).

**Before — `aed0b7e`:**

```
declared            bound                score clamp att  R-own I-own del  revoke agent:agent-spawned
hook:session-end    hook:session-end     0.8   F     F    YES   YES   YES  YES
api:ingest          api:ingest           0.7   F     F    YES   YES   YES  YES
file:notes          file:notes           0.6   F     F    no    YES   YES  no
agent:browser       agent:browser        0.3   F     F    no    YES   no   no
```

**After — this branch:**

```
declared            bound                        score clamp att envOK R-own I-own del revoke
hook:session-end    hook:unattested>session-end  0.8   F     F   F     no    YES   no  YES
api:ingest          api:unattested>ingest        0.7   F     F   F     no    YES   no  YES
file:notes          file:unattested>notes        0.6   F     F   F     no    YES   no  no
agent:browser       agent:unattested>browser     0.3   F     F   F     no    no    no  no
```

Every ownership-derived capability is gone: cross-identity RESTRICTED read (AC: `guardReadBySensitivity` bootstrap **and** per-caller owner-read), and own-delete of another identity's rows. The surviving `YES` columns are **not** ownership:

- **I-own** is the `trust ≥ 0.5` shared-read gate. A declared 0.8 under a 0.9 ceiling is a genuine downgrade and is entitled to it. `agent:browser` flips to `no`, which is the tell that ownership stopped applying.
- **revoke** is trust-hierarchy revoke (`0.8 > 0.3`), not ownership. It stays off the wire because `forget` (`src/server.ts:366`) derives its identity from `inferSourceFromEnvironment()` and ignores `args.source`. Pinned by a regression test in this PR so it cannot quietly start honouring it.

## Deliberate behaviour changes

1. **`envConfirmed` is not `attested`.** `attested` folds in `strictSourceMode`, an opt-in to hardened *consequences*, defensible there. Not defensible for ownership — under strict mode a declared `hook:session-end` would otherwise own the real hook's rows, so the hardened posture would carry the hole the default one does. Ownership asks only about the environment.
2. **A stamped `agent:` identifier may not claim a privileged ORIGIN** (`env-override`, `cron`, `user-spawned`). Those mean "the host or the integrator's environment said so"; a writer-chosen string claiming one is the claim under audit, so it gets the unprivileged 0.3 default. This is the only place the stamp moves a score and it only ever lowers it — and it is what keeps a writer-chosen `agent:env-override>…` off the 0.5 pin, i.e. below the `trust ≥ 0.5` delete floor. Concretely: declared `agent:user-spawned>task-1` scores 0.21, not 0.63.
3. **Self-declaration now leaves a row.** `SOURCE_UNATTESTED`, `firewall_result: ALLOW` — the declaration stands, only its ownership is namespaced. It was previously the quietest path in the resolver.

## Known residual

Rows written **before** this fix cannot be retro-attributed: an impostor's pre-existing rows stay keyed `hook:session-end` and are therefore now owned by the genuine host-attested hook. That is the safe direction (the attested identity absorbs them, the impostor loses them), but it is not a clean separation for historical data and there is no migration in this PR.

## Verification

- `npm test` — **439/439 suites, 5329 passed, 7 skipped, 0 failed.** Baseline at `aed0b7e` on the same box is also fully green, so this is a true zero-delta.
- `tsc -p tsconfig.build.json --noEmit` — clean.
- New suite `src/defence/__tests__/attestation-stamp.test.ts` — 30 tests: stamp primitives (idempotent, non-colliding, round-trip), score-preservation, the privileged-origin demotion, `deriveEnvConfirmed` truth table, the four-host × four-type resolver matrix, the ACL matrix, own-write ownership retained, and the `forget` pin.
- Two existing tests updated in place — both asserted the old behaviour and both are the exact case this fixes (a below-ceiling declaration returned verbatim, with no audit row): `env-detector.test.ts` "honours declared sources that score at or below the env ceiling", `threat-graph-attestation.test.ts` "keeps a genuine trust downgrade".

Design lock followed: no `attested` field on `DefenceSource`, no inbound-only side-channel, not stamped as `env-override>` (which would raise the score to 0.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
