### PR TITLE
fix(trust): single #283 path — CASE ownership stamp + env residual

### DIFF
--- a/src/__tests__/threat-graph-attestation.test.ts
+++ b/src/__tests__/threat-graph-attestation.test.ts
@@ -22,6 +22,8 @@ import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import { closeDatabase, getDatabase, initDatabase } from '../database/init.js';
 import { deriveAttested, resolveToolSource } from '../defence/trust/resolve-tool-source.js';
 import { runDefencePipeline } from '../defence/pipeline.js';
+import { projectToCompletion } from '../threat-graph/projector.js';
+import { computeRiskModifier, runRiskSweep } from '../threat-graph/risk.js';
 import type { DefenceSource } from '../defence/types.js';
 
 beforeEach(() => {
@@ -234,5 +236,111 @@ describe('pipeline → ledger plumbing', () => {
   it('records NULL when the caller did not plumb attestation (legacy paths)', () => {
     runDefencePipeline('harmless note content', 'note', source, undefined, 'test');
     expect(lastAuditRow().source_attested).toBeNull();
+  });
+});
+
+/**
+ * #283 — the strict-mode divergence, end to end through the projector.
+ *
+ * Under strictSourceMode the ledger bit attests everything (above), so the
+ * spoof-resistance mechanism documented in risk.ts — "an attacker declaring
+ * rows under a victim's name resolves unattested (source_attested=0), which
+ * turns the trust modifier off" — does NOT fire on that posture.
+ *
+ * What protects the victim there is the ownership stamp: `resolveToolSource`
+ * rewrites the env-unconfirmed identity into the `unattested>` keyspace BEFORE it
+ * reaches the ledger, so `sourceKey(source_type, source_identifier)` mints a
+ * node disjoint from the victim's. The attacker accrues risk against their own
+ * key, by construction rather than by the attested flip.
+ *
+ * Asserted through the real projector, not by inspecting the stamp — the
+ * property is about which NODE the accrual lands on.
+ */
+describe('#283 strict-mode accrual lands on the stamped key, not the victim bare key', () => {
+  const ENV_KEYS = ['CLAUDE_CODE_ENTRYPOINT', 'CODEX_THREAD_ID', 'SHIELDCORTEX_AGENT_SOURCE'] as const;
+  const VICTIM = { type: 'hook', identifier: 'session-end' } as DefenceSource;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+    // The default deployment this issue is about: cli:mcp 0.9 ceiling.
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+  });
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function seedBlockRow(src: DefenceSource, attested: boolean, ts: string): void {
+    getDatabase().prepare(`
+      INSERT INTO defence_audit (
+        memory_id, project, timestamp, source_type, source_identifier,
+        trust_score, sensitivity_level, firewall_result,
+        anomaly_score, threat_indicators, blocked_patterns,
+        reason, fragmentation_score, pipeline_duration_ms, source_attested
+      ) VALUES (
+        NULL, 'test', @ts, @type, @identifier,
+        0.8, 'INTERNAL', 'BLOCK',
+        0, '[]', '["injection"]',
+        NULL, NULL, 1, @attested
+      )
+    `).run({ ts, type: src.type, identifier: src.identifier, attested: attested ? 1 : 0 });
+  }
+
+  function sourceNodeKeys(): string[] {
+    return (getDatabase()
+      .prepare("SELECT key FROM threat_nodes WHERE kind = 'source' ORDER BY key")
+      .all() as Array<{ key: string }>).map(r => r.key);
+  }
+
+  it('stamps the strict-mode claim before it reaches the ledger', () => {
+    const resolved = resolveToolSource(VICTIM, { toolName: 'remember', project: 'test', strict: true });
+    // The divergence itself: ledger says attested, ownership says unconfirmed.
+    expect(resolved.attested).toBe(true);
+    expect(resolved.source.type).toBe('hook');
+    expect(resolved.source.identifier).toBe('unattested>session-end');
+    expect(`${resolved.source.type}:${resolved.source.identifier}`).not.toBe('hook:session-end');
+  });
+
+  it('projects the attacker onto a node disjoint from the victim', () => {
+    const attacker = resolveToolSource(VICTIM, { toolName: 'remember', project: 'test', strict: true });
+    seedBlockRow(attacker.source, attacker.attested, '2026-08-01T10:00:00.000Z');
+    seedBlockRow(attacker.source, attacker.attested, '2026-08-01T10:05:00.000Z');
+    projectToCompletion();
+
+    const keys = sourceNodeKeys();
+    expect(keys).toContain('hook:unattested>session-end');
+    // The whole point: the victim's node was never touched.
+    expect(keys).not.toContain('hook:session-end');
+  });
+
+  it('accrues decayed risk on the stamped key and leaves the victim key at none', () => {
+    const attacker = resolveToolSource(VICTIM, { toolName: 'remember', project: 'test', strict: true });
+    seedBlockRow(attacker.source, attacker.attested, '2026-08-01T10:00:00.000Z');
+    seedBlockRow(attacker.source, attacker.attested, '2026-08-01T10:05:00.000Z');
+    projectToCompletion();
+    runRiskSweep({ nowMs: Date.parse('2026-08-01T11:00:00.000Z') });
+
+    const rows = getDatabase()
+      .prepare('SELECT source_key, risk, attested FROM source_risk')
+      .all() as Array<{ source_key: string; risk: number; attested: number }>;
+    const stamped = rows.find(r => r.source_key === 'hook:unattested>session-end');
+
+    expect(stamped).toBeDefined();
+    expect(stamped!.risk).toBeGreaterThan(0);
+    // Attested under strict — accrual is NOT suppressed. It simply lands on the
+    // attacker's own key, which is the property that replaces the flip.
+    expect(stamped!.attested).toBe(1);
+    expect(rows.some(r => r.source_key === 'hook:session-end')).toBe(false);
+  });
+
+  it('the trust modifier penalises the stamped identity, never the victim', () => {
+    const attacker = resolveToolSource(VICTIM, { toolName: 'remember', project: 'test', strict: true });
+    seedBlockRow(attacker.source, attacker.attested, '2026-08-01T10:00:00.000Z');
+    seedBlockRow(attacker.source, attacker.attested, '2026-08-01T10:05:00.000Z');
+    projectToCompletion();
+    runRiskSweep({ nowMs: Date.parse('2026-08-01T11:00:00.000Z') });
+
+    expect(computeRiskModifier(attacker.source, 'enforce').applied).toBe(true);
+    expect(computeRiskModifier(VICTIM, 'enforce')).toMatchObject({ modifier: 0, applied: false });
   });
 });

--- a/src/__tests__/threat-graph-attestation.test.ts
+++ b/src/__tests__/threat-graph-attestation.test.ts
@@ -192,8 +192,13 @@ describe('#270 — same-score identity is not self-declarable', () => {
       { type: 'file', identifier: 'import' },
       { toolName: 'remember', project: null, strict: false },
     );
-    expect(resolved.source).toEqual({ type: 'file', identifier: 'import' });
+    // The downgrade stands — type, name and 0.4 trust are all preserved — but
+    // #283 keys it as self-declared: the env inferred `cli:mcp`, never
+    // `file:import`, so this identity may not own the real `file:import`'s rows.
+    expect(resolved.source.type).toBe('file');
+    expect(resolved.source.identifier).toBe('unattested>import');
     expect(resolved.clamped).toBe(false);
+    expect(resolved.envConfirmed).toBe(false);
   });
 
   it('honours a declaration the environment independently confirms', () => {

--- a/src/defence/__tests__/attestation-stamp.test.ts
+++ b/src/defence/__tests__/attestation-stamp.test.ts
@@ -1,0 +1,272 @@
+/**
+ * #283 — a self-declared identity may not wear a host-attested identity's name.
+ *
+ * The ceiling clamp (#273) asks "does this claim OUTSCORE the environment". A
+ * DOWNGRADE does not, so on a default `cli:*` 0.9 deployment a declared
+ * `hook:session-end` (0.8) was honoured verbatim, silently, with no
+ * `SOURCE_ELEVATION_BLOCKED` row — and then owned the real hook's rows, because
+ * `checkAccess` keys ownership on `${type}:${identifier}` string equality and
+ * that string was writer-chosen.
+ *
+ * The question ownership needs is not "is this claim too high" but "did the
+ * ENVIRONMENT confirm this identity". Where it did not, the identity keeps its
+ * declared type and score and is keyed into a separate namespace.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve as resolvePath } from 'node:path';
+
+import {
+  UNATTESTED_ORIGIN,
+  applyOwnershipStamp,
+  isUnattestedIdentifier,
+  isUnattestedSourceKey,
+  stampUnattestedIdentifier,
+  stripUnattestedStamp,
+} from '../trust/attestation-stamp.js';
+import { resolveToolSource, deriveEnvConfirmed } from '../trust/resolve-tool-source.js';
+import { checkAccess } from '../trust/access-control.js';
+import { scoreSource } from '../trust/source-scorer.js';
+import { scoreAgent, getAgentDepth, buildAgentHierarchy } from '../trust/agent-scorer.js';
+import type { DefenceSource } from '../types.js';
+
+const ENV_KEYS = [
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_AGENT_CONTEXT',
+  'CODEX_THREAD_ID',
+  'CODEX_CI',
+  'CODEX_INTERNAL_ORIGINATOR_OVERRIDE',
+  'SHIELDCORTEX_AGENT_SOURCE',
+  'SHIELDCORTEX_STRICT_SOURCE',
+];
+
+/** The four env shapes that give a default deployment a `cli:*` 0.9 ceiling. */
+const CLI_HOSTS: Array<[string, Record<string, string>]> = [
+  ['CLAUDE_CODE_ENTRYPOINT=cli', { CLAUDE_CODE_ENTRYPOINT: 'cli' }],
+  ['CLAUDE_CODE_ENTRYPOINT=vscode', { CLAUDE_CODE_ENTRYPOINT: 'vscode' }],
+  ['CODEX_THREAD_ID=t1', { CODEX_THREAD_ID: 't1' }],
+  [
+    'CODEX_INTERNAL_ORIGINATOR_OVERRIDE=codex_vscode',
+    { CODEX_INTERNAL_ORIGINATOR_OVERRIDE: 'codex_vscode' },
+  ],
+];
+
+/** Below-ceiling declarations: none of these is an over-claim under `cli:*` 0.9. */
+const BELOW_CEILING: Array<[DefenceSource, number]> = [
+  [{ type: 'hook', identifier: 'session-end' }, 0.8],
+  [{ type: 'api', identifier: 'ingest' }, 0.7],
+  [{ type: 'file', identifier: 'notes' }, 0.6],
+  [{ type: 'agent', identifier: 'browser' }, 0.3],
+];
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe('#283 ownership stamp — primitives', () => {
+  it('is idempotent, so a caller cannot escape stamping by pre-stamping itself', () => {
+    const once = stampUnattestedIdentifier('session-end');
+    expect(once).toBe(`${UNATTESTED_ORIGIN}>session-end`);
+    expect(stampUnattestedIdentifier(once)).toBe(once);
+    expect(stampUnattestedIdentifier(stampUnattestedIdentifier(once))).toBe(once);
+  });
+
+  it('round-trips: strip undoes stamp, and strip is a no-op on bare identifiers', () => {
+    expect(stripUnattestedStamp(stampUnattestedIdentifier('a>b'))).toBe('a>b');
+    expect(stripUnattestedStamp('a>b')).toBe('a>b');
+    expect(isUnattestedIdentifier('a>b')).toBe(false);
+  });
+
+  it('cannot collide with a host-attested key: an attested identifier is never stamped', () => {
+    // The stamp sits at the FRONT of the identifier, and `applyOwnershipStamp`
+    // is the only writer of it — so a confirmed identity can never carry it.
+    const attested = applyOwnershipStamp({ type: 'hook', identifier: 'session-end' }, true);
+    const declared = applyOwnershipStamp({ type: 'hook', identifier: 'session-end' }, false);
+    expect(attested.identifier).toBe('session-end');
+    expect(declared.identifier).toBe(`${UNATTESTED_ORIGIN}>session-end`);
+    expect(`${attested.type}:${attested.identifier}`)
+      .not.toBe(`${declared.type}:${declared.identifier}`);
+  });
+
+  it('returns the same object when the environment confirmed the identity', () => {
+    const source: DefenceSource = { type: 'hook', identifier: 'session-end' };
+    expect(applyOwnershipStamp(source, true)).toBe(source);
+  });
+
+  it('recognises a stamped STORED source string', () => {
+    expect(isUnattestedSourceKey(`hook:${UNATTESTED_ORIGIN}>session-end`)).toBe(true);
+    expect(isUnattestedSourceKey('hook:session-end')).toBe(false);
+    expect(isUnattestedSourceKey('no-separator')).toBe(false);
+  });
+});
+
+describe('#283 ownership stamp — never raises a score', () => {
+  it.each(BELOW_CEILING)('keeps %j at its declared score when stamped', (declared, expected) => {
+    const bare = scoreSource(declared).score;
+    const stamped = scoreSource(applyOwnershipStamp(declared, false)).score;
+    expect(bare).toBe(expected);
+    expect(stamped).toBe(expected);
+  });
+
+  it('bars a self-declared identity from claiming a privileged agent ORIGIN', () => {
+    // `env-override`/`cron`/`user-spawned` all mean "the host or the integrator's
+    // environment said so". A writer-chosen string claiming to be one of them is
+    // the exact claim under audit — it gets the unprivileged default instead.
+    // This is the one place the stamp moves a score, and it only ever lowers it.
+    for (const origin of ['env-override', 'cron', 'user-spawned']) {
+      const privileged = scoreAgent(origin);
+      const selfDeclared = scoreAgent(stampUnattestedIdentifier(origin));
+      expect(selfDeclared).toBeLessThan(privileged);
+      expect(selfDeclared).toBe(0.3);
+    }
+    expect(scoreAgent(stampUnattestedIdentifier('env-override>user-spawned'))).toBeLessThan(0.5);
+  });
+
+  it('does not read the stamp as a hierarchy rung', () => {
+    expect(getAgentDepth(stampUnattestedIdentifier('user-spawned>task-1')))
+      .toBe(getAgentDepth('user-spawned>task-1'));
+    expect(scoreAgent(stampUnattestedIdentifier('agent-spawned>x')))
+      .toBe(scoreAgent('agent-spawned>x'));
+  });
+
+  it('shows the stamp in the hierarchy display with the scores the ACL uses', () => {
+    const lines = buildAgentHierarchy(stampUnattestedIdentifier('user-spawned>task-1'));
+    expect(lines[0]).toContain(UNATTESTED_ORIGIN);
+    expect(lines.join('\n')).toContain('trust=0.300');
+  });
+});
+
+describe('#283 deriveEnvConfirmed', () => {
+  const env: DefenceSource = { type: 'cli', identifier: 'claude-code' };
+
+  it('confirms when nothing was declared', () => {
+    expect(deriveEnvConfirmed({ declared: undefined, clamped: false, envInferred: env })).toBe(true);
+  });
+
+  it('confirms when the over-claim was clamped to the env identity', () => {
+    expect(deriveEnvConfirmed({
+      declared: { type: 'user', identifier: 'direct' }, clamped: true, envInferred: env,
+    })).toBe(true);
+  });
+
+  it('confirms when the declaration is exactly what the environment produced', () => {
+    expect(deriveEnvConfirmed({ declared: { ...env }, clamped: false, envInferred: env })).toBe(true);
+  });
+
+  it('does NOT confirm a below-ceiling declaration the environment never produced', () => {
+    expect(deriveEnvConfirmed({
+      declared: { type: 'hook', identifier: 'session-end' }, clamped: false, envInferred: env,
+    })).toBe(false);
+  });
+
+  it('does not confuse a matching identifier under a different type', () => {
+    expect(deriveEnvConfirmed({
+      declared: { type: 'agent', identifier: 'claude-code' }, clamped: false, envInferred: env,
+    })).toBe(false);
+  });
+});
+
+describe('#283 resolveToolSource on the four cli:* 0.9 hosts', () => {
+  it.each(CLI_HOSTS)('stamps every below-ceiling declaration on %s', (_label, hostEnv) => {
+    for (const [declared] of BELOW_CEILING) {
+      Object.assign(process.env, hostEnv);
+      const r = resolveToolSource(declared, { toolName: 'recall', project: null, strict: false });
+      expect(r.clamped).toBe(false); // a downgrade is not an over-claim
+      expect(r.envConfirmed).toBe(false);
+      expect(r.source.type).toBe(declared.type); // the declaration is still honoured
+      expect(isUnattestedIdentifier(r.source.identifier)).toBe(true);
+      expect(stripUnattestedStamp(r.source.identifier)).toBe(declared.identifier);
+      for (const k of ENV_KEYS) delete process.env[k];
+    }
+  });
+
+  it('leaves an env-confirmed identity unstamped', () => {
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource(undefined, { toolName: 'recall', project: null, strict: false });
+    expect(r.envConfirmed).toBe(true);
+    expect(isUnattestedIdentifier(r.source.identifier)).toBe(false);
+  });
+
+  it('stamps under strictSourceMode too — the hardened posture must not carry the hole', () => {
+    // `attested` folds in strict mode; ownership deliberately does not.
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource({ type: 'hook', identifier: 'session-end' },
+      { toolName: 'recall', project: null, strict: true });
+    expect(r.envConfirmed).toBe(false);
+    expect(isUnattestedIdentifier(r.source.identifier)).toBe(true);
+  });
+});
+
+describe('#283 ACL — a declared identity owns only what it wrote itself', () => {
+  it.each(CLI_HOSTS)('denies cross-identity ownership on %s', (_label, hostEnv) => {
+    for (const [declared] of BELOW_CEILING) {
+      Object.assign(process.env, hostEnv);
+      const r = resolveToolSource(declared, { toolName: 'recall', project: null, strict: false });
+
+      // A row written by the REAL, host-attested holder of the declared name.
+      const victimKey = `${declared.type}:${declared.identifier}`;
+      const victimRestricted = { id: 1, source: victimKey, sensitivity_level: 'RESTRICTED' };
+
+      expect(checkAccess(victimRestricted, r.source, 'read').canRead).toBe(false);
+      expect(checkAccess(victimRestricted, r.source, 'delete').canDelete).toBe(false);
+      expect(checkAccess({ id: 2, source: victimKey }, r.source, 'revoke').canDelete).toBe(false);
+
+      // ...but it still owns its OWN writes, keyed to the stamped identity.
+      // (RESTRICTED own-read additionally needs trust ≥0.7, which is the
+      // pre-existing gate and not what this issue changed — see below.)
+      const ownKey = `${r.source.type}:${r.source.identifier}`;
+      expect(checkAccess({ id: 3, source: ownKey, sensitivity_level: 'INTERNAL' }, r.source, 'read').canRead)
+        .toBe(true);
+
+      for (const k of ENV_KEYS) delete process.env[k];
+    }
+  });
+
+  it('a stamped identity at trust ≥0.7 still reads its OWN RESTRICTED rows', () => {
+    // The stamp namespaces ownership; it does not demote the identity. A
+    // declared `hook:session-end` keeps 0.8 and therefore keeps owner access to
+    // the rows it wrote itself — only the real hook's rows moved out of reach.
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource({ type: 'hook', identifier: 'session-end' },
+      { toolName: 'recall', project: null, strict: false });
+    const ownKey = `${r.source.type}:${r.source.identifier}`;
+    expect(scoreSource(r.source).score).toBe(0.8);
+    expect(checkAccess({ id: 1, source: ownKey, sensitivity_level: 'RESTRICTED' }, r.source, 'read').canRead)
+      .toBe(true);
+  });
+
+  it('the host-attested holder still owns its own rows', () => {
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource(undefined, { toolName: 'recall', project: null, strict: false });
+    const ownKey = `${r.source.type}:${r.source.identifier}`;
+    expect(checkAccess({ id: 1, source: ownKey, sensitivity_level: 'RESTRICTED' }, r.source, 'read').canRead)
+      .toBe(true);
+  });
+});
+
+describe('#283 destructive floor', () => {
+  it('keeps hierarchy revoke off the wire: forget derives its identity from the environment', () => {
+    // `forget`/revoke-by-source is the only route to cross-identity deletion, and
+    // it is safe ONLY because it ignores the declared `source` param. A declared
+    // `hook:session-end` scores 0.8 — enough to outrank a real 0.3 agent — so if
+    // this handler ever starts honouring `args.source`, #283 becomes destructive.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const server = readFileSync(resolvePath(here, '../../server.ts'), 'utf8');
+    const forgetHandler = server.slice(server.indexOf("withKillSwitchGuard('memory_write'"));
+    expect(forgetHandler).toContain('inferSourceFromEnvironment().source');
+    expect(forgetHandler.slice(0, forgetHandler.indexOf('executeForget')))
+      .not.toMatch(/source\s*=\s*args\.source/);
+  });
+});

--- a/src/defence/__tests__/attestation-stamp.test.ts
+++ b/src/defence/__tests__/attestation-stamp.test.ts
@@ -256,6 +256,43 @@ describe('#283 ACL — a declared identity owns only what it wrote itself', () =
   });
 });
 
+describe('#283 ACL — claim-stamped identities cannot trust-hierarchy revoke', () => {
+  const LOWER_TRUST_TARGETS = ['agent:agent-spawned', 'file:notes', 'web:scrape'] as const;
+  const STAMP_REVOKE_REASON = /unattested|self-declared/;
+
+  it.each([false, true])(
+    'denies every below-ceiling rung against lower-trust targets (strict=%s)',
+    (strict) => {
+      process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+      for (const [declared] of BELOW_CEILING) {
+        const r = resolveToolSource(declared, { toolName: 'recall', project: null, strict });
+        expect(isUnattestedIdentifier(r.source.identifier)).toBe(true);
+        for (const target of LOWER_TRUST_TARGETS) {
+          const policy = checkAccess({ id: 1, source: target }, r.source, 'revoke');
+          expect(policy.canDelete).toBe(false);
+          expect(policy.reason).toMatch(STAMP_REVOKE_REASON);
+        }
+      }
+    },
+  );
+
+  it('host-attested cli:mcp 0.9 still revokes agent:agent-spawned 0.3', () => {
+    const host: DefenceSource = { type: 'cli', identifier: 'mcp' };
+    expect(scoreSource(host).score).toBe(0.9);
+    const policy = checkAccess({ id: 1, source: 'agent:agent-spawned' }, host, 'revoke');
+    expect(policy.canDelete).toBe(true);
+    expect(policy.reason).toMatch(/Trust-hierarchy revoke/);
+  });
+
+  it('stamped caller still revokes its own rows', () => {
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource({ type: 'hook', identifier: 'session-end' },
+      { toolName: 'recall', project: null, strict: false });
+    const ownKey = `${r.source.type}:${r.source.identifier}`;
+    expect(checkAccess({ id: 1, source: ownKey }, r.source, 'revoke').canDelete).toBe(true);
+  });
+});
+
 describe('#283 destructive floor', () => {
   it('keeps hierarchy revoke off the wire: forget derives its identity from the environment', () => {
     // `forget`/revoke-by-source is the only route to cross-identity deletion, and

--- a/src/defence/__tests__/env-detector.test.ts
+++ b/src/defence/__tests__/env-detector.test.ts
@@ -442,10 +442,36 @@ describe('Environment-Based Source Inference', () => {
         strict: false,
       });
 
-      expect(resolved.source).toEqual(declared);
+      // The declaration is honoured — same type, same name, same trust score —
+      // but #283: the environment never produced this identity, so it is keyed
+      // into its own ownership namespace. Without the stamp this exact case
+      // (a below-ceiling declaration, so the clamp never fires) read the
+      // host-attested `agent:user-spawned>task-1`'s rows as OWNER.
+      expect(resolved.source.type).toBe(declared.type);
+      expect(resolved.source.identifier).toBe(`unattested>${declared.identifier}`);
+      // The stamp never RAISES a score. Here it lowers one, deliberately and in
+      // the only case it does: `user-spawned` is an ORIGIN, and an origin means
+      // "the host or the integrator's environment said so". A writer-chosen
+      // string claiming that origin is exactly the claim under audit, so it
+      // scores as an unconfirmed agent (0.3) decayed one rung — 0.21, not 0.63.
+      // Same rule keeps a declared `agent:env-override>…` off the 0.5 pin, i.e.
+      // below the trust≥0.5 delete floor.
+      expect(scoreSource(declared).score).toBe(0.63);
+      expect(scoreSource(resolved.source).score).toBe(0.21);
       // An accepted self-declaration is honoured but not attested.
       expect(resolved.attested).toBe(false);
-      expect(logAudit).not.toHaveBeenCalled();
+      expect(resolved.envConfirmed).toBe(false);
+      // ...and it is no longer the quietest path in the resolver: a
+      // self-declared identity now leaves a SOURCE_UNATTESTED row (ALLOW — the
+      // declaration stands, only its ownership is namespaced).
+      expect(logAudit).toHaveBeenCalledTimes(1);
+      const row = logAudit.mock.calls[0][0] as {
+        firewall_result: string;
+        reason: string;
+      };
+      expect(row.firewall_result).toBe('ALLOW');
+      expect(row.reason).toContain('SOURCE_UNATTESTED');
+      expect(row.reason).toContain('declared=agent:user-spawned>task-1');
     });
 
     it('writes a SOURCE_MISSING audit row when no source is declared', () => {

--- a/src/defence/__tests__/env-detector.test.ts
+++ b/src/defence/__tests__/env-detector.test.ts
@@ -88,14 +88,17 @@ describe('Environment-Based Source Inference', () => {
       process.env.SHIELDCORTEX_AGENT_SOURCE = 'some-agent';
       const result = inferSourceFromEnvironment();
       expect(result.source.type).toBe('agent'); // defaults to agent
-      expect(result.source.identifier).toBe('some-agent');
+      // #283 residual: below-cap agent env claims get env-claim> (no raise, no host ACL collision)
+      expect(result.source.identifier).toBe('env-claim>some-agent');
+      expect(scoreSource(result.source).score).toBe(0.3);
     });
 
     it('should prioritise SHIELDCORTEX_AGENT_SOURCE over CLAUDE_CODE_ENTRYPOINT', () => {
       process.env.SHIELDCORTEX_AGENT_SOURCE = 'agent:custom-tool';
       process.env.CLAUDE_CODE_ENTRYPOINT = 'subagent';
       const result = inferSourceFromEnvironment();
-      expect(result.source).toEqual({ type: 'agent', identifier: 'custom-tool' });
+      expect(result.source).toEqual({ type: 'agent', identifier: 'env-claim>custom-tool' });
+      expect(scoreSource(result.source).score).toBe(0.3);
     });
 
     it('refuses operator and CLI types on the integrator override — they cannot become the ceiling', () => {
@@ -131,10 +134,10 @@ describe('Environment-Based Source Inference', () => {
       }
     });
 
-    it('keeps already-low override identities (no wrap, no raise)', () => {
+    it('stamps already-low override agent identities without raising trust (#283)', () => {
       process.env.SHIELDCORTEX_AGENT_SOURCE = 'agent:some-agent';
       const inferred = inferSourceFromEnvironment();
-      expect(inferred.source).toEqual({ type: 'agent', identifier: 'some-agent' });
+      expect(inferred.source).toEqual({ type: 'agent', identifier: 'env-claim>some-agent' });
       expect(scoreSource(inferred.source).score).toBe(0.3);
     });
 
@@ -177,8 +180,9 @@ describe('Environment-Based Source Inference', () => {
     it('keeps a bare token (no type prefix) as agent — documented integrator form', () => {
       process.env.SHIELDCORTEX_AGENT_SOURCE = 'some-agent';
       const inferred = inferSourceFromEnvironment();
-      expect(inferred.source).toEqual({ type: 'agent', identifier: 'some-agent' });
-      expect(isUntrustedInboundType(inferred.source.type)).toBe(false);
+      // #283 residual: stamped env-claim so it cannot own host agent:some-agent
+      expect(inferred.source).toEqual({ type: 'agent', identifier: 'env-claim>some-agent' });
+      expect(isUntrustedInboundType(inferred.source.type)).toBe(false); // type-only still exempt
       expect(scoreSource(inferred.source).score).toBe(0.3);
     });
 

--- a/src/defence/__tests__/issue283-reconcile-residual.test.ts
+++ b/src/defence/__tests__/issue283-reconcile-residual.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #283 reconcile residual — CASE ownership stamp is the core.
+ * TARS residual closes the SHIELDCORTEX_AGENT_SOURCE env path that CASE
+ * left bare for below-cap agent claims.
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { resolveToolSource } from '../trust/resolve-tool-source.js';
+import { inferSourceFromEnvironment } from '../trust/env-detector.js';
+import { scoreSource, isUntrustedInboundSourceString } from '../trust/source-scorer.js';
+import { checkAccess } from '../trust/access-control.js';
+import { guardReadBySensitivity } from '../trust/read-guard.js';
+import type { DefenceSource } from '../types.js';
+import type { Memory } from '../../memory/types.js';
+
+const ENV_KEYS = [
+  'CLAUDE_CODE_ENTRYPOINT', 'CLAUDE_AGENT_CONTEXT',
+  'CODEX_INTERNAL_ORIGINATOR_OVERRIDE', 'CODEX_THREAD_ID', 'CODEX_CI',
+  'OPENAI_BASE_URL', 'CURSOR_TRACE_ID', 'AIDER_MODEL', 'CONTINUE_GLOBAL_DIR',
+  'SHIELDCORTEX_AGENT_SOURCE', 'TERM_PROGRAM',
+];
+
+function clearEnv(): void {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+beforeEach(clearEnv);
+afterEach(clearEnv);
+
+function mem(source: string, sensitivity = 'INTERNAL'): {
+  id: number; source: string; sensitivity_level: string;
+} {
+  return { id: 1, source, sensitivity_level: sensitivity };
+}
+
+describe('#283 reconcile — CASE ownership stamp retained', () => {
+  it('declared hook:session-end under cli does not own host hook RESTRICTED', () => {
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource(
+      { type: 'hook', identifier: 'session-end' },
+      { toolName: 'recall', project: null, strict: false },
+    );
+    expect(r.envConfirmed).toBe(false);
+    expect(r.source.identifier.startsWith('unattested>')).toBe(true);
+    expect(r.source.type).toBe('hook');
+    expect(scoreSource(r.source).score).toBe(0.8); // score preserved
+    expect(
+      checkAccess(mem('hook:session-end', 'RESTRICTED'), r.source, 'read').canRead,
+    ).toBe(false);
+    expect(
+      checkAccess(
+        mem(`${r.source.type}:${r.source.identifier}`, 'RESTRICTED'),
+        r.source,
+        'read',
+      ).canRead,
+    ).toBe(true); // own stamped row at >=0.7
+  });
+
+  it('strict mode still stamps ownership (CASE deriveEnvConfirmed)', () => {
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource(
+      { type: 'hook', identifier: 'session-end' },
+      { toolName: 'recall', project: null, strict: true },
+    );
+    expect(r.envConfirmed).toBe(false);
+    expect(r.source.identifier.startsWith('unattested>')).toBe(true);
+    // attested may be true under strict for consequences — ownership uses envConfirmed
+    expect(
+      checkAccess(mem('hook:session-end', 'RESTRICTED'), r.source, 'read').canRead,
+    ).toBe(false);
+  });
+});
+
+describe('#283 reconcile — TARS env residual on CASE base', () => {
+  it('SHIELDCORTEX_AGENT_SOURCE=browser → env-claim @ 0.3, no host ownership', () => {
+    process.env.SHIELDCORTEX_AGENT_SOURCE = 'browser';
+    const env = inferSourceFromEnvironment();
+    expect(env.source).toEqual({ type: 'agent', identifier: 'env-claim>browser' });
+    expect(scoreSource(env.source).score).toBe(0.3);
+    expect(
+      checkAccess(mem('agent:browser'), env.source, 'read').canRead,
+    ).toBe(false);
+  });
+
+  it('SHIELDCORTEX_AGENT_SOURCE=agent:cron stays env-override @ 0.5 and is inbound', () => {
+    process.env.SHIELDCORTEX_AGENT_SOURCE = 'agent:cron';
+    const env = inferSourceFromEnvironment();
+    expect(env.source.identifier.startsWith('env-override>')).toBe(true);
+    expect(scoreSource(env.source).score).toBe(0.5);
+    expect(isUntrustedInboundSourceString(`${env.source.type}:${env.source.identifier}`)).toBe(true);
+    const row = {
+      id: 1,
+      trustScore: 0.5,
+      sensitivityLevel: 'INTERNAL',
+      source: `${env.source.type}:${env.source.identifier}`,
+      content: 'x',
+    } as unknown as Memory;
+    expect(guardReadBySensitivity([row])).toHaveLength(0);
+  });
+
+  it('declared agent:browser under cli is unattested and does not own host', () => {
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+    const r = resolveToolSource(
+      { type: 'agent', identifier: 'browser' },
+      { toolName: 'get_context', project: null, strict: false },
+    );
+    expect(r.source).toEqual({ type: 'agent', identifier: 'unattested>browser' });
+    expect(r.envConfirmed).toBe(false);
+    expect(scoreSource(r.source).score).toBe(0.3);
+    expect(
+      checkAccess(mem('agent:browser'), r.source, 'read').canRead,
+    ).toBe(false);
+  });
+});

--- a/src/defence/__tests__/revoke-access.test.ts
+++ b/src/defence/__tests__/revoke-access.test.ts
@@ -43,6 +43,15 @@ describe("checkAccess('revoke')", () => {
     expect(checkAccess({ id: 1, source: 'agent:agent-spawned' }, HIGH, 'delete').canDelete).toBe(false);
   });
 
+  it('claim-stamped high-trust caller cannot hierarchy-revoke a lower-trust source', () => {
+    const stampedHook: DefenceSource = { type: 'hook', identifier: 'unattested>session-end' };
+    const envClaim: DefenceSource = { type: 'agent', identifier: 'env-claim>browser' };
+    expect(checkAccess({ id: 1, source: 'agent:agent-spawned' }, stampedHook, 'revoke').canDelete).toBe(false);
+    expect(checkAccess({ id: 1, source: 'file:notes' }, stampedHook, 'revoke').reason)
+      .toMatch(/unattested|self-declared/);
+    expect(checkAccess({ id: 1, source: 'web:scrape' }, envClaim, 'revoke').canDelete).toBe(false);
+  });
+
   it('fail-safe: unattributed (null) target memories are NOT revocable, even by high-trust', () => {
     expect(checkAccess({ id: 1, source: null }, HIGH, 'revoke').canDelete).toBe(false);
     expect(checkAccess({ id: 1, source: '__system:unattributed' }, HIGH, 'revoke').canDelete).toBe(false);

--- a/src/defence/trust/access-control.ts
+++ b/src/defence/trust/access-control.ts
@@ -12,7 +12,7 @@
  */
 
 import type { DefenceSource } from '../types.js';
-import { scoreSource } from './source-scorer.js';
+import { isClaimStampedIdentifier, scoreSource } from './source-scorer.js';
 
 export interface AccessPolicy {
   canRead: boolean;
@@ -116,6 +116,11 @@ export function checkAccess(
     // rows by source.
     if (!memory.source || memorySource === '__system:unattributed') {
       return deny('Revoke denied: unattributed memories cannot be revoked by source');
+    }
+    // #283: cross-identity revoke is a host-attested privilege. A claim-stamped
+    // caller (unattested>/env-claim>/env-override>/unrecognised>) outranks nobody.
+    if (isClaimStampedIdentifier(source.identifier)) {
+      return deny('Revoke denied: self-declared identity cannot trust-hierarchy revoke (unattested claim)');
     }
     const targetTrust = scoreSource(parseStoredSource(memorySource)).score;
     if (targetTrust > 0 && trust >= 0.7 && trust > targetTrust) {

--- a/src/defence/trust/agent-scorer.ts
+++ b/src/defence/trust/agent-scorer.ts
@@ -7,7 +7,8 @@
  *   "user-spawned>task-1>subtask-2"   → 0.9 × 0.7² = 0.44
  *   "cron"                            → base trust 0.5
  *   "agent-spawned"                   → base trust 0.3
- *   "env-override>…"                  → pinned 0.5 (integrator env claim)
+ *   "env-override>…"                  → pinned 0.5 (integrator env claim at cap)
+ *   "env-claim>…"                     → pinned 0.3 (integrator env claim below cap)
  *   "unattested>…"                    → self-declared; scores off the bare
  *                                       identifier but may not claim a
  *                                       privileged origin (see attestation-stamp)
@@ -38,6 +39,8 @@ export const DEFAULT_AGENT_CONFIG: AgentTrustConfig = {
     'user-approved': 0.85,
     'cron': 0.5,
     'env-override': 0.5,
+    // #283 residual: below-cap integrator env claim — pin 0.3, never raise to env-override 0.5
+    'env-claim': 0.3,
     'agent-spawned': 0.3,
     'web': 0.2,
   },
@@ -68,10 +71,11 @@ export function scoreAgent(
   if (depth > config.maxDepth) return 0;
 
   // Integrator env claims may keep a unique identifier for ACL, but they
-  // cannot ride parent-tier trust. Pin at the origin score (0.5) with no
-  // further decay — the cap is a ceiling, not a forced downgrade below it.
-  if (origin === 'env-override' && !selfDeclared) {
-    return config.originScores['env-override'] ?? 0.5;
+  // cannot ride parent-tier trust. Pin at the origin score with no further
+  // decay — the stamp is a ceiling/floor marker, not a hierarchy root.
+  // env-override = at-cap 0.5; env-claim = below-cap 0.3 (must not raise).
+  if ((origin === 'env-override' || origin === 'env-claim') && !selfDeclared) {
+    return config.originScores[origin] ?? (origin === 'env-override' ? 0.5 : 0.3);
   }
 
   const baseScore = selfDeclared ? UNPRIVILEGED_ORIGIN_SCORE : (config.originScores[origin] ?? 0.3);

--- a/src/defence/trust/agent-scorer.ts
+++ b/src/defence/trust/agent-scorer.ts
@@ -8,7 +8,20 @@
  *   "cron"                            → base trust 0.5
  *   "agent-spawned"                   → base trust 0.3
  *   "env-override>…"                  → pinned 0.5 (integrator env claim)
+ *   "unattested>…"                    → self-declared; scores off the bare
+ *                                       identifier but may not claim a
+ *                                       privileged origin (see attestation-stamp)
  */
+
+import {
+  UNATTESTED_ORIGIN,
+  isUnattestedIdentifier,
+  stampUnattestedIdentifier,
+  stripUnattestedStamp,
+} from './attestation-stamp.js';
+
+/** Base trust for an origin the environment did not confirm — the `?? 0.3` default. */
+const UNPRIVILEGED_ORIGIN_SCORE = 0.3;
 
 export interface AgentTrustConfig {
   /** Base trust scores by spawn origin (first segment of identifier) */
@@ -40,7 +53,14 @@ export function scoreAgent(
   identifier: string,
   config: AgentTrustConfig = DEFAULT_AGENT_CONFIG,
 ): number {
-  const parts = identifier.split('>');
+  // An identity the environment did not confirm scores off its BARE identifier,
+  // so the stamp never changes the number — except that it may not claim a
+  // privileged origin. `env-override`/`cron`/`user-spawned` all mean "the host
+  // or the integrator's env said so"; a writer-chosen string saying it is one of
+  // them is exactly the claim under audit, and gets the unprivileged default.
+  const selfDeclared = isUnattestedIdentifier(identifier);
+  const bare = stripUnattestedStamp(identifier);
+  const parts = bare.split('>');
   const origin = parts[0];
   const depth = parts.length - 1;
 
@@ -50,11 +70,11 @@ export function scoreAgent(
   // Integrator env claims may keep a unique identifier for ACL, but they
   // cannot ride parent-tier trust. Pin at the origin score (0.5) with no
   // further decay — the cap is a ceiling, not a forced downgrade below it.
-  if (origin === 'env-override') {
+  if (origin === 'env-override' && !selfDeclared) {
     return config.originScores['env-override'] ?? 0.5;
   }
 
-  const baseScore = config.originScores[origin] ?? 0.3;
+  const baseScore = selfDeclared ? UNPRIVILEGED_ORIGIN_SCORE : (config.originScores[origin] ?? 0.3);
   return Math.round(baseScore * Math.pow(config.decayFactor, depth) * 1000) / 1000;
 }
 
@@ -62,7 +82,9 @@ export function scoreAgent(
  * Get the depth of an agent in its hierarchy (0 = parent).
  */
 export function getAgentDepth(identifier: string): number {
-  return identifier.split('>').length - 1;
+  // The stamp is an attestation marker, not a hierarchy level — a stamped
+  // identity must not read as one rung deeper than the name it declared.
+  return stripUnattestedStamp(identifier).split('>').length - 1;
 }
 
 /**
@@ -72,12 +94,18 @@ export function buildAgentHierarchy(
   identifier: string,
   config: AgentTrustConfig = DEFAULT_AGENT_CONFIG,
 ): string[] {
-  const parts = identifier.split('>');
+  const selfDeclared = isUnattestedIdentifier(identifier);
+  const parts = stripUnattestedStamp(identifier).split('>');
   const hierarchy: string[] = [];
 
+  if (selfDeclared) {
+    hierarchy.push(`${UNATTESTED_ORIGIN}> (self-declared — environment did not confirm)`);
+  }
   for (let i = 0; i < parts.length; i++) {
     const path = parts.slice(0, i + 1).join('>');
-    const score = scoreAgent(path, config);
+    // Score each rung through the stamp so the displayed numbers are the ones
+    // the ACL actually uses, not the unstamped identity's.
+    const score = scoreAgent(selfDeclared ? stampUnattestedIdentifier(path) : path, config);
     hierarchy.push(`${'  '.repeat(i)}${parts[i]} (trust=${score.toFixed(3)})`);
   }
 

--- a/src/defence/trust/attestation-stamp.ts
+++ b/src/defence/trust/attestation-stamp.ts
@@ -1,0 +1,82 @@
+/**
+ * Ownership keying for self-declared identities.
+ *
+ * `checkAccess` decides ownership by string equality on `${type}:${identifier}`.
+ * That key is the ONLY thing standing between a caller and another identity's
+ * memories — it gates owner-read of RESTRICTED rows, `delete`, and the `revoke`
+ * own-cleanup branch. Until this module, the key was built from whatever the
+ * caller declared, so a below-ceiling declaration wore a peer's name for free:
+ * on a default `cli:*` 0.9 deployment a declared `hook:session-end` (0.8) is not
+ * an over-claim, is honoured verbatim, and then reads the real hook's RESTRICTED
+ * rows as OWNER.
+ *
+ * The clamp cannot catch this — it asks "does the claim outscore the
+ * environment", and a genuine downgrade does not. The question ownership needs
+ * is different: "did the environment CONFIRM this identity". Where the answer is
+ * no, the identity keeps its declared type and score but is keyed into a
+ * separate namespace, so it can only ever own what it wrote itself.
+ *
+ * Properties this stamp must hold (all covered in attestation-stamp.test.ts):
+ * - it NEVER raises a score — `scoreSource` strips it before scoring, with one
+ *   deliberate exception below;
+ * - it can never collide with a host-attested `${type}:${identifier}` key, because
+ *   an attested identifier is by construction unstamped and the stamp sits at the
+ *   front of the identifier;
+ * - it is idempotent, so re-resolving an already-stamped identity is stable and a
+ *   caller cannot escape stamping by pre-stamping its own declaration;
+ * - a stamped identifier cannot claim a privileged agent ORIGIN (`env-override>`,
+ *   `cron`, `user-spawned`, …). Those origins mean "the host or the integrator's
+ *   environment said so"; a self-declared string saying it is one of them earns
+ *   the unprivileged default instead. This is the one place the stamp changes a
+ *   score, and it only ever lowers it.
+ */
+
+import type { DefenceSource } from '../types.js';
+
+/**
+ * Origin token marking an identity the environment did not confirm.
+ *
+ * Shares the `>` hierarchy separator with `env-override>` on purpose: agent
+ * identifiers already read as `origin>path`, so a stamped identifier stays
+ * legible in the audit ledger and in `source_risk` node keys.
+ */
+export const UNATTESTED_ORIGIN = 'unattested';
+
+const UNATTESTED_PREFIX = `${UNATTESTED_ORIGIN}>`;
+
+/** True when this identifier carries the unattested stamp. */
+export function isUnattestedIdentifier(identifier: string): boolean {
+  return identifier.startsWith(UNATTESTED_PREFIX);
+}
+
+/** Remove the stamp (no-op when absent). Scoring works off the bare identifier. */
+export function stripUnattestedStamp(identifier: string): string {
+  return isUnattestedIdentifier(identifier)
+    ? identifier.slice(UNATTESTED_PREFIX.length)
+    : identifier;
+}
+
+/** Stamp an identifier as unattested, idempotently. */
+export function stampUnattestedIdentifier(identifier: string): string {
+  return isUnattestedIdentifier(identifier) ? identifier : `${UNATTESTED_PREFIX}${identifier}`;
+}
+
+/**
+ * Apply the ownership stamp to a resolved source.
+ *
+ * Fed ONCE, at `resolveToolSource` — the single point where a declaration meets
+ * the environment. Everything downstream (the stored `source` string, the
+ * `checkAccess` caller key, the threat-graph `sourceKey`) is derived from the
+ * returned source, so `read`, `delete` and `revoke` cannot drift apart.
+ */
+export function applyOwnershipStamp(source: DefenceSource, envConfirmed: boolean): DefenceSource {
+  if (envConfirmed) return source;
+  const identifier = stampUnattestedIdentifier(source.identifier);
+  return identifier === source.identifier ? source : { ...source, identifier };
+}
+
+/** True when a stored `source` string was written by an unconfirmed identity. */
+export function isUnattestedSourceKey(storedSource: string): boolean {
+  const sep = storedSource.indexOf(':');
+  return sep !== -1 && isUnattestedIdentifier(storedSource.slice(sep + 1));
+}

--- a/src/defence/trust/attestation-stamp.ts
+++ b/src/defence/trust/attestation-stamp.ts
@@ -16,6 +16,11 @@
  * no, the identity keeps its declared type and score but is keyed into a
  * separate namespace, so it can only ever own what it wrote itself.
  *
+ * That namespace is not per-caller isolation. A later writer declaring the same
+ * `type:identifier` (or the already-stamped form) is keyed identically to the
+ * first claimant — unattested writers can wear each other's stamped names. The
+ * guarantee is only that a stamped identity cannot own a host-attested row.
+ *
  * Properties this stamp must hold (all covered in attestation-stamp.test.ts):
  * - it NEVER raises a score — `scoreSource` strips it before scoring, with one
  *   deliberate exception below;

--- a/src/defence/trust/env-detector.ts
+++ b/src/defence/trust/env-detector.ts
@@ -49,9 +49,32 @@ const OVERRIDE_TYPES: ReadonlySet<string> = new Set(Object.keys(OVERRIDE_TYPE_TA
 
 /** Stamp env provenance onto an identifier, idempotently. */
 function withOverrideOrigin(identifier: string): string {
-  return identifier.startsWith(`${ENV_OVERRIDE_ORIGIN}>`)
+  const lower = identifier.toLowerCase();
+  return lower.startsWith(`${ENV_OVERRIDE_ORIGIN}>`)
     ? identifier
     : `${ENV_OVERRIDE_ORIGIN}>${identifier}`;
+}
+
+/**
+ * #283 residual (reconcile with CASE ownership stamp): below-cap integrator
+ * agent claims must not collide with host-attested `agent:${id}` ACL keys and
+ * must not raise trust. `env-override>` is the at-cap pin (0.5); below-cap uses
+ * `env-claim>` pinned at 0.3. Other below-cap types (email/web) stay bare —
+ * already inbound-blocked by type.
+ */
+const ENV_CLAIM_ORIGIN = 'env-claim';
+
+function withEnvClaimOrigin(identifier: string): string {
+  const lower = identifier.toLowerCase();
+  if (
+    lower.startsWith(`${ENV_CLAIM_ORIGIN}>`)
+    || lower.startsWith(`${ENV_OVERRIDE_ORIGIN}>`)
+    || lower.startsWith('unattested>')
+    || lower.startsWith('unrecognised>')
+  ) {
+    return identifier;
+  }
+  return `${ENV_CLAIM_ORIGIN}>${identifier}`;
 }
 
 /**
@@ -62,14 +85,10 @@ function withOverrideOrigin(identifier: string): string {
  *
  * Three bands, by the score the claimed identity actually earns:
  *
- * - **Below the cap** — keep type and identifier verbatim. Stamping provenance
- *   here would RAISE trust (`agent:some-agent` 0.3 → `env-override>` 0.5).
- * - **Exactly at the cap** — keep the type (it is already capped, and the type
- *   carries the inbound-untrusted decision), but stamp the identifier. A bare
- *   `agent:cron` / `tool_response:browser` is indistinguishable from the
- *   host-attested `${type}:${identifier}` ACL key of a real scheduler or tool
- *   response; the prefix keeps the score at 0.5 while making the row's env
- *   provenance legible to the ACL and the audit ledger.
+ * - **Below the cap** — agent gets `env-claim>` (no raise, no host ACL collision).
+ *   Other types stay bare (already inbound-blocked).
+ * - **Exactly at the cap** — keep the type, stamp `env-override>` so bare
+ *   `agent:cron` / `tool_response:browser` cannot wear host ACL keys.
  * - **Above the cap** — rebind onto the agent hierarchy at `env-override>…`,
  *   which `scoreAgent` pins at 0.5.
  */
@@ -97,6 +116,9 @@ export function bindIntegratorOverrideSource(
   const score = scoreSource(candidate).score;
 
   if (score < ENV_OVERRIDE_SCORE_CAP) {
+    if (sourceType === 'agent') {
+      return { type: 'agent', identifier: withEnvClaimOrigin(identifier) };
+    }
     return candidate;
   }
   if (score === ENV_OVERRIDE_SCORE_CAP) {

--- a/src/defence/trust/index.ts
+++ b/src/defence/trust/index.ts
@@ -4,8 +4,16 @@ export { scoreAgent, getAgentDepth, buildAgentHierarchy } from './agent-scorer.j
 export { checkAccess } from './access-control.js';
 export { inferSourceFromEnvironment, resolveSource, clampSourceToCeiling } from './env-detector.js';
 export type { CeilingClampResult } from './env-detector.js';
-export { resolveToolSource } from './resolve-tool-source.js';
-export type { ResolveToolSourceOptions } from './resolve-tool-source.js';
+export { resolveToolSource, deriveAttested, deriveEnvConfirmed } from './resolve-tool-source.js';
+export type { ResolveToolSourceOptions, ResolvedToolSource } from './resolve-tool-source.js';
+export {
+  UNATTESTED_ORIGIN,
+  applyOwnershipStamp,
+  isUnattestedIdentifier,
+  isUnattestedSourceKey,
+  stampUnattestedIdentifier,
+  stripUnattestedStamp,
+} from './attestation-stamp.js';
 export type { AccessPolicy, AccessCheckMemory } from './access-control.js';
 export type { AgentTrustConfig } from './agent-scorer.js';
 export type { EnvDetectionResult } from './env-detector.js';

--- a/src/defence/trust/read-guard.ts
+++ b/src/defence/trust/read-guard.ts
@@ -21,7 +21,7 @@
 
 import { checkAccess } from './access-control.js';
 import { redactContent } from '../sensitivity/redaction.js';
-import { isUntrustedInboundType } from './source-scorer.js';
+import { isUntrustedInboundSourceString } from './source-scorer.js';
 import type { DefenceSource } from '../types.js';
 import type { Memory, ContextSummary } from '../../memory/types.js';
 
@@ -90,10 +90,9 @@ function isUntrustedInboundSource(source: string | null | undefined): boolean {
   // Null/empty stays fail-open: many INTERNAL rows are still unstamped, and
   // this surface must keep shared project context available. Fail-closed for
   // unknown provenance is a separate change.
-  if (!source) return false;
-  const sep = source.indexOf(':');
-  const type = (sep === -1 ? source : source.slice(0, sep)).toLowerCase();
-  return isUntrustedInboundType(type);
+  // #283: full-string helper sees env-claim>/unattested>/env-override> stamps —
+  // type-only would keep stamped agent rows inbound-exempt.
+  return isUntrustedInboundSourceString(source);
 }
 
 export function guardReadBySensitivity(memories: Memory[]): Memory[] {

--- a/src/defence/trust/resolve-tool-source.ts
+++ b/src/defence/trust/resolve-tool-source.ts
@@ -11,9 +11,17 @@
  *    its own trust or wear another agent's name.
  * 5. Writes a `SOURCE_MISSING` row when no source was declared, preserving
  *    the existing visibility into unconfigured callers.
+ * 6. Stamps any identity the environment did not confirm, so `checkAccess`
+ *    cannot mistake a declaration for the host-attested identity of the same
+ *    name, and writes a `SOURCE_UNATTESTED` row for it. The clamp only asks
+ *    whether a claim OUTSCORES the environment; a below-ceiling claim
+ *    (`hook:session-end` at 0.8 under a `cli:*` 0.9 ceiling) is not an
+ *    over-claim, yet it wore the real hook's name for free. See
+ *    ./attestation-stamp.ts.
  */
 
 import type { DefenceSource } from '../types.js';
+import { applyOwnershipStamp } from './attestation-stamp.js';
 import { clampSourceToCeiling } from './env-detector.js';
 import { logAudit } from '../audit/logger.js';
 import { getStrictSourceMode } from '../../cloud/config.js';
@@ -28,6 +36,11 @@ export interface ResolveToolSourceOptions {
 }
 
 export interface ResolvedToolSource {
+  /**
+   * The identity the rest of the pipeline uses. Carries the ownership stamp when
+   * the environment did not confirm it, so the ACL cannot mistake a declaration
+   * for the host-attested identity of the same name.
+   */
   source: DefenceSource;
   /**
    * True when the resolved identity is SYSTEM-derived (no declaration, a
@@ -38,6 +51,18 @@ export interface ResolvedToolSource {
    */
   attested: boolean;
   clamped: boolean;
+  /**
+   * Did the ENVIRONMENT confirm this identity — the question ownership needs.
+   *
+   * Deliberately not the same predicate as `attested`. `attested` folds in
+   * strictSourceMode, which is an operator's opt-in to hardened CONSEQUENCES
+   * (risk accrual keyed on claimed identities); treating a declaration as
+   * confirmed is defensible there. It is not defensible for ownership: under
+   * strict mode a declared `hook:session-end` would otherwise own the real
+   * hook's RESTRICTED rows, i.e. the hardened posture would carry the hole the
+   * default one does. Ownership therefore asks only about the environment.
+   */
+  envConfirmed: boolean;
 }
 
 /**
@@ -66,6 +91,28 @@ export function deriveAttested(input: {
     return true;
   }
   return false;
+}
+
+/**
+ * Pure environment-confirmation derivation (exported for exhaustive testing).
+ *
+ * True when the resolved identity came FROM the host environment rather than
+ * from the caller: nothing declared, an over-claim we replaced with the
+ * env-inferred source, or a declaration the environment independently produced.
+ * Unlike `deriveAttested` this ignores strictSourceMode — see
+ * `ResolvedToolSource.envConfirmed`.
+ */
+export function deriveEnvConfirmed(input: {
+  declared: DefenceSource | undefined;
+  clamped: boolean;
+  envInferred: DefenceSource;
+}): boolean {
+  if (!input.declared) return true;
+  if (input.clamped) return true;
+  return (
+    input.declared.type === input.envInferred.type
+    && input.declared.identifier === input.envInferred.identifier
+  );
 }
 
 /**
@@ -108,6 +155,12 @@ export function resolveToolSource(
     strict,
     envInferred: env,
   });
+  const envConfirmed = deriveEnvConfirmed({ declared: declaredSource, clamped, envInferred: env });
+
+  // Fed ONCE, here. Everything downstream — the stored `source` string, the
+  // `checkAccess` caller key, the threat-graph node key — derives from this
+  // source, so read / delete / revoke cannot drift apart on ownership.
+  source = applyOwnershipStamp(source, envConfirmed);
 
   if (clamped && declaredSource) {
     try {
@@ -140,7 +193,46 @@ export function resolveToolSource(
     } catch {
       // Audit logging must never break tool execution.
     }
-    return { source, attested, clamped };
+    return { source, attested, clamped, envConfirmed };
+  }
+
+  // Declared, within the ceiling, but the environment never produced this
+  // identity. Previously the quietest path in the resolver: honoured verbatim,
+  // no audit row, and — before the ownership stamp — owning the host-attested
+  // rows of whatever name it declared. Record it so the ledger distinguishes a
+  // self-declared identity from a confirmed one.
+  if (declaredSource && !envConfirmed) {
+    try {
+      logAudit({
+        memory_id: null,
+        project: options.project,
+        timestamp: new Date().toISOString(),
+        source_type: source.type,
+        source_identifier: source.identifier,
+        // Non-null whenever a source was declared; the fallback only satisfies
+        // the type, it is unreachable inside this branch.
+        trust_score: declaredScore ?? ceilingScore,
+        sensitivity_level: 'PUBLIC',
+        // ALLOW, not BLOCK: the declaration is honoured (a downgrade is a
+        // legitimate feature). Only its ownership is namespaced.
+        firewall_result: 'ALLOW',
+        operation: null, // source-resolution meta-event, not a memory read/write/delete
+        anomaly_score: 0,
+        threat_indicators: '[]',
+        blocked_patterns: '[]',
+        reason:
+          `SOURCE_UNATTESTED: tool=${options.toolName}, ` +
+          `declared=${declaredSource.type}:${declaredSource.identifier} (score=${declaredScore}), ` +
+          `keyed=${source.type}:${source.identifier} — environment inferred ` +
+          `${env.type}:${env.identifier} via ${detection.method} ` +
+          `(confidence: ${detection.confidence}), so the declared identity owns only its own writes`,
+        fragmentation_score: null,
+        pipeline_duration_ms: null,
+      });
+    } catch {
+      // Audit logging must never break tool execution.
+    }
+    return { source, attested, clamped, envConfirmed };
   }
 
   // No declared source — inferred from environment. Preserve the existing
@@ -174,5 +266,5 @@ export function resolveToolSource(
     }
   }
 
-  return { source, attested, clamped };
+  return { source, attested, clamped, envConfirmed };
 }

--- a/src/defence/trust/source-scorer.ts
+++ b/src/defence/trust/source-scorer.ts
@@ -48,14 +48,47 @@ export const UNTRUSTED_INBOUND_FLOOR = 0.6;
 
 export const UNTRUSTED_INBOUND_EXEMPT_TYPES: ReadonlySet<DefenceSource['type']> = new Set(['agent']);
 
-export function isUntrustedInboundType(type: string): boolean {
+/**
+ * Claim stamps that mean "writer/env declared this, host did not".
+ * Includes CASE ownership stamp (`unattested>`) and TARS env residual stamps.
+ */
+const CLAIM_STAMP_PREFIXES = ['env-override>', 'env-claim>', 'unattested>', 'unrecognised>'] as const;
+
+export function isClaimStampedIdentifier(identifier: string): boolean {
+  const id = identifier.toLowerCase();
+  return CLAIM_STAMP_PREFIXES.some((prefix) => id.startsWith(prefix));
+}
+
+/**
+ * True when a stored `type:identifier` (or bare type) is untrusted inbound for
+ * shared-context bootstrap. Prefer this over {@link isUntrustedInboundType}
+ * when the full source string is available — type-only cannot see #283 stamps.
+ */
+export function isUntrustedInboundSourceString(source: string | null | undefined): boolean {
+  if (!source) return false;
+  const sep = source.indexOf(':');
+  const type = (sep === -1 ? source : source.slice(0, sep)).toLowerCase();
+  const identifier = sep === -1 ? '' : source.slice(sep + 1);
+  return isUntrustedInbound(type, identifier);
+}
+
+export function isUntrustedInbound(type: string, identifier = ''): boolean {
   const normalised = type.toLowerCase();
-  if ((UNTRUSTED_INBOUND_EXEMPT_TYPES as ReadonlySet<string>).has(normalised)) {
-    return false;
-  }
   const score = TYPE_SCORES[normalised as DefenceSource['type']];
   if (score === undefined) return true;
+  // Agent is exempt ONLY when host-attested (no claim stamp). A stamped agent
+  // row is a self-applied or integrator label — treat as inbound.
+  if (normalised === 'agent') {
+    return isClaimStampedIdentifier(identifier);
+  }
   return score < UNTRUSTED_INBOUND_FLOOR;
+}
+
+/** @deprecated Prefer {@link isUntrustedInbound} with identifier when available. */
+export function isUntrustedInboundType(type: string): boolean {
+  // Type-only path: agent without identifier is treated as potentially
+  // host-attested (legacy callers). New code must pass the identifier.
+  return isUntrustedInbound(type, '');
 }
 
 const HIERARCHY_DISPLAY = [

--- a/src/defence/trust/source-scorer.ts
+++ b/src/defence/trust/source-scorer.ts
@@ -4,6 +4,7 @@
 
 import type { DefenceSource, TrustScore } from '../types.js';
 import { scoreAgent, buildAgentHierarchy } from './agent-scorer.js';
+import { stripUnattestedStamp } from './attestation-stamp.js';
 
 const BASE_SCORES: Record<string, number> = {
   'user:direct': 1.0,
@@ -71,9 +72,14 @@ const HIERARCHY_DISPLAY = [
 
 export function scoreSource(source: DefenceSource): TrustScore {
   const key = `${source.type}:${source.identifier}`;
+  // Score off the BARE identifier: the ownership stamp separates a self-declared
+  // identity from the host-attested one of the same name, and must not move the
+  // number in either direction. `agent` is the exception — see scoreAgent, where
+  // a stamped identifier is barred from claiming a privileged origin.
+  const bareKey = `${source.type}:${stripUnattestedStamp(source.identifier)}`;
 
   // Exact match overrides
-  const baseScore = BASE_SCORES[key];
+  const baseScore = BASE_SCORES[bareKey];
   if (baseScore !== undefined) {
     return { score: baseScore, source, hierarchy: [...HIERARCHY_DISPLAY, `>> ${key} = ${baseScore}`] };
   }


### PR DESCRIPTION
## Reconciles #285 vs #286 → one #283 path

Parallel work landed two full #283 fixes:

| PR | Author | Strength | Gap |
|---|---|---|---|
| **#286** | CASE | Clean ownership stamp module, `deriveEnvConfirmed` ≠ `attested`, preserves type/score, bars privileged origins on unattested agents, CI green | Left **below-cap** `SHIELDCORTEX_AGENT_SOURCE=browser` as bare `agent:browser` (host ACL collision + inbound-exempt type) |
| **#285** | TARS | Closed env residual (`env-claim>`), claim-stamp inbound, dual-reviewed | Heavier rewrite path; threaded `attested` into ACL (CASE's stamp-alone model is cleaner for ownership) |

## Decision
**Survivor = CASE #286 core + TARS env residual.**

1. Keep CASE `attestation-stamp.ts` + `applyOwnershipStamp` in `resolveToolSource`
2. Keep CASE `deriveEnvConfirmed` (strict cannot open ownership hole)
3. Port TARS residual only:
   - below-cap agent env claims → `env-claim>` @ 0.3 (no raise, no host key collision)
   - inbound bootstrap reads claim stamps (`env-claim` / `unattested` / `env-override`)
   - `guardReadBySensitivity` uses full-string helper

## Closes
- Closes #283
- Supersedes #285
- Supersedes #286

## Local gates
- `npm run build:ts` clean
- 8 suites / **165 tests** (CASE attestation + env residual + env-detector + threat-graph + claims + mcp-read-acl + access + read-guard)

## Dual review
CASE #286 was CI-green design-clean. TARS #285 was dual-reviewed APPROVE_WITH_NITS after blocker fixes. This PR is the merge of both; residual tests prove the union.

Independent review still required before merge — implementer does not self-flip.