### PR TITLE
fix(guard): deny-path forensics — signals, origin, action id, notify (#284)

### DIFF
--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -916,6 +916,15 @@ function classifyNotifyStatus(notifyMod, result) {
 
 async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict, outcome, event, sessionKey, actionId }) {
   const id = actionId || mintActionId();
+  // #284 dual-review blocker (SOL): write the denial row FIRST with notify pending,
+  // then attempt delivery and append/update status. A hang/crash during notify must
+  // not drop the forensics row that operators open first (denials.jsonl).
+  const pendingRow = buildLocalGuardOutcome({
+    toolName, toolInput, verdict, outcome, event, sessionKey, actionId: id,
+    notify: { status: 'pending', deliveredVia: null },
+  });
+  recordLocalGuardOutcome(pendingRow);
+
   let notify = null;
   try {
     notify = typeof notifyOrPromise?.then === 'function' ? await notifyOrPromise : notifyOrPromise;
@@ -930,10 +939,7 @@ async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict
     typeof notify.buildActionGuardOutcomeNotification === 'function'
   ) {
     try {
-      const provisional = buildLocalGuardOutcome({
-        toolName, toolInput, verdict, outcome, event, sessionKey, actionId: id,
-      });
-      const notification = notify.buildActionGuardOutcomeNotification(provisional);
+      const notification = notify.buildActionGuardOutcomeNotification(pendingRow);
       deliveryResult = await notify.deliverOperatorNotification(notification, {
         channels: [notify.denialChannel],
         timeoutMs: notify.config?.timeoutMs,
@@ -952,10 +958,15 @@ async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict
   }
 
   const notifyStatus = classifyNotifyStatus(notify, deliveryResult);
-  const localOutcome = buildLocalGuardOutcome({
-    toolName, toolInput, verdict, outcome, event, sessionKey, actionId: id, notify: notifyStatus,
+  // Append a second denials.jsonl line with final notify status (same actionId)
+  // so operators can see both "denied" and "were they told" without losing the
+  // first row if delivery hangs.
+  const finalRow = buildLocalGuardOutcome({
+    toolName, toolInput, verdict, outcome, event, sessionKey, actionId: id,
+    notify: notifyStatus,
   });
-  recordLocalGuardOutcome(localOutcome);
+  recordLocalGuardOutcome(finalRow);
+
   return {
     deliveredVia: deliveryResult?.deliveredVia ?? null,
     attempts: deliveryResult?.attempts ?? [],
@@ -963,6 +974,7 @@ async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict
     actionId: id,
   };
 }
+
 
 function notificationAudit(result) {
   if (!result) return {};

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -482,7 +482,7 @@ async function pingOperator(notify, { toolName, toolInput, verdict, hash, noProm
   if (!channel) return null;
   try {
     const displayVerdict = safeApprovalVerdict(verdict);
-    const safeSessionId = notificationContext(sessionKey).correlationId;
+    const safeSessionId = notificationContext(sessionKey).sessionId;
     const result = await notify.requestOperatorApproval(
       {
         hash,
@@ -520,11 +520,27 @@ const SAFE_TOOL_NAMES = new Set([
   'TodoWrite', 'WebFetch', 'WebSearch', 'NotebookEdit', 'Workflow',
 ]);
 const SAFE_SIGNALS = new Set([
+  // Generic / legacy summary names kept for older rows and broker payloads.
   'secret-egress', 'approval-required', 'fallback-scan', 'privilege-escalation',
   'filesystem-destructive', 'destructive-filesystem', 'dangerous-shell',
   'command-exec', 'network-egress', 'credential-access', 'data-exfiltration',
   'untrusted-script', 'reviewed-script', 'shell-injection', 'persistence-risk',
   'install-package', 'git-force-push', 'local-package-install', 'move-or-copy', 'file-delete', 'service-restart', 'exec-like',
+  // #284 Face 1 — real Action Guard signal names must survive the local
+  // denials.jsonl / operator-notify path. Previously almost every live
+  // catastrophic signal collapsed to "redacted-signal".
+  'recursive-force-delete', 'delete-root-or-home', 'fork-bomb', 'format-filesystem',
+  'raw-disk-write', 'redirect-to-block-device', 'disk-partition-tool',
+  'pipe-download-to-shell', 'pipe-download-stdin-exec', 'pipe-download-module-exec',
+  'recursive-perms-on-root', 'shred-device', 'git-delete-branch',
+  'stop-process-or-service', 'modify-network-firewall', 'install-package-global',
+  'modify-scheduler', 'truncate-to-zero', 'wipe-history-or-logs',
+  'touch-sensitive-path', 'touch-approval-store', 'touch-decisions-ledger',
+  'dd-overwrite', 'recursive-perms-system-dir', 'registry-code-exec',
+  'decode-pipe-to-shell', 'change-permissions', 'git-mutate',
+  'recursive-find-delete', 'external-egress', 'oversized-command',
+  'opaque-script-invocation', 'opaque-script', 'secret-egress-fold',
+  'force-push', 'force-push-invocation',
 ]);
 const MAX_SESSION_SALT_RECOVERY_ATTEMPTS = 256;
 const GUARD_DEGRADED_OUTCOMES = new Set(['auto_denied', 'denied_no_prompt_surface', 'failure_denied', 'warned', 'failure_allowed']);
@@ -697,8 +713,21 @@ function safePermissionMode(value) {
     : null;
 }
 
-function notificationContext(sessionKey) {
-  return /^sc-[a-f0-9]{16}$/.test(String(sessionKey ?? '')) ? { correlationId: sessionKey } : {};
+function mintActionId() {
+  // #284 Face 3 — action-scoped id, distinct from the session key.
+  return `act-${randomBytes(8).toString('hex')}`;
+}
+
+function notificationContext(sessionKey, actionId) {
+  const out = {};
+  if (/^sc-[a-f0-9]{16}$/.test(String(sessionKey ?? ''))) {
+    out.sessionId = sessionKey;
+  }
+  if (typeof actionId === 'string' && /^act-[a-f0-9]{16}$/.test(actionId)) {
+    out.actionId = actionId;
+    out.correlationId = actionId;
+  }
+  return out;
 }
 
 function safeBrokerAudit(audit) {
@@ -724,7 +753,9 @@ function redactedActionSurface(toolName, toolInput) {
   const keys = ['command', 'script', 'file_path', 'path', 'url', 'pattern'];
   const present = keys.filter((k) => toolInput?.[k] !== undefined && toolInput?.[k] !== null);
   const suffix = present.length > 0 ? ` fields=${present.join(',')}` : ' no command field';
-  return `${safeToolName(toolName)}: [redacted action surface; inspect local audit]${suffix}`;
+  // #284 Face 1 — name the verified sink. denials.jsonl is a summary; unredacted
+  // command lives in ~/.shieldcortex/audit/realtime-YYYY-MM-DD.jsonl.
+  return `${safeToolName(toolName)}: [redacted action surface; unredacted command in ~/.shieldcortex/audit/realtime-*.jsonl]${suffix}`;
 }
 
 function redactedAuditArgs(toolName, toolInput) {
@@ -764,14 +795,24 @@ function safeAllowAuditVerdict(verdict, outcome = 'allowed') {
 }
 
 function writeTerminalOutcomeAudit(toolName, verdict, toolInput, action, outcome, event, extra = {}) {
+  const actionId = extra.actionId || mintActionId();
+  // #284: do NOT pass raw toolInput as intentArgs on the deny path. Binding would
+  // mint actionKey from the full command and put it on the durable audit row —
+  // the same leak denials.jsonl is carefully redacting. Terminal outcomes are
+  // already refused; reconciliation uses actionId, not a replayable actionKey.
   writeAuditEntry(
     safeToolName(toolName),
     terminalOutcomeAuditVerdict(verdict, outcome, event),
     redactedAuditArgs(toolName, toolInput),
     action,
     outcome,
-    { ...extra, intentArgs: toolInput },
+    {
+      ...extra,
+      actionId,
+      origin: extra.origin || 'claude-code-hook',
+    },
   );
+  return actionId;
 }
 
 function safeDiagnosticReason(reason) {
@@ -811,19 +852,28 @@ function terminalDecisionReason(verdict, outcome, event) {
   return `ShieldCortex Action Guard: ${severityPrefix}${safeGuardOutcomeReason(verdict, outcome, event)}${nextStep}${suffix}`;
 }
 
-function buildLocalGuardOutcome({ toolName, toolInput, verdict, outcome, event, sessionKey }) {
-  const context = notificationContext(sessionKey);
-  return {
+function buildLocalGuardOutcome({ toolName, toolInput, verdict, outcome, event, sessionKey, actionId, notify }) {
+  const id = actionId || mintActionId();
+  const context = notificationContext(sessionKey, id);
+  const row = {
     event,
     outcome,
+    // #284 Face 2 — origin on every denial row (especially auto_deny/critical).
+    origin: 'claude-code-hook',
     tool: safeToolName(toolName),
     surface: redactedActionSurface(toolName, toolInput),
     signals: safeSignalList(verdict.signals),
     severity: verdict.severity === 'catastrophic' ? 'critical' : String(verdict.severity ?? 'unknown'),
     reason: safeGuardOutcomeReason(verdict, outcome, event),
+    ...(context.sessionId ? { sessionId: context.sessionId } : {}),
+    ...(context.actionId ? { actionId: context.actionId } : {}),
     ...(context.correlationId ? { correlationId: context.correlationId } : {}),
     detectedAt: new Date().toISOString(),
   };
+  if (notify && typeof notify === 'object') {
+    row.notify = notify;
+  }
+  return row;
 }
 
 function recordLocalGuardOutcome(outcome) {
@@ -836,35 +886,82 @@ function recordLocalGuardOutcome(outcome) {
   return false;
 }
 
-async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict, outcome, event, sessionKey }) {
-  const localOutcome = buildLocalGuardOutcome({ toolName, toolInput, verdict, outcome, event, sessionKey });
-  recordLocalGuardOutcome(localOutcome);
+function classifyNotifyStatus(notifyMod, result) {
+  // #284 Face 4 — distinguish not_configured / no_channel / delivered / error.
+  if (!notifyMod) {
+    return { status: 'not_configured', deliveredVia: null };
+  }
+  if (
+    !notifyMod.denialChannel ||
+    typeof notifyMod.deliverOperatorNotification !== 'function' ||
+    typeof notifyMod.buildActionGuardOutcomeNotification !== 'function'
+  ) {
+    return { status: 'no_channel', deliveredVia: null };
+  }
+  if (result?.deliveredVia) {
+    return {
+      status: 'delivered',
+      deliveredVia: safeNotifyLabel(result.deliveredVia) ?? 'redacted-channel',
+    };
+  }
+  const attemptReason = Array.isArray(result?.attempts)
+    ? result.attempts.map((a) => a?.result?.reason).find(Boolean)
+    : null;
+  return {
+    status: 'error',
+    deliveredVia: null,
+    error: safeDiagnosticReason(attemptReason ?? 'delivery failed'),
+  };
+}
+
+async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict, outcome, event, sessionKey, actionId }) {
+  const id = actionId || mintActionId();
   let notify = null;
   try {
     notify = typeof notifyOrPromise?.then === 'function' ? await notifyOrPromise : notifyOrPromise;
   } catch {
     notify = null;
   }
+
+  let deliveryResult = null;
   if (
-    !notify?.denialChannel ||
-    typeof notify.deliverOperatorNotification !== 'function' ||
-    typeof notify.buildActionGuardOutcomeNotification !== 'function'
-  ) return null;
-  try {
-    const notification = notify.buildActionGuardOutcomeNotification(localOutcome);
-    const result = await notify.deliverOperatorNotification(notification, {
-      channels: [notify.denialChannel],
-      timeoutMs: notify.config.timeoutMs,
-    });
-    if (result?.deliveredVia) {
-      const via = safeNotifyLabel(result.deliveredVia) ?? 'redacted-channel';
-      console.error(`[shieldcortex] operator-notify: reported ${outcome} for ${safeToolName(toolName)} via ${via}.`);
+    notify?.denialChannel &&
+    typeof notify.deliverOperatorNotification === 'function' &&
+    typeof notify.buildActionGuardOutcomeNotification === 'function'
+  ) {
+    try {
+      const provisional = buildLocalGuardOutcome({
+        toolName, toolInput, verdict, outcome, event, sessionKey, actionId: id,
+      });
+      const notification = notify.buildActionGuardOutcomeNotification(provisional);
+      deliveryResult = await notify.deliverOperatorNotification(notification, {
+        channels: [notify.denialChannel],
+        timeoutMs: notify.config?.timeoutMs,
+      }) ?? null;
+      if (deliveryResult?.deliveredVia) {
+        const via = safeNotifyLabel(deliveryResult.deliveredVia) ?? 'redacted-channel';
+        console.error(`[shieldcortex] operator-notify: reported ${outcome} for ${safeToolName(toolName)} via ${via}.`);
+      }
+    } catch (err) {
+      console.error('[shieldcortex] ⚠️ operator-notify error — guard outcome unchanged.');
+      deliveryResult = {
+        deliveredVia: null,
+        attempts: [{ channel: 'operator-notify', result: { delivered: false, reason: safeDiagnosticReason(err?.message ?? err) } }],
+      };
     }
-    return result ?? null;
-  } catch (err) {
-    console.error('[shieldcortex] ⚠️ operator-notify error — guard outcome unchanged.');
-    return { deliveredVia: null, attempts: [{ channel: 'operator-notify', result: { delivered: false, reason: safeDiagnosticReason(err?.message ?? err) } }] };
   }
+
+  const notifyStatus = classifyNotifyStatus(notify, deliveryResult);
+  const localOutcome = buildLocalGuardOutcome({
+    toolName, toolInput, verdict, outcome, event, sessionKey, actionId: id, notify: notifyStatus,
+  });
+  recordLocalGuardOutcome(localOutcome);
+  return {
+    deliveredVia: deliveryResult?.deliveredVia ?? null,
+    attempts: deliveryResult?.attempts ?? [],
+    notify: notifyStatus,
+    actionId: id,
+  };
 }
 
 function notificationAudit(result) {
@@ -884,11 +981,46 @@ function notificationAudit(result) {
 }
 
 function recordNotifyAudit(toolName, verdict, toolInput, baseExtra, result) {
-  if (!result) return;
-  writeAuditEntry(safeToolName(toolName), { severity: safeSeverity(verdict?.severity, 'action_guard_warning'), decision: safeDecision(verdict?.decision, 'action_guard_warning'), signals: safeSignalList(verdict?.signals) }, { notification: 'redacted' }, 'notify', result.deliveredVia ? 'notified' : 'notify_failed', {
-    ...baseExtra,
-    ...notificationAudit(result),
-  });
+  // #284 Face 4 — always record notify status when the deny path ran alert.
+  if (!result) {
+    writeAuditEntry(
+      safeToolName(toolName),
+      {
+        severity: safeSeverity(verdict?.severity, 'action_guard_warning'),
+        decision: safeDecision(verdict?.decision, 'action_guard_warning'),
+        signals: safeSignalList(verdict?.signals),
+      },
+      { notification: 'redacted' },
+      'notify',
+      'notify_not_configured',
+      { ...baseExtra, notify: { status: 'not_configured', deliveredVia: null } },
+    );
+    return;
+  }
+  const status = result.notify?.status
+    ?? (result.deliveredVia ? 'delivered' : 'error');
+  const outcome =
+    status === 'delivered' ? 'notified'
+      : status === 'not_configured' ? 'notify_not_configured'
+        : status === 'no_channel' ? 'notify_no_channel'
+          : 'notify_failed';
+  writeAuditEntry(
+    safeToolName(toolName),
+    {
+      severity: safeSeverity(verdict?.severity, 'action_guard_warning'),
+      decision: safeDecision(verdict?.decision, 'action_guard_warning'),
+      signals: safeSignalList(verdict?.signals),
+    },
+    { notification: 'redacted' },
+    'notify',
+    outcome,
+    {
+      ...baseExtra,
+      ...(result.actionId ? { actionId: result.actionId } : {}),
+      notify: result.notify ?? notificationAudit(result).notify,
+      ...notificationAudit(result),
+    },
+  );
 }
 
 /**
@@ -1305,7 +1437,7 @@ async function emitApprovalRequired(toolName, auditVerdict, toolInput, permissio
     emitDecision('ask', safeDiagnosticApprovalReason(reason));
     return;
   }
-  writeTerminalOutcomeAudit(toolName, { ...auditVerdict, reason }, toolInput, action, 'denied_no_prompt_surface', 'action_guard_denial', {
+  const actionId = writeTerminalOutcomeAudit(toolName, { ...auditVerdict, reason }, toolInput, action, 'denied_no_prompt_surface', 'action_guard_denial', {
     ...baseExtra,
     ...(safePermissionMode(permissionMode) ? { permissionMode: safePermissionMode(permissionMode) } : {}),
     noPromptSurfaceReason: noPromptSurface,
@@ -1318,8 +1450,9 @@ async function emitApprovalRequired(toolName, auditVerdict, toolInput, permissio
     outcome: 'denied_no_prompt_surface',
     event: 'action_guard_denial',
     sessionKey: baseExtra.sessionKey,
+    actionId,
   });
-  recordNotifyAudit(toolName, { ...auditVerdict, reason }, toolInput, baseExtra, notified);
+  recordNotifyAudit(toolName, { ...auditVerdict, reason }, toolInput, { ...baseExtra, actionId }, notified);
   console.error(
     `[shieldcortex] action-guard DENIED ${safeToolName(toolName)}: approval required, but ${noPromptSurface} — denying rather than raising a prompt nothing will answer.`,
   );
@@ -1344,7 +1477,7 @@ async function handleDegradedGuard(toolName, toolInput, cfg, failureNote, permis
   // 1. Catastrophic — hard deny, always.
   if (fallbackCatastrophicMatch(toolInput)) {
     const fallbackVerdict = { severity: 'catastrophic', decision: 'block', signals: ['fallback-scan'], reason: `Guard unavailable: ${failureSummary}; fallback catastrophic scan matched` };
-    writeTerminalOutcomeAudit(
+    const actionId = writeTerminalOutcomeAudit(
       toolName,
       fallbackVerdict,
       toolInput, 'auto_deny', 'auto_denied', 'action_guard_denial', baseExtra,
@@ -1356,8 +1489,9 @@ async function handleDegradedGuard(toolName, toolInput, cfg, failureNote, permis
       outcome: 'auto_denied',
       event: 'action_guard_denial',
       sessionKey: baseExtra.sessionKey,
+      actionId,
     });
-    recordNotifyAudit(toolName, fallbackVerdict, toolInput, baseExtra, notified);
+    recordNotifyAudit(toolName, fallbackVerdict, toolInput, { ...baseExtra, actionId }, notified);
     console.error(`[shieldcortex] ⚠️ action-guard UNAVAILABLE (${failureSummary}) and fallback scan matched a catastrophic pattern — DENYING ${safeToolName(toolName)} (fail-closed, WS2)`);
     emitDecision('deny', terminalDecisionReason(fallbackVerdict, 'auto_denied', 'action_guard_denial'));
     process.exit(0);
@@ -1368,7 +1502,7 @@ async function handleDegradedGuard(toolName, toolInput, cfg, failureNote, permis
   if (dangerousSignal) {
     if (!cfg.enforce) {
       const fallbackWarnVerdict = { severity: 'dangerous', decision: 'require_approval', signals: ['fallback-scan', dangerousSignal], reason: `Guard unavailable: ${failureSummary}; enforce:false advisory` };
-      writeTerminalOutcomeAudit(
+      const actionId = writeTerminalOutcomeAudit(
         toolName,
         fallbackWarnVerdict,
         toolInput, 'gate_degraded', 'failure_allowed', 'action_guard_warning', baseExtra,
@@ -1380,8 +1514,9 @@ async function handleDegradedGuard(toolName, toolInput, cfg, failureNote, permis
         outcome: 'failure_allowed',
         event: 'action_guard_warning',
         sessionKey: baseExtra.sessionKey,
+        actionId,
       });
-      recordNotifyAudit(toolName, fallbackWarnVerdict, toolInput, baseExtra, notified);
+      recordNotifyAudit(toolName, fallbackWarnVerdict, toolInput, { ...baseExtra, actionId }, notified);
       console.error(`[shieldcortex] ⚠️ action-guard unavailable (${failureSummary}) — advisory (enforce:false), allowing dangerous ${safeToolName(toolName)} [${safeSignalList([dangerousSignal]).join(', ')}]`);
       process.exit(0);
     }
@@ -1402,7 +1537,7 @@ async function handleDegradedGuard(toolName, toolInput, cfg, failureNote, permis
 
   // 3. No match — benign/unknown. Fail open, but never silently.
   const fallbackOpenVerdict = { severity: 'benign', decision: 'allow', signals: ['fallback-scan'], reason: `Guard unavailable: ${failureSummary}; fallback matched nothing` };
-  writeTerminalOutcomeAudit(
+  const actionId = writeTerminalOutcomeAudit(
     toolName,
     fallbackOpenVerdict,
     toolInput, 'gate_degraded', 'failure_allowed', 'action_guard_warning', baseExtra,
@@ -1414,8 +1549,9 @@ async function handleDegradedGuard(toolName, toolInput, cfg, failureNote, permis
     outcome: 'failure_allowed',
     event: 'action_guard_warning',
     sessionKey: baseExtra.sessionKey,
+    actionId,
   });
-  recordNotifyAudit(toolName, fallbackOpenVerdict, toolInput, baseExtra, notified);
+  recordNotifyAudit(toolName, fallbackOpenVerdict, toolInput, { ...baseExtra, actionId }, notified);
   console.error(`[shieldcortex] action-guard unavailable (${failureSummary}) — allowing ${safeToolName(toolName)} (fallback matched nothing; fail-open)`);
   process.exit(0);
 }
@@ -1540,7 +1676,7 @@ process.stdin.on('end', async () => {
       if (leaseGate?.acquired) {
         try { (await loadLease())?.releaseToolCallLease(toolName, toolInput, { self: leaseSelf }); } catch { /* self-heals at TTL */ }
       }
-      writeTerminalOutcomeAudit(toolName, verdict, toolInput, 'auto_deny', 'auto_denied', 'action_guard_denial', baseExtra);
+      const actionId = writeTerminalOutcomeAudit(toolName, verdict, toolInput, 'auto_deny', 'auto_denied', 'action_guard_denial', baseExtra);
       const notified = await alertGuardOutcome(getNotify(), {
         toolName,
         toolInput,
@@ -1548,8 +1684,9 @@ process.stdin.on('end', async () => {
         outcome: 'auto_denied',
         event: 'action_guard_denial',
         sessionKey: baseExtra.sessionKey,
+        actionId,
       });
-      recordNotifyAudit(toolName, verdict, toolInput, baseExtra, notified);
+      recordNotifyAudit(toolName, verdict, toolInput, { ...baseExtra, actionId }, notified);
       console.error(
         `[shieldcortex] action-guard BLOCKED ${safeToolName(toolName)}: ${safeGuardOutcomeReason(verdict, 'auto_denied', 'action_guard_denial')} [${safeSignalList(verdict.signals).join(', ')}]`,
       );
@@ -1574,7 +1711,7 @@ process.stdin.on('end', async () => {
     }
 
     if (!cfg.enforce) {
-      writeTerminalOutcomeAudit(toolName, verdict, toolInput, 'warn', 'warned', 'action_guard_warning', baseExtra);
+      const actionId = writeTerminalOutcomeAudit(toolName, verdict, toolInput, 'warn', 'warned', 'action_guard_warning', baseExtra);
       const notified = await alertGuardOutcome(getNotify(), {
         toolName,
         toolInput,
@@ -1582,8 +1719,9 @@ process.stdin.on('end', async () => {
         outcome: 'warned',
         event: 'action_guard_warning',
         sessionKey: baseExtra.sessionKey,
+        actionId,
       });
-      recordNotifyAudit(toolName, verdict, toolInput, baseExtra, notified);
+      recordNotifyAudit(toolName, verdict, toolInput, { ...baseExtra, actionId }, notified);
       console.error(`[shieldcortex] ⚠️ Action Guard: ${safeToolName(toolName)} — ${safeGuardOutcomeReason(verdict, 'warned', 'action_guard_warning')}`);
       process.exit(0); // Advisory: warn, emit no decision.
     }
@@ -1620,7 +1758,7 @@ process.stdin.on('end', async () => {
 
     if (brokered?.outcome === 'harden') {
       const brokerAudit = safeBrokerAudit(brokered.audit);
-      writeTerminalOutcomeAudit(toolName, { ...verdict, reason: brokered.reason ?? verdict.reason }, toolInput, 'require_approval', 'auto_denied', 'action_guard_denial', { ...baseExtra, ...(brokerAudit ? { broker: brokerAudit } : {}) });
+      const actionId = writeTerminalOutcomeAudit(toolName, { ...verdict, reason: brokered.reason ?? verdict.reason }, toolInput, 'require_approval', 'auto_denied', 'action_guard_denial', { ...baseExtra, ...(brokerAudit ? { broker: brokerAudit } : {}) });
       const notified = await alertGuardOutcome(getNotify(), {
         toolName,
         toolInput,
@@ -1628,8 +1766,9 @@ process.stdin.on('end', async () => {
         outcome: 'auto_denied',
         event: 'action_guard_denial',
         sessionKey: baseExtra.sessionKey,
+        actionId,
       });
-      recordNotifyAudit(toolName, { ...verdict, reason: brokered.reason ?? verdict.reason }, toolInput, baseExtra, notified);
+      recordNotifyAudit(toolName, { ...verdict, reason: brokered.reason ?? verdict.reason }, toolInput, { ...baseExtra, actionId, ...(brokerAudit ? { broker: brokerAudit } : {}) }, notified);
       console.error(`[shieldcortex] approval broker HARDENED ${safeToolName(toolName)} to a denial: ${safeDiagnosticReason(brokered.reason)}`);
       // No approve-hash offered. Hardening exists precisely for the case where
       // the request is trying to talk somebody into saying yes.

--- a/src/__tests__/prompt-surface-deny.test.ts
+++ b/src/__tests__/prompt-surface-deny.test.ts
@@ -90,6 +90,12 @@ describe('Action Guard hook — prompt-surface rule', () => {
     const dir = path.join(tempHome, '.shieldcortex', 'audit');
     const file = fs.readdirSync(dir).find((n) => /^realtime-.*\.jsonl$/.test(n))!;
     const lines = fs.readFileSync(path.join(dir, file), 'utf-8').trim().split('\n');
+    // #284 writes a trailing notify-status row after the denial. Prefer the
+    // last non-notify intercept so existing assertions keep reading the verdict.
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const row = JSON.parse(lines[i]) as Record<string, unknown>;
+      if (row.action !== 'notify') return row;
+    }
     return JSON.parse(lines[lines.length - 1]);
   }
 
@@ -163,7 +169,10 @@ describe('Action Guard hook — prompt-surface rule', () => {
       expect(String(rows[0].surface)).toMatch(/redacted action surface/i);
       expect(JSON.stringify(rows[0])).not.toContain(DANGEROUS_COMMAND);
       expect(JSON.stringify(rows[0])).not.toContain(secret);
-      expect(String(rows[0].correlationId)).toMatch(/^sc-[a-f0-9]{16}$/);
+      // #284 Face 3 — correlationId is action-scoped; session identity is sessionId.
+      expect(String(rows[0].correlationId)).toMatch(/^act-[a-f0-9]{16}$/);
+      expect(rows[0].origin).toBe('claude-code-hook');
+      expect(String(rows[0].actionId)).toMatch(/^act-[a-f0-9]{16}$/);
     });
 
     it('records the local denial before notify loading, even when the configured dist root is unusable', async () => {
@@ -329,8 +338,11 @@ describe('Action Guard hook — prompt-surface rule', () => {
       expect(deliveries[0].headers['x-shieldcortex-event']).toBe('action_guard_denial');
       expect(body.event).toBe('action_guard_denial');
       expect(body.outcome).toBe('denied_no_prompt_surface');
-      expect(body.correlationId).toMatch(/^sc-[a-f0-9]{16}$/);
-      expect(body.sessionId).toBeUndefined();
+      // #284 — correlation is the action id; session may be present as sessionId.
+      expect(String(body.correlationId)).toMatch(/^act-[a-f0-9]{16}$/);
+      if (body.sessionId !== undefined) {
+        expect(String(body.sessionId)).toMatch(/^sc-[a-f0-9]{16}$/);
+      }
       expect(body.cwd).toBeUndefined();
       expect(String(body.surface)).toMatch(/redacted action surface/i);
       expect(JSON.stringify(body)).not.toContain(DANGEROUS_COMMAND);

--- a/src/__tests__/prompt-surface-deny.test.ts
+++ b/src/__tests__/prompt-surface-deny.test.ts
@@ -160,19 +160,21 @@ describe('Action Guard hook — prompt-surface rule', () => {
       expect(decisionOf(result.stdout).permissionDecision).toBe('deny');
       expect(result.stderr).toMatch(/denials\.jsonl/);
       const rows = localDenials();
-      expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({
+      // #284 write-first: pending + final notify status share one actionId.
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      const row = rows[rows.length - 1];
+      expect(row).toMatchObject({
         event: 'action_guard_denial',
         outcome: 'denied_no_prompt_surface',
         tool: 'Bash',
       });
-      expect(String(rows[0].surface)).toMatch(/redacted action surface/i);
-      expect(JSON.stringify(rows[0])).not.toContain(DANGEROUS_COMMAND);
-      expect(JSON.stringify(rows[0])).not.toContain(secret);
+      expect(String(row.surface)).toMatch(/redacted action surface/i);
+      expect(JSON.stringify(rows)).not.toContain(DANGEROUS_COMMAND);
+      expect(JSON.stringify(rows)).not.toContain(secret);
       // #284 Face 3 — correlationId is action-scoped; session identity is sessionId.
-      expect(String(rows[0].correlationId)).toMatch(/^act-[a-f0-9]{16}$/);
-      expect(rows[0].origin).toBe('claude-code-hook');
-      expect(String(rows[0].actionId)).toMatch(/^act-[a-f0-9]{16}$/);
+      expect(String(row.correlationId)).toMatch(/^act-[a-f0-9]{16}$/);
+      expect(row.origin).toBe('claude-code-hook');
+      expect(String(row.actionId)).toMatch(/^act-[a-f0-9]{16}$/);
     });
 
     it('records the local denial before notify loading, even when the configured dist root is unusable', async () => {
@@ -184,8 +186,8 @@ describe('Action Guard hook — prompt-surface rule', () => {
 
       expect(decisionOf(result.stdout).permissionDecision).toBe('deny');
       const rows = localDenials();
-      expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      expect(rows[rows.length - 1]).toMatchObject({
         event: 'action_guard_denial',
         outcome: 'denied_no_prompt_surface',
         tool: 'Bash',

--- a/src/defence/iron-dome/__tests__/deny-path-forensics-284.test.ts
+++ b/src/defence/iron-dome/__tests__/deny-path-forensics-284.test.ts
@@ -1,0 +1,138 @@
+/**
+ * #284 — Deny-path forensics.
+ *
+ * Four faces from live production hosts:
+ * 1. signals must not collapse to redacted-signal for real guard rules
+ * 2. origin present on auto_deny / critical denial rows
+ * 3. action-scoped id distinct from session id
+ * 4. notify status on the denial/audit path (not only stderr)
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { buildActionGuardOutcomeNotification, formatActionGuardOutcomeNotification } from '../operator-notify.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const hookPath = path.resolve(here, '../../../../scripts/pre-tool-hook.mjs');
+
+function runHook(payload: Record<string, unknown>, home: string) {
+  const res = spawnSync(process.execPath, [hookPath], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+    timeout: 15_000,
+  });
+  return res;
+}
+
+function readJsonl(file: string): Array<Record<string, unknown>> {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('#284 deny-path forensics', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-284-'));
+    fs.mkdirSync(path.join(home, '.shieldcortex'), { recursive: true });
+    // enforced Action Guard with no notify channel configured
+    fs.writeFileSync(
+      path.join(home, '.shieldcortex', 'config.json'),
+      JSON.stringify({
+        actionGuard: { enabled: true, enforce: true, autoApprove: [] },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('Face 1+2+3: auto_deny row names real signal, origin, and action id', () => {
+    const session = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; // 32 hex → sc- hash path may differ; pass session_id
+    const res = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+      session_id: session,
+      permission_mode: 'default',
+    }, home);
+    expect(res.status).toBe(0);
+
+    const denials = readJsonl(path.join(home, '.shieldcortex', 'denials.jsonl'));
+    expect(denials.length).toBeGreaterThan(0);
+    const row = denials[denials.length - 1];
+
+    // Face 1 — real signal, not only redacted-signal
+    expect(Array.isArray(row.signals)).toBe(true);
+    expect(row.signals).toEqual(expect.arrayContaining(['recursive-force-delete']));
+    expect(row.signals).not.toEqual(['redacted-signal']);
+
+    // Face 1 wording — points at realtime audit, not vague "local audit"
+    expect(String(row.surface)).toMatch(/realtime-\*\.jsonl/);
+
+    // Face 2 — origin on auto_deny/critical
+    expect(row.origin).toBe('claude-code-hook');
+    expect(row.outcome).toBe('auto_denied');
+    expect(row.severity === 'critical' || row.severity === 'catastrophic').toBe(true);
+
+    // Face 3 — action-scoped id
+    expect(String(row.actionId)).toMatch(/^act-[a-f0-9]{16}$/);
+    expect(String(row.correlationId)).toMatch(/^act-[a-f0-9]{16}$/);
+    // session id separate when present
+    if (row.sessionId) {
+      expect(String(row.sessionId)).toMatch(/^sc-[a-f0-9]{16}$/);
+      expect(row.sessionId).not.toBe(row.actionId);
+    }
+
+    // Face 4 — notify status on the denial row itself
+    expect(row.notify).toEqual(expect.objectContaining({
+      status: expect.stringMatching(/^(not_configured|no_channel|delivered|error)$/),
+    }));
+  });
+
+  it('Face 3: two denials in one session get distinct action ids', () => {
+    const session = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    for (const cmd of ['rm -rf /', 'mkfs.ext4 /dev/sda']) {
+      const res = runHook({
+        tool_name: 'Bash',
+        tool_input: { command: cmd },
+        session_id: session,
+        permission_mode: 'bypassPermissions',
+      }, home);
+      expect(res.status).toBe(0);
+    }
+    const denials = readJsonl(path.join(home, '.shieldcortex', 'denials.jsonl'));
+    expect(denials.length).toBeGreaterThanOrEqual(2);
+    const ids = denials.map((d) => d.actionId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('operator-notify keeps recursive-force-delete and action correlation', () => {
+    const n = buildActionGuardOutcomeNotification({
+      event: 'action_guard_denial',
+      outcome: 'auto_denied',
+      tool: 'Bash',
+      signals: ['recursive-force-delete', 'totally-unknown-signal'],
+      severity: 'critical',
+      detectedAt: '2026-08-14T12:00:00.000Z',
+      correlationId: 'act-0123456789abcdef',
+      // @ts-expect-error extended fields for #284
+      actionId: 'act-0123456789abcdef',
+      sessionId: 'sc-0123456789abcdef',
+      origin: 'claude-code-hook',
+    } as any);
+    expect(n.signals).toEqual(expect.arrayContaining(['recursive-force-delete', 'redacted-signal']));
+    expect(n.correlationId).toBe('act-0123456789abcdef');
+    const text = formatActionGuardOutcomeNotification(n as any);
+    expect(text).toMatch(/recursive-force-delete/);
+    expect(text).toMatch(/Origin:\s+claude-code-hook/);
+    expect(text).toMatch(/Action:\s+act-0123456789abcdef/);
+  });
+});

--- a/src/defence/iron-dome/__tests__/deny-path-forensics-284.test.ts
+++ b/src/defence/iron-dome/__tests__/deny-path-forensics-284.test.ts
@@ -109,9 +109,35 @@ describe('#284 deny-path forensics', () => {
       expect(res.status).toBe(0);
     }
     const denials = readJsonl(path.join(home, '.shieldcortex', 'denials.jsonl'));
+    // write-first records pending+final per call (same actionId); two calls → 2 unique ids.
+    expect(denials.length).toBeGreaterThanOrEqual(4);
+    const ids = [...new Set(denials.map((d) => d.actionId))];
+    expect(ids.length).toBe(2);
+    for (const id of ids) expect(String(id)).toMatch(/^act-[a-f0-9]{16}$/);
+  });
+
+
+  it('Face 4 write-first: denial row exists before notify settles (pending then final)', () => {
+    const res = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+      session_id: 'cccccccccccccccccccccccccccccccc',
+      permission_mode: 'default',
+    }, home);
+    expect(res.status).toBe(0);
+    const denials = readJsonl(path.join(home, '.shieldcortex', 'denials.jsonl'));
+    // With no notify channel: pending + final(not_configured|no_channel)
     expect(denials.length).toBeGreaterThanOrEqual(2);
-    const ids = denials.map((d) => d.actionId);
-    expect(new Set(ids).size).toBe(ids.length);
+    const ids = new Set(denials.map((d) => d.actionId));
+    expect(ids.size).toBe(1);
+    const statuses = denials.map((d) => (d.notify as { status?: string } | undefined)?.status);
+    expect(statuses).toEqual(expect.arrayContaining(['pending']));
+    expect(statuses.some((s) => s && s !== 'pending')).toBe(true);
+    // Every row still carries forensics faces
+    for (const row of denials) {
+      expect(row.origin).toBe('claude-code-hook');
+      expect(row.signals).toEqual(expect.arrayContaining(['recursive-force-delete']));
+    }
   });
 
   it('operator-notify keeps recursive-force-delete and action correlation', () => {

--- a/src/defence/iron-dome/operator-notify.ts
+++ b/src/defence/iron-dome/operator-notify.ts
@@ -397,6 +397,20 @@ const SAFE_ACTION_GUARD_SIGNALS = new Set([
   'filesystem-destructive', 'destructive-filesystem', 'dangerous-shell',
   'command-exec', 'network-egress', 'credential-access', 'data-exfiltration',
   'untrusted-script', 'reviewed-script', 'shell-injection', 'persistence-risk',
+  // #284 Face 1 — keep real guard signals on operator-notify / denial rows.
+  'install-package', 'git-force-push', 'local-package-install', 'move-or-copy', 'file-delete', 'service-restart', 'exec-like',
+  'recursive-force-delete', 'delete-root-or-home', 'fork-bomb', 'format-filesystem',
+  'raw-disk-write', 'redirect-to-block-device', 'disk-partition-tool',
+  'pipe-download-to-shell', 'pipe-download-stdin-exec', 'pipe-download-module-exec',
+  'recursive-perms-on-root', 'shred-device', 'git-delete-branch',
+  'stop-process-or-service', 'modify-network-firewall', 'install-package-global',
+  'modify-scheduler', 'truncate-to-zero', 'wipe-history-or-logs',
+  'touch-sensitive-path', 'touch-approval-store', 'touch-decisions-ledger',
+  'dd-overwrite', 'recursive-perms-system-dir', 'registry-code-exec',
+  'decode-pipe-to-shell', 'change-permissions', 'git-mutate',
+  'recursive-find-delete', 'external-egress', 'oversized-command',
+  'opaque-script-invocation', 'opaque-script', 'secret-egress-fold',
+  'force-push', 'force-push-invocation',
 ]);
 const SAFE_ACTION_GUARD_OUTCOMES = new Set([
   'auto_denied', 'denied_no_prompt_surface', 'failure_denied', 'warned', 'failure_allowed',
@@ -448,7 +462,8 @@ function safeActionGuardReason(event: ActionGuardOutcomeEvent, outcome: string):
 
 function safeActionGuardCorrelationId(v: unknown): string | undefined {
   const text = String(v ?? '').trim();
-  return /^sc-[a-f0-9]{16}$/.test(text) ? text : undefined;
+  // #284: correlationId is action-scoped (act-…) going forward; keep sc- for legacy.
+  return /^(?:act|sc)-[a-f0-9]{16}$/.test(text) ? text : undefined;
 }
 
 function safeDetectedAt(v: unknown): string {
@@ -473,8 +488,17 @@ export function buildActionGuardOutcomeNotification(
     reason: safeActionGuardReason(event, outcome),
     detectedAt: safeDetectedAt(input.detectedAt),
   };
-  const correlationId = safeActionGuardCorrelationId(input.correlationId);
+  const correlationId = safeActionGuardCorrelationId(input.correlationId)
+    ?? safeActionGuardCorrelationId((input as { actionId?: string }).actionId);
   if (correlationId) n.correlationId = correlationId;
+  const actionId = safeActionGuardCorrelationId((input as { actionId?: string }).actionId);
+  if (actionId) (n as { actionId?: string }).actionId = actionId;
+  const sessionRaw = String((input as { sessionId?: string }).sessionId ?? '').trim();
+  if (/^sc-[a-f0-9]{16}$/.test(sessionRaw)) (n as { sessionId?: string }).sessionId = sessionRaw;
+  const origin = String((input as { origin?: string }).origin ?? '').trim();
+  if (origin === 'claude-code-hook' || origin === 'openclaw-interceptor') {
+    (n as { origin?: string }).origin = origin;
+  }
   return n;
 }
 
@@ -559,6 +583,9 @@ export function formatActionGuardOutcomeNotification(n: ActionGuardOutcomeNotifi
     `Outcome:   ${n.outcome}`,
     `Reason:    ${n.reason}`,
   ];
+  if ((n as { origin?: string }).origin) lines.push(`Origin:    ${(n as { origin?: string }).origin}`);
+  if ((n as { actionId?: string }).actionId) lines.push(`Action:    ${(n as { actionId?: string }).actionId}`);
+  if ((n as { sessionId?: string }).sessionId) lines.push(`Session:   ${(n as { sessionId?: string }).sessionId}`);
   if (n.correlationId) lines.push(`Correlation: ${n.correlationId}`);
   lines.push(`At:        ${n.detectedAt}`);
   lines.push('');


### PR DESCRIPTION
## Why
#284 (Jarvis + Veronica live hosts): an enforced host could not audit its own guard.

Four faces:
1. Denial signals collapsed to `redacted-signal`
2. `origin` missing on auto_deny/critical denials.jsonl rows
3. `correlationId` was session-scoped (many actions, one id)
4. Notify delivery only on stderr

## What
- Expand SAFE signal allowlists (hook + operator-notify) with real Action Guard rule names
- Point redacted surface text at `~/.shieldcortex/audit/realtime-*.jsonl`
- Stamp `origin: claude-code-hook` on every local denial row
- Mint `act-…` action ids; keep `sessionId` separate; correlationId = action id
- Record notify status on denial row + durable audit notify row (`not_configured` / `no_channel` / `delivered` / `error`)
- Do not mint `actionKey` from raw deny-path toolInput (would re-leak command)

## Verify
- build clean
- 3 suites / **72 tests** (new #284 + prompt-surface-deny + operator-notify)

Closes #284