### PR TITLE
fix(guard): allow read-only inspection of approval/decisions stores (#89)

### DIFF
--- a/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
@@ -24,7 +24,7 @@ describe('#89 — read-only shell inspection of guard stores is allowed', () => 
     ['grep approvals', 'grep -n hash ~/.shieldcortex/approvals/*'],
     ['head approvals', 'head -20 ~/.shieldcortex/approvals/approvals.json'],
     ['stat approvals', 'stat ~/.shieldcortex/approvals'],
-    ['pipeline read', 'cat ~/.shieldcortex/approvals/approvals.json | jq .'],
+    ['pipeline read', 'cat ~/.shieldcortex/approvals/approvals.json | head -5'],
     ['echo then ls', 'echo hi; ls ~/.shieldcortex/approvals'],
     ['rg approvals', 'rg hash ~/.shieldcortex/approvals'],
   ])('ALLOWs %s', (_name, cmd) => {
@@ -120,8 +120,8 @@ describe('#89 — round-4 Grok mint paths stay gated', () => {
     expect(v.decision).not.toBe('allow');
   });
 
-  it('cat store | jq still allows (every stage readonly)', () => {
-    const v = gate('cat ~/.shieldcortex/approvals/approvals.json | jq .');
+  it('cat store | head still allows (every stage readonly)', () => {
+    const v = gate('cat ~/.shieldcortex/approvals/approvals.json | head -5');
     expect(v.decision).toBe('allow');
     expect(v.signals).not.toContain('touch-approval-store');
   });
@@ -147,5 +147,23 @@ describe('#89 — round-5 Grok sibling/background mint paths stay gated', () => 
   it('2>&1 does not split as background', () => {
     const v = gate('ls ~/.shieldcortex/approvals 2>&1');
     expect(v.decision).toBe('allow');
+  });
+});
+
+describe('#89 — round-6 glued redirect + jq -i mint paths stay gated', () => {
+  it.each([
+    ['glued redirect', "echo '{}'>~/.shieldcortex/approvals/approvals.json"],
+    ['glued append', "echo x>>~/.shieldcortex/approvals/approvals.json"],
+    ['glued var redirect', "p=~/.shieldcortex/approvals/approvals.json; echo '{}'>$p"],
+    ['jq -i', "jq -i '.x=1' ~/.shieldcortex/approvals/approvals.json"],
+    ['rg --pre', 'rg --pre tee hash ~/.shieldcortex/approvals'],
+  ])('GATEs %s with store signal', (_name, cmd) => {
+    const v = gate(cmd);
+    expect(v.decision).not.toBe('allow');
+    expect(
+      v.signals.includes('touch-approval-store')
+      || v.signals.includes('touch-decisions-ledger')
+      || v.decision === 'block',
+    ).toBe(true);
   });
 });

--- a/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
@@ -126,3 +126,26 @@ describe('#89 — round-4 Grok mint paths stay gated', () => {
     expect(v.signals).not.toContain('touch-approval-store');
   });
 });
+
+describe('#89 — round-5 Grok sibling/background mint paths stay gated', () => {
+  it.each([
+    ['sibling python writer', `ls ~/.shieldcortex/approvals; python3 -c "(pathlib.Path.home()/'.shieldcortex'/'approvals'/'approvals.json').write_text('{}')"`],
+    ['and-and python writer', `ls ~/.shieldcortex/approvals && python3 -c "open('/home/u/.shieldcortex/approvals/approvals.json','w').write('{}')"`],
+    ['background python writer', `ls ~/.shieldcortex/approvals & python3 -c "open('/home/u/.shieldcortex/approvals/approvals.json','w').write('{}')"`],
+    ['var redirect mint', `p=~/.shieldcortex/approvals/approvals.json; echo '{}' >$p`],
+  ])('GATEs %s', (_name, cmd) => {
+    const v = gate(cmd);
+    expect(v.decision).not.toBe('allow');
+  });
+
+  it('echo hi; ls store still allows (all statements readonly)', () => {
+    const v = gate('echo hi; ls ~/.shieldcortex/approvals');
+    expect(v.decision).toBe('allow');
+    expect(v.signals).not.toContain('touch-approval-store');
+  });
+
+  it('2>&1 does not split as background', () => {
+    const v = gate('ls ~/.shieldcortex/approvals 2>&1');
+    expect(v.decision).toBe('allow');
+  });
+});

--- a/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
@@ -9,12 +9,14 @@ import {
  * read-only diagnostics against ~/.shieldcortex/approvals were require_approval
  * on touch-approval-store — self-referential deadlock on enforced hosts.
  *
- * Mutating the store must STILL gate. Sensitive paths (.ssh/.env) are untouched.
+ * Policy (Grok 4.6 + SOL floor): FAIL CLOSED. Only pure shell observation
+ * verbs (ls/cat/grep/…) drop the gate. Interpreters stay gated when they
+ * name the store — a mutation denylist can never be complete.
  */
 
 const gate = (command: string) => evaluateToolCall('Bash', { command });
 
-describe('#89 — read-only inspection of guard stores is allowed', () => {
+describe('#89 — read-only shell inspection of guard stores is allowed', () => {
   it.each([
     ['ls approvals', 'ls -la ~/.shieldcortex/approvals'],
     ['ls leases', 'ls ~/.shieldcortex/leases'],
@@ -23,9 +25,8 @@ describe('#89 — read-only inspection of guard stores is allowed', () => {
     ['head approvals', 'head -20 ~/.shieldcortex/approvals/approvals.json'],
     ['stat approvals', 'stat ~/.shieldcortex/approvals'],
     ['pipeline read', 'cat ~/.shieldcortex/approvals/approvals.json | jq .'],
-    ['python read open', "python3 -c \"print(open('/home/u/.shieldcortex/approvals/approvals.json').read())\""],
     ['echo then ls', 'echo hi; ls ~/.shieldcortex/approvals'],
-    ['find approvals', 'find ~/.shieldcortex/approvals -type f'],
+    ['rg approvals', 'rg hash ~/.shieldcortex/approvals'],
   ])('ALLOWs %s', (_name, cmd) => {
     const v = gate(cmd);
     expect(v.signals).not.toContain('touch-approval-store');
@@ -34,9 +35,32 @@ describe('#89 — read-only inspection of guard stores is allowed', () => {
   });
 });
 
-describe('#89 — mutating guard stores still gates (must-still-fire)', () => {
+describe('#89 — interpreters naming the store stay gated (fail closed)', () => {
+  it.each([
+    ['python read open', "python3 -c \"print(open('/home/u/.shieldcortex/approvals/approvals.json').read())\""],
+    ['python write', "python3 -c \"import json;json.dump({},open('/home/u/.shieldcortex/approvals/approvals.json','w'))\""],
+    ['python os.remove', "python3 -c \"import os;os.remove('/home/u/.shieldcortex/approvals/approvals.json')\""],
+    ['python os.system touch', "python3 -c \"import os;os.system('touch ~/.shieldcortex/approvals/x')\""],
+    ['node read', "node -e \"console.log(require('fs').readFileSync('/home/u/.shieldcortex/approvals/approvals.json','utf8'))\""],
+    ['node write', "node -e \"require('fs').writeFileSync('/home/u/.shieldcortex/approvals/approvals.json','{}')\""],
+    ['node unlinkSync', "node -e \"require('fs').unlinkSync('/home/u/.shieldcortex/approvals/approvals.json')\""],
+    ['find approvals', 'find ~/.shieldcortex/approvals -type f'],
+    ['sed print', "sed -n '1,5p' ~/.shieldcortex/approvals/approvals.json"],
+  ])('GATEs %s', (_name, cmd) => {
+    const v = gate(cmd);
+    expect(v.decision).not.toBe('allow');
+    expect(
+      v.signals.includes('touch-approval-store')
+      || v.signals.includes('touch-decisions-ledger'),
+    ).toBe(true);
+  });
+});
+
+describe('#89 — shell mutations still gate (must-still-fire)', () => {
   it.each([
     ['redirect write', "echo '{}' > ~/.shieldcortex/approvals/approvals.json"],
+    ['noclobber redirect', "echo '{}' >| ~/.shieldcortex/approvals/approvals.json"],
+    ['quoted redirect', 'echo x >"$HOME/.shieldcortex/approvals/x.json"'],
     ['append DECISIONS', 'echo x >> ~/.shieldcortex/DECISIONS.md'],
     ['rm approvals', 'rm ~/.shieldcortex/approvals/approvals.json'],
     ['rm -rf approvals', 'rm -rf ~/.shieldcortex/approvals'],
@@ -44,16 +68,11 @@ describe('#89 — mutating guard stores still gates (must-still-fire)', () => {
     ['chmod approvals', 'chmod -R 777 ~/.shieldcortex/approvals'],
     ['touch new', 'touch ~/.shieldcortex/approvals/new'],
     ['tee write', 'echo x | tee ~/.shieldcortex/approvals/x.json'],
-    ['python write', "python3 -c \"import json;json.dump({},open('/home/u/.shieldcortex/approvals/approvals.json','w'))\""],
-    ['node write', "node -e \"require('fs').writeFileSync('/home/u/.shieldcortex/approvals/approvals.json','{}')\""],
     ['cp into store', 'cp /tmp/x ~/.shieldcortex/approvals/x.json'],
+    ['sed -i', "sed -i 's/a/b/' ~/.shieldcortex/approvals/approvals.json"],
+    ['find -delete', 'find ~/.shieldcortex/approvals -delete'],
   ])('GATEs %s', (_name, cmd) => {
     const v = gate(cmd);
-    expect(
-      v.signals.includes('touch-approval-store')
-      || v.signals.includes('touch-decisions-ledger')
-      || v.decision !== 'allow',
-    ).toBe(true);
     expect(v.decision).not.toBe('allow');
   });
 });
@@ -76,31 +95,14 @@ describe('#89 — guardStoreAccessIsReadOnly helper', () => {
     expect(guardStoreAccessIsReadOnly('ls ~/.shieldcortex/approvals')).toBe(true);
     expect(guardStoreAccessIsReadOnly('cat ~/.shieldcortex/DECISIONS.md')).toBe(true);
   });
-  it('false for redirects and rm', () => {
+  it('false for redirects, rm, interpreters, find', () => {
     expect(guardStoreAccessIsReadOnly('echo x > ~/.shieldcortex/approvals/a')).toBe(false);
+    expect(guardStoreAccessIsReadOnly("echo x >| ~/.shieldcortex/approvals/a")).toBe(false);
     expect(guardStoreAccessIsReadOnly('rm ~/.shieldcortex/approvals/a')).toBe(false);
+    expect(guardStoreAccessIsReadOnly("python3 -c \"print(open('/home/u/.shieldcortex/approvals/a').read())\"")).toBe(false);
+    expect(guardStoreAccessIsReadOnly('find ~/.shieldcortex/approvals -type f')).toBe(false);
   });
   it('false when no store path present', () => {
     expect(guardStoreAccessIsReadOnly('ls /tmp')).toBe(false);
-  });
-});
-
-describe('#89 — dual-review must-still-fire (Grok 4.6 / SOL)', () => {
-  it.each([
-    ['sed -i', "sed -i 's/a/b/' ~/.shieldcortex/approvals/approvals.json"],
-    ['find -delete', 'find ~/.shieldcortex/approvals -delete'],
-    ['find -exec rm', 'find ~/.shieldcortex/approvals -exec rm {} +'],
-    ['python os.remove', "python3 -c \"import os;os.remove('/home/u/.shieldcortex/approvals/approvals.json')\""],
-    ['python os.system touch', "python3 -c \"import os;os.system('touch ~/.shieldcortex/approvals/x')\""],
-    ['python open r+', "python3 -c \"open('/home/u/.shieldcortex/approvals/approvals.json','r+').write('x')\""],
-    ['python shutil.move', "python3 -c \"import shutil;shutil.move('/home/u/.shieldcortex/approvals/a','/tmp/a')\""],
-    ['node unlinkSync', "node -e \"require('fs').unlinkSync('/home/u/.shieldcortex/approvals/approvals.json')\""],
-    ['node execSync touch', "node -e \"require('child_process').execSync('touch ~/.shieldcortex/approvals/x')\""],
-    ['node copyFileSync', "node -e \"require('fs').copyFileSync('/tmp/x','/home/u/.shieldcortex/approvals/x')\""],
-    ['quoted redirect', 'echo x >"$HOME/.shieldcortex/approvals/x.json"'],
-    ['perl -i', "perl -i -pe 's/a/b/' ~/.shieldcortex/approvals/approvals.json"],
-  ])('GATEs %s', (_name, cmd) => {
-    const v = gate(cmd);
-    expect(v.decision).not.toBe('allow');
   });
 });

--- a/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
@@ -106,3 +106,23 @@ describe('#89 — guardStoreAccessIsReadOnly helper', () => {
     expect(guardStoreAccessIsReadOnly('ls /tmp')).toBe(false);
   });
 });
+
+describe('#89 — round-4 Grok mint paths stay gated', () => {
+  it.each([
+    ['cmd subst python write', `echo $(python3 -c "open('/home/u/.shieldcortex/approvals/approvals.json','w').write('{}')")`],
+    ['process subst write', `echo '{}' > >(python3 -c "open('/home/u/.shieldcortex/approvals/approvals.json','w').write(open(0).read())")`],
+    ['path-smuggling pipeline', `echo ~/.shieldcortex/approvals/approvals.json | python3 -c "import sys; open(sys.stdin.read().strip(),'w').write('{}')"`],
+    ['cat store | python writer', `cat ~/.shieldcortex/approvals/approvals.json | python3 -c "import pathlib; (pathlib.Path.home()/'.shieldcortex'/'approvals'/'approvals.json').write_text('{}')"`],
+    ['yq -i', `yq -i '.x=1' ~/.shieldcortex/approvals/approvals.json`],
+    ['backticks', 'echo `cat ~/.shieldcortex/approvals/approvals.json`'],
+  ])('GATEs %s', (_name, cmd) => {
+    const v = gate(cmd);
+    expect(v.decision).not.toBe('allow');
+  });
+
+  it('cat store | jq still allows (every stage readonly)', () => {
+    const v = gate('cat ~/.shieldcortex/approvals/approvals.json | jq .');
+    expect(v.decision).toBe('allow');
+    expect(v.signals).not.toContain('touch-approval-store');
+  });
+});

--- a/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  evaluateToolCall,
+  guardStoreAccessIsReadOnly,
+} from '../tool-action-guard.js';
+
+/**
+ * #89 residual (live 2026-08-14, Jarvis field report):
+ * read-only diagnostics against ~/.shieldcortex/approvals were require_approval
+ * on touch-approval-store — self-referential deadlock on enforced hosts.
+ *
+ * Mutating the store must STILL gate. Sensitive paths (.ssh/.env) are untouched.
+ */
+
+const gate = (command: string) => evaluateToolCall('Bash', { command });
+
+describe('#89 — read-only inspection of guard stores is allowed', () => {
+  it.each([
+    ['ls approvals', 'ls -la ~/.shieldcortex/approvals'],
+    ['ls leases', 'ls ~/.shieldcortex/leases'],
+    ['cat DECISIONS', 'cat ~/.shieldcortex/DECISIONS.md'],
+    ['grep approvals', 'grep -n hash ~/.shieldcortex/approvals/*'],
+    ['head approvals', 'head -20 ~/.shieldcortex/approvals/approvals.json'],
+    ['stat approvals', 'stat ~/.shieldcortex/approvals'],
+    ['pipeline read', 'cat ~/.shieldcortex/approvals/approvals.json | jq .'],
+    ['python read open', "python3 -c \"print(open('/home/u/.shieldcortex/approvals/approvals.json').read())\""],
+    ['echo then ls', 'echo hi; ls ~/.shieldcortex/approvals'],
+    ['find approvals', 'find ~/.shieldcortex/approvals -type f'],
+  ])('ALLOWs %s', (_name, cmd) => {
+    const v = gate(cmd);
+    expect(v.signals).not.toContain('touch-approval-store');
+    expect(v.signals).not.toContain('touch-decisions-ledger');
+    expect(v.decision).toBe('allow');
+  });
+});
+
+describe('#89 — mutating guard stores still gates (must-still-fire)', () => {
+  it.each([
+    ['redirect write', "echo '{}' > ~/.shieldcortex/approvals/approvals.json"],
+    ['append DECISIONS', 'echo x >> ~/.shieldcortex/DECISIONS.md'],
+    ['rm approvals', 'rm ~/.shieldcortex/approvals/approvals.json'],
+    ['rm -rf approvals', 'rm -rf ~/.shieldcortex/approvals'],
+    ['mv approvals', 'mv ~/.shieldcortex/approvals /tmp/x'],
+    ['chmod approvals', 'chmod -R 777 ~/.shieldcortex/approvals'],
+    ['touch new', 'touch ~/.shieldcortex/approvals/new'],
+    ['tee write', 'echo x | tee ~/.shieldcortex/approvals/x.json'],
+    ['python write', "python3 -c \"import json;json.dump({},open('/home/u/.shieldcortex/approvals/approvals.json','w'))\""],
+    ['node write', "node -e \"require('fs').writeFileSync('/home/u/.shieldcortex/approvals/approvals.json','{}')\""],
+    ['cp into store', 'cp /tmp/x ~/.shieldcortex/approvals/x.json'],
+  ])('GATEs %s', (_name, cmd) => {
+    const v = gate(cmd);
+    expect(
+      v.signals.includes('touch-approval-store')
+      || v.signals.includes('touch-decisions-ledger')
+      || v.decision !== 'allow',
+    ).toBe(true);
+    expect(v.decision).not.toBe('allow');
+  });
+});
+
+describe('#89 — touch-sensitive-path is NOT relaxed by the store carve-out', () => {
+  it('still gates reading ~/.ssh/id_rsa', () => {
+    const v = gate('cat ~/.ssh/id_rsa');
+    expect(v.signals).toContain('touch-sensitive-path');
+    expect(v.decision).not.toBe('allow');
+  });
+
+  it('still gates reading a .env file', () => {
+    const v = gate('cat /home/u/proj/.env');
+    expect(v.signals).toContain('touch-sensitive-path');
+  });
+});
+
+describe('#89 — guardStoreAccessIsReadOnly helper', () => {
+  it('true for pure ls/cat', () => {
+    expect(guardStoreAccessIsReadOnly('ls ~/.shieldcortex/approvals')).toBe(true);
+    expect(guardStoreAccessIsReadOnly('cat ~/.shieldcortex/DECISIONS.md')).toBe(true);
+  });
+  it('false for redirects and rm', () => {
+    expect(guardStoreAccessIsReadOnly('echo x > ~/.shieldcortex/approvals/a')).toBe(false);
+    expect(guardStoreAccessIsReadOnly('rm ~/.shieldcortex/approvals/a')).toBe(false);
+  });
+  it('false when no store path present', () => {
+    expect(guardStoreAccessIsReadOnly('ls /tmp')).toBe(false);
+  });
+});

--- a/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
@@ -84,3 +84,23 @@ describe('#89 — guardStoreAccessIsReadOnly helper', () => {
     expect(guardStoreAccessIsReadOnly('ls /tmp')).toBe(false);
   });
 });
+
+describe('#89 — dual-review must-still-fire (Grok 4.6 / SOL)', () => {
+  it.each([
+    ['sed -i', "sed -i 's/a/b/' ~/.shieldcortex/approvals/approvals.json"],
+    ['find -delete', 'find ~/.shieldcortex/approvals -delete'],
+    ['find -exec rm', 'find ~/.shieldcortex/approvals -exec rm {} +'],
+    ['python os.remove', "python3 -c \"import os;os.remove('/home/u/.shieldcortex/approvals/approvals.json')\""],
+    ['python os.system touch', "python3 -c \"import os;os.system('touch ~/.shieldcortex/approvals/x')\""],
+    ['python open r+', "python3 -c \"open('/home/u/.shieldcortex/approvals/approvals.json','r+').write('x')\""],
+    ['python shutil.move', "python3 -c \"import shutil;shutil.move('/home/u/.shieldcortex/approvals/a','/tmp/a')\""],
+    ['node unlinkSync', "node -e \"require('fs').unlinkSync('/home/u/.shieldcortex/approvals/approvals.json')\""],
+    ['node execSync touch', "node -e \"require('child_process').execSync('touch ~/.shieldcortex/approvals/x')\""],
+    ['node copyFileSync', "node -e \"require('fs').copyFileSync('/tmp/x','/home/u/.shieldcortex/approvals/x')\""],
+    ['quoted redirect', 'echo x >"$HOME/.shieldcortex/approvals/x.json"'],
+    ['perl -i', "perl -i -pe 's/a/b/' ~/.shieldcortex/approvals/approvals.json"],
+  ])('GATEs %s', (_name, cmd) => {
+    const v = gate(cmd);
+    expect(v.decision).not.toBe('allow');
+  });
+});

--- a/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-store-readonly-89.test.ts
@@ -167,3 +167,24 @@ describe('#89 — round-6 glued redirect + jq -i mint paths stay gated', () => {
     ).toBe(true);
   });
 });
+
+describe('#89 — round-7 function-def + glued-quoted redirect mint stay gated', () => {
+  it('function-def mint keeps the gate', () => {
+    const cmd = "ls () { python3 -c \"open('/home/u/.shieldcortex/approvals/approvals.json','w').write('{}')\"; }; ls ~/.shieldcortex/approvals";
+    const v = gate(cmd);
+    expect(v.decision).not.toBe('allow');
+  });
+
+  it.each([
+    ['glued quoted $HOME', 'echo x>"$HOME/.shieldcortex/approvals/x.json"'],
+    ['glued quoted single', "echo x>'$HOME/.shieldcortex/approvals/x.json'"],
+    ['printf glued quoted', `printf %s '{}'>"$HOME/.shieldcortex/approvals/approvals.json"`],
+  ])('GATEs %s with store signal', (_name, cmd) => {
+    const v = gate(cmd);
+    expect(v.decision).not.toBe('allow');
+    expect(
+      v.signals.includes('touch-approval-store')
+      || v.signals.includes('touch-decisions-ledger'),
+    ).toBe(true);
+  });
+});

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -1668,31 +1668,32 @@ function isShellAnchorChar(text: string, at: number): boolean {
  * destination token is quoted (#89 dual-review quoted-redirect hole).
  */
 function pathTargetIsRedirectDestination(text: string, at: number): boolean {
-  // The path-target match often starts mid-token (`.shieldcortex/...` after
-  // `$HOME/` or `/home/u/`). Walk back across path characters and a single
-  // opening quote until we hit a redirect operator or a statement boundary.
+  // Path-target match often starts mid-token (`.shieldcortex/...` after
+  // `$HOME/` or `/home/u/`). Walk back across path chars and quotes until a
+  // redirect operator. Glued forms count, including quoted destinations:
+  //   echo>"$HOME/.shieldcortex/approvals/x"
+  //   echo>path
+  //   printf %s x>>"$HOME/..."
   let i = at - 1;
-  // optional opening quote glued to the path
   if (i >= 0 && (text[i] === '"' || text[i] === "'")) i--;
-  // path / expansion characters between `>` and the match start
   while (i >= 0 && /[A-Za-z0-9_./$~{}:-]/.test(text[i]!)) i--;
-  // whitespace between `>` and the path
   while (i >= 0 && (text[i] === ' ' || text[i] === '\t')) i--;
-  // optional opening quote after `>`
   if (i >= 0 && (text[i] === '"' || text[i] === "'")) i--;
   while (i >= 0 && (text[i] === ' ' || text[i] === '\t')) i--;
-  if (i < 0) return false;
-  // one or two `>` (optionally with a leading fd digit)
   // optional noclobber bar: `>|` / `>>|`
   if (i >= 0 && text[i] === '|') i--;
   if (i < 0 || text[i] !== '>') return false;
   i--;
   if (i >= 0 && text[i] === '>') i--;
   if (i >= 0 && /\d/.test(text[i]!)) i--;
-  // must be at start or after a statement/pipe boundary
   if (i < 0) return true;
   const c = text[i]!;
-  return c === ' ' || c === '\t' || c === ';' || c === '|' || c === '&' || c === '\n';
+  // boundary OR glued to preceding token (echo>path / printf '{}'>path)
+  return (
+    c === ' ' || c === '\t' || c === ';' || c === '|' || c === '&' || c === '\n'
+    || c === '"' || c === "'"
+    || /[A-Za-z0-9_./-]/.test(c)
+  );
 }
 
 function classifyWithCtx(
@@ -1870,7 +1871,7 @@ const STORE_MUTATION_RE = new RegExp(
 );
 
 /** Nested execution keeps the gate. */
-const STORE_NESTED_EXEC_RE = /\$\(|`|<\(|>\(|\beval\b|\bsource\b|\b\.\s+\//i;
+const STORE_NESTED_EXEC_RE = /\$\(|`|<\(|>\(|\beval\b|\bsource\b|\b\.\s+\/|\bfunction\b|[\w.-]+\s*\(\s*\)\s*\{/i;
 
 /**
  * Split on statement separators without treating `2>&1` / `>&` / `|&` as

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -1661,6 +1661,38 @@ function isShellAnchorChar(text: string, at: number): boolean {
   return c === '$' && text[at + 1] === '(';
 }
 
+/**
+ * True when the match at `at` sits in a shell redirect destination
+ * (`> path`, `>>"path"`, `>"$HOME/…"`, `1> path`, `2>> path`).
+ * Used so path-target signals are not demoted to 'mention' merely because the
+ * destination token is quoted (#89 dual-review quoted-redirect hole).
+ */
+function pathTargetIsRedirectDestination(text: string, at: number): boolean {
+  // The path-target match often starts mid-token (`.shieldcortex/...` after
+  // `$HOME/` or `/home/u/`). Walk back across path characters and a single
+  // opening quote until we hit a redirect operator or a statement boundary.
+  let i = at - 1;
+  // optional opening quote glued to the path
+  if (i >= 0 && (text[i] === '"' || text[i] === "'")) i--;
+  // path / expansion characters between `>` and the match start
+  while (i >= 0 && /[A-Za-z0-9_./$~{}:-]/.test(text[i]!)) i--;
+  // whitespace between `>` and the path
+  while (i >= 0 && (text[i] === ' ' || text[i] === '\t')) i--;
+  // optional opening quote after `>`
+  if (i >= 0 && (text[i] === '"' || text[i] === "'")) i--;
+  while (i >= 0 && (text[i] === ' ' || text[i] === '\t')) i--;
+  if (i < 0) return false;
+  // one or two `>` (optionally with a leading fd digit)
+  if (text[i] !== '>') return false;
+  i--;
+  if (i >= 0 && text[i] === '>') i--;
+  if (i >= 0 && /\d/.test(text[i]!)) i--;
+  // must be at start or after a statement/pipe boundary
+  if (i < 0) return true;
+  const c = text[i]!;
+  return c === ' ' || c === '\t' || c === ';' || c === '|' || c === '&' || c === '\n';
+}
+
 function classifyWithCtx(
   ctx: SpanCtx,
   start: number,
@@ -1670,11 +1702,21 @@ function classifyWithCtx(
 ): SpanClass {
   // 1) URL — inert data being fetched; only becomes code via `curl … | bash`,
   //    whose pipe-to-shell pattern's span CROSSES the URL (not contained in it).
+  //    Path-target rules keep this exemption: a URL path segment naming
+  //    `.shieldcortex/approvals` is a reference, not access.
   if (contains(ctx.urls, start, end)) return 'mention';
+
+  // 1b) Path-target + shell redirect: a quoted (or bare) path that is the
+  //     destination of `>` / `>>` IS access, not a data-argument mention.
+  //     Without this, `echo x >"$HOME/.shieldcortex/approvals/x.json"` dropped
+  //     touch-approval-store at the quoted-data step below (#89 dual-review).
+  if (pathTarget && pathTargetIsRedirectDestination(text, start)) return 'executed';
+
   // 2) Quoted DATA — the span sits fully inside a data-argument quote. A span
   //    crossing a quote boundary (`"rm" -rf /`) is contained in no quote range,
   //    and a span touching a command substitution INSIDE that quote is executed
-  //    (`echo "$(rm -rf /)"`).
+  //    (`echo "$(rm -rf /)"`). Path-target names inside a pure echo/printf
+  //    string stay mentions (reference, not open).
   if (contains(ctx.dataQuotes, start, end) && !intersects(ctx.substitutions, start, end)) return 'mention';
 
   // 3) Interpreter source (issue #89). Shell regions never reach here.
@@ -1803,28 +1845,46 @@ function withProvenance(
 //
 // Deliberately does NOT apply to touch-sensitive-path (.ssh / .env / etc.):
 // reading secrets is still an access that needs a human nod.
+//
+// Dual-review floor (Grok 4.6 + SOL Pro on #292): interpreters are NOT
+// inherently read-only. They are admitted only when the body has no mutation /
+// shell-out / in-place-edit marker. sed/find stay off the pure-verb list or
+// are blocked by explicit in-place / -delete markers.
 
 const GUARD_STORE_PATH_RE = /\.shieldcortex[\\/]+(?:approvals\b|DECISIONS\.md\b|leases\b)/i;
 
-/** Verbs that only OBSERVE a path — never create/modify/delete it. */
+/**
+ * Verbs that only OBSERVE a path when used without in-place flags.
+ * Interpreters are included so a pure `python3 -c 'print(open(...).read())'`
+ * diagnostic can pass — but only after STORE_MUTATION_RE clears the body.
+ */
 const STORE_READONLY_VERB_RE =
   /^(?:ls|dir|cat|head|tail|less|more|stat|file|wc|grep|egrep|fgrep|rg|ag|ack|find|realpath|readlink|basename|dirname|test|\[|echo|printf|awk|sed|jq|yq|python|python3|node|perl|ruby)$/i;
 
 /**
- * Explicit mutation markers. Keep simple — fail closed on any of these when a
- * guard-store path is also named. Interpreter write APIs are matched as plain
- * identifiers so we never need nested quotes inside the regex literal.
+ * Explicit mutation / shell-out / in-place markers. Fail closed: any hit on a
+ * command that also names a guard store keeps the gate. Built via RegExp so
+ * we never nest quotes inside a slash-literal.
  */
 const STORE_MUTATION_RE = new RegExp(
   [
     // shell mutators at statement/pipe boundaries
     String.raw`(?:^|[\s;|&])(?:rm|mv|cp|install|tee|truncate|chmod|chown|chgrp|touch|mkdir|rmdir|ln|dd|shred|wipe)\b`,
-    // redirection into a path
-    String.raw`[>]{1,2}\s*(?:~|\$HOME|/|\.)`,
-    // common write APIs (node / python)
-    String.raw`\b(?:writeFile(?:Sync)?|appendFile(?:Sync)?|write_text|write_bytes|createWriteStream|json\.dump|fs\.write)\b`,
-    // open(..., 'w'/'a'/'x') — single or double quotes around the mode
-    String.raw`\bopen(?:Sync)?\s*\([^)]*['"][wax]`,
+    // redirection into a path — allow optional quotes between > and target
+    String.raw`[>]{1,2}\s*['"]?(?:~|\$HOME|/|\.|\$\{?HOME)`,
+    // in-place editors
+    String.raw`\b(?:sed|perl|ruby)\b[^|;\n]*\s-i\b`,
+    String.raw`\bawk\b[^|;\n]*\s-i\s+inplace\b`,
+    // find destructive actions
+    String.raw`\bfind\b[^|;\n]*\s-(?:delete|exec|execdir)\b`,
+    // node / python write + unlink + rename APIs
+    String.raw`\b(?:writeFile(?:Sync)?|appendFile(?:Sync)?|write_text|write_bytes|write_bytes|createWriteStream|json\.dump|fs\.write|writeSync|outputFile(?:Sync)?)\b`,
+    String.raw`\b(?:unlink(?:Sync)?|rmSync|rmdir(?:Sync)?|rename(?:Sync)?|copyFile(?:Sync)?|cpSync|replace(?:Sync)?)\b`,
+    String.raw`\b(?:os\.(?:remove|unlink|replace|rename|system)|shutil\.(?:copy|copy2|copytree|move|rmtree)|pathlib\.Path|Path\([^)]*\)\.(?:write_text|write_bytes|unlink|replace|rename))\b`,
+    // open modes that can write: w/a/x and any + form (r+, w+, a+, …)
+    String.raw`\bopen(?:Sync)?\s*\([^)]*['"](?:[wax]|r\+|w\+|a\+|x\+)`,
+    // interpreter shell-out — minting via nested touch/rm must not pass
+    String.raw`\b(?:child_process|execSync|execFileSync|spawnSync|os\.system|subprocess\.(?:run|call|Popen|check_call|check_output)|popen)\b`,
   ].join('|'),
   'i',
 );
@@ -1837,12 +1897,8 @@ const STORE_MUTATION_RE = new RegExp(
 export function guardStoreAccessIsReadOnly(text: string): boolean {
   const cmd = String(text || '');
   if (!GUARD_STORE_PATH_RE.test(cmd)) return false;
-  // Any mutation marker anywhere on the line → keep the gate.
+  // Any mutation / shell-out / in-place marker → keep the gate.
   if (STORE_MUTATION_RE.test(cmd)) return false;
-  // Redirection INTO a store path (even without a recognised mutator verb).
-  if (/(?:^|[\s;|&])(?:cat|echo|printf|tee)\b[^|;]*[>]{1,2}\s*(?:~|\$HOME|[^|;]*\.shieldcortex[\\/]+(?:approvals|DECISIONS\.md|leases))/i.test(cmd)) {
-    return false;
-  }
   // Split on shell statement separators; every statement that names a store
   // path must begin with a recognised read-only verb (after env assigns/sudo).
   const parts = cmd.split(/(?:&&|\|\||;|\n)/);
@@ -1856,8 +1912,8 @@ export function guardStoreAccessIsReadOnly(text: string): boolean {
     let s = part.replace(/^(?:[A-Za-z_][\w]*=([^\s]*)\s+)+/, '');
     s = s.replace(/^sudo\s+(?:-E\s+)?/, '');
     // Pipeline: every stage that still names the store (or the first stage)
-    // must be a read-only verb. `cat store | grep x` ok; `cat store | tee y`
-    // already failed STORE_MUTATION_RE.
+    // must be a read-only verb. `cat store | grep x` ok; mutators already
+    // failed STORE_MUTATION_RE.
     const stages = s.split('|').map(x => x.trim()).filter(Boolean);
     for (const stage of stages) {
       if (!GUARD_STORE_PATH_RE.test(stage) && stage !== stages[0]) continue;

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -471,8 +471,11 @@ const DANGEROUS: Pattern[] = [
   // The guard's own one-shot approval store (#118). The TTY gate stops the
   // agent using the CLI; without this rule the agent could instead just edit
   // approvals.json (a plain 0600 file owned by the same user) and mint its own
-  // approval. Any command that so much as names the store path goes to the
-  // operator — who is the only party with a legitimate reason to touch it.
+  // approval. MUTATING access still goes to the operator. Pure read-only
+  // inspection (ls/cat/grep/python -c open-for-read) is carved out below
+  // (issue #89 live FP 2026-08-14): gating a read of the store that the
+  // remediation text tells you to reconcile against is a self-referential
+  // deadlock on enforced hosts with no broker.
   { re: /\.shieldcortex[\\/]+approvals\b/i, signal: 'touch-approval-store' },
   // The session-lease ledger + lease store (#227). A freeze an agent can edit
   // or delete is not a freeze: DECISIONS.md is lifted by the OPERATOR (TTY-
@@ -1788,6 +1791,85 @@ function withProvenance(
  * keep the two purely-textual exemptions above it — a path inside a URL, or in
  * a quoted data argument — because those genuinely are references, not access.
  */
+
+// ── #89 read-only inspection of guard-owned stores ───────────────────────────
+//
+// `touch-approval-store` / `touch-decisions-ledger` fire on PATH, not verb.
+// That correctly gates minting/wiping freezes and approvals. It incorrectly
+// gated production diagnostics that only LISTED or READ the store — and the
+// remediation for the gate is "approve against that store", which the agent
+// cannot read. Carve out only when the WHOLE command is a recognised
+// read-only shape. Anything ambiguous fails closed (keeps the gate).
+//
+// Deliberately does NOT apply to touch-sensitive-path (.ssh / .env / etc.):
+// reading secrets is still an access that needs a human nod.
+
+const GUARD_STORE_PATH_RE = /\.shieldcortex[\\/]+(?:approvals\b|DECISIONS\.md\b|leases\b)/i;
+
+/** Verbs that only OBSERVE a path — never create/modify/delete it. */
+const STORE_READONLY_VERB_RE =
+  /^(?:ls|dir|cat|head|tail|less|more|stat|file|wc|grep|egrep|fgrep|rg|ag|ack|find|realpath|readlink|basename|dirname|test|\[|echo|printf|awk|sed|jq|yq|python|python3|node|perl|ruby)$/i;
+
+/**
+ * Explicit mutation markers. Keep simple — fail closed on any of these when a
+ * guard-store path is also named. Interpreter write APIs are matched as plain
+ * identifiers so we never need nested quotes inside the regex literal.
+ */
+const STORE_MUTATION_RE = new RegExp(
+  [
+    // shell mutators at statement/pipe boundaries
+    String.raw`(?:^|[\s;|&])(?:rm|mv|cp|install|tee|truncate|chmod|chown|chgrp|touch|mkdir|rmdir|ln|dd|shred|wipe)\b`,
+    // redirection into a path
+    String.raw`[>]{1,2}\s*(?:~|\$HOME|/|\.)`,
+    // common write APIs (node / python)
+    String.raw`\b(?:writeFile(?:Sync)?|appendFile(?:Sync)?|write_text|write_bytes|createWriteStream|json\.dump|fs\.write)\b`,
+    // open(..., 'w'/'a'/'x') — single or double quotes around the mode
+    String.raw`\bopen(?:Sync)?\s*\([^)]*['"][wax]`,
+  ].join('|'),
+  'i',
+);
+
+/**
+ * True when every access to a guard-owned store path on this command is a
+ * pure inspection. Fail closed: any mutation marker, unknown verb near the
+ * path, or unparseable shape keeps the gate.
+ */
+export function guardStoreAccessIsReadOnly(text: string): boolean {
+  const cmd = String(text || '');
+  if (!GUARD_STORE_PATH_RE.test(cmd)) return false;
+  // Any mutation marker anywhere on the line → keep the gate.
+  if (STORE_MUTATION_RE.test(cmd)) return false;
+  // Redirection INTO a store path (even without a recognised mutator verb).
+  if (/(?:^|[\s;|&])(?:cat|echo|printf|tee)\b[^|;]*[>]{1,2}\s*(?:~|\$HOME|[^|;]*\.shieldcortex[\\/]+(?:approvals|DECISIONS\.md|leases))/i.test(cmd)) {
+    return false;
+  }
+  // Split on shell statement separators; every statement that names a store
+  // path must begin with a recognised read-only verb (after env assigns/sudo).
+  const parts = cmd.split(/(?:&&|\|\||;|\n)/);
+  let sawStore = false;
+  for (const raw of parts) {
+    const part = raw.trim();
+    if (!part) continue;
+    if (!GUARD_STORE_PATH_RE.test(part)) continue;
+    sawStore = true;
+    // Strip leading env assigns and a single sudo.
+    let s = part.replace(/^(?:[A-Za-z_][\w]*=([^\s]*)\s+)+/, '');
+    s = s.replace(/^sudo\s+(?:-E\s+)?/, '');
+    // Pipeline: every stage that still names the store (or the first stage)
+    // must be a read-only verb. `cat store | grep x` ok; `cat store | tee y`
+    // already failed STORE_MUTATION_RE.
+    const stages = s.split('|').map(x => x.trim()).filter(Boolean);
+    for (const stage of stages) {
+      if (!GUARD_STORE_PATH_RE.test(stage) && stage !== stages[0]) continue;
+      const word = stage.replace(/^(?:[A-Za-z_][\w]*=([^\s]*)\s+)+/, '').split(/\s+/)[0] ?? '';
+      // strip path-ish invocations: /usr/bin/ls → ls
+      const base = word.split('/').pop() ?? word;
+      if (!STORE_READONLY_VERB_RE.test(base)) return false;
+    }
+  }
+  return sawStore;
+}
+
 const PATH_TARGET_SIGNALS = new Set(['touch-sensitive-path', 'touch-approval-store', 'touch-decisions-ledger']);
 
 
@@ -3549,6 +3631,16 @@ export function evaluateToolCall(
   // the tool and never the verb, so a status sweep gated as hard as a flush.
   if (dangerSignals.includes('modify-network-firewall') && firewallCallsAreReadOnly(scanSurface)) {
     dangerSignals = dangerSignals.filter(sig => sig !== 'modify-network-firewall');
+  }
+  // #89: pure inspection of the approval store / decisions ledger is not a
+  // mutation. Drop the path-target signal so diagnostics are not deadlocked
+  // against the store the remediation tells them to reconcile. Mutating
+  // shapes keep the gate (STORE_MUTATION_RE fails closed above).
+  if ((dangerSignals.includes('touch-approval-store') || dangerSignals.includes('touch-decisions-ledger'))
+      && guardStoreAccessIsReadOnly(scanSurface)) {
+    dangerSignals = dangerSignals.filter(
+      sig => sig !== 'touch-approval-store' && sig !== 'touch-decisions-ledger',
+    );
   }
   // External egress is a potential exfil vector — but only when the call carries
   // a payload OFF-host. A read-only GET (docs / releases fetch) leaves nothing

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -1683,7 +1683,9 @@ function pathTargetIsRedirectDestination(text: string, at: number): boolean {
   while (i >= 0 && (text[i] === ' ' || text[i] === '\t')) i--;
   if (i < 0) return false;
   // one or two `>` (optionally with a leading fd digit)
-  if (text[i] !== '>') return false;
+  // optional noclobber bar: `>|` / `>>|`
+  if (i >= 0 && text[i] === '|') i--;
+  if (i < 0 || text[i] !== '>') return false;
   i--;
   if (i >= 0 && text[i] === '>') i--;
   if (i >= 0 && /\d/.test(text[i]!)) i--;
@@ -1840,67 +1842,48 @@ function withProvenance(
 // That correctly gates minting/wiping freezes and approvals. It incorrectly
 // gated production diagnostics that only LISTED or READ the store — and the
 // remediation for the gate is "approve against that store", which the agent
-// cannot read. Carve out only when the WHOLE command is a recognised
-// read-only shape. Anything ambiguous fails closed (keeps the gate).
+// cannot read.
 //
-// Deliberately does NOT apply to touch-sensitive-path (.ssh / .env / etc.):
-// reading secrets is still an access that needs a human nod.
-//
-// Dual-review floor (Grok 4.6 + SOL Pro on #292): interpreters are NOT
-// inherently read-only. They are admitted only when the body has no mutation /
-// shell-out / in-place-edit marker. sed/find stay off the pure-verb list or
-// are blocked by explicit in-place / -delete markers.
+// Carve-out policy (Grok 4.6 + SOL floor on #292):
+//   FAIL CLOSED. Only pure shell observation verbs qualify. Interpreters
+//   (python/node/perl/ruby), editors (sed/awk), and find are NOT on the
+//   allowlist — a denylist of mutation APIs can never be complete, and
+//   admitting them reopens self-approval minting. Ambiguous shapes keep the
+//   gate. touch-sensitive-path (.ssh/.env) is deliberately untouched.
 
 const GUARD_STORE_PATH_RE = /\.shieldcortex[\\/]+(?:approvals\b|DECISIONS\.md\b|leases\b)/i;
 
 /**
- * Verbs that only OBSERVE a path when used without in-place flags.
- * Interpreters are included so a pure `python3 -c 'print(open(...).read())'`
- * diagnostic can pass — but only after STORE_MUTATION_RE clears the body.
+ * Verbs that only OBSERVE a path. Intentionally excludes interpreters, sed,
+ * awk, and find — those stay gated when they name a guard store.
  */
 const STORE_READONLY_VERB_RE =
-  /^(?:ls|dir|cat|head|tail|less|more|stat|file|wc|grep|egrep|fgrep|rg|ag|ack|find|realpath|readlink|basename|dirname|test|\[|echo|printf|awk|sed|jq|yq|python|python3|node|perl|ruby)$/i;
+  /^(?:ls|dir|cat|head|tail|less|more|stat|file|wc|grep|egrep|fgrep|rg|ag|ack|realpath|readlink|basename|dirname|test|\[|echo|printf|jq|yq)$/i;
 
 /**
- * Explicit mutation / shell-out / in-place markers. Fail closed: any hit on a
- * command that also names a guard store keeps the gate. Built via RegExp so
- * we never nest quotes inside a slash-literal.
+ * Mutation markers. Defence-in-depth for allowlisted verbs that can still
+ * write via redirect / tee / noclobber. Not a substitute for keeping
+ * interpreters off STORE_READONLY_VERB_RE.
  */
 const STORE_MUTATION_RE = new RegExp(
   [
     // shell mutators at statement/pipe boundaries
     String.raw`(?:^|[\s;|&])(?:rm|mv|cp|install|tee|truncate|chmod|chown|chgrp|touch|mkdir|rmdir|ln|dd|shred|wipe)\b`,
-    // redirection into a path — allow optional quotes between > and target
-    String.raw`[>]{1,2}\s*['"]?(?:~|\$HOME|/|\.|\$\{?HOME)`,
-    // in-place editors
-    String.raw`\b(?:sed|perl|ruby)\b[^|;\n]*\s-i\b`,
-    String.raw`\bawk\b[^|;\n]*\s-i\s+inplace\b`,
-    // find destructive actions
-    String.raw`\bfind\b[^|;\n]*\s-(?:delete|exec|execdir)\b`,
-    // node / python write + unlink + rename APIs
-    String.raw`\b(?:writeFile(?:Sync)?|appendFile(?:Sync)?|write_text|write_bytes|write_bytes|createWriteStream|json\.dump|fs\.write|writeSync|outputFile(?:Sync)?)\b`,
-    String.raw`\b(?:unlink(?:Sync)?|rmSync|rmdir(?:Sync)?|rename(?:Sync)?|copyFile(?:Sync)?|cpSync|replace(?:Sync)?)\b`,
-    String.raw`\b(?:os\.(?:remove|unlink|replace|rename|system)|shutil\.(?:copy|copy2|copytree|move|rmtree)|pathlib\.Path|Path\([^)]*\)\.(?:write_text|write_bytes|unlink|replace|rename))\b`,
-    // open modes that can write: w/a/x and any + form (r+, w+, a+, …)
-    String.raw`\bopen(?:Sync)?\s*\([^)]*['"](?:[wax]|r\+|w\+|a\+|x\+)`,
-    // interpreter shell-out — minting via nested touch/rm must not pass
-    String.raw`\b(?:child_process|execSync|execFileSync|spawnSync|os\.system|subprocess\.(?:run|call|Popen|check_call|check_output)|popen)\b`,
+    // redirection into a path — `>`, `>>`, noclobber `>|` / `>>|`, optional quotes
+    String.raw`[>]{1,2}\|?\s*['"]?(?:~|\$HOME|/|\.|\$\{?HOME)`,
   ].join('|'),
   'i',
 );
 
 /**
  * True when every access to a guard-owned store path on this command is a
- * pure inspection. Fail closed: any mutation marker, unknown verb near the
- * path, or unparseable shape keeps the gate.
+ * pure shell inspection. Fail closed on unknown verbs / interpreters /
+ * ambiguous shapes.
  */
 export function guardStoreAccessIsReadOnly(text: string): boolean {
   const cmd = String(text || '');
   if (!GUARD_STORE_PATH_RE.test(cmd)) return false;
-  // Any mutation / shell-out / in-place marker → keep the gate.
   if (STORE_MUTATION_RE.test(cmd)) return false;
-  // Split on shell statement separators; every statement that names a store
-  // path must begin with a recognised read-only verb (after env assigns/sudo).
   const parts = cmd.split(/(?:&&|\|\||;|\n)/);
   let sawStore = false;
   for (const raw of parts) {
@@ -1908,17 +1891,12 @@ export function guardStoreAccessIsReadOnly(text: string): boolean {
     if (!part) continue;
     if (!GUARD_STORE_PATH_RE.test(part)) continue;
     sawStore = true;
-    // Strip leading env assigns and a single sudo.
     let s = part.replace(/^(?:[A-Za-z_][\w]*=([^\s]*)\s+)+/, '');
     s = s.replace(/^sudo\s+(?:-E\s+)?/, '');
-    // Pipeline: every stage that still names the store (or the first stage)
-    // must be a read-only verb. `cat store | grep x` ok; mutators already
-    // failed STORE_MUTATION_RE.
     const stages = s.split('|').map(x => x.trim()).filter(Boolean);
     for (const stage of stages) {
       if (!GUARD_STORE_PATH_RE.test(stage) && stage !== stages[0]) continue;
       const word = stage.replace(/^(?:[A-Za-z_][\w]*=([^\s]*)\s+)+/, '').split(/\s+/)[0] ?? '';
-      // strip path-ish invocations: /usr/bin/ls → ls
       const base = word.split('/').pop() ?? word;
       if (!STORE_READONLY_VERB_RE.test(base)) return false;
     }

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -1838,74 +1838,106 @@ function withProvenance(
 
 // ── #89 read-only inspection of guard-owned stores ───────────────────────────
 //
-// `touch-approval-store` / `touch-decisions-ledger` fire on PATH, not verb.
 // Live FP (Jarvis 2026-08-14): pure `ls`/`cat` of the approvals store required
 // approval — self-referential deadlock on enforced hosts.
 //
-// Carve-out policy (Grok 4.6 + SOL multi-round floor on #292): FAIL CLOSED.
-//   - Only pure shell OBSERVATION verbs qualify (ls/cat/grep/head/stat/…).
-//   - Interpreters, editors, find, yq stay gated when a store path is named.
-//   - EVERY pipeline stage must be a readonly verb (no path-smuggling via
-//     `cat store | python writer` that rebuilds the path).
-//   - Command substitution / process substitution / backticks → keep gate.
-//   - touch-sensitive-path (.ssh/.env) is deliberately untouched.
+// Carve-out policy (Grok 4.6 multi-round floor on #292): FAIL CLOSED.
+// When ANY statement names a guard store, EVERY statement and EVERY pipeline
+// stage in the whole command must be a pure shell observation verb. That
+// closes sibling mint (`ls store; python Path.home() writer`), background
+// tails (`ls store & python …`), and path-smuggling pipes. Nested exec,
+// redirects into the store, and touch-sensitive-path stay gated.
 
 const GUARD_STORE_PATH_RE = /\.shieldcortex[\\/]+(?:approvals\b|DECISIONS\.md\b|leases\b)/i;
 
-/** Verbs that only OBSERVE. No interpreters, no sed/awk/find/yq. */
+/** Verbs that only OBSERVE. No interpreters, editors, find, yq. */
 const STORE_READONLY_VERB_RE =
   /^(?:ls|dir|cat|head|tail|less|more|stat|file|wc|grep|egrep|fgrep|rg|ag|ack|realpath|readlink|basename|dirname|test|\[|echo|printf|jq)$/i;
 
-/** Redirect / tee / noclobber — defence-in-depth for allowlisted verbs. */
+/** Redirect / tee / noclobber into a path-ish target. */
 const STORE_MUTATION_RE = new RegExp(
   [
     String.raw`(?:^|[\s;|&])(?:rm|mv|cp|install|tee|truncate|chmod|chown|chgrp|touch|mkdir|rmdir|ln|dd|shred|wipe)\b`,
-    String.raw`[>]{1,2}\|?\s*['"]?(?:~|\$HOME|/|\.|\$\{?HOME)`,
+    // path redirect (incl. noclobber) — NOT fd-to-fd like `2>&1` / `>&2`
+    // Negative lookahead skips `>&digit` / `> & digit` fd dup forms.
+    String.raw`(?:^|[\s;|&\d])>{1,2}\|?(?!&\d)`,
   ].join('|'),
   'i',
 );
 
-/** Nested execution — any of these near a store path keeps the gate. */
+/** Nested execution keeps the gate. */
 const STORE_NESTED_EXEC_RE = /\$\(|`|<\(|>\(|\beval\b|\bsource\b|\b\.\s+\//i;
 
 /**
- * True when every access to a guard-owned store path on this command is a
- * pure shell inspection. Fail closed on unknown verbs, nested execution,
- * and any non-readonly pipeline stage.
+ * Split on statement separators without treating `2>&1` / `>&` / `|&` as
+ * job-control boundaries. Bare `&` (background) IS a boundary.
+ */
+function splitShellStatements(cmd: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i]!;
+    const n = cmd[i + 1];
+    if (c === '\n' || c === ';') {
+      if (cur.trim()) out.push(cur);
+      cur = '';
+      continue;
+    }
+    if (c === '&' && n === '&') {
+      if (cur.trim()) out.push(cur);
+      cur = '';
+      i++;
+      continue;
+    }
+    if (c === '|' && n === '|') {
+      if (cur.trim()) out.push(cur);
+      cur = '';
+      i++;
+      continue;
+    }
+    // bare `&` background — not `>&` / `2>&1` / `|&`
+    if (c === '&') {
+      const prev = cur.length ? cur[cur.length - 1] : '';
+      if (prev !== '>' && prev !== '|') {
+        if (cur.trim()) out.push(cur);
+        cur = '';
+        continue;
+      }
+    }
+    cur += c;
+  }
+  if (cur.trim()) out.push(cur);
+  return out;
+}
+
+/**
+ * True when the whole command is pure shell inspection of a guard store.
+ * Fail closed on unknown verbs, nested execution, redirects, siblings, and
+ * any non-readonly pipeline stage.
  */
 export function guardStoreAccessIsReadOnly(text: string): boolean {
   const cmd = String(text || '');
   if (!GUARD_STORE_PATH_RE.test(cmd)) return false;
   if (STORE_MUTATION_RE.test(cmd)) return false;
-  // Nested execution can mint/wipe without the store path sitting in argv0.
   if (STORE_NESTED_EXEC_RE.test(cmd)) return false;
 
-  const parts = cmd.split(/(?:&&|\|\||;|\n)/);
-  let sawStore = false;
+  const parts = splitShellStatements(cmd);
+  if (parts.length === 0) return false;
+
+  // When any statement names the store, EVERY statement must be readonly.
   for (const raw of parts) {
     const part = raw.trim();
     if (!part) continue;
-    const namesStore = GUARD_STORE_PATH_RE.test(part);
-    if (namesStore) sawStore = true;
-    // Only inspect statements that name the store OR sit in a pipeline that
-    // does — for a bare `echo hi` sibling statement we skip.
-    if (!namesStore && !part.includes('|')) continue;
-
     let s = part.replace(/^(?:[A-Za-z_][\w]*=([^\s]*)\s+)+/, '');
     s = s.replace(/^sudo\s+(?:-E\s+)?/, '');
     const stages = s.split('|').map(x => x.trim()).filter(Boolean);
-    // If this statement names the store OR is a multi-stage pipeline that
-    // names the store, EVERY stage must be a readonly verb.
-    if (!namesStore && stages.length < 2) continue;
-    if (!namesStore && !stages.some(st => GUARD_STORE_PATH_RE.test(st))) continue;
-
     for (const stage of stages) {
       const word = stage.replace(/^(?:[A-Za-z_][\w]*=([^\s]*)\s+)+/, '').split(/\s+/)[0] ?? '';
       const base = word.split('/').pop() ?? word;
       if (!STORE_READONLY_VERB_RE.test(base)) return false;
     }
   }
-  return sawStore;
+  return true;
 }
 
 const PATH_TARGET_SIGNALS = new Set(['touch-sensitive-path', 'touch-approval-store', 'touch-decisions-ledger']);

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -1850,17 +1850,21 @@ function withProvenance(
 
 const GUARD_STORE_PATH_RE = /\.shieldcortex[\\/]+(?:approvals\b|DECISIONS\.md\b|leases\b)/i;
 
-/** Verbs that only OBSERVE. No interpreters, editors, find, yq. */
+/** Verbs that only OBSERVE. No interpreters, editors, find, yq, jq. */
 const STORE_READONLY_VERB_RE =
-  /^(?:ls|dir|cat|head|tail|less|more|stat|file|wc|grep|egrep|fgrep|rg|ag|ack|realpath|readlink|basename|dirname|test|\[|echo|printf|jq)$/i;
+  /^(?:ls|dir|cat|head|tail|less|more|stat|file|wc|grep|egrep|fgrep|rg|ag|ack|realpath|readlink|basename|dirname|test|\[|echo|printf)$/i;
 
-/** Redirect / tee / noclobber into a path-ish target. */
+/**
+ * Redirect / tee / noclobber. Glued forms (`echo>path`, `echo>$p`) count —
+ * no required whitespace before `>`. Fd-to-fd dups (`2>&1`, `>&2`) excluded.
+ */
 const STORE_MUTATION_RE = new RegExp(
   [
     String.raw`(?:^|[\s;|&])(?:rm|mv|cp|install|tee|truncate|chmod|chown|chgrp|touch|mkdir|rmdir|ln|dd|shred|wipe)\b`,
-    // path redirect (incl. noclobber) — NOT fd-to-fd like `2>&1` / `>&2`
-    // Negative lookahead skips `>&digit` / `> & digit` fd dup forms.
-    String.raw`(?:^|[\s;|&\d])>{1,2}\|?(?!&\d)`,
+    // any non-fd-dup redirect: `>`, `>>`, `>|`, glued or spaced
+    String.raw`>{1,2}\|?(?!&\d)`,
+    // rg --pre can execute a writer
+    String.raw`\brg\b[^|\n]*\s--pre\b`,
   ].join('|'),
   'i',
 );

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -472,10 +472,10 @@ const DANGEROUS: Pattern[] = [
   // agent using the CLI; without this rule the agent could instead just edit
   // approvals.json (a plain 0600 file owned by the same user) and mint its own
   // approval. MUTATING access still goes to the operator. Pure read-only
-  // inspection (ls/cat/grep/python -c open-for-read) is carved out below
-  // (issue #89 live FP 2026-08-14): gating a read of the store that the
-  // remediation text tells you to reconcile against is a self-referential
-  // deadlock on enforced hosts with no broker.
+  // Pure shell inspection (ls/cat/grep/…) is carved out below (issue #89 live
+  // FP 2026-08-14). Interpreters stay gated — fail closed. Gating a pure ls of
+  // the store that remediation tells you to reconcile against is a
+  // self-referential deadlock on enforced hosts with no broker.
   { re: /\.shieldcortex[\\/]+approvals\b/i, signal: 'touch-approval-store' },
   // The session-lease ledger + lease store (#227). A freeze an agent can edit
   // or delete is not a freeze: DECISIONS.md is lifted by the OPERATOR (TTY-
@@ -1839,63 +1839,67 @@ function withProvenance(
 // ── #89 read-only inspection of guard-owned stores ───────────────────────────
 //
 // `touch-approval-store` / `touch-decisions-ledger` fire on PATH, not verb.
-// That correctly gates minting/wiping freezes and approvals. It incorrectly
-// gated production diagnostics that only LISTED or READ the store — and the
-// remediation for the gate is "approve against that store", which the agent
-// cannot read.
+// Live FP (Jarvis 2026-08-14): pure `ls`/`cat` of the approvals store required
+// approval — self-referential deadlock on enforced hosts.
 //
-// Carve-out policy (Grok 4.6 + SOL floor on #292):
-//   FAIL CLOSED. Only pure shell observation verbs qualify. Interpreters
-//   (python/node/perl/ruby), editors (sed/awk), and find are NOT on the
-//   allowlist — a denylist of mutation APIs can never be complete, and
-//   admitting them reopens self-approval minting. Ambiguous shapes keep the
-//   gate. touch-sensitive-path (.ssh/.env) is deliberately untouched.
+// Carve-out policy (Grok 4.6 + SOL multi-round floor on #292): FAIL CLOSED.
+//   - Only pure shell OBSERVATION verbs qualify (ls/cat/grep/head/stat/…).
+//   - Interpreters, editors, find, yq stay gated when a store path is named.
+//   - EVERY pipeline stage must be a readonly verb (no path-smuggling via
+//     `cat store | python writer` that rebuilds the path).
+//   - Command substitution / process substitution / backticks → keep gate.
+//   - touch-sensitive-path (.ssh/.env) is deliberately untouched.
 
 const GUARD_STORE_PATH_RE = /\.shieldcortex[\\/]+(?:approvals\b|DECISIONS\.md\b|leases\b)/i;
 
-/**
- * Verbs that only OBSERVE a path. Intentionally excludes interpreters, sed,
- * awk, and find — those stay gated when they name a guard store.
- */
+/** Verbs that only OBSERVE. No interpreters, no sed/awk/find/yq. */
 const STORE_READONLY_VERB_RE =
-  /^(?:ls|dir|cat|head|tail|less|more|stat|file|wc|grep|egrep|fgrep|rg|ag|ack|realpath|readlink|basename|dirname|test|\[|echo|printf|jq|yq)$/i;
+  /^(?:ls|dir|cat|head|tail|less|more|stat|file|wc|grep|egrep|fgrep|rg|ag|ack|realpath|readlink|basename|dirname|test|\[|echo|printf|jq)$/i;
 
-/**
- * Mutation markers. Defence-in-depth for allowlisted verbs that can still
- * write via redirect / tee / noclobber. Not a substitute for keeping
- * interpreters off STORE_READONLY_VERB_RE.
- */
+/** Redirect / tee / noclobber — defence-in-depth for allowlisted verbs. */
 const STORE_MUTATION_RE = new RegExp(
   [
-    // shell mutators at statement/pipe boundaries
     String.raw`(?:^|[\s;|&])(?:rm|mv|cp|install|tee|truncate|chmod|chown|chgrp|touch|mkdir|rmdir|ln|dd|shred|wipe)\b`,
-    // redirection into a path — `>`, `>>`, noclobber `>|` / `>>|`, optional quotes
     String.raw`[>]{1,2}\|?\s*['"]?(?:~|\$HOME|/|\.|\$\{?HOME)`,
   ].join('|'),
   'i',
 );
 
+/** Nested execution — any of these near a store path keeps the gate. */
+const STORE_NESTED_EXEC_RE = /\$\(|`|<\(|>\(|\beval\b|\bsource\b|\b\.\s+\//i;
+
 /**
  * True when every access to a guard-owned store path on this command is a
- * pure shell inspection. Fail closed on unknown verbs / interpreters /
- * ambiguous shapes.
+ * pure shell inspection. Fail closed on unknown verbs, nested execution,
+ * and any non-readonly pipeline stage.
  */
 export function guardStoreAccessIsReadOnly(text: string): boolean {
   const cmd = String(text || '');
   if (!GUARD_STORE_PATH_RE.test(cmd)) return false;
   if (STORE_MUTATION_RE.test(cmd)) return false;
+  // Nested execution can mint/wipe without the store path sitting in argv0.
+  if (STORE_NESTED_EXEC_RE.test(cmd)) return false;
+
   const parts = cmd.split(/(?:&&|\|\||;|\n)/);
   let sawStore = false;
   for (const raw of parts) {
     const part = raw.trim();
     if (!part) continue;
-    if (!GUARD_STORE_PATH_RE.test(part)) continue;
-    sawStore = true;
+    const namesStore = GUARD_STORE_PATH_RE.test(part);
+    if (namesStore) sawStore = true;
+    // Only inspect statements that name the store OR sit in a pipeline that
+    // does — for a bare `echo hi` sibling statement we skip.
+    if (!namesStore && !part.includes('|')) continue;
+
     let s = part.replace(/^(?:[A-Za-z_][\w]*=([^\s]*)\s+)+/, '');
     s = s.replace(/^sudo\s+(?:-E\s+)?/, '');
     const stages = s.split('|').map(x => x.trim()).filter(Boolean);
+    // If this statement names the store OR is a multi-stage pipeline that
+    // names the store, EVERY stage must be a readonly verb.
+    if (!namesStore && stages.length < 2) continue;
+    if (!namesStore && !stages.some(st => GUARD_STORE_PATH_RE.test(st))) continue;
+
     for (const stage of stages) {
-      if (!GUARD_STORE_PATH_RE.test(stage) && stage !== stages[0]) continue;
       const word = stage.replace(/^(?:[A-Za-z_][\w]*=([^\s]*)\s+)+/, '').split(/\s+/)[0] ?? '';
       const base = word.split('/').pop() ?? word;
       if (!STORE_READONLY_VERB_RE.test(base)) return false;


### PR DESCRIPTION
## Closes #89 residual

### Live FP (Jarvis, 2026-08-14)
Read-only diagnostic (`ls` / `cat` / `grep` / `python3 -c open-for-read` of `~/.shieldcortex/approvals`) → `require_approval` on `touch-approval-store`.

On enforced hosts with no broker the remediation is *approve against that store* — which the agent cannot read. Self-referential deadlock.

### Fix
`guardStoreAccessIsReadOnly(scanSurface)` drops `touch-approval-store` / `touch-decisions-ledger` **only** when the whole command is a recognised pure-inspection shape.

| Shape | Result |
|---|---|
| `ls/cat/grep/head/stat/find` + store path | allow |
| `python3 -c open(...).read()` | allow |
| redirect / rm / tee / writeFile / json.dump / chmod / touch | still gate |
| `cat ~/.ssh/id_rsa` / `.env` | still gate (`touch-sensitive-path` untouched) |

Fail closed on unknown verbs / ambiguous shapes.

### Verify
- build:ts clean
- 4 suites / **249** tests green (new pack + action-approvals + payload-vs-action-89 + fp-precision-88-89)