### PR TITLE
fix(broker): #143 residual — 15s judge timeout + timed_out audit + doctor honesty

### DIFF
--- a/docs/design/2026-07-31-ai-approval-broker.md
+++ b/docs/design/2026-07-31-ai-approval-broker.md
@@ -1,6 +1,6 @@
 # Design: AI-assisted approval broker
 
-**Status:** proposal (no code yet — spec first, per Michael 31 Jul 2026)
+**Status:** shipped, off by default (opt-in) — core + both transports landed; field residuals from the Jarvis box folded in 15 Aug 2026. Open questions 1 and 2 below remain open.
 **Author:** Jarvis
 **Depends on:** #118 one-shot approval store (shipped 4.47.18), #139 deny-when-no-prompt-surface
 **Issue:** #143
@@ -124,6 +124,40 @@ Open questions 1 (confidence calibration) and 2 (injection detection ANDed with
 the `llm_input` scanner) are **not** closed — the threshold is a conservative
 0.9 chosen a priori and has not been validated against the 429-event corpus, and
 the judge's injection signal is currently used alone.
+
+### Field residuals (15 Aug 2026)
+
+Shipped after the broker ran on the Jarvis box. Neither changes what can be
+released; both change what the operator can see.
+
+**Judge deadline: 8s → 15s.** Observed judge latency reached ~6s, so an 8s
+ceiling was turning answered judges into silent nulls. A null holds for a human,
+so the old value was safe but wasteful — the deadline exists to bound the
+operator's wait, not to race the model. The default now lives in three files
+that cannot import each other and are kept in step by hand:
+`DEFAULT_BROKER_CONFIG.judgeTimeoutMs`, `approval-judge.ts`'s
+`DEFAULT_JUDGE_TIMEOUT_MS`, and `cli-invoker.ts`'s `DEFAULT_TIMEOUT_MS`. Config
+bounds are unchanged (500ms–60s), and the tighten-only rule still holds.
+
+**`judge_timed_out` in the audit.** "The judge never answered" and "the judge
+said hold" were the same `null`, so a judge timing out on every call looked
+exactly like a cautious one — which is how a silently-broken judge stays broken.
+`runJudgeDetailed()` now returns `{ result, timedOut, error }` where `error` is
+one of `timeout | unreachable | parse | thrown`; `runJudge()` is a thin wrapper
+returning `.result`, so existing callers are unchanged. The transports pass that
+through as `judgeMeta`, and `BrokerAudit` carries `judgeTimedOut` and
+`judgeUnavailableReason`.
+
+This is **audit metadata only**. `result` is still null on every failure path,
+`judgeAssessment` is still `unavailable`, the outcome is still `hold`, and
+`canAutoApproveOnTimeout` is still derived from `outcome === 'pre_clear'` alone.
+No value of `timedOut` can produce a pre-clear.
+
+**Doctor tells the truth about the broker.** With the Action Guard enforcing,
+`doctor` now reports whether the broker block is armed or merely present — a
+disabled broker is the default and protects nothing, and doctor no longer lets
+an operator infer otherwise. Either way the notify channel is still the human
+path.
 
 Question 3 ("in-context" definition) is answered differently per surface, and
 deliberately: the OpenClaw path sends a list of bare tool NAMES from the session

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -3300,6 +3300,11 @@ function resolveBrokerRuntime(
     return {
       config,
       runJudge: defenceMod.runJudge,
+      // #143 residual, and deliberately NOT in `needed`: an older shieldcortex
+      // build has runJudge alone, and the interceptor falls back to it. Missing
+      // it costs an audit field, never a gate.
+      runJudgeDetailed:
+        typeof defenceMod.runJudgeDetailed === 'function' ? defenceMod.runJudgeDetailed : undefined,
       brokerDecision: defenceMod.brokerDecision,
       timeoutOutcome: defenceMod.timeoutOutcome,
       approvalTimeoutMs: typeof defenceMod.approvalTimeoutMs === 'function' ? defenceMod.approvalTimeoutMs : undefined,

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -107,6 +107,10 @@ export interface BrokerAuditLike {
   judgeConfidence: number | null;
   injectionSuspected: boolean;
   inContext: boolean | null;
+  /** #143 residual — "the judge never answered" told apart from "the judge said
+   *  hold". Audit only; neither field can reach an outcome. */
+  judgeTimedOut?: boolean;
+  judgeUnavailableReason?: string | null;
   reason: string;
 }
 
@@ -142,11 +146,26 @@ export interface BrokerRuntime {
     invoke: ModelInvokerLike,
     opts?: { timeoutMs?: number },
   ) => Promise<JudgeResultLike | null>;
+  /** #143 residual, and OPTIONAL: this plugin is built across a package
+   *  boundary, so a main package from before the residual injects `runJudge`
+   *  alone and the pass below falls back to it. Absent costs an audit field,
+   *  never a gate. */
+  runJudgeDetailed?: (
+    req: {
+      tool: string;
+      toolInput: unknown;
+      verdict: { severity: string; action: string; reason: string; signals: string[] };
+      sessionSummary?: string;
+    },
+    invoke: ModelInvokerLike,
+    opts?: { timeoutMs?: number },
+  ) => Promise<{ result: JudgeResultLike | null; timedOut: boolean; error?: string }>;
   brokerDecision: (input: {
     tool: string;
     toolInput: unknown;
     verdict: ToolGuardVerdictLike;
     judge: JudgeResultLike | null;
+    judgeMeta?: { timedOut?: boolean; error?: string | null };
     policy?: { allowPreClear: boolean; preClearConfidence: number };
   }) => BrokerDecisionLike;
   timeoutOutcome: (decision: BrokerDecisionLike) => 'approve' | 'deny';
@@ -941,17 +960,28 @@ export function createInterceptor(
       });
 
       let judge: JudgeResultLike | null = null;
+      // Only set when a judge pass actually ran: "no seam on this build" and
+      // "budget spent" are not timeouts, and claiming otherwise would be the
+      // same overclaim in the audit that this residual removes from doctor.
+      let judgeMeta: { timedOut?: boolean; error?: string | null } | undefined;
       if (invoke && judgeLimiter.shouldAllow()) {
-        judge = await broker.runJudge(
-          {
-            tool: context.toolName,
-            toolInput: context.arguments,
-            verdict: { severity: v.severity, action: v.action, reason: v.reason, signals: v.signals },
-            sessionSummary: buildSessionSummary(),
-          },
-          invoke,
-          { timeoutMs: broker.config.judgeTimeoutMs },
-        );
+        const request = {
+          tool: context.toolName,
+          toolInput: context.arguments,
+          verdict: { severity: v.severity, action: v.action, reason: v.reason, signals: v.signals },
+          sessionSummary: buildSessionSummary(),
+        };
+        const opts = { timeoutMs: broker.config.judgeTimeoutMs };
+        if (typeof broker.runJudgeDetailed === 'function') {
+          const detailed = await broker.runJudgeDetailed(request, invoke, opts);
+          judge = detailed?.result ?? null;
+          judgeMeta = {
+            timedOut: detailed?.timedOut === true,
+            error: typeof detailed?.error === 'string' ? detailed.error : null,
+          };
+        } else {
+          judge = await broker.runJudge(request, invoke, opts);
+        }
       } else if (invoke) {
         log.warn(`[shieldcortex] approval broker: judge budget spent this minute — holding ${context.toolName} for the operator`);
       }
@@ -961,6 +991,7 @@ export function createInterceptor(
         toolInput: context.arguments,
         verdict: v,
         judge,
+        ...(judgeMeta ? { judgeMeta } : {}),
         policy: {
           allowPreClear: broker.config.allowPreClear,
           preClearConfidence: broker.config.preClearConfidence,

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -298,6 +298,10 @@ async function loadBroker(rawBrokerConfig) {
       config: normalised,
       brokerDecision: core.brokerDecision,
       runJudge: judge.runJudge,
+      // #143 residual. Optional on purpose: a dist build from before the
+      // residual has runJudge and nothing else, and the pass below falls back
+      // to it. A missing detail function costs an audit field, never a gate.
+      runJudgeDetailed: typeof judge.runJudgeDetailed === 'function' ? judge.runJudgeDetailed : null,
       createCliInvoker: cli.createCliInvoker,
     };
   } catch {
@@ -546,6 +550,9 @@ const MAX_SESSION_SALT_RECOVERY_ATTEMPTS = 256;
 const GUARD_DEGRADED_OUTCOMES = new Set(['auto_denied', 'denied_no_prompt_surface', 'failure_denied', 'warned', 'failure_allowed']);
 const SAFE_BROKER_OUTCOMES = new Set(['harden', 'pre_clear', 'hold', 'unavailable', 'not_brokerable']);
 const SAFE_JUDGE_ASSESSMENTS = new Set(['approve', 'deny', 'hold', 'uncertain', 'in_context', 'out_of_context', 'benign', 'unavailable']);
+/** #143 residual — why a judge is 'unavailable'. Allowlisted, like every other
+ *  string this hook copies into an audit row that leaves the process. */
+const SAFE_JUDGE_UNAVAILABLE_REASONS = new Set(['timeout', 'unreachable', 'parse', 'thrown', 'disabled']);
 
 function readExistingSessionSalt(file) {
   try {
@@ -744,6 +751,12 @@ function safeBrokerAudit(audit) {
   }
   if (typeof audit.injectionSuspected === 'boolean') out.injectionSuspected = audit.injectionSuspected;
   if (typeof audit.inContext === 'boolean') out.inContext = audit.inContext;
+  // #143 residual. A boolean and one allowlisted word — the same treatment
+  // every other field here gets, because "it came from our own core" is not a
+  // property this function is allowed to assume.
+  if (typeof audit.judgeTimedOut === 'boolean') out.judgeTimedOut = audit.judgeTimedOut;
+  const unavailableReason = String(audit.judgeUnavailableReason ?? '');
+  if (SAFE_JUDGE_UNAVAILABLE_REASONS.has(unavailableReason)) out.judgeUnavailableReason = unavailableReason;
   const signals = safeSignalList(audit.signals);
   if (signals.length > 0) out.signals = signals;
   return Object.keys(out).length > 0 ? out : undefined;
@@ -1052,25 +1065,41 @@ async function runBrokerPass(broker, toolName, toolInput, verdict) {
       model: broker.config.model,
       timeoutMs: broker.config.judgeTimeoutMs,
     });
-    const judgeResult = await broker.runJudge(
-      {
-        tool: toolName,
-        toolInput,
-        verdict: {
-          severity: verdict.severity,
-          action: verdict.action,
-          reason: verdict.reason,
-          signals: verdict.signals,
-        },
+    const request = {
+      tool: toolName,
+      toolInput,
+      verdict: {
+        severity: verdict.severity,
+        action: verdict.action,
+        reason: verdict.reason,
+        signals: verdict.signals,
       },
-      invoke,
-      { timeoutMs: broker.config.judgeTimeoutMs },
-    );
+    };
+    const opts = { timeoutMs: broker.config.judgeTimeoutMs };
+
+    // #143 residual — "the judge never answered" and "the judge said hold" were
+    // the same null, so a judge timing out on every call looked like a cautious
+    // one. The detail is metadata: `result` is still null on every failure, and
+    // null still holds for a human.
+    let judgeResult = null;
+    let judgeMeta;
+    if (broker.runJudgeDetailed) {
+      const detailed = await broker.runJudgeDetailed(request, invoke, opts);
+      judgeResult = detailed?.result ?? null;
+      judgeMeta = {
+        timedOut: detailed?.timedOut === true,
+        error: typeof detailed?.error === 'string' ? detailed.error : null,
+      };
+    } else {
+      judgeResult = await broker.runJudge(request, invoke, opts);
+    }
+
     const decision = broker.brokerDecision({
       tool: toolName,
       toolInput,
       verdict,
       judge: judgeResult,
+      ...(judgeMeta ? { judgeMeta } : {}),
       policy: {
         allowPreClear: broker.config.allowPreClear,
         preClearConfidence: broker.config.preClearConfidence,

--- a/src/__tests__/pre-tool-hook-broker-143.test.ts
+++ b/src/__tests__/pre-tool-hook-broker-143.test.ts
@@ -280,6 +280,35 @@ describe('#143 — the approval broker through the real Claude Code hook', () =>
     expect(Date.now() - started).toBeLessThan(20_000);
   }, 60_000);
 
+  // #143 residual — a judge that times out on every call used to be
+  // indistinguishable in the audit from a cautious one that answered "hold".
+  it('marks a timed-out judge as timed out in the audit row, and still holds', () => {
+    writeBrokerConfig(true, { judgeTimeoutMs: 500 });
+    const p = join(binDir, 'claude');
+    writeFileSync(p, '#!/usr/bin/env bash\nsleep 30\n');
+    chmodSync(p, 0o755);
+
+    expect(runHook(PRE_CLEARABLE).decision).toBe('ask');
+
+    const row = auditRows().find(r => r.broker);
+    expect(row!.broker).toMatchObject({
+      outcome: 'hold',
+      judgeAssessment: 'unavailable',
+      judgeTimedOut: true,
+      judgeUnavailableReason: 'timeout',
+    });
+  }, 60_000);
+
+  it('does NOT mark a judge that answered badly as timed out', () => {
+    writeBrokerConfig(true);
+    installFakeClaude({ exitCode: 1 });
+    runHook(PRE_CLEARABLE);
+
+    const row = auditRows().find(r => r.broker);
+    expect(row!.broker).toMatchObject({ outcome: 'hold', judgeTimedOut: false });
+    expect((row!.broker as Record<string, unknown>).judgeUnavailableReason).toBe('thrown');
+  }, 60_000);
+
   // ── the red line ──────────────────────────────────────────────────────────
 
   it('never brokers a catastrophic call — no model is even consulted', () => {

--- a/src/cli/__tests__/doctor-action-guard.test.ts
+++ b/src/cli/__tests__/doctor-action-guard.test.ts
@@ -277,6 +277,62 @@ describe('doctor — Action Guard notify fix is a signed CLI command (#275)', ()
 });
 
 /**
+ * #143 residual — the broker block is the thing operators most often believe is
+ * protecting them, and it is OFF by default. Doctor must say which it is, and
+ * must not let "broker configured" read as "broker working".
+ */
+describe('doctor — approval broker honesty (#143)', () => {
+  const brokerResult = async () => {
+    const results = await checkActionGuard();
+    return results.find((r) => /broker/.test(r.label));
+  };
+
+  it('says the broker is present but disabled when it is not opted into', async () => {
+    writeConfig({ actionGuard: { enabled: true, enforce: true, broker: { allowPreClear: true } } });
+    const broker = await brokerResult();
+    expect(broker).toBeDefined();
+    expect(broker!.message).toMatch(/disabled/i);
+    expect(broker!.message).toMatch(/opt-in/i);
+    // No claim of protection from a broker that never runs.
+    expect(broker!.message).not.toMatch(/armed|protecting/i);
+    // The human path is still notify, armed or not.
+    expect(broker!.message).toMatch(/notify channel/i);
+  });
+
+  it('treats a non-true `enabled` as disabled, exactly as the runtime does', async () => {
+    for (const enabled of ['true', 1, 'yes']) {
+      writeConfig({ actionGuard: { enabled: true, enforce: true, broker: { enabled } } });
+      const broker = await brokerResult();
+      expect(broker!.message).toMatch(/disabled/i);
+    }
+  });
+
+  it('says the broker is armed when it is switched on, without overclaiming', async () => {
+    writeConfig({ actionGuard: { enabled: true, enforce: true, broker: { enabled: true } } });
+    const broker = await brokerResult();
+    expect(broker).toBeDefined();
+    expect(broker!.message).toMatch(/armed/i);
+    // Armed still means: catastrophic never brokered, no judge → hold, and the
+    // human is reached through notify.
+    expect(broker!.message).toMatch(/catastrophic is never brokered/i);
+    expect(broker!.message).toMatch(/notify channel/i);
+    expect(broker!.message).not.toMatch(/disabled/i);
+  });
+
+  it('says nothing about a broker on a config that has no broker block', async () => {
+    writeConfig({ actionGuard: { enabled: true, enforce: true } });
+    expect(await brokerResult()).toBeUndefined();
+  });
+
+  it('does not report on the broker when the guard is not enforcing', async () => {
+    // Nothing is gated, so nothing is brokered — reporting on the broker here
+    // would imply a gate that is not there.
+    writeConfig({ actionGuard: { enforce: false, broker: { enabled: true } } });
+    expect(await brokerResult()).toBeUndefined();
+  });
+});
+
+/**
  * #275 acceptance 7 — `doctor --fix-action-guard` used a bare fs.writeFileSync,
  * so the migration it performed carried the OLD `_sig` (or none) and the fix
  * itself tripped the integrity check into strict mode. The write must go

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2173,6 +2173,34 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
             'forces strict mode. OpenClaw lastRunStatus is not ShieldCortex\'s to write.',
         });
       }
+
+      // #143 residual: the broker block is the thing operators most often
+      // believe is protecting them. Say what is actually true — present and
+      // disabled is the default, and a disabled broker does nothing at all.
+      // Neither state removes the need for a notify channel: the broker can
+      // harden or hold, but the human path is still the notify path.
+      const brokerBlock = isBlock(merged.broker) ? merged.broker : null;
+      if (brokerBlock) {
+        results.push(
+          brokerBlock.enabled === true
+            ? {
+                label: `${label} broker`,
+                status: 'info',
+                message:
+                  'approval broker is armed (`actionGuard.broker.enabled: true`) — it can harden a gate or hold it, ' +
+                  'and only pre-clears reversible on-host actions; catastrophic is never brokered and an unavailable ' +
+                  'or timed-out judge holds for a human. The human path is still the notify channel.',
+              }
+            : {
+                label: `${label} broker`,
+                status: 'info',
+                message:
+                  'approval broker is present but disabled (opt-in; `actionGuard.broker.enabled` is not true) — ' +
+                  'no judge runs and no gate is brokered. Denials still need a notify channel to reach a human.',
+                fix: 'Set `actionGuard.broker.enabled: true` to opt in — the broker never widens a gate, but it is off until you say so.',
+              },
+        );
+      }
     }
 
     if (alias) {

--- a/src/defence/index.ts
+++ b/src/defence/index.ts
@@ -111,9 +111,9 @@ export type { LeaseGateResult, LeaseGateOptions } from './iron-dome/session-leas
 // Code hook) can reach them at runtime without importing the package at compile
 // time, the same seam `evaluateToolCall` already uses.
 export { brokerDecision, timeoutOutcome, isPreClearable, PRE_CLEARABLE_SIGNALS, DEFAULT_BROKER_POLICY } from './iron-dome/approval-broker.js';
-export type { BrokerInput, BrokerDecision, BrokerOutcome, BrokerAudit, BrokerPolicy, BrokerVerdictLike, JudgeResult } from './iron-dome/approval-broker.js';
-export { runJudge, buildJudgePrompt, parseJudgeResponse, JUDGE_SYSTEM_PROMPT } from './iron-dome/approval-judge.js';
-export type { JudgeRequest, ModelInvoker, RunJudgeOptions } from './iron-dome/approval-judge.js';
+export type { BrokerInput, BrokerDecision, BrokerOutcome, BrokerAudit, BrokerPolicy, BrokerVerdictLike, JudgeResult, JudgeUnavailableReason } from './iron-dome/approval-broker.js';
+export { runJudge, runJudgeDetailed, buildJudgePrompt, parseJudgeResponse, JUDGE_SYSTEM_PROMPT } from './iron-dome/approval-judge.js';
+export type { JudgeRequest, JudgeRunResult, JudgeFailureReason, ModelInvoker, RunJudgeOptions } from './iron-dome/approval-judge.js';
 export { normaliseBrokerConfig, normaliseBrokerModel, toBrokerPolicy, approvalTimeoutMs, DEFAULT_BROKER_CONFIG } from './iron-dome/broker-config.js';
 export type { BrokerConfig, BrokerGatedSeverity } from './iron-dome/broker-config.js';
 export { createCliInvoker } from './iron-dome/cli-invoker.js';

--- a/src/defence/iron-dome/__tests__/approval-broker.test.ts
+++ b/src/defence/iron-dome/__tests__/approval-broker.test.ts
@@ -298,3 +298,83 @@ describe('every broker decision is explainable', () => {
     expect(d.audit.judgeAssessment).toBe('unavailable');
   });
 });
+
+// ── #143 residual: a timed-out judge is named, and still holds ─────────────
+
+/**
+ * The marker exists so an operator can tell a judge that never answered from a
+ * judge that answered "hold" — until now both were the same `null`, and a
+ * systematically-timing-out judge looked exactly like a cautious one.
+ *
+ * It is metadata. Every test here also re-asserts the outcome, because the one
+ * way this feature could go wrong is by becoming an input to the decision.
+ */
+describe('#143 residual: judge timeout is visible in the audit and never a release', () => {
+  const timedOut = { judge: null, judgeMeta: { timedOut: true, error: 'timeout' } };
+
+  it('holds on a timed-out judge, and says so in the reason', () => {
+    const d = brokerDecision(input(timedOut));
+    expect(d.outcome).toBe('hold');
+    expect(d.reason).toMatch(/timed out/i);
+    expect(d.audit.judgeTimedOut).toBe(true);
+    expect(d.audit.judgeUnavailableReason).toBe('timeout');
+    expect(d.audit.judgeAssessment).toBe('unavailable');
+    expect(d.audit.judgeConfidence).toBeNull();
+  });
+
+  it('a timeout NEVER auto-approves, on the most pre-clearable request there is', () => {
+    // Reversible signal, pre-clear allowed, threshold floored — everything the
+    // pre-clear path wants, except a judge.
+    const d = brokerDecision(
+      input({ ...timedOut, policy: { allowPreClear: true, preClearConfidence: 0 } }),
+    );
+    expect(d.outcome).toBe('hold');
+    expect(d.canAutoApproveOnTimeout).toBe(false);
+    expect(timeoutOutcome(d)).toBe('deny');
+  });
+
+  it('catastrophic stays not_brokerable when the judge timed out', () => {
+    const d = brokerDecision(
+      input({
+        ...timedOut,
+        verdict: { ...dangerous(['delete-root-or-home']), severity: 'catastrophic', decision: 'block' },
+      }),
+    );
+    expect(d.outcome).toBe('not_brokerable');
+    expect(d.canAutoApproveOnTimeout).toBe(false);
+    expect(timeoutOutcome(d)).toBe('deny');
+  });
+
+  it('distinguishes a timeout from every other reason there is no judge', () => {
+    for (const error of ['unreachable', 'parse', 'thrown', 'disabled']) {
+      const d = brokerDecision(input({ judge: null, judgeMeta: { timedOut: false, error } }));
+      expect(d.outcome).toBe('hold');
+      expect(d.audit.judgeTimedOut).toBe(false);
+      expect(d.audit.judgeUnavailableReason).toBe(error);
+      expect(d.reason).not.toMatch(/timed out/i);
+    }
+  });
+
+  it('drops a reason it does not recognise rather than carrying it into the audit', () => {
+    const d = brokerDecision(
+      input({ judge: null, judgeMeta: { timedOut: false, error: 'approved-by-the-model-honestly' } }),
+    );
+    expect(d.outcome).toBe('hold');
+    expect(d.audit.judgeUnavailableReason).toBeNull();
+  });
+
+  it('a caller cannot mark a judge that actually answered as timed out', () => {
+    const d = brokerDecision(input({ judge: judge(), judgeMeta: { timedOut: true, error: 'timeout' } }));
+    expect(d.outcome).toBe('pre_clear');
+    expect(d.audit.judgeTimedOut).toBe(false);
+    expect(d.audit.judgeUnavailableReason).toBeNull();
+  });
+
+  it('reports no timeout when the transport says nothing (the pre-residual caller)', () => {
+    const d = brokerDecision(input({ judge: null }));
+    expect(d.outcome).toBe('hold');
+    expect(d.audit.judgeTimedOut).toBe(false);
+    expect(d.audit.judgeUnavailableReason).toBeNull();
+    expect(d.reason).toMatch(/no usable judge/i);
+  });
+});

--- a/src/defence/iron-dome/__tests__/approval-judge.test.ts
+++ b/src/defence/iron-dome/__tests__/approval-judge.test.ts
@@ -9,6 +9,7 @@ import {
   buildJudgePrompt,
   parseJudgeResponse,
   runJudge,
+  runJudgeDetailed,
   JUDGE_SYSTEM_PROMPT,
   type ModelInvoker,
 } from '../approval-judge.js';
@@ -150,5 +151,78 @@ describe('runJudge fails closed', () => {
     expect(seen).toHaveLength(1);
     expect(seen[0].system).toBe(JUDGE_SYSTEM_PROMPT);
     expect(seen[0].user).toContain('ls');
+  });
+});
+
+/**
+ * #143 residual — "the judge never answered" and "the judge said hold" were the
+ * same null, so a judge timing out on every call was indistinguishable from a
+ * cautious one. `runJudgeDetailed` names the difference; it does not change it.
+ * Every test here asserts `result` is still null.
+ */
+describe('runJudgeDetailed names WHY there is no judge, and never invents one', () => {
+  const req = { tool: 'Bash', toolInput: { command: 'ls' }, verdict };
+  const invoker = (fn: () => Promise<string>): ModelInvoker => fn as unknown as ModelInvoker;
+
+  it('reports a timeout as timedOut with a null result', async () => {
+    const slow: ModelInvoker = () => new Promise(res => { setTimeout(() => res(ok), 5_000).unref?.(); });
+    const r = await runJudgeDetailed(req, slow, { timeoutMs: 50 });
+    expect(r.result).toBeNull();
+    expect(r.timedOut).toBe(true);
+    expect(r.error).toBe('timeout');
+  });
+
+  it('reports a transport that rejects on ITS own deadline as a timeout too', async () => {
+    // cli-invoker.ts runs its own deadline and rejects with this exact shape;
+    // on the hook both timers are set from one config value, so either may win.
+    const r = await runJudgeDetailed(
+      req,
+      invoker(async () => { throw new Error('judge CLI timed out after 15000ms'); }),
+    );
+    expect(r.result).toBeNull();
+    expect(r.timedOut).toBe(true);
+    expect(r.error).toBe('timeout');
+  });
+
+  it('reports an unreachable model as thrown, NOT as a timeout', async () => {
+    const r = await runJudgeDetailed(req, invoker(async () => { throw new Error('ENOTFOUND'); }));
+    expect(r.result).toBeNull();
+    expect(r.timedOut).toBe(false);
+    expect(r.error).toBe('thrown');
+  });
+
+  it('reports an unparseable reply as parse, NOT as a timeout', async () => {
+    const r = await runJudgeDetailed(req, invoker(async () => 'Sure, looks fine to me!'));
+    expect(r.result).toBeNull();
+    expect(r.timedOut).toBe(false);
+    expect(r.error).toBe('parse');
+  });
+
+  it('reports an invoker that resolves a non-string as unreachable', async () => {
+    const r = await runJudgeDetailed(req, (async () => null) as unknown as ModelInvoker);
+    expect(r.result).toBeNull();
+    expect(r.timedOut).toBe(false);
+    expect(r.error).toBe('unreachable');
+  });
+
+  it('a successful pass carries the verdict, no timeout and no error', async () => {
+    const r = await runJudgeDetailed(req, invoker(async () => ok));
+    expect(r.result?.assessment).toBe('benign');
+    expect(r.timedOut).toBe(false);
+    expect(r.error).toBeUndefined();
+  });
+
+  it('runJudge is exactly runJudgeDetailed().result — existing callers are unchanged', async () => {
+    const cases: Array<ModelInvoker> = [
+      invoker(async () => ok),
+      invoker(async () => 'junk'),
+      invoker(async () => { throw new Error('ENOTFOUND'); }),
+      invoker(async () => { throw new Error('judge CLI timed out after 15000ms'); }),
+    ];
+    for (const invoke of cases) {
+      const detailed = await runJudgeDetailed(req, invoke, { timeoutMs: 200 });
+      const plain = await runJudge(req, invoke, { timeoutMs: 200 });
+      expect(plain).toEqual(detailed.result);
+    }
   });
 });

--- a/src/defence/iron-dome/__tests__/broker-config.test.ts
+++ b/src/defence/iron-dome/__tests__/broker-config.test.ts
@@ -48,6 +48,21 @@ describe('defaults', () => {
   it('agrees with the decision core about the pre-clear confidence floor', () => {
     expect(DEFAULT_BROKER_CONFIG.preClearConfidence).toBe(DEFAULT_BROKER_POLICY.preClearConfidence);
   });
+
+  // #143 residual. Field latency reached ~6s, so 8s was turning answered judges
+  // into silent nulls. Pinned because the same number lives in three files that
+  // cannot import each other (approval-judge.ts, cli-invoker.ts, here).
+  it('gives the judge 15s, the residual default', () => {
+    expect(DEFAULT_BROKER_CONFIG.judgeTimeoutMs).toBe(15_000);
+    expect(normaliseBrokerConfig({ enabled: true }).judgeTimeoutMs).toBe(15_000);
+  });
+
+  it('still bounds the judge timeout at 500ms..60s — the default moved, the bounds did not', () => {
+    expect(normaliseBrokerConfig({ judgeTimeoutMs: 500 }).judgeTimeoutMs).toBe(500);
+    expect(normaliseBrokerConfig({ judgeTimeoutMs: 60_000 }).judgeTimeoutMs).toBe(60_000);
+    expect(normaliseBrokerConfig({ judgeTimeoutMs: 499 }).judgeTimeoutMs).toBe(15_000);
+    expect(normaliseBrokerConfig({ judgeTimeoutMs: 60_001 }).judgeTimeoutMs).toBe(15_000);
+  });
 });
 
 // ── hostile input: unknown fields ───────────────────────────────────────────

--- a/src/defence/iron-dome/approval-broker.ts
+++ b/src/defence/iron-dome/approval-broker.ts
@@ -104,12 +104,30 @@ export const DEFAULT_BROKER_POLICY: BrokerPolicy = {
   preClearConfidence: 0.9,
 };
 
+/**
+ * Why there is no judge result, for the audit row (#143 residual).
+ *
+ * Every value means exactly the same thing to the policy — no usable judge,
+ * hold for a human. It exists so an operator can tell "the judge never
+ * answered" from "the judge said hold", which were the same null until now: a
+ * judge that times out on every call used to be indistinguishable from a
+ * cautious one, and that is how a silently-broken judge stays broken.
+ */
+export type JudgeUnavailableReason = 'timeout' | 'unreachable' | 'parse' | 'thrown' | 'disabled';
+
+const JUDGE_UNAVAILABLE_REASONS: ReadonlySet<string> = new Set<JudgeUnavailableReason>([
+  'timeout', 'unreachable', 'parse', 'thrown', 'disabled',
+]);
+
 export interface BrokerInput {
   tool: string;
   toolInput: unknown;
   verdict: BrokerVerdictLike;
   /** null when no judge ran: model unreachable, disabled, or out of budget. */
   judge: JudgeResult | null;
+  /** Optional availability metadata from the transport, for the audit row only.
+   *  It can add a WORD to the reason; it can never add an outcome. */
+  judgeMeta?: { timedOut?: boolean; error?: string | null };
   policy?: BrokerPolicy;
 }
 
@@ -133,6 +151,11 @@ export interface BrokerAudit {
   judgeConfidence: number | null;
   injectionSuspected: boolean;
   inContext: boolean | null;
+  /** True only when the transport reported a deadline AND no judge came back.
+   *  Never true alongside a usable judge — a judge that answered did not time out. */
+  judgeTimedOut?: boolean;
+  /** Why the judge is 'unavailable', or null when one was actually used. */
+  judgeUnavailableReason?: JudgeUnavailableReason | null;
   reason: string;
 }
 
@@ -164,6 +187,25 @@ function judgeIsUsable(j: JudgeResult | null): j is JudgeResult {
   return true;
 }
 
+/**
+ * Normalise the transport's availability metadata (#143 residual).
+ *
+ * A usable judge always reports "did not time out, no reason" regardless of
+ * what the transport claimed — a judge that answered did not time out, and a
+ * caller cannot mark a live verdict as an outage. Unrecognised reason strings
+ * are dropped rather than carried, so a hostile or stale transport cannot write
+ * free text into the audit row.
+ */
+function judgeAvailability(
+  meta: BrokerInput['judgeMeta'],
+  usable: boolean,
+): { timedOut: boolean; reason: JudgeUnavailableReason | null } {
+  if (usable) return { timedOut: false, reason: null };
+  const raw = typeof meta?.error === 'string' ? meta.error : '';
+  const reason = JUDGE_UNAVAILABLE_REASONS.has(raw) ? (raw as JudgeUnavailableReason) : null;
+  return { timedOut: meta?.timedOut === true || reason === 'timeout', reason };
+}
+
 function decide(input: BrokerInput): { outcome: BrokerOutcome; reason: string } {
   const policy = input.policy ?? DEFAULT_BROKER_POLICY;
   const { verdict, judge } = input;
@@ -176,11 +218,15 @@ function decide(input: BrokerInput): { outcome: BrokerOutcome; reason: string } 
     };
   }
 
-  // (4) No usable judge → the human is the only path.
+  // (4) No usable judge → the human is the only path. A timeout is named
+  // explicitly: same outcome, but the operator can see that the judge never
+  // answered rather than assuming it looked and hesitated.
   if (!judgeIsUsable(judge)) {
     return {
       outcome: 'hold',
-      reason: 'no usable judge assessment — holding for operator approval',
+      reason: judgeAvailability(input.judgeMeta, false).timedOut
+        ? 'judge timed out — holding for operator approval'
+        : 'no usable judge assessment — holding for operator approval',
     };
   }
 
@@ -227,6 +273,7 @@ function decide(input: BrokerInput): { outcome: BrokerOutcome; reason: string } 
 export function brokerDecision(input: BrokerInput): BrokerDecision {
   const { outcome, reason } = decide(input);
   const usable = judgeIsUsable(input.judge);
+  const availability = judgeAvailability(input.judgeMeta, usable);
 
   return {
     outcome,
@@ -245,6 +292,10 @@ export function brokerDecision(input: BrokerInput): BrokerDecision {
       judgeConfidence: usable ? (input.judge as JudgeResult).confidence : null,
       injectionSuspected: usable ? (input.judge as JudgeResult).injectionSuspected : false,
       inContext: usable ? (input.judge as JudgeResult).inContext : null,
+      // Audit only. Neither field is read by any decision above, and
+      // canAutoApproveOnTimeout stays derived from the outcome alone.
+      judgeTimedOut: availability.timedOut,
+      judgeUnavailableReason: availability.reason,
       reason,
     },
   };

--- a/src/defence/iron-dome/approval-judge.ts
+++ b/src/defence/iron-dome/approval-judge.ts
@@ -174,33 +174,98 @@ export interface RunJudgeOptions {
   timeoutMs?: number;
 }
 
-const DEFAULT_JUDGE_TIMEOUT_MS = 8_000;
+/** Raised from 8s in the #143 residual; see broker-config.ts for the field
+ *  evidence. Kept identical to DEFAULT_BROKER_CONFIG.judgeTimeoutMs. */
+const DEFAULT_JUDGE_TIMEOUT_MS = 15_000;
+
+/**
+ * Why there is no judge result. Reported for the audit row ONLY — every value
+ * here means the same thing to the policy: no usable judge, hold for a human.
+ */
+export type JudgeFailureReason = 'timeout' | 'unreachable' | 'parse' | 'thrown';
+
+/**
+ * A judge pass and the reason it failed, if it did.
+ *
+ * The distinction exists for the operator reading an audit row, not for the
+ * broker: "the judge never answered" and "the judge said hold" used to be the
+ * same null, so a systematically-timing-out judge looked exactly like a
+ * cautious one. Pure data — `result` is still null on every failure path, so
+ * nothing here can become a verdict.
+ */
+export interface JudgeRunResult {
+  result: JudgeResult | null;
+  timedOut: boolean;
+  error?: JudgeFailureReason;
+}
+
+/** Distinguishes "our timer won the race" from "the invoker resolved null". */
+const TIMED_OUT: unique symbol = Symbol('judge-timed-out');
+
+/**
+ * Did a transport's rejection describe a deadline rather than an outage?
+ *
+ * `cli-invoker.ts` runs its own deadline and rejects with "judge CLI timed out
+ * after Nms"; on the hook that timer and this one are set from the same config
+ * value, so either may win. Reading the message keeps the audit honest about
+ * the case this residual exists to name. It is a LABEL, never a decision: this
+ * branch returns `result: null` whichever way it answers.
+ */
+function isTimeoutError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err ?? '');
+  return /timed?\s*out|timeout|ETIMEDOUT/i.test(message);
+}
+
+/**
+ * Run one judge pass and report why it failed.
+ *
+ * Returns a null `result` on ANY failure — unreachable model, junk response,
+ * timeout — because the broker reads null as "hold for a human", which is the
+ * fail-closed direction. `timedOut` and `error` are audit metadata layered on
+ * top of that, and no combination of them can produce a verdict.
+ */
+export async function runJudgeDetailed(
+  req: JudgeRequest,
+  invoke: ModelInvoker,
+  opts: RunJudgeOptions = {},
+): Promise<JudgeRunResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_JUDGE_TIMEOUT_MS;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const prompt = buildJudgePrompt(req);
+    const raced = await Promise.race<string | typeof TIMED_OUT>([
+      invoke(JUDGE_SYSTEM_PROMPT, prompt),
+      new Promise<typeof TIMED_OUT>(resolve => {
+        timer = setTimeout(() => resolve(TIMED_OUT), timeoutMs);
+      }),
+    ]);
+    if (raced === TIMED_OUT) return { result: null, timedOut: true, error: 'timeout' };
+    // An invoker that resolves a non-string is not speaking the protocol —
+    // treated as no model rather than handed to the parser.
+    if (typeof raced !== 'string') return { result: null, timedOut: false, error: 'unreachable' };
+    const parsed = parseJudgeResponse(raced);
+    if (!parsed) return { result: null, timedOut: false, error: 'parse' };
+    return { result: parsed, timedOut: false };
+  } catch (err) {
+    if (isTimeoutError(err)) return { result: null, timedOut: true, error: 'timeout' };
+    return { result: null, timedOut: false, error: 'thrown' };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
 
 /**
  * Run one judge pass. Returns null on ANY failure — unreachable model, junk
  * response, timeout — because the broker reads null as "hold for a human",
  * which is the fail-closed direction.
+ *
+ * The original signature, kept as the thin wrapper it now is: callers that do
+ * not care WHY there is no judge are not made to handle it.
  */
 export async function runJudge(
   req: JudgeRequest,
   invoke: ModelInvoker,
   opts: RunJudgeOptions = {},
 ): Promise<JudgeResult | null> {
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_JUDGE_TIMEOUT_MS;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    const prompt = buildJudgePrompt(req);
-    const raced = await Promise.race([
-      invoke(JUDGE_SYSTEM_PROMPT, prompt),
-      new Promise<null>(resolve => {
-        timer = setTimeout(() => resolve(null), timeoutMs);
-      }),
-    ]);
-    if (typeof raced !== 'string') return null;
-    return parseJudgeResponse(raced);
-  } catch {
-    return null;
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
+  return (await runJudgeDetailed(req, invoke, opts)).result;
 }

--- a/src/defence/iron-dome/broker-config.ts
+++ b/src/defence/iron-dome/broker-config.ts
@@ -65,7 +65,12 @@ export const DEFAULT_BROKER_CONFIG: BrokerConfig = {
   enabled: false,
   allowPreClear: DEFAULT_BROKER_POLICY.allowPreClear,
   preClearConfidence: DEFAULT_BROKER_POLICY.preClearConfidence,
-  judgeTimeoutMs: 8_000,
+  // 15s, raised from 8s in the #143 residual. Field latency on the Jarvis box
+  // reached ~6s, and an 8s ceiling turned an answered judge into a silent null
+  // often enough to matter. A null holds for a human, so the old value was safe
+  // but wasteful; the ceiling exists to bound the operator's wait, not to race
+  // the model. Still well inside the 60s bound.
+  judgeTimeoutMs: 15_000,
   approvalTimeoutMs: {
     // The more dangerous the action, the sooner we stop waiting — because
     // "stop waiting" resolves to DENY for everything the broker did not

--- a/src/defence/iron-dome/cli-invoker.ts
+++ b/src/defence/iron-dome/cli-invoker.ts
@@ -66,7 +66,9 @@ export interface CliInvokerOptions {
 }
 
 const DEFAULT_COMMAND = 'claude';
-const DEFAULT_TIMEOUT_MS = 8_000;
+/** Matches DEFAULT_BROKER_CONFIG.judgeTimeoutMs and approval-judge's own
+ *  default — three files, one deadline, kept in step by hand (#143 residual). */
+const DEFAULT_TIMEOUT_MS = 15_000;
 /** Grace between "please stop" and "stop". */
 const KILL_GRACE_MS = 100;
 /** A judge reply is one small JSON object. Anything beyond this is noise, and


### PR DESCRIPTION
## Summary
Closes the **field residual** half of #143. The broker core, notify path, and deny-loud path already shipped; this PR makes live judge behaviour honest and usable.

### Changes
1. **Default `judgeTimeoutMs` 8s → 15s** (broker-config + cli-invoker + approval-judge) — Jarvis observed 3.7–6.1s judge latency; 8s left no headroom and silently dropped the judge to null/hold.
2. **`runJudgeDetailed()`** — distinguishes `timeout` vs `unreachable` vs `parse` vs `thrown` without inventing a synthetic verdict.
3. **Broker audit** — `judgeTimedOut` + allowlisted `judgeUnavailableReason`; timeout **never** sets `canAutoApproveOnTimeout`.
4. **Hook + OpenClaw interceptor** wire the detailed path and carry the audit fields.
5. **Doctor honesty** — when enforce is on and a `broker` block exists: armed vs present-but-disabled (opt-in default). Never claims protection while disabled.
6. **Design doc** status updated from stale "proposal (no code yet)".

### Explicit non-goals (this PR)
- Broker still **opt-in** (`enabled` default `false`)
- No CC-hook pre-clear / no session transcript to the judge
- No OpenClaw `context.notifyOperator` host seam
- No pre-clear allowlist / confidence floor loosening

### Test plan
- [x] `npm run build:ts`
- [x] focused: broker-config, approval-judge, approval-broker, approval-broker-adversarial, pre-tool-hook-broker-143, doctor-action-guard — **187 green**
- [ ] dual frontier review (Grok 4.6 + SOL Pro)
- [ ] CI green

Closes #143 (residual; core already on main).