### PR TITLE
feat(cli): Action Guard enable/enforce via signed config flags

### DIFF
--- a/src/__tests__/config-action-guard-core-cli.test.ts
+++ b/src/__tests__/config-action-guard-core-cli.test.ts
@@ -1,0 +1,154 @@
+/**
+ * `shieldcortex config --action-guard-enable|disable|enforce|advisory` — the
+ * signed CLI path for the Action Guard core switches. Before this, doctor's
+ * suggested fix for `actionGuard.enabled: false` was to hand-edit
+ * ~/.shieldcortex/config.json — which invalidated the embedded `_sig` HMAC and
+ * forced defenceMode strict. These flags write through
+ * mutateRawConfig/writeRawConfig, so the config is re-signed and the integrity
+ * check stays green. Both keys default ON when absent (`!== false` read
+ * semantics, mirroring doctor's effective-config merge), so disable/advisory
+ * must write an explicit false.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { handleCloudConfig } from '../cloud/cli.js';
+import {
+  getActionGuardCoreConfig,
+  setReviewedScripts,
+  getConfigDir,
+  clearCloudConfigCache,
+  readRawConfig,
+  isConfigTampered,
+} from '../cloud/config.js';
+
+const configFile = () => path.join(getConfigDir(), 'config.json');
+const legacySigFile = () => path.join(getConfigDir(), '.config-sig');
+
+function resetConfigDir(): void {
+  fs.rmSync(configFile(), { force: true });
+  fs.rmSync(legacySigFile(), { force: true });
+  clearCloudConfigCache();
+}
+
+let logSpy: ReturnType<typeof jest.spyOn>;
+
+beforeEach(() => {
+  resetConfigDir();
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  resetConfigDir();
+});
+
+describe('config --action-guard-* core flags', () => {
+  it('defaults ON for both keys when the config has no actionGuard block', () => {
+    const cfg = getActionGuardCoreConfig();
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.enforce).toBe(true);
+  });
+
+  it('--action-guard-enable writes enabled:true and a SIGNED config that does not trip the tamper flag', () => {
+    handleCloudConfig(['--action-guard-enable']);
+    expect(getActionGuardCoreConfig().enabled).toBe(true);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    expect(onDisk.actionGuard.enabled).toBe(true);
+    expect(typeof onDisk._sig).toBe('string');
+    expect(onDisk._sig).toMatch(/^[0-9a-f]{64}$/);
+    clearCloudConfigCache();
+    const raw = readRawConfig();
+    expect(isConfigTampered()).toBe(false);
+    expect(raw.defenceMode).not.toBe('strict');
+  });
+
+  it('--action-guard-disable writes an explicit enabled:false and status shows Off', () => {
+    handleCloudConfig(['--action-guard-disable']);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    expect(onDisk.actionGuard.enabled).toBe(false);
+    expect(getActionGuardCoreConfig().enabled).toBe(false);
+    logSpy.mockClear();
+    handleCloudConfig(['--cloud-status']);
+    const lines = logSpy.mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.includes('Action Guard: Off'))).toBe(true);
+  });
+
+  it('--action-guard-enforce writes enabled:true AND enforce:true, and status shows Enforce', () => {
+    handleCloudConfig(['--action-guard-enforce']);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    expect(onDisk.actionGuard.enabled).toBe(true);
+    expect(onDisk.actionGuard.enforce).toBe(true);
+    logSpy.mockClear();
+    handleCloudConfig(['--cloud-status']);
+    const lines = logSpy.mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.includes('Action Guard: Enforce'))).toBe(true);
+  });
+
+  it('--action-guard-advisory writes enforce:false and leaves enabled as-is, status shows Advisory', () => {
+    handleCloudConfig(['--action-guard-enable']);
+    handleCloudConfig(['--action-guard-advisory']);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    expect(onDisk.actionGuard.enabled).toBe(true);
+    expect(onDisk.actionGuard.enforce).toBe(false);
+    const cfg = getActionGuardCoreConfig();
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.enforce).toBe(false);
+    logSpy.mockClear();
+    handleCloudConfig(['--cloud-status']);
+    const lines = logSpy.mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.includes('Action Guard: Advisory (warn-mode)'))).toBe(true);
+  });
+
+  it('--action-guard-advisory on a disabled guard still writes enforce:false without re-enabling', () => {
+    handleCloudConfig(['--action-guard-disable']);
+    handleCloudConfig(['--action-guard-advisory']);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    expect(onDisk.actionGuard.enabled).toBe(false);
+    expect(onDisk.actionGuard.enforce).toBe(false);
+  });
+
+  it('disable then enforce re-enables: enforce implies enabled', () => {
+    handleCloudConfig(['--action-guard-disable']);
+    handleCloudConfig(['--action-guard-enforce']);
+    const cfg = getActionGuardCoreConfig();
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.enforce).toBe(true);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    expect(onDisk.actionGuard.enabled).toBe(true);
+    expect(onDisk.actionGuard.enforce).toBe(true);
+  });
+
+  it('preserves sibling actionGuard keys (notify, reviewedScripts) on write', () => {
+    handleCloudConfig(['--action-guard-notify-webhook', 'https://hooks.example.invalid/sc']);
+    setReviewedScripts([{ hash: 'abc123' }]);
+    handleCloudConfig(['--action-guard-enforce']);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    expect(onDisk.actionGuard.notify.enabled).toBe(true);
+    expect(onDisk.actionGuard.notify.webhookUrl).toBe('https://hooks.example.invalid/sc');
+    expect(onDisk.actionGuard.reviewedScripts).toEqual([{ hash: 'abc123' }]);
+    expect(onDisk.actionGuard.enabled).toBe(true);
+    expect(onDisk.actionGuard.enforce).toBe(true);
+  });
+
+  it('preserves unrelated top-level keys (defenceMode) on write', () => {
+    handleCloudConfig(['--mode', 'balanced']);
+    handleCloudConfig(['--action-guard-enable']);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    expect(onDisk.defenceMode).toBe('balanced');
+    expect(onDisk.actionGuard.enabled).toBe(true);
+  });
+
+  it('the same hand-edit the CLI replaces DOES trip the integrity check (why doctor must not recommend it)', () => {
+    handleCloudConfig(['--action-guard-enable']);
+    const onDisk = JSON.parse(fs.readFileSync(configFile(), 'utf-8'));
+    onDisk.actionGuard.enabled = false;
+    fs.writeFileSync(configFile(), JSON.stringify(onDisk, null, 2) + '\n');
+    clearCloudConfigCache();
+    const raw = readRawConfig();
+    expect(isConfigTampered()).toBe(true);
+    expect(raw.defenceMode).toBe('strict');
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2139,13 +2139,14 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
         label: `${label} config`,
         status: 'warn',
         message: `Action Guard is disabled in config (\`${provenance('enabled')}: false\`) — tool calls are not gated on either surface`,
-        fix: `Remove \`${provenance('enabled')}: false\` from ~/.shieldcortex/config.json to restore gating.`,
+        fix: 'Run `shieldcortex config --action-guard-enable` to restore gating — the CLI writes a signed config; hand-editing config.json invalidates its integrity signature.',
       });
     } else if (!effective.enforce) {
       results.push({
         label: `${label} config`,
         status: 'warn',
         message: `Action Guard runs in warn-mode (\`${provenance('enforce')}: false\`) on both surfaces — dangerous ops log but are not gated (catastrophic still blocks)`,
+        fix: 'Run `shieldcortex config --action-guard-enforce` to gate dangerous ops — the CLI writes a signed config; hand-editing config.json invalidates its integrity signature.',
       });
     }
 

--- a/src/cloud/cli.ts
+++ b/src/cloud/cli.ts
@@ -22,6 +22,8 @@ import {
   setRevokeBySourceEnabled,
   getActionGuardNotifyConfig,
   setActionGuardNotifyConfig,
+  getActionGuardCoreConfig,
+  setActionGuardCoreConfig,
   type DefenceMode,
 } from './config.js';
 import type { RankerEngine } from '../memory/types.js';
@@ -53,8 +55,11 @@ export function handleCloudConfig(args: string[]): void {
     const agNotifyChannels = [agNotify.openclaw ? 'openclaw' : null, agNotify.webhookUrl ? 'webhook' : null]
       .filter(Boolean)
       .join(' + ');
+    const agCore = getActionGuardCoreConfig();
+    const agStatus = !agCore.enabled ? 'Off' : agCore.enforce ? 'Enforce' : 'Advisory (warn-mode)';
     console.log(`  Defence Mode: ${mode}`);
     console.log(`  Tool-Output Firewall: ${toolFirewall.scanToolResponses ? toolFirewall.toolResponseMode : 'Off'}`);
+    console.log(`  Action Guard: ${agStatus}`);
     console.log(`  Action Guard Notify: ${agNotify.enabled ? (agNotifyChannels || 'Enabled (no channel configured!)') : 'Off'}`);
     console.log(`  Revoke-by-source: ${isRevokeBySourceEnabled() ? 'Enabled (destructive)' : 'Disabled (default)'}`);
     console.log(`  Cloud Enabled:  ${config.cloudEnabled ? 'Yes' : 'No'}`);
@@ -291,6 +296,39 @@ export function handleCloudConfig(args: string[]): void {
     changed = true;
   }
 
+  // ── Action Guard core switches (enable/enforce) ──
+  // The SIGNED path for actionGuard.enabled / actionGuard.enforce, same reason
+  // the notify flags exist: hand-editing config.json for these keys invalidates
+  // the `_sig` HMAC and forces defenceMode strict. Both keys default ON when
+  // absent (`!== false` semantics on read), so disable/advisory write an
+  // explicit false.
+
+  if (args.includes('--action-guard-enable')) {
+    setActionGuardCoreConfig({ enabled: true });
+    console.log('Action Guard enabled — tool calls are gated on both surfaces.');
+    changed = true;
+  }
+
+  if (args.includes('--action-guard-disable')) {
+    setActionGuardCoreConfig({ enabled: false });
+    console.log('Action Guard DISABLED — tool calls are NOT gated on either surface, and catastrophic checks may not fire while the guard is off entirely. Re-enable with --action-guard-enable.');
+    changed = true;
+  }
+
+  if (args.includes('--action-guard-enforce')) {
+    // Enforce implies enabled: enforcing a disabled guard is nonsense, so this
+    // flag also switches the guard on rather than writing a dead enforce key.
+    setActionGuardCoreConfig({ enabled: true, enforce: true });
+    console.log('Action Guard ENFORCE — dangerous ops require approval / block.');
+    changed = true;
+  }
+
+  if (args.includes('--action-guard-advisory')) {
+    setActionGuardCoreConfig({ enforce: false });
+    console.log('Action Guard ADVISORY (warn-mode) — dangerous ops log but are not gated (catastrophic still blocks when enabled).');
+    changed = true;
+  }
+
   // ── Action Guard notify channel (#275) ──
   // The SIGNED path for what doctor's "enforcing with no notify channel" warn
   // prescribes. Hand-editing config.json for these keys invalidates the `_sig`
@@ -370,6 +408,10 @@ export function handleCloudConfig(args: string[]): void {
     console.log('  --tool-firewall-advisory  Log tool-output threats but deliver intact (default)');
     console.log('  --tool-firewall-off / --tool-firewall-on  Disable / enable tool-output scanning');
     console.log('  --allow-revoke-by-source / --disallow-revoke-by-source  Enable/disable destructive forget --fromSource (default: disabled)');
+    console.log('  --action-guard-enable    Enable Action Guard tool-call gating (default: on)');
+    console.log('  --action-guard-disable   Disable Action Guard entirely — tool calls are NOT gated');
+    console.log('  --action-guard-enforce   Gate dangerous ops (approval/block); also enables the guard');
+    console.log('  --action-guard-advisory  Warn-mode — dangerous ops log but are not gated (catastrophic still blocks)');
     console.log('  --action-guard-notify-openclaw  Notify Action Guard denials via the native OpenClaw approval card');
     console.log('  --action-guard-notify-webhook <https-url>  Notify Action Guard denials to an https webhook');
     console.log('  --action-guard-notify-disable   Disable Action Guard denial notifications');

--- a/src/cloud/config.ts
+++ b/src/cloud/config.ts
@@ -735,6 +735,56 @@ export function setActionGuardNotifyConfig(updates: Partial<ActionGuardNotifyCon
   });
 }
 
+// ── Action Guard core switches (enable/enforce) ───────
+
+export interface ActionGuardCoreConfig {
+  /** Master switch. Default ON when the key is absent (`enabled !== false`). */
+  enabled: boolean;
+  /** When true, gate dangerous ops. When false, warn-mode — dangerous ops log
+   *  but are not gated (catastrophic may still block). Default ON when absent. */
+  enforce: boolean;
+}
+
+/**
+ * EFFECTIVE core config, resolved the same way both runtime surfaces and
+ * doctor's posture check resolve it (#209): top-level `actionGuard` merged
+ * over the deprecated `interceptor.actionGuard` alias (top-level wins per
+ * key), with default-ON semantics — a key is only off when explicitly false.
+ */
+export function getActionGuardCoreConfig(): ActionGuardCoreConfig {
+  const raw = readRawConfig();
+  const interceptor = raw.interceptor && typeof raw.interceptor === 'object' && !Array.isArray(raw.interceptor)
+    ? (raw.interceptor as Record<string, unknown>)
+    : {};
+  const alias = interceptor.actionGuard && typeof interceptor.actionGuard === 'object' && !Array.isArray(interceptor.actionGuard)
+    ? (interceptor.actionGuard as Record<string, unknown>)
+    : {};
+  const merged = { ...alias, ...actionGuardBlock(raw) };
+  return {
+    enabled: merged.enabled !== false,
+    enforce: merged.enforce !== false,
+  };
+}
+
+/**
+ * The SIGNED write path for `actionGuard.enabled` / `actionGuard.enforce` —
+ * what the `shieldcortex config --action-guard-enable|disable|enforce|advisory`
+ * flags call. Same discipline as setActionGuardNotifyConfig: routed through
+ * mutateRawConfig so the `_sig` HMAC is recomputed, and read-modify-write on
+ * the actionGuard block so sibling keys (notify, reviewedScripts, broker,
+ * autoApprove) survive untouched. The deprecated `interceptor.actionGuard`
+ * alias is deliberately left alone — top-level wins on both surfaces (#209),
+ * and migration is `doctor --fix-action-guard`'s job.
+ */
+export function setActionGuardCoreConfig(updates: Partial<ActionGuardCoreConfig>): void {
+  mutateRawConfig((raw) => {
+    const guard = actionGuardBlock(raw);
+    if (updates.enabled !== undefined) guard.enabled = updates.enabled;
+    if (updates.enforce !== undefined) guard.enforce = updates.enforce;
+    raw.actionGuard = guard;
+  });
+}
+
 /**
  * `doctor --fix-action-guard`'s write path (#209 migration, #275 fix): merge
  * the deprecated `interceptor.actionGuard` alias into the top-level block —


### PR DESCRIPTION
## Summary
Operators can toggle Action Guard without hand-editing `~/.shieldcortex/config.json` (which invalidated `_sig`).

### New flags
```bash
shieldcortex config --action-guard-enable
shieldcortex config --action-guard-disable
shieldcortex config --action-guard-enforce    # also enables
shieldcortex config --action-guard-advisory   # warn-mode; leaves enabled as-is
```

`--cloud-status` now shows: `Action Guard: Off | Enforce | Advisory (warn-mode)`.

Doctor fix text points at these flags instead of hand-edit paths.

### Design
- Signed write via `mutateRawConfig` (same path as notify flags)
- Effective defaults match doctor/runtime: absent key = ON (`!== false`)
- `--action-guard-enforce` implies `enabled: true`
- Preserves notify / reviewedScripts / broker siblings

## Test plan
- [x] `npm run build:ts`
- [x] 47 focused tests (core CLI + notify CLI + doctor-action-guard)