### PR TITLE
chore(release): v4.52.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.52.1] - 2026-08-15
+
+**Patch — Action Guard enable/enforce via signed CLI flags.**
+
+Hosts on `shieldcortex update` can now toggle Action Guard without hand-editing `~/.shieldcortex/config.json` (which invalidated the embedded `_sig` HMAC and forced defenceMode strict).
+
+### Added
+
+- **`shieldcortex config --action-guard-enable|disable|enforce|advisory`** — signed write path for `actionGuard.enabled` / `actionGuard.enforce` (PR #296).
+  - `--action-guard-enforce` also sets `enabled: true` (enforcing a disabled guard is nonsense).
+  - `--action-guard-advisory` writes warn-mode only and leaves `enabled` as-is.
+  - `--cloud-status` reports `Action Guard: Off | Enforce | Advisory (warn-mode)`.
+  - Doctor fix text points at these flags instead of hand-edit paths.
+  - Defaults match runtime/doctor: absent key = ON (`!== false`). Sibling keys (notify, reviewedScripts, broker) preserved on write.
+
+### Notes
+
+- No security-behaviour change for default hosts (Action Guard remains on/enforce when keys are absent).
+- SDK/PyPI stay at 0.3.0 (no client API change). Cloud dep floor moves to `^4.52.1`.
+
 ## [4.52.0] - 2026-08-15
 
 **Security residual grind — Action Guard precision, approval-broker field residual, and an instruction-detector floor that stops treating English morphology as a different language.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.52.0",
+  "version": "4.52.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.52.0",
+      "version": "4.52.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.52.0",
+  "version": "4.52.1",
   "description": "Trustworthy memory and security for AI agents. Recall debugging, review queue, OpenClaw session capture, and memory poisoning defence for Claude Code, Codex, OpenClaw, LangChain, and MCP agents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.52.0",
+  "version": "4.52.1",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.52.0",
+  "version": "4.52.1",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.52.0
+  version: 4.52.1
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Summary
Patch release so hosts get Action Guard enable/enforce CLI flags via `shieldcortex update`.

- Core + plugin → **4.52.1**
- Ships PR #296 (`--action-guard-enable|disable|enforce|advisory`)
- No security default change (absent keys still ON/enforce)
- Coordinated train after merge: npm publish, GH release, ClawHub, cloud dep `^4.52.1`, websites

## Test plan
- [x] version sync script
- [ ] CI green
- [ ] publish workflow after tag