### PR TITLE
docs: bound vs not-bound planes + shieldcortex/enforce

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,17 @@ shieldcortex quickstart
 > [!NOTE]
 > ShieldCortex is MIT licensed and **free — every local feature is included**, with no trial and no licence key. An optional cloud free tier adds centralised audit visibility (500 scans/month, 7-day retention, 1 member — sign in with just your email). Teams, servers, and fleets are Enterprise: sales@drakonsystems.com.
 
-**Works with** Claude Code · Codex CLI / VS Code · Cursor · VS Code · OpenClaw · LangChain · MCP agents · Python via REST API
+**Where it can actually say no**
+
+| Host | Memory firewall | Tool gate | Turn gate | Freeze / lease |
+|---|---|---|---|---|
+| **Claude Code** | yes | **bound** (PreToolUse) | unbound | **bound** |
+| **OpenClaw** | yes | **bound** (`before_tool_call`) | **bound** only if you grant conversation access *and* set posture `enforce` (default is `observe`) | **bound** |
+| **Hermes** | via local API | **bound** (`pre_tool_call`, enforce by default) | unbound | unbound |
+| **Codex / Cursor / Copilot / any MCP host** | yes, if the agent calls the tools | **unbound** — MCP cannot wrap the host's Bash | unbound | unbound |
+| **LangChain JS / Python SDK** | yes, if you call `scan` / `save` | **unbound** | unbound | unbound |
+
+Memory security is portable. Runtime enforcement is not. `shieldcortex doctor` and `shieldcortex lease` report **bound / not-bound / unknown** per plane on this host — they will not print “protected” for a host that cannot deny.
 
 **Why teams adopt ShieldCortex**
 
@@ -190,7 +200,7 @@ npm install -g shieldcortex
 shieldcortex quickstart
 ```
 
-`quickstart` scans your machine and auto-detects which agent tools are installed — **Claude Code, OpenClaw, VS Code, Cursor, and Codex** — then configures ShieldCortex for all of them in one go. One command, everything detected, no per-tool setup steps.
+`quickstart` detects which agent tools are installed and configures what each host can actually support. Claude Code and OpenClaw get hooks that can **deny**. Codex, Cursor, and VS Code get an MCP memory server — that is a scanner the model may call, not a tool gate. `doctor` will say so.
 
 > If you want to configure a single tool manually, use `shieldcortex install` instead. It registers the MCP server and session hooks for whichever agent is in the current working directory.
 
@@ -211,7 +221,7 @@ shieldcortex doctor
 
 ShieldCortex has two tiers:
 
-- **Free (MIT)** — every local feature: memory, recall, review, dashboard, Iron Dome, custom injection patterns, custom policies, custom firewall rules, audit export, the dependency scanner, Cortex mistake learning, unlimited X-Ray (including npm deep scans and the CI/CD gate), and the OpenClaw/Codex integrations. No trial, no licence key, no signup. The cloud free tier is included too: 500 scans/month, 7-day audit retention, 1 member — sign in with just your email.
+- **Free (MIT)** — every local feature: memory, recall, review, dashboard, Iron Dome, custom injection patterns, custom policies, custom firewall rules, audit export, the dependency scanner, Cortex mistake learning, unlimited X-Ray (including npm deep scans and the CI/CD gate), and the OpenClaw / Claude Code / Hermes enforcement planes plus MCP memory on other hosts. No trial, no licence key, no signup. The cloud free tier is included too: 500 scans/month, 7-day audit retention, 1 member — sign in with just your email.
 - **Enterprise** — full cloud memory/graph replication, team management, shared patterns, servers and fleets, self-hosted deployments, SLA. Contact **sales@drakonsystems.com**.
 
 Check the current state at any time:
@@ -699,18 +709,18 @@ Every time you type a message, ShieldCortex automatically recalls relevant memor
 
 ShieldCortex also runs natively on **Hermes** — the Python agent runtime — not as a shim but as a Hermes-native plugin.
 
-Drop the plugin folder in and enable it:
+Install and enable:
 
 ```bash
-# from a clone of this repo
-cp -r plugins/hermes/shieldcortex ~/.hermes/plugins/shieldcortex
+shieldcortex hermes install
 hermes plugins enable shieldcortex
+shieldcortex api   # local Action Guard API on :3001 — required
 ```
 
 It registers a **`pre_tool_call` gate**: before every Hermes tool execution it asks Action Guard via the local REST API (`POST /api/v1/action-guard`) — the same `evaluateToolCall` verdict the Claude Code hook and OpenClaw interceptor already share.
 
-- 🛡️ **Advisory-first** — `enforce` is off by default; it logs what it *would* block. Set `SHIELDCORTEX_ENFORCE=1` to actively block.
-- 🪂 **Fail-open** — if the ShieldCortex API is unreachable, the gate never blocks. A down scanner must not wedge the agent; every fail-open is logged.
+- 🛡️ **Enforce by default** (since 4.47.2). Opt out to advisory with `SHIELDCORTEX_ENFORCE=0` (or `false` / `no` / `off` / `advisory`).
+- 🪂 **Fail-open if the API is down** — a scanner outage must not wedge the agent. Catastrophic shapes still fail closed via the local fallback. Every degrade is logged.
 - 🔒 **Authenticated** — reads the API token from `SHIELDCORTEX_API_TOKEN` or `~/.shieldcortex/.api-token` and sends `Authorization: Bearer`.
 - 📦 **Isolated** — installs under `~/.hermes/plugins/shieldcortex/`, touching nothing else on the host. Coexists cleanly with an OpenClaw ShieldCortex on the same machine (separate state dirs, no shared-SQLite contention).
 
@@ -807,16 +817,16 @@ SHIELDCORTEX_RANKER=legacy npm run bench   # env var overrides config for a sing
 
 ## 🔌 Integrations
 
-| Platform | Setup |
-|---|---|
-| **Claude Code** | `shieldcortex install` |
-| **Codex CLI / VS Code** | `shieldcortex codex install` |
-| **Cursor** | `shieldcortex install` |
-| **VS Code** (Copilot) | `shieldcortex install` |
-| **OpenClaw** | `openclaw skills install shieldcortex && openclaw plugins install @drakon-systems/shieldcortex-realtime` — [details above](#-openclaw-integration) |
-| **LangChain JS** | `import { ShieldCortexMemory } from 'shieldcortex/integrations/langchain'` |
-| **Python** (CrewAI, LangChain) | `pip install shieldcortex` — [hosted-API client](#python), needs a cloud key |
-| **Any MCP agent** | `shieldcortex install` |
+| Platform | Setup | What you get |
+|---|---|---|
+| **Claude Code** | `shieldcortex install` | MCP memory **and** PreToolUse tool gate (bound) |
+| **OpenClaw** | `openclaw skills install shieldcortex && openclaw plugins install @drakon-systems/shieldcortex-realtime` — [details](#-openclaw-integration) | MCP memory **and** `before_tool_call` gate (bound) |
+| **Hermes** | `shieldcortex hermes install` — [details](#-hermes-integration) | `pre_tool_call` gate via local Action Guard API (bound; enforce by default) |
+| **Codex CLI / VS Code** | `shieldcortex codex install` | MCP memory server only — **not bound** |
+| **Cursor / Copilot** | `shieldcortex install` / `copilot install` | MCP memory server only — **not bound** |
+| **LangChain JS** | `import { ShieldCortexMemory } from 'shieldcortex/integrations/langchain'` | In-process scan on `save` — **not bound** |
+| **Python** (CrewAI, LangChain extras) | `pip install shieldcortex` — [hosted-API client](#python) | Cloud `scan()` — **not bound** |
+| **Any MCP agent** | `shieldcortex install` | Memory + advisory tools the model may ignore — **not bound** |
 
 <br>
 
@@ -824,8 +834,8 @@ SHIELDCORTEX_RANKER=legacy npm run bench   # env var overrides config for a sing
 
 `shieldcortex` ships as ESM only (`"type": "module"`, no CommonJS build) — this is a
 deliberate choice, not an oversight, and it won't change silently. Every entry point
-(`shieldcortex`, `shieldcortex/defence`, `shieldcortex/scan`, `shieldcortex/lib`,
-`shieldcortex/integrations/*`, `shieldcortex/environment`) works with:
+(`shieldcortex`, `shieldcortex/defence`, `shieldcortex/scan`, `shieldcortex/enforce`,
+`shieldcortex/lib`, `shieldcortex/integrations/*`, `shieldcortex/environment`) works with:
 
 ```js
 import shieldcortex from 'shieldcortex';
@@ -867,7 +877,8 @@ shieldcortex iron-dome status     # Check Iron Dome status
 openclaw skills install shieldcortex
 openclaw plugins install @drakon-systems/shieldcortex-realtime
 shieldcortex openclaw status      # Check OpenClaw hook status
-shieldcortex codex install        # Connect Codex CLI / VS Code
+shieldcortex hermes install       # Hermes pre_tool_call Action Guard (bound)
+shieldcortex codex install        # Codex MCP memory server (NOT a tool gate)
 shieldcortex consolidate          # Run Dream Mode (merge, archive, contradict)
 shieldcortex audit                # Dependency scanner
 shieldcortex xray <path>          # Deep file analysis for hidden threats

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -2,7 +2,9 @@
 
 *A second brain with a defence system built in.*
 
-Status anchor: **v4.47.39** · 2026-08-12 · claims proven: **12/12** (`docs/CLAIMS-PROOF.md`)
+Status anchor: **v4.52.1** · 2026-08-15 · claims proven: **12/12** (`docs/CLAIMS-PROOF.md`)
+
+Runtime enforcement is **bound** on Claude Code (PreToolUse), OpenClaw (`before_tool_call`), and Hermes (`pre_tool_call`). Codex, Cursor, Copilot, LangChain, and generic MCP get the memory firewall / scanner only — they are **not bound**. Conversation-turn blocking on OpenClaw requires an operator grant and posture `enforce` (default `observe`). See the README capability matrix.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shieldcortex",
   "version": "4.52.1",
-  "description": "Trustworthy memory and security for AI agents. Recall debugging, review queue, OpenClaw session capture, and memory poisoning defence for Claude Code, Codex, OpenClaw, LangChain, and MCP agents.",
+  "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -40,6 +40,11 @@
       "import": "./dist/scan-only.js",
       "require": "./scripts/lib/cjs-not-supported.cjs",
       "types": "./dist/scan-only.d.ts"
+    },
+    "./enforce": {
+      "import": "./dist/enforce.js",
+      "require": "./scripts/lib/cjs-not-supported.cjs",
+      "types": "./dist/enforce.d.ts"
     },
     "./environment": {
       "import": "./dist/environment/index.js",
@@ -170,6 +175,7 @@
     "scripts/prompt-recall-hook.mjs",
     "scripts/pre-tool-hook.mjs",
     "scripts/lib",
-    "dashboard/.next/standalone"
+    "dashboard/.next/standalone",
+    "plugins/hermes"
   ]
 }

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -22,8 +22,10 @@ install:
   minVersion: "20"
   note: >
     Run the installed `shieldcortex` binary directly. The quickstart command
-    detects your environment and guides MCP server registration. All data stays
-    local in ~/.shieldcortex/. No account or API key needed for local use.
+    detects your environment. Claude Code and OpenClaw get hooks that can deny;
+    Codex/Cursor/VS Code get an MCP memory server only (not a tool gate).
+    All data stays local in ~/.shieldcortex/. No account or API key needed
+    for local use.
 permissions:
   filesystem: readwrite
   network: optional
@@ -87,7 +89,7 @@ This is an enforcing memory boundary, not a passive scanner. Across the read/wri
 
 This section explains every privileged operation the tool performs and why.
 
-- **Active interception, not scan-only.** Beyond read-only scans, ShieldCortex *enforces* at the boundary: writes failing the pipeline are quarantined/blocked; recalled memory is trust/ACL-filtered before the agent sees it; in enforce mode the tool-output firewall redacts/withholds malicious tool results; and the OpenClaw `before_tool_call` interceptor + Iron Dome kill-switch can block operations. Surprising enforcement is opt-in (tool-output firewall defaults to advisory). `shieldcortex status` and `iron-dome status` report which controls are active.
+- **Active interception, not scan-only — on hosts that can deny.** Writes failing the pipeline are quarantined/blocked; recalled memory is trust/ACL-filtered before the agent sees it. Tool-call denial is **bound** on Claude Code (PreToolUse), OpenClaw (`before_tool_call`), and Hermes (`pre_tool_call`, enforce by default). Codex, Cursor, Copilot, and generic MCP get a memory server / scanner the model may ignore — they are **not bound**. Tool-output firewall defaults to advisory. `shieldcortex doctor` and `shieldcortex lease` report bound / not-bound / unknown per plane.
 - **Setup is user-initiated, with one bounded exception.** Installing hooks, registering the MCP server, and migrating data are manual steps the user runs in their terminal, and `quickstart` asks before each action. The npm postinstall script (disclosed in the trust table above) never adds integrations that weren't already present — on global installs it only prints instructions, checks the native binding, seeds default config on first install, and refreshes an existing OpenClaw hook/plugin install. The exception: the bundled cortex-memory hook performs a small automatic self-heal at gateway bootstrap, documented in full under **"Automatic self-heal at gateway bootstrap"** below.
 - **Setup migrates legacy data.** The first `quickstart`/`setup` run may move or remove legacy config/memory directories (e.g. `~/.claude-cortex/`, `~/.claude-memory/`) into `~/.shieldcortex/` and copy hook files into place. This happens only on the user-run setup command — never on `npm install` (the postinstall script does not touch memory or config data beyond seeding defaults on a first-ever global install).
 - **Destructive `forget` is bounded and gated.** Per-memory and filtered bulk deletes go through a delete ACL (own-only) and are recorded in the audit ledger. Revoke-by-source (`forget --fromSource`, bulk-delete every memory from one source — for purging a poisoned agent) is **disabled by default** and only enabled by an out-of-band human action (`shieldcortex config --allow-revoke-by-source`); even then it is bounded by a trust-hierarchy ACL (you must own the source or out-rank it) and a per-call row cap. A compromised agent cannot mass-delete your memory.
@@ -234,9 +236,9 @@ shieldcortex service start|stop|status  # Manage background service
 ### Integrations
 ```bash
 # subcommand is `install`, not `setup` (also: status, uninstall; openclaw adds repair, skill)
-shieldcortex openclaw install    # Set up OpenClaw hook + realtime plugin
-shieldcortex copilot install     # Set up VS Code / Cursor MCP server
-shieldcortex codex install       # Set up Codex CLI MCP server
+shieldcortex openclaw install    # Hook + realtime plugin — tool gate BOUND
+shieldcortex copilot install     # VS Code / Cursor MCP memory server — NOT a tool gate
+shieldcortex codex install       # Codex CLI MCP memory server — NOT a tool gate
 shieldcortex config --openclaw-auto-memory true   # Enable auto-memory in OpenClaw
 shieldcortex config --proactive-recall true|false  # Enable/disable proactive recall
 ```

--- a/src/__tests__/enforce-entry.test.ts
+++ b/src/__tests__/enforce-entry.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from '@jest/globals';
+import { evaluateAction, evaluateToolCall } from '../enforce.js';
+
+describe('shieldcortex/enforce', () => {
+  it('evaluateToolCall hard-blocks a catastrophic rm', () => {
+    const v = evaluateToolCall('Bash', { command: 'rm -rf /' });
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('catastrophic');
+  });
+
+  it('evaluateAction returns a guard verdict and a lease slot', () => {
+    const result = evaluateAction('Bash', { command: 'echo hello' }, { skipLease: true });
+    expect(result.verdict.decision).toBe('allow');
+    expect(result.lease).toBeNull();
+  });
+
+  it('allows a benign read', () => {
+    const v = evaluateToolCall('Read', { path: 'README.md' });
+    expect(v.decision).toBe('allow');
+  });
+});

--- a/src/cli/__tests__/freeze-command.test.ts
+++ b/src/cli/__tests__/freeze-command.test.ts
@@ -64,6 +64,7 @@ describe('freeze → enforcement parser round-trip', () => {
     const text = out.join('\n');
     expect(text).toMatch(/claude-code hook/);
     expect(text).toMatch(/openclaw interceptor/);
+    expect(text).toMatch(/hermes pre_tool_call/);
     expect(text).toMatch(/NOT bound anywhere/);
   });
 });

--- a/src/cli/freeze.ts
+++ b/src/cli/freeze.ts
@@ -80,6 +80,26 @@ export function describeLocalPlanes(home: string = os.homedir()): string[] {
       : '  openclaw interceptor:  UNKNOWN — plugin registry exists but cannot be read');
   }
 
+  // Hermes plane: plugin files on disk. Enable is Hermes' own command.
+  try {
+    const hermesPlugin = path.join(home, '.hermes', 'plugins', 'shieldcortex', 'plugin.yaml');
+    lines.push(fs.existsSync(hermesPlugin)
+      ? '  hermes pre_tool_call:  BOUND (plugin on disk; binds when Hermes has it enabled + API up)'
+      : '  hermes pre_tool_call:  NOT BOUND — run `shieldcortex hermes install`');
+  } catch {
+    lines.push('  hermes pre_tool_call:  UNKNOWN — cannot inspect ~/.hermes/plugins');
+  }
+
+  // MCP-only hosts: present config is not a deny plane.
+  const cursorMcp = path.join(home, '.cursor', 'mcp.json');
+  const codexCfg = path.join(home, '.codex', 'config.toml');
+  if (fs.existsSync(cursorMcp)) {
+    lines.push('  cursor / vscode mcp:   NOT BOUND — MCP memory only; host cannot wrap Bash');
+  }
+  if (fs.existsSync(codexCfg)) {
+    lines.push('  codex mcp:             NOT BOUND — MCP memory only; host cannot wrap Bash');
+  }
+
   lines.push('  NOT bound anywhere:    direct shell outside tool calls; hosts without the guard;');
   lines.push('                         installs older than this feature. A freeze binds tool calls');
   lines.push('                         where a plane above says BOUND — nothing else. Verify other');

--- a/src/enforce.ts
+++ b/src/enforce.ts
@@ -1,0 +1,73 @@
+/**
+ * shieldcortex/enforce — the portable Action Guard.
+ *
+ * One function a host adapter calls before executing a tool:
+ *   evaluateAction(toolName, args) → allow | require_approval | block
+ *
+ * This is NOT a hook protocol. The host must honour `block` / `require_approval`.
+ * MCP, LangChain, and a custom loop that ignore the verdict are unbound.
+ *
+ * Deliberately does NOT import iron-dome/index.ts (that pulls sqlite).
+ * Freeze / lease is a separate call so a scanner-only consumer never
+ * touches ~/.shieldcortex/DECISIONS.md.
+ */
+
+export {
+  evaluateToolCall,
+  type ToolGuardDecision,
+  type ToolGuardSeverity,
+  type ToolGuardVerdict,
+  type ToolGuardOptions,
+  type ToolFamily,
+} from './defence/iron-dome/tool-action-guard.js';
+
+export {
+  evaluateToolCallLease,
+  type LeaseGateResult,
+  type LeaseGateOptions,
+} from './defence/iron-dome/session-lease-store.js';
+
+import { evaluateToolCall, type ToolGuardVerdict } from './defence/iron-dome/tool-action-guard.js';
+import {
+  evaluateToolCallLease,
+  type LeaseGateOptions,
+  type LeaseGateResult,
+} from './defence/iron-dome/session-lease-store.js';
+
+export interface EvaluateActionOptions {
+  /** Session identity for the lease mutex. Required when skipLease is false. */
+  self?: string;
+  dir?: string;
+  nowMs?: number;
+  ttlMs?: number;
+  /** Skip freeze/lease. Use only when the host already consulted the ledger. */
+  skipLease?: boolean;
+}
+
+export interface EvaluateActionResult {
+  verdict: ToolGuardVerdict;
+  lease: LeaseGateResult | null;
+}
+
+/**
+ * Guard + freeze in one call. Freeze is consulted first in the lease helper
+ * (it never throws). A freeze `block` is the host's problem to honour —
+ * this function still returns the guard verdict so the audit row can record both.
+ */
+export function evaluateAction(
+  toolName: string,
+  args: Record<string, unknown> | null | undefined,
+  opts: EvaluateActionOptions = {},
+): EvaluateActionResult {
+  const toolArgs = args ?? {};
+  const lease = opts.skipLease
+    ? null
+    : evaluateToolCallLease(toolName, toolArgs, {
+        self: opts.self ?? `anon-pid-${process.pid}`,
+        dir: opts.dir,
+        nowMs: opts.nowMs,
+        ttlMs: opts.ttlMs,
+      });
+  const verdict = evaluateToolCall(toolName, toolArgs);
+  return { verdict, lease };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -662,7 +662,8 @@ ${bold}COMMANDS${reset}
   ${cyan}uninstall${reset}             Remove ShieldCortex from your project
   ${cyan}openclaw${reset} <action>     Manage OpenClaw hook integration
   ${cyan}copilot${reset} <action>      Set up VS Code / Cursor MCP integration
-  ${cyan}codex${reset} <action>        Set up Codex CLI / VS Code MCP integration
+  ${cyan}codex${reset} <action>        Set up Codex CLI / VS Code MCP integration (memory only)
+  ${cyan}hermes${reset} <action>       Install the Hermes pre_tool_call Action Guard plugin
   ${cyan}graph${reset} backfill        Backfill knowledge graph from memories
   ${cyan}hook${reset} <action>         Manage hooks (start, stop, status)
   ${cyan}service${reset} <action>      Manage background service
@@ -771,6 +772,12 @@ ${bold}DOCS${reset}
   if (process.argv[2] === 'codex') {
     const { handleCodexCommand } = await import('./setup/codex.js');
     await handleCodexCommand(process.argv[3] || '');
+    return;
+  }
+
+  if (process.argv[2] === 'hermes') {
+    const { handleHermesCommand } = await import('./setup/hermes.js');
+    await handleHermesCommand(process.argv[3] || '');
     return;
   }
 
@@ -1477,7 +1484,7 @@ ${bold}DOCS${reset}
   const knownCommands = new Set([
 
     'doctor', 'quickstart', 'setup', 'install', 'migrate', 'uninstall', 'hook', 'update', 'repair',
-    'openclaw', 'clawdbot', 'copilot', 'codex', 'service', 'config', 'status',
+    'openclaw', 'clawdbot', 'copilot', 'codex', 'hermes', 'service', 'config', 'status',
     'graph', 'license', 'licence', 'audit', 'mcp', 'iron-dome', 'scan', 'cloud', 'review-copilot',
     'scan-skill', 'scan-skills', 'dashboard', 'api', 'worker', 'stats', 'cortex', 'consolidate', 'xray', 'xray-preinstall',
     'memories', 'import-jsonl', 'remember', 'vacuum', 'compact', 'sessions', 'approve', 'deny', 'allowlist',

--- a/src/setup/__tests__/hermes-install.test.ts
+++ b/src/setup/__tests__/hermes-install.test.ts
@@ -1,0 +1,24 @@
+import { mkdtempSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, afterEach } from '@jest/globals';
+import { installHermes, hermesPluginInstalled, uninstallHermes } from '../hermes.js';
+
+describe('hermes install', () => {
+  const homes: string[] = [];
+  afterEach(() => {
+    for (const home of homes) rmSync(home, { recursive: true, force: true });
+    homes.length = 0;
+  });
+
+  it('copies plugin.yaml into ~/.hermes/plugins/shieldcortex', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'sc-hermes-'));
+    homes.push(home);
+    expect(hermesPluginInstalled(home)).toBe(false);
+    await installHermes(home);
+    expect(hermesPluginInstalled(home)).toBe(true);
+    expect(existsSync(join(home, '.hermes', 'plugins', 'shieldcortex', 'plugin.yaml'))).toBe(true);
+    await uninstallHermes(home);
+    expect(hermesPluginInstalled(home)).toBe(false);
+  });
+});

--- a/src/setup/codex.ts
+++ b/src/setup/codex.ts
@@ -155,6 +155,9 @@ export async function installCodex(): Promise<void> {
   console.log();
   console.log('This Codex config is shared by the Codex CLI and IDE extension.');
   console.log('Restart Codex / VS Code if it was already open.');
+  console.log();
+  console.log('This is an MCP memory server — NOT a tool gate.');
+  console.log('Codex cannot deny Bash via MCP. `shieldcortex lease` will report NOT BOUND.');
 }
 
 export async function uninstallCodex(): Promise<void> {

--- a/src/setup/copilot.ts
+++ b/src/setup/copilot.ts
@@ -352,6 +352,9 @@ export async function installCopilot(): Promise<void> {
     console.log('  • Defence pipeline (firewall, trust scoring, audit trail)');
     console.log('  • Knowledge graph queries');
     console.log('  • Memory consolidation');
+    console.log();
+    console.log('This is an MCP memory server — NOT a tool gate.');
+    console.log('VS Code / Cursor cannot deny Bash via MCP. `shieldcortex lease` will report NOT BOUND.');
   } else if (vscodeDirs.length === 0 && !cursorDir) {
     console.error('Neither VS Code nor Cursor was found on this system.');
     process.exit(1);

--- a/src/setup/hermes.ts
+++ b/src/setup/hermes.ts
@@ -1,0 +1,106 @@
+/**
+ * Hermes plugin installer.
+ *
+ * Copies plugins/hermes/shieldcortex into ~/.hermes/plugins/shieldcortex
+ * and tells the operator what is actually bound: pre_tool_call via the
+ * local Action Guard API. Not a conversation gate. Not a freeze plane
+ * until Hermes consults DECISIONS.md (it does not, today).
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function pluginSourceDir(): string {
+  // dist/setup/hermes.js → repo-or-package root / plugins/hermes/shieldcortex
+  return path.resolve(__dirname, '..', '..', 'plugins', 'hermes', 'shieldcortex');
+}
+
+function pluginDestDir(home: string = os.homedir()): string {
+  return path.join(home, '.hermes', 'plugins', 'shieldcortex');
+}
+
+function copyDir(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    if (entry.name === '__pycache__' || entry.name === '.pytest_cache' || entry.name === 'tests') {
+      continue;
+    }
+    const from = path.join(src, entry.name);
+    const to = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(from, to);
+    } else {
+      fs.copyFileSync(from, to);
+    }
+  }
+}
+
+export function hermesPluginInstalled(home: string = os.homedir()): boolean {
+  return fs.existsSync(path.join(pluginDestDir(home), 'plugin.yaml'));
+}
+
+export async function installHermes(home: string = os.homedir()): Promise<void> {
+  const src = pluginSourceDir();
+  if (!fs.existsSync(path.join(src, 'plugin.yaml'))) {
+    console.error('Hermes plugin source not found. Package may be missing plugins/hermes.');
+    console.error(`Expected: ${src}`);
+    process.exit(1);
+  }
+
+  const dest = pluginDestDir(home);
+  copyDir(src, dest);
+  console.log(`✓ Hermes — plugin copied to ${dest}`);
+  console.log();
+  console.log('This is a tool gate (pre_tool_call → POST /api/v1/action-guard).');
+  console.log('Enforce is ON by default. Opt out: SHIELDCORTEX_ENFORCE=0');
+  console.log('Requires a running local API:  shieldcortex api   (http://127.0.0.1:3001)');
+  console.log('Enable in Hermes:              hermes plugins enable shieldcortex');
+  console.log('Conversation / freeze:         NOT bound on this plane.');
+}
+
+export async function uninstallHermes(home: string = os.homedir()): Promise<void> {
+  const dest = pluginDestDir(home);
+  if (!fs.existsSync(dest)) {
+    console.log('Hermes plugin was not installed.');
+    return;
+  }
+  fs.rmSync(dest, { recursive: true, force: true });
+  console.log(`✓ Hermes — removed ${dest}`);
+}
+
+export async function hermesStatus(home: string = os.homedir()): Promise<void> {
+  const src = pluginSourceDir();
+  const dest = pluginDestDir(home);
+  console.log(`Hermes plugin dest: ${dest}`);
+  console.log(`  Installed: ${hermesPluginInstalled(home) ? 'yes' : 'no'}`);
+  console.log(`  Source: ${src}`);
+  console.log(`  Source present: ${fs.existsSync(path.join(src, 'plugin.yaml')) ? 'yes' : 'no'}`);
+  console.log('  Tool gate: bound after `hermes plugins enable shieldcortex` + local API up');
+  console.log('  Turn gate / freeze: not bound');
+}
+
+export async function handleHermesCommand(subcommand: string): Promise<void> {
+  console.log();
+  switch (subcommand) {
+    case 'install':
+      await installHermes();
+      break;
+    case 'uninstall':
+      await uninstallHermes();
+      break;
+    case 'status':
+      await hermesStatus();
+      break;
+    default:
+      console.log('Usage: shieldcortex hermes <install|uninstall|status>');
+      console.log();
+      console.log('Installs the Hermes pre_tool_call plugin (Action Guard).');
+      console.log('This is a deny plane. Codex/Cursor MCP install is not.');
+      process.exit(1);
+  }
+}


### PR DESCRIPTION
## Why
The README and skill sold Codex/Cursor/MCP as if they were shields. They are memory servers. This states which hosts can actually deny, and gives foreign runtimes one import for the Action Guard.

## What
- Bound/not-bound matrix in README, SKILL, SCOPE (anchor v4.52.1)
- `import { evaluateAction } from 'shieldcortex/enforce'`
- `shieldcortex hermes install|status|uninstall`
- `lease` reports Hermes + NOT-BOUND for Cursor/Codex MCP
- Codex/Copilot installers print that they are not a tool gate
- Version stays **4.52.1** — do not tag this as a release

## Not in this PR
Action Guard CLI flags from #296 are untouched. No publish.

## Test
`npm test -- src/__tests__/enforce-entry.test.ts src/setup/__tests__/hermes-install.test.ts src/cli/__tests__/freeze-command.test.ts` (14/14)