### PR TITLE
chore(release): v4.52.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.52.2] - 2026-08-15
+
+**Patch — bound-plane honesty + portable `shieldcortex/enforce` + Hermes install CLI.**
+
+Docs and packaging stop overclaiming Codex/Cursor/MCP as tool gates. Ships the portable Action Guard entry point and Hermes plugin install path that 4.52.1 README already described but did not publish on npm `@latest`.
+
+### Added
+
+- **`import { evaluateAction, evaluateToolCall } from 'shieldcortex/enforce'`** — portable Action Guard entry (no sqlite pull via iron-dome index). Host must honour `block` / `require_approval`.
+- **`shieldcortex hermes install|status|uninstall`** — copies `plugins/hermes/shieldcortex` into `~/.hermes/plugins/shieldcortex`. Tool gate bound via local Action Guard API; conversation/freeze not bound on this plane.
+- **`plugins/hermes` included in the npm package `files` list** so the installer works from a global install, not only a git clone.
+- **`shieldcortex lease` / plane report** names Hermes + explicitly marks Cursor/Codex MCP as NOT BOUND.
+
+### Docs
+
+- README capability matrix: Claude Code / OpenClaw / Hermes = bound; Codex / Cursor / Copilot / LangChain / generic MCP = not bound.
+- SCOPE anchor → v4.52.2. SKILL + Codex/Copilot installers print honesty lines.
+- Paired site honesty: pricing/docs stop calling Codex/Cursor installs “hooks”.
+
+### Notes
+
+- Version was left at 4.52.1 on the feature PR (#298); this patch is the publish vehicle.
+- Dual-reviewed APPROVE_WITH_NITS (Grok 4.6 + SOL). Nits retained: lease default `anon-pid`, evaluateAction returns verdict+lease separately, hermes BOUND-on-disk vs armed.
+
 ## [4.52.1] - 2026-08-15
 
 **Patch — Action Guard enable/enforce via signed CLI flags.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.52.1",
+  "version": "4.52.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.52.1",
+      "version": "4.52.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.52.1",
+  "version": "4.52.2",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.52.1",
+  "version": "4.52.2",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.52.1",
+  "version": "4.52.2",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.52.1
+  version: 4.52.2
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Summary
Patch so npm `@latest` gets what #298 landed on main:

- `shieldcortex/enforce` package export
- `plugins/hermes` in package files + `shieldcortex hermes install`
- Bound-plane honesty (already on main via #298)

Dual review on #298: Grok + SOL **APPROVE_WITH_NITS**, both **CUT_4522: YES**.

## Coordinated train after tag
npm core+plugin, GH release, ClawHub, cloud dep `^4.52.2`, websites.