### PR TITLE
chore(release): v4.52.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.52.3] - 2026-08-15
+
+**Patch — Hermes Action Guard: malformed 200 is unavailable, not allow.**
+
+The advertised Hermes bound plane treated a 200 JSON body without a valid `decision` as `allow` + `available=True`, which skipped the catastrophic/dangerous fallback. Those responses are now unavailable so the fallback still runs. Remote `reason` is bounded. CI runs the Hermes Python suite.
+
 ### Fixed
 
-- **Hermes Action Guard client: a 200 JSON body is not a verdict.** Missing, blank, or unknown `decision` used to coerce to `allow` with `available=True`, which skipped the #59 catastrophic/dangerous fallback on the advertised bound plane. Those responses are now unavailable so the fallback still runs. CI now executes the Hermes Python suite.
-- **Hermes Action Guard remote `reason` is bounded.** Valid `block`/`require_approval` reasons (and scan-path reasons) are flattened to a single line and capped so a misbound local service cannot inject a message boundary or an unbounded prompt in ShieldCortex's voice.
+- **Hermes `evaluate_tool_call`**: missing / null / blank / bool / list / unknown / non-dict `decision` → `available=False` (PR #301, closes #300).
+- **Remote reason sanitisation**: single-line, control-stripped, 400-char cap before hook messages.
+- **CI**: Linux job runs `python3 -m unittest discover -s plugins/hermes/shieldcortex/tests -v`.
 
 ## [4.52.2] - 2026-08-15
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.52.2",
+  "version": "4.52.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.52.2",
+      "version": "4.52.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.52.2",
+  "version": "4.52.3",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.52.2",
+  "version": "4.52.3",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.52.2",
+  "version": "4.52.3",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.52.2
+  version: 4.52.3
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Summary
Patch so npm `@latest` gets #301 (Hermes Action Guard malformed 200 → unavailable, not allow).

Hosts pull the Hermes plugin from the package `files` list via `shieldcortex update` / `hermes install`. Without this cut, the fix is main-only.

## Coordinated train after tag
npm core+plugin, GH, ClawHub, cloud dep lock, websites.