### PR TITLE
feat(cli): allowlist scan + update-time batch review (#309)

### DIFF
--- a/src/cli/__tests__/allowlist-scan.test.ts
+++ b/src/cli/__tests__/allowlist-scan.test.ts
@@ -84,7 +84,7 @@ describe('shieldcortex allowlist scan (#309)', () => {
 
   test('discovery: absolute .py path inside a Hermes prompt string', () => {
     writeHermesCron({ jobs: [{ prompt: `Every morning run python3 ${scriptPath} and email the result` }] });
-    const found = discoverScripts({ home: dir });
+    const found = discoverScripts({ home: dir }).scripts;
     expect(found.map((f) => f.path)).toContain(scriptPath);
   });
 
@@ -92,13 +92,13 @@ describe('shieldcortex allowlist scan (#309)', () => {
     mkdirSync(join(dir, 'jobs'), { recursive: true });
     writeFileSync(join(dir, 'jobs', 'nightly.sh'), '#!/bin/sh\necho hi\n');
     writeHermesCron({ jobs: [{ prompt: 'run bash ~/jobs/nightly.sh please' }] });
-    const found = discoverScripts({ home: dir });
+    const found = discoverScripts({ home: dir }).scripts;
     expect(found.map((f) => f.path)).toContain(join(dir, 'jobs', 'nightly.sh'));
   });
 
   test('discovery: explicit Hermes `script` field', () => {
     writeHermesCron({ jobs: [{ prompt: 'do the thing', script: scriptPath }] });
-    const found = discoverScripts({ home: dir });
+    const found = discoverScripts({ home: dir }).scripts;
     expect(found.map((f) => f.path)).toContain(scriptPath);
   });
 
@@ -108,7 +108,7 @@ describe('shieldcortex allowlist scan (#309)', () => {
       jobs: [{ payload: { kind: 'agentTurn', message: `node ${join(dir, 'poll.mjs')} --daily` } }],
     });
     writeFileSync(join(dir, 'poll.mjs'), 'console.log(1)\n');
-    const found = discoverScripts({ home: dir });
+    const found = discoverScripts({ home: dir }).scripts;
     expect(found.map((f) => f.path)).toContain(join(dir, 'poll.mjs'));
   });
 
@@ -117,17 +117,17 @@ describe('shieldcortex allowlist scan (#309)', () => {
     mkdirSync(join(dir, '.hermes', 'skills', 'sentry'), { recursive: true });
     writeFileSync(skillScript, SOURCE);
     writeHermesCron({ jobs: [{ prompt: `use the memory skill: python3 ${skillScript}` }] });
-    const found = discoverScripts({ home: dir });
+    const found = discoverScripts({ home: dir }).scripts;
     expect(found.map((f) => f.path)).toContain(skillScript);
   });
 
   test('discovery: bare-array Hermes shape, malformed JSON and absent files never throw', () => {
     writeHermesCron([{ prompt: `sh ${scriptPath}` }]);
-    expect(discoverScripts({ home: dir }).map((f) => f.path)).toContain(scriptPath);
+    expect(discoverScripts({ home: dir }).scripts.map((f) => f.path)).toContain(scriptPath);
     writeHermesCron('{not json');
     expect(() => discoverScripts({ home: dir })).not.toThrow();
     rmSync(join(dir, '.hermes'), { recursive: true, force: true });
-    expect(discoverScripts({ home: dir })).toEqual([]);
+    expect(discoverScripts({ home: dir }).scripts).toEqual([]);
   });
 
   // ── Classification ────────────────────────────────────────
@@ -344,4 +344,50 @@ describe('shieldcortex allowlist scan (#309)', () => {
     expect(stored).toHaveLength(1);
     expect((stored[0] as Record<string, unknown>).path).toBe(realpathSync(scriptPath));
   });
+
+  test('pin binds expectedSha256 — TOCTOU rewrite refuses write', async () => {
+    const { pinReviewedScript } = await import('../allowlist.js');
+    const { hashScriptSource } = await import('../../defence/iron-dome/reviewed-scripts.js');
+    writeFileSync(scriptPath, SOURCE);
+    const seen = hashScriptSource(SOURCE);
+    writeFileSync(scriptPath, SOURCE + '# swapped\n');
+    const pin = pinReviewedScript(scriptPath, undefined, {
+      expectedSha256: seen,
+      readEntries: () => stored,
+      writeEntries: (e) => { stored = e; },
+    });
+    expect(pin.ok).toBe(false);
+    expect(stored).toEqual([]);
+    if (!pin.ok) expect(pin.error).toMatch(/Content changed since review/);
+  });
+
+  test('invalid cron JSON is incomplete discovery, not empty-ok exit 0', async () => {
+    const cronDir = join(dir, '.hermes', 'cron');
+    mkdirSync(cronDir, { recursive: true });
+    writeFileSync(join(cronDir, 'jobs.json'), '{not-json');
+    const logs: string[] = [];
+    const errs: string[] = [];
+    const code = await runAllowlistScan([], {
+      home: dir,
+      interactive: false,
+      log: (m) => logs.push(m),
+      error: (m) => errs.push(m),
+      readEntries: () => stored,
+      writeEntries: (e) => { stored = e; },
+    });
+    expect(code).toBe(1);
+    expect(stored).toEqual([]);
+    expect(errs.join('\n') + logs.join('\n')).toMatch(/INVALID JSON|incomplete/i);
+  });
+
+  test('discovery reports source status ok vs absent', () => {
+    const r = discoverScripts({ home: dir });
+    expect(r.sources.hermes.status).toBe('absent');
+    mkdirSync(join(dir, '.hermes', 'cron'), { recursive: true });
+    writeFileSync(join(dir, '.hermes', 'cron', 'jobs.json'), JSON.stringify({ jobs: [] }));
+    const r2 = discoverScripts({ home: dir });
+    expect(r2.sources.hermes.status).toBe('ok');
+    expect(r2.scripts).toEqual([]);
+  });
+
 });

--- a/src/cli/__tests__/allowlist-scan.test.ts
+++ b/src/cli/__tests__/allowlist-scan.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Spec for `shieldcortex allowlist scan` (#309) — batch review flow for the
+ * reviewed-script allowlist. The load-bearing properties, in order:
+ *
+ *   1. Non-interactive runs NEVER write — they list, report, and exit 3 when
+ *      human review is needed, so automation can detect the state without
+ *      being able to act on it.
+ *   2. The interactive review pins through the SAME canonical-path + content-
+ *      hash write path as `allowlist add` — one item, one human decision.
+ *   3. `--yes` is refused outright without a TTY, and even with one it demands
+ *      the typed word "approve", not a keystroke.
+ *
+ * Discovery reads Hermes/OpenClaw cron files injected via deps/flags — tests
+ * never touch a real ~/.hermes or ~/.openclaw.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  discoverScripts,
+  reviewScanItems,
+  runAllowlistScan,
+  maybeReviewAllowlistAfterUpdate,
+  classifyScripts,
+} from '../allowlist-scan.js';
+import { runAllowlist } from '../allowlist.js';
+import { hashScriptSource } from '../../defence/iron-dome/reviewed-scripts.js';
+
+const SOURCE = '#!/usr/bin/env python3\nprint("sentry sweep")\n';
+
+describe('shieldcortex allowlist scan (#309)', () => {
+  let dir: string; // stands in for $HOME — real ~/.hermes and ~/.openclaw are never read
+  let scriptPath: string;
+  let stored: unknown[];
+  let logs: string[];
+  let errs: string[];
+
+  const writeHermesCron = (doc: unknown): string => {
+    const cronDir = join(dir, '.hermes', 'cron');
+    mkdirSync(cronDir, { recursive: true });
+    const file = join(cronDir, 'jobs.json');
+    writeFileSync(file, typeof doc === 'string' ? doc : JSON.stringify(doc));
+    return file;
+  };
+
+  const writeOpenClawCron = (doc: unknown): string => {
+    const cronDir = join(dir, '.openclaw', 'cron');
+    mkdirSync(cronDir, { recursive: true });
+    const file = join(cronDir, 'jobs.json');
+    writeFileSync(file, typeof doc === 'string' ? doc : JSON.stringify(doc));
+    return file;
+  };
+
+  const deps = (over: Record<string, unknown> = {}) => ({
+    home: dir,
+    cwd: dir,
+    interactive: false,
+    log: (m: string) => logs.push(m),
+    error: (m: string) => errs.push(m),
+    readEntries: () => stored,
+    writeEntries: (e: Array<Record<string, unknown>>) => {
+      stored = e;
+    },
+    ...over,
+  });
+
+  /** Scripted stdin — each prompt consumes the next answer. */
+  const answers = (list: string[]) => {
+    const queue = [...list];
+    return async () => queue.shift() ?? '';
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sc-cli-309-'));
+    scriptPath = join(dir, 'sentry.py');
+    writeFileSync(scriptPath, SOURCE);
+    stored = [];
+    logs = [];
+    errs = [];
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  // ── Discovery ─────────────────────────────────────────────
+
+  test('discovery: absolute .py path inside a Hermes prompt string', () => {
+    writeHermesCron({ jobs: [{ prompt: `Every morning run python3 ${scriptPath} and email the result` }] });
+    const found = discoverScripts({ home: dir });
+    expect(found.map((f) => f.path)).toContain(scriptPath);
+  });
+
+  test('discovery: ~/ path in a Hermes prompt expands against the injected home', () => {
+    mkdirSync(join(dir, 'jobs'), { recursive: true });
+    writeFileSync(join(dir, 'jobs', 'nightly.sh'), '#!/bin/sh\necho hi\n');
+    writeHermesCron({ jobs: [{ prompt: 'run bash ~/jobs/nightly.sh please' }] });
+    const found = discoverScripts({ home: dir });
+    expect(found.map((f) => f.path)).toContain(join(dir, 'jobs', 'nightly.sh'));
+  });
+
+  test('discovery: explicit Hermes `script` field', () => {
+    writeHermesCron({ jobs: [{ prompt: 'do the thing', script: scriptPath }] });
+    const found = discoverScripts({ home: dir });
+    expect(found.map((f) => f.path)).toContain(scriptPath);
+  });
+
+  test('discovery: OpenClaw payload.message', () => {
+    writeOpenClawCron({
+      version: 1,
+      jobs: [{ payload: { kind: 'agentTurn', message: `node ${join(dir, 'poll.mjs')} --daily` } }],
+    });
+    writeFileSync(join(dir, 'poll.mjs'), 'console.log(1)\n');
+    const found = discoverScripts({ home: dir });
+    expect(found.map((f) => f.path)).toContain(join(dir, 'poll.mjs'));
+  });
+
+  test('discovery: mislabeled skills-subdir path in prompt text still found', () => {
+    const skillScript = join(dir, '.hermes', 'skills', 'sentry', 'runner.py');
+    mkdirSync(join(dir, '.hermes', 'skills', 'sentry'), { recursive: true });
+    writeFileSync(skillScript, SOURCE);
+    writeHermesCron({ jobs: [{ prompt: `use the memory skill: python3 ${skillScript}` }] });
+    const found = discoverScripts({ home: dir });
+    expect(found.map((f) => f.path)).toContain(skillScript);
+  });
+
+  test('discovery: bare-array Hermes shape, malformed JSON and absent files never throw', () => {
+    writeHermesCron([{ prompt: `sh ${scriptPath}` }]);
+    expect(discoverScripts({ home: dir }).map((f) => f.path)).toContain(scriptPath);
+    writeHermesCron('{not json');
+    expect(() => discoverScripts({ home: dir })).not.toThrow();
+    rmSync(join(dir, '.hermes'), { recursive: true, force: true });
+    expect(discoverScripts({ home: dir })).toEqual([]);
+  });
+
+  // ── Classification ────────────────────────────────────────
+
+  test('classify: current / changed / new / missing / too_large', () => {
+    const changed = join(dir, 'changed.sh');
+    writeFileSync(changed, 'echo v2\n');
+    const big = join(dir, 'big.sh');
+    writeFileSync(big, 'x'.repeat(262_145));
+    const entries = [
+      { path: realpathSync(scriptPath), sha256: hashScriptSource(SOURCE) },
+      { path: realpathSync(changed), sha256: hashScriptSource('echo v1\n') },
+    ];
+    const items = classifyScripts(
+      [
+        { path: scriptPath, sources: ['hermes-cron'] },
+        { path: changed, sources: ['hermes-cron'] },
+        { path: join(dir, 'fresh.py'), sources: ['openclaw-cron'] },
+        { path: big, sources: ['glob'] },
+      ],
+      entries,
+    );
+    writeFileSync(join(dir, 'fresh.py'), 'print(1)\n'); // written after classify — stays missing
+    const byPath = new Map(items.map((i) => [i.path, i.status]));
+    expect(byPath.get(realpathSync(scriptPath))).toBe('current');
+    expect(byPath.get(realpathSync(changed))).toBe('changed');
+    expect(byPath.get(join(dir, 'fresh.py'))).toBe('missing');
+    expect(byPath.get(realpathSync(big))).toBe('too_large');
+  });
+
+  test('classify: network sniff is advisory metadata, never a gate', () => {
+    const net = join(dir, 'net.py');
+    writeFileSync(net, 'import requests\nrequests.get("https://x")\n');
+    const items = classifyScripts([{ path: net, sources: ['glob'] }], []);
+    expect(items[0].status).toBe('new');
+    expect(items[0].networkHint).toBe(true);
+    const quiet = classifyScripts([{ path: scriptPath, sources: ['glob'] }], []);
+    expect(quiet[0].networkHint).toBe(false);
+  });
+
+  // ── Non-interactive: report only, exit codes for automation ──
+
+  test('non-interactive scan reports new scripts but NEVER writes (exit 3)', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    const code = await runAllowlistScan([], deps({ prompt: answers(['y', '']) }));
+    expect(code).toBe(3);
+    expect(stored).toEqual([]);
+    expect(logs.join('\n')).toContain(realpathSync(scriptPath));
+    expect(logs.join('\n')).toContain('shieldcortex allowlist scan');
+  });
+
+  test('non-interactive scan with nothing new/changed exits 0', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    stored = [{ path: realpathSync(scriptPath), sha256: hashScriptSource(SOURCE) }];
+    expect(await runAllowlistScan([], deps())).toBe(0);
+    expect(stored).toHaveLength(1);
+  });
+
+  test('missing file referenced in cron: reported, never pinned, not review-worthy', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${join(dir, 'gone.py')}` }] });
+    const code = await runAllowlistScan([], deps({ interactive: true, prompt: answers(['y', '']) }));
+    expect(code).toBe(0); // nothing pinnable → nothing needing review
+    expect(stored).toEqual([]);
+    expect(logs.join('\n')).toContain('missing');
+  });
+
+  test('--json emits a machine-readable, non-mutating report', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    const code = await runAllowlistScan(['--json'], deps({ interactive: true, prompt: answers(['y', '']) }));
+    expect(code).toBe(3);
+    expect(stored).toEqual([]);
+    const report = JSON.parse(logs.join('\n')) as {
+      counts: Record<string, number>;
+      items: Array<{ path: string; status: string; sources: string[] }>;
+    };
+    expect(report.counts.new).toBe(1);
+    expect(report.items[0].path).toBe(realpathSync(scriptPath));
+    expect(report.items[0].status).toBe('new');
+  });
+
+  test('--glob discovers script files under an explicit pattern', async () => {
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    const globbed = join(dir, 'scripts', 'task.sh');
+    writeFileSync(globbed, 'echo run\n');
+    writeFileSync(join(dir, 'scripts', 'notes.txt'), 'not a script\n');
+    const code = await runAllowlistScan(['--glob', join(dir, 'scripts', '*.sh')], deps());
+    expect(code).toBe(3);
+    expect(logs.join('\n')).toContain(realpathSync(globbed));
+    expect(logs.join('\n')).not.toContain('notes.txt');
+  });
+
+  test('cron path flags override the defaults', async () => {
+    const elsewhere = join(dir, 'elsewhere');
+    mkdirSync(elsewhere, { recursive: true });
+    const hermes = join(elsewhere, 'h.json');
+    writeFileSync(hermes, JSON.stringify({ jobs: [{ prompt: `sh ${scriptPath}` }] }));
+    const code = await runAllowlistScan(['--hermes-cron', hermes], deps());
+    expect(code).toBe(3);
+    expect(logs.join('\n')).toContain(realpathSync(scriptPath));
+  });
+
+  // ── Interactive review: the only path that writes ─────────
+
+  test('interactive review pins a new script with canonical path + hash', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    const code = await runAllowlistScan([], deps({ interactive: true, now: 4321, prompt: answers(['y', 'nightly sentry']) }));
+    expect(code).toBe(0);
+    expect(stored).toEqual([
+      {
+        path: realpathSync(scriptPath),
+        sha256: hashScriptSource(SOURCE),
+        note: 'nightly sentry',
+        addedAt: 4321,
+      },
+    ]);
+  });
+
+  test('changed script is offered as changed; re-pin updates the hash', async () => {
+    stored = [{ path: realpathSync(scriptPath), sha256: hashScriptSource('# old\n') }];
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    const code = await runAllowlistScan([], deps({ interactive: true, prompt: answers(['y', '']) }));
+    expect(code).toBe(0);
+    expect(logs.join('\n')).toContain('changed');
+    expect(stored).toHaveLength(1);
+    expect((stored[0] as Record<string, unknown>).sha256).toBe(hashScriptSource(SOURCE));
+  });
+
+  test('n skips, q stops the rest but keeps what was already pinned', async () => {
+    const second = join(dir, 'zz-second.py');
+    writeFileSync(second, 'print(2)\n');
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath} && python3 ${second}` }] });
+    const code = await runAllowlistScan([], deps({ interactive: true, prompt: answers(['y', '', 'q']) }));
+    expect(code).toBe(0);
+    expect(stored).toHaveLength(1);
+    expect((stored[0] as Record<string, unknown>).path).toBe(realpathSync(scriptPath));
+  });
+
+  // ── TTY gate ──────────────────────────────────────────────
+
+  test('TTY gate: review helper with interactive=false never writes', async () => {
+    const items = classifyScripts([{ path: scriptPath, sources: ['hermes-cron'] }], []);
+    const result = await reviewScanItems(items, deps({ interactive: false, prompt: answers(['y', '']) }));
+    expect(result.pinned).toBe(0);
+    expect(stored).toEqual([]);
+    expect(errs.join('\n')).toContain('interactive terminal');
+  });
+
+  test('--yes without a TTY is refused with exit 1 and no writes', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    const code = await runAllowlistScan(['--yes'], deps({ interactive: false, prompt: answers(['approve']) }));
+    expect(code).toBe(1);
+    expect(stored).toEqual([]);
+    expect(errs.join('\n')).toContain('interactive terminal');
+  });
+
+  test('--yes on a TTY demands the typed word "approve"', async () => {
+    const second = join(dir, 'zz-second.py');
+    writeFileSync(second, 'print(2)\n');
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath} && python3 ${second}` }] });
+
+    let code = await runAllowlistScan(['--yes'], deps({ interactive: true, prompt: answers(['y']) }));
+    expect(code).toBe(0);
+    expect(stored).toEqual([]); // "y" is not "approve" — nothing pinned
+
+    code = await runAllowlistScan(['--yes'], deps({ interactive: true, prompt: answers(['approve']) }));
+    expect(code).toBe(0);
+    expect(stored).toHaveLength(2);
+  });
+
+  // ── Dispatch through `shieldcortex allowlist scan` ────────
+
+  test('runAllowlist dispatches the scan subcommand', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    const code = await runAllowlist(['scan'], deps());
+    expect(code).toBe(3);
+    expect(stored).toEqual([]);
+  });
+
+  // ── `shieldcortex update` hook ────────────────────────────
+
+  test('update hook: non-interactive prints one pointer line, never writes', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    await maybeReviewAllowlistAfterUpdate(deps());
+    expect(stored).toEqual([]);
+    const out = logs.join('\n');
+    expect(out).toContain('1 new/changed');
+    expect(out).toContain('shieldcortex allowlist scan');
+  });
+
+  test('update hook: silent when there is nothing new or changed', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    stored = [{ path: realpathSync(scriptPath), sha256: hashScriptSource(SOURCE) }];
+    await maybeReviewAllowlistAfterUpdate(deps());
+    expect(logs).toEqual([]);
+  });
+
+  test('update hook: scan errors are swallowed, never fail the update', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    await expect(
+      maybeReviewAllowlistAfterUpdate(
+        deps({
+          readEntries: () => {
+            throw new Error('config exploded');
+          },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+    expect(logs.join('\n')).toContain('skipped');
+  });
+
+  test('update hook: interactive runs the same per-item review', async () => {
+    writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
+    await maybeReviewAllowlistAfterUpdate(deps({ interactive: true, prompt: answers(['y', '']) }));
+    expect(stored).toHaveLength(1);
+    expect((stored[0] as Record<string, unknown>).path).toBe(realpathSync(scriptPath));
+  });
+});

--- a/src/cli/allowlist-scan.ts
+++ b/src/cli/allowlist-scan.ts
@@ -93,12 +93,26 @@ export function extractScriptPaths(text: string, home: string): string[] {
   return out;
 }
 
-/** A cron store that is absent, unreadable, or not JSON is an empty source. */
-function readJsonSafe(path: string): unknown {
+/** A cron store that is absent is empty-ok; unreadable/malformed is distinct. */
+export type CronSourceStatus = 'absent' | 'ok' | 'unreadable' | 'invalid_json';
+
+export interface CronSourceReport {
+  path: string;
+  status: CronSourceStatus;
+}
+
+function inspectJsonFile(path: string): { status: CronSourceStatus; doc?: unknown } {
   try {
-    return JSON.parse(readFileSync(path, 'utf8'));
-  } catch {
-    return undefined;
+    const raw = readFileSync(path, 'utf8');
+    try {
+      return { status: 'ok', doc: JSON.parse(raw) };
+    } catch {
+      return { status: 'invalid_json' };
+    }
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    if (err && err.code === 'ENOENT') return { status: 'absent' };
+    return { status: 'unreadable' };
   }
 }
 
@@ -207,8 +221,12 @@ function expandGlob(pattern: string, cwd: string): string[] {
   return out;
 }
 
-/** Union of every discovery source, deduped by expanded path. Never throws. */
-export function discoverScripts(deps: ScanDeps = {}): DiscoveredScript[] {
+/** Union of every discovery source, deduped by expanded path. Never throws.
+ *  Cron source health is returned separately so "file missing" ≠ "we could not look". */
+export function discoverScripts(deps: ScanDeps = {}): {
+  scripts: DiscoveredScript[];
+  sources: { hermes: CronSourceReport; openclaw: CronSourceReport };
+} {
   const home = deps.home ?? homedir();
   const cwd = deps.cwd ?? process.cwd();
   const bySource = new Map<string, Set<string>>();
@@ -219,10 +237,16 @@ export function discoverScripts(deps: ScanDeps = {}): DiscoveredScript[] {
   };
 
   const hermesPath = deps.hermesCronPath ?? join(home, '.hermes', 'cron', 'jobs.json');
-  for (const p of hermesCandidates(readJsonSafe(hermesPath), home)) add(p, 'hermes-cron');
+  const hermes = inspectJsonFile(hermesPath);
+  if (hermes.status === 'ok') {
+    for (const p of hermesCandidates(hermes.doc, home)) add(p, 'hermes-cron');
+  }
 
   const openclawPath = deps.openclawCronPath ?? join(home, '.openclaw', 'cron', 'jobs.json');
-  for (const p of openclawCandidates(readJsonSafe(openclawPath), home)) add(p, 'openclaw-cron');
+  const openclaw = inspectJsonFile(openclawPath);
+  if (openclaw.status === 'ok') {
+    for (const p of openclawCandidates(openclaw.doc, home)) add(p, 'openclaw-cron');
+  }
 
   for (const pattern of deps.globs ?? []) {
     try {
@@ -232,9 +256,21 @@ export function discoverScripts(deps: ScanDeps = {}): DiscoveredScript[] {
     }
   }
 
-  return [...bySource.entries()]
-    .map(([path, sources]) => ({ path, sources: [...sources] }))
-    .sort((a, b) => a.path.localeCompare(b.path));
+  return {
+    scripts: [...bySource.entries()]
+      .map(([path, sources]) => ({ path, sources: [...sources] }))
+      .sort((a, b) => a.path.localeCompare(b.path)),
+    sources: {
+      hermes: { path: hermesPath, status: hermes.status },
+      openclaw: { path: openclawPath, status: openclaw.status },
+    },
+  };
+}
+
+function sourcesBroken(sources: { hermes: CronSourceReport; openclaw: CronSourceReport }): CronSourceReport[] {
+  return [sources.hermes, sources.openclaw].filter(
+    (s) => s.status === 'unreadable' || s.status === 'invalid_json',
+  );
 }
 
 // ── Classification ──────────────────────────────────────────
@@ -331,17 +367,37 @@ function statusPaint(status: ScanStatus): string {
   return `${RED}too_large${RESET}`;
 }
 
-function renderSummary(items: ScanItem[]): string {
+function renderSummary(
+  items: ScanItem[],
+  sources?: { hermes: CronSourceReport; openclaw: CronSourceReport },
+): string {
+  const lines: string[] = [];
+  if (sources) {
+    for (const s of [sources.hermes, sources.openclaw]) {
+      if (s.status === 'absent') continue;
+      if (s.status === 'ok') {
+        lines.push(`${DIM}source ok: ${s.path}${RESET}`);
+      } else if (s.status === 'invalid_json') {
+        lines.push(`${RED}source INVALID JSON (did not scan): ${s.path}${RESET}`);
+      } else {
+        lines.push(`${RED}source UNREADABLE (did not scan): ${s.path}${RESET}`);
+      }
+    }
+  }
   if (items.length === 0) {
-    return `${DIM}Reviewed-script scan — no scripts discovered in Hermes/OpenClaw cron jobs.${RESET}`;
+    lines.push(
+      `${DIM}Reviewed-script scan — no scripts discovered from readable Hermes/OpenClaw cron jobs ` +
+        `(absolute or ~/ paths with script extensions only; relative names are not extracted).${RESET}`,
+    );
+    return lines.join('\n');
   }
   const count = (s: ScanStatus): number => items.filter((i) => i.status === s).length;
-  const lines: string[] = [
+  lines.push(
     `${BOLD}Reviewed-script scan${RESET} — ${items.length} script(s) discovered: ` +
       `${count('current')} current · ${count('new')} new · ${count('changed')} changed · ` +
       `${count('missing')} missing · ${count('too_large')} too large`,
-    '',
-  ];
+  );
+  lines.push('');
   for (const i of items) {
     const notes: string[] = [i.sources.join(', ')];
     if (i.sha256) notes.push(`sha256 ${i.sha256.slice(0, 12)}…`);
@@ -427,7 +483,10 @@ export async function reviewScanItems(items: ScanItem[], deps: ScanDeps = {}): P
       continue;
     }
     const note = (await ask('  note (optional, why is this trusted): ')).trim() || undefined;
-    const pin = pinReviewedScript(item.path, note, deps);
+    const pin = pinReviewedScript(item.path, note, {
+      ...deps,
+      ...(item.sha256 ? { expectedSha256: item.sha256 } : {}),
+    });
     if (pin.ok) {
       result.pinned += 1;
       log(`  ${GREEN}✓${RESET} Pinned ${BOLD}${pin.entry.path}${RESET} — any edit re-gates it.`);
@@ -488,20 +547,26 @@ export async function runAllowlistScan(argv: string[], deps: ScanDeps = {}): Pro
 
   const scanDeps: ScanDeps = { ...deps, hermesCronPath, openclawCronPath, globs };
   let items: ScanItem[];
+  let sourceReport: { hermes: CronSourceReport; openclaw: CronSourceReport };
   try {
     const readEntries = deps.readEntries ?? getReviewedScriptsRaw;
-    items = classifyScripts(discoverScripts(scanDeps), readEntries());
+    const discovered = discoverScripts(scanDeps);
+    sourceReport = discovered.sources;
+    items = classifyScripts(discovered.scripts, readEntries());
   } catch (e) {
     err(`Scan failed: ${e instanceof Error ? e.message : String(e)}`);
     return 1;
   }
 
+  const broken = sourcesBroken(sourceReport);
   const needsReview = items.filter((i) => i.status === 'new' || i.status === 'changed');
 
   if (json) {
     log(
       JSON.stringify(
         {
+          sources: sourceReport,
+          discoveryIncomplete: broken.length > 0,
           counts: {
             current: items.filter((i) => i.status === 'current').length,
             new: items.filter((i) => i.status === 'new').length,
@@ -522,22 +587,40 @@ export async function runAllowlistScan(argv: string[], deps: ScanDeps = {}): Pro
         2,
       ),
     );
+    if (broken.length > 0) return 1;
     return needsReview.length > 0 ? 3 : 0;
   }
 
-  log(renderSummary(items));
+  log(renderSummary(items, sourceReport));
+  if (broken.length > 0) {
+    err(
+      `Cron source(s) present but not readable/parseable — scan is incomplete. Fix: ${broken
+        .map((s) => s.path)
+        .join(', ')}`,
+    );
+    // Incomplete discovery must not look like "all clear".
+    return 1;
+  }
   if (needsReview.length === 0) return 0;
 
   if (!interactive) {
     log('');
-    log(`${needsReview.length} new/changed need human review — run: ${BOLD}shieldcortex allowlist scan${RESET} in an interactive terminal.`);
+    log(
+      `${needsReview.length} new/changed need human review — run: ${BOLD}shieldcortex allowlist scan${RESET} in an interactive terminal.`,
+    );
     return 3;
   }
 
   if (yes) {
+    // Show the same previews the per-item loop would before batch approve.
+    for (let i = 0; i < needsReview.length; i++) {
+      log(renderReviewItem(needsReview[i], i + 1, needsReview.length));
+    }
     const ask = deps.prompt ?? ttyPrompt;
     const answer = (
-      await ask(`\nType ${BOLD}approve${RESET} to pin ALL ${needsReview.length} new/changed script(s) listed above, anything else to cancel: `)
+      await ask(
+        `\nType ${BOLD}approve${RESET} to pin ALL ${needsReview.length} new/changed script(s) listed above at the hashes shown, anything else to cancel: `,
+      )
     )
       .trim()
       .toLowerCase();
@@ -547,7 +630,10 @@ export async function runAllowlistScan(argv: string[], deps: ScanDeps = {}): Pro
     }
     let failed = 0;
     for (const item of needsReview) {
-      const pin = pinReviewedScript(item.path, undefined, deps);
+      const pin = pinReviewedScript(item.path, undefined, {
+        ...deps,
+        ...(item.sha256 ? { expectedSha256: item.sha256 } : {}),
+      });
       if (pin.ok) {
         log(`${GREEN}✓${RESET} Pinned ${BOLD}${pin.entry.path}${RESET}`);
       } else {
@@ -574,16 +660,33 @@ export async function maybeReviewAllowlistAfterUpdate(deps: ScanDeps = {}): Prom
   const log = deps.log ?? ((m: string) => console.log(m));
   try {
     const readEntries = deps.readEntries ?? getReviewedScriptsRaw;
-    const items = classifyScripts(discoverScripts(deps), readEntries());
+    const discovered = discoverScripts(deps);
+    const broken = sourcesBroken(discovered.sources);
+    const items = classifyScripts(discovered.scripts, readEntries());
     const needsReview = items.filter((i) => i.status === 'new' || i.status === 'changed');
-    if (needsReview.length === 0) return;
+
+    if (broken.length > 0) {
+      log(
+        `${DIM}reviewed-script scan: cron source incomplete (${broken
+          .map((s) => `${s.path}:${s.status}`)
+          .join(', ')}) — run: shieldcortex allowlist scan${RESET}`,
+      );
+      // Still offer review for whatever we *did* find when interactive.
+    }
+
+    if (needsReview.length === 0 && broken.length === 0) return;
 
     const interactive = deps.interactive ?? isInteractive();
     if (!interactive) {
-      log(`${DIM}reviewed-script scan: ${needsReview.length} new/changed — run: shieldcortex allowlist scan${RESET}`);
+      if (needsReview.length > 0) {
+        log(
+          `${DIM}reviewed-script scan: ${needsReview.length} new/changed — run: shieldcortex allowlist scan${RESET}`,
+        );
+      }
       return;
     }
-    log(renderSummary(items));
+    if (needsReview.length === 0) return;
+    log(renderSummary(items, discovered.sources));
     await reviewScanItems(items, deps);
   } catch (e) {
     log(`${DIM}reviewed-script scan skipped — ${e instanceof Error ? e.message : String(e)}${RESET}`);

--- a/src/cli/allowlist-scan.ts
+++ b/src/cli/allowlist-scan.ts
@@ -278,8 +278,19 @@ function sourcesBroken(sources: { hermes: CronSourceReport; openclaw: CronSource
 const PREVIEW_MAX_LINES = 40;
 const PREVIEW_MAX_BYTES = 2_048;
 
+/** Strip CSI/OSC and most C0 controls so a hostile script cannot spoof the
+ *  review banner/path/hash on a TTY. Keep tab; turn CR into a visible marker. */
+function sanitisePreviewLine(line: string): string {
+  return line
+    .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '')
+    .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)?/g, '')
+    .replace(/\u001b./g, '')
+    .replace(/\r/g, '⏎')
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '');
+}
+
 function makePreview(content: string): string {
-  const lines = content.split('\n');
+  const lines = content.split('\n').map(sanitisePreviewLine);
   let preview = lines.slice(0, PREVIEW_MAX_LINES).join('\n');
   if (preview.length > PREVIEW_MAX_BYTES) preview = preview.slice(0, PREVIEW_MAX_BYTES);
   if (preview.length < content.length) preview += '\n…';

--- a/src/cli/allowlist-scan.ts
+++ b/src/cli/allowlist-scan.ts
@@ -1,0 +1,591 @@
+/**
+ * `shieldcortex allowlist scan` (#309) — the batch review flow for the
+ * reviewed-script allowlist.
+ *
+ * Discovery walks the places configured agent crons actually name scripts —
+ * Hermes cron jobs (`~/.hermes/cron/jobs.json`), OpenClaw cron jobs
+ * (`~/.openclaw/cron/jobs.json`), and any explicit `--glob` patterns — and
+ * diffs every resolvable script against `actionGuard.reviewedScripts` by
+ * content hash. Missing files never throw; a cron store we cannot read is an
+ * empty discovery source, not an error.
+ *
+ * Trust surface discipline, same #118 threat model as `allowlist add`:
+ *   - Non-interactive runs LIST ONLY. They exit 3 when there is something a
+ *     human should look at, so automation can detect "review needed" without
+ *     being able to perform the review.
+ *   - Pinning happens only per-item, on a TTY, through `pinReviewedScript` —
+ *     the exact write path `add` uses. No env-var escape hatch.
+ *   - `--yes` is refused outright without a TTY, and even with one it demands
+ *     the operator TYPE the word "approve" — a batch pin must cost more than
+ *     a reflex keystroke.
+ *
+ * The network sniff is advisory colour for the reviewer ("this thing talks to
+ * the outside world"), never a gate: a script that hides its networking from
+ * a one-line regex must not thereby earn a quieter review.
+ */
+
+import { readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute, join, resolve as resolvePath } from 'node:path';
+import { isInteractive } from './approve.js';
+import { pinReviewedScript, MAX_REVIEWABLE_BYTES, type AllowlistDeps } from './allowlist.js';
+import { hashScriptSource, normaliseReviewedScripts } from '../defence/iron-dome/reviewed-scripts.js';
+import { getReviewedScriptsRaw } from '../cloud/config.js';
+
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const RED = '\x1b[31m';
+const RESET = '\x1b[0m';
+
+export interface ScanDeps extends AllowlistDeps {
+  /** Injected home for tests — default `os.homedir()`. Real ~/.hermes and
+   *  ~/.openclaw must never be read under test. */
+  home?: string;
+  cwd?: string;
+  hermesCronPath?: string;
+  openclawCronPath?: string;
+  globs?: string[];
+  /** Injected stdin for tests; default asks on the real terminal. */
+  prompt?: (question: string) => Promise<string>;
+}
+
+export interface DiscoveredScript {
+  /** Absolute path after `~/` expansion — NOT canonicalised yet. */
+  path: string;
+  sources: string[];
+}
+
+export type ScanStatus = 'current' | 'changed' | 'new' | 'missing' | 'too_large';
+
+export interface ScanItem {
+  /** Canonical path when the file resolves; the discovered path otherwise. */
+  path: string;
+  status: ScanStatus;
+  sha256?: string;
+  pinnedSha256?: string;
+  networkHint: boolean;
+  sources: string[];
+  preview?: string;
+}
+
+// ── Discovery ───────────────────────────────────────────────
+
+/** Path-shaped tokens ending in a script extension — absolute or `~/`.
+ *  Deliberately narrow: no spaces, no shell metacharacters, so a prompt like
+ *  `python3 /a/b.py && rm x` yields exactly the script path. */
+const SCRIPT_PATH_RE = /(?:~\/|\/)[\w.\/@+-]*\.(?:py|sh|bash|mjs|cjs|js|ts|rb|pl)\b/g;
+const SCRIPT_EXT_RE = /\.(?:py|sh|bash|mjs|cjs|js|ts|rb|pl)$/;
+
+/** Advisory only — a reviewer hint, never a gate (see module header). */
+const NETWORK_SNIFF_RE = /\b(?:requests|urllib|imaplib|smtplib|httpx|aiohttp|googleapiclient)\b|fetch\s*\(|\bcurl\b/;
+
+function expandHome(p: string, home: string): string {
+  return p.startsWith('~/') ? join(home, p.slice(2)) : p;
+}
+
+export function extractScriptPaths(text: string, home: string): string[] {
+  const out: string[] = [];
+  for (const match of text.matchAll(SCRIPT_PATH_RE)) {
+    out.push(expandHome(match[0], home));
+  }
+  return out;
+}
+
+/** A cron store that is absent, unreadable, or not JSON is an empty source. */
+function readJsonSafe(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function jobsOf(doc: unknown): unknown[] {
+  if (Array.isArray(doc)) return doc;
+  if (doc && typeof doc === 'object' && Array.isArray((doc as Record<string, unknown>).jobs)) {
+    return (doc as Record<string, unknown>).jobs as unknown[];
+  }
+  return [];
+}
+
+/** Hermes shape: `{ jobs: [{ prompt, script, … }] }` or a bare array. */
+function hermesCandidates(doc: unknown, home: string): string[] {
+  const out: string[] = [];
+  for (const job of jobsOf(doc)) {
+    if (!job || typeof job !== 'object') continue;
+    const rec = job as Record<string, unknown>;
+    if (typeof rec.script === 'string') {
+      const s = rec.script.trim();
+      if ((isAbsolute(s) || s.startsWith('~/')) && SCRIPT_EXT_RE.test(s) && !/\s/.test(s)) {
+        out.push(expandHome(s, home));
+      } else {
+        // A `script` field holding a command line still names its script.
+        out.push(...extractScriptPaths(s, home));
+      }
+    }
+    if (typeof rec.prompt === 'string') out.push(...extractScriptPaths(rec.prompt, home));
+  }
+  return out;
+}
+
+/** OpenClaw shape: `{ version, jobs: [{ payload: { kind, message } }] }`.
+ *  The stringified-payload sweep catches paths in fields we did not predict. */
+function openclawCandidates(doc: unknown, home: string): string[] {
+  const out: string[] = [];
+  for (const job of jobsOf(doc)) {
+    if (!job || typeof job !== 'object') continue;
+    const payload = (job as Record<string, unknown>).payload;
+    if (!payload || typeof payload !== 'object') continue;
+    const rec = payload as Record<string, unknown>;
+    if (typeof rec.message === 'string') out.push(...extractScriptPaths(rec.message, home));
+    if (typeof rec.prompt === 'string') out.push(...extractScriptPaths(rec.prompt, home));
+    try {
+      out.push(...extractScriptPaths(JSON.stringify(payload), home));
+    } catch {
+      /* circular payloads cannot come from JSON, but never throw regardless */
+    }
+  }
+  return out;
+}
+
+// Minimal glob: `*` and `?` within a segment, `**` for any directory depth.
+// The walk budget caps runaway patterns; dirent.isDirectory() is false for
+// symlinks, so `**` cannot loop through a symlink cycle.
+const GLOB_WALK_BUDGET = 20_000;
+
+function segmentToRegExp(segment: string): RegExp {
+  const escaped = segment.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*').replace(/\?/g, '[^/]');
+  return new RegExp(`^${escaped}$`);
+}
+
+function expandGlob(pattern: string, cwd: string): string[] {
+  const abs = isAbsolute(pattern) ? pattern : resolvePath(cwd, pattern);
+  const out: string[] = [];
+  const budget = { left: GLOB_WALK_BUDGET };
+
+  const walk = (base: string, segs: string[]): void => {
+    if (budget.left-- <= 0) return;
+    if (segs.length === 0) {
+      try {
+        if (statSync(base).isFile() && SCRIPT_EXT_RE.test(base)) out.push(base);
+      } catch {
+        /* pattern named something that is not there */
+      }
+      return;
+    }
+    const [head, ...rest] = segs;
+    if (head === '**') {
+      walk(base, rest);
+      let dirs: string[] = [];
+      try {
+        dirs = readdirSync(base, { withFileTypes: true })
+          .filter((d) => d.isDirectory())
+          .map((d) => d.name);
+      } catch {
+        /* unreadable directory — nothing beneath it to match */
+      }
+      for (const d of dirs) walk(join(base, d), segs);
+      return;
+    }
+    if (head.includes('*') || head.includes('?')) {
+      const re = segmentToRegExp(head);
+      let names: string[] = [];
+      try {
+        names = readdirSync(base);
+      } catch {
+        return;
+      }
+      for (const n of names) if (re.test(n)) walk(join(base, n), rest);
+      return;
+    }
+    walk(join(base, head), rest);
+  };
+
+  walk('/', abs.split('/').filter(Boolean));
+  return out;
+}
+
+/** Union of every discovery source, deduped by expanded path. Never throws. */
+export function discoverScripts(deps: ScanDeps = {}): DiscoveredScript[] {
+  const home = deps.home ?? homedir();
+  const cwd = deps.cwd ?? process.cwd();
+  const bySource = new Map<string, Set<string>>();
+  const add = (path: string, source: string): void => {
+    const sources = bySource.get(path) ?? new Set<string>();
+    sources.add(source);
+    bySource.set(path, sources);
+  };
+
+  const hermesPath = deps.hermesCronPath ?? join(home, '.hermes', 'cron', 'jobs.json');
+  for (const p of hermesCandidates(readJsonSafe(hermesPath), home)) add(p, 'hermes-cron');
+
+  const openclawPath = deps.openclawCronPath ?? join(home, '.openclaw', 'cron', 'jobs.json');
+  for (const p of openclawCandidates(readJsonSafe(openclawPath), home)) add(p, 'openclaw-cron');
+
+  for (const pattern of deps.globs ?? []) {
+    try {
+      for (const p of expandGlob(pattern, cwd)) add(p, 'glob');
+    } catch {
+      /* a glob that cannot expand discovers nothing */
+    }
+  }
+
+  return [...bySource.entries()]
+    .map(([path, sources]) => ({ path, sources: [...sources] }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+// ── Classification ──────────────────────────────────────────
+
+const PREVIEW_MAX_LINES = 40;
+const PREVIEW_MAX_BYTES = 2_048;
+
+function makePreview(content: string): string {
+  const lines = content.split('\n');
+  let preview = lines.slice(0, PREVIEW_MAX_LINES).join('\n');
+  if (preview.length > PREVIEW_MAX_BYTES) preview = preview.slice(0, PREVIEW_MAX_BYTES);
+  if (preview.length < content.length) preview += '\n…';
+  return preview;
+}
+
+const STATUS_ORDER: Record<ScanStatus, number> = { new: 0, changed: 1, current: 2, missing: 3, too_large: 4 };
+
+/** Diff discovered paths against the allowlist. Same drop rules as `add`:
+ *  a path that does not resolve to a regular file cannot be pinned (reported
+ *  as `missing`), and a >256KB file is never folded so there is nothing to
+ *  exempt (reported as `too_large`). */
+export function classifyScripts(discovered: DiscoveredScript[], rawEntries: unknown[]): ScanItem[] {
+  const entries = normaliseReviewedScripts(rawEntries);
+  const byPinnedPath = new Map(entries.map((e) => [e.path, e]));
+  const byCanonical = new Map<string, ScanItem>();
+  const missingSeen = new Map<string, ScanItem>();
+  const out: ScanItem[] = [];
+
+  for (const d of discovered) {
+    let canonical: string;
+    let size: number;
+    try {
+      canonical = realpathSync(d.path);
+      const st = statSync(canonical);
+      if (!st.isFile()) throw new Error('not a regular file');
+      size = st.size;
+    } catch {
+      const seen = missingSeen.get(d.path);
+      if (seen) {
+        for (const s of d.sources) if (!seen.sources.includes(s)) seen.sources.push(s);
+        continue;
+      }
+      const item: ScanItem = { path: d.path, status: 'missing', networkHint: false, sources: [...d.sources] };
+      missingSeen.set(d.path, item);
+      out.push(item);
+      continue;
+    }
+
+    const seen = byCanonical.get(canonical);
+    if (seen) {
+      for (const s of d.sources) if (!seen.sources.includes(s)) seen.sources.push(s);
+      continue;
+    }
+
+    let item: ScanItem;
+    if (size > MAX_REVIEWABLE_BYTES) {
+      item = { path: canonical, status: 'too_large', networkHint: false, sources: [...d.sources] };
+    } else {
+      let content: string;
+      try {
+        content = readFileSync(canonical, 'utf8');
+      } catch {
+        item = { path: d.path, status: 'missing', networkHint: false, sources: [...d.sources] };
+        out.push(item);
+        continue;
+      }
+      const sha256 = hashScriptSource(content);
+      const pinned = byPinnedPath.get(canonical);
+      const status: ScanStatus = !pinned ? 'new' : pinned.sha256 === sha256 ? 'current' : 'changed';
+      item = {
+        path: canonical,
+        status,
+        sha256,
+        ...(pinned ? { pinnedSha256: pinned.sha256 } : {}),
+        networkHint: NETWORK_SNIFF_RE.test(content),
+        sources: [...d.sources],
+        preview: makePreview(content),
+      };
+    }
+    byCanonical.set(canonical, item);
+    out.push(item);
+  }
+
+  return out.sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status] || a.path.localeCompare(b.path));
+}
+
+// ── Rendering ───────────────────────────────────────────────
+
+function statusPaint(status: ScanStatus): string {
+  if (status === 'new') return `${YELLOW}new${RESET}`;
+  if (status === 'changed') return `${YELLOW}changed${RESET}`;
+  if (status === 'current') return `${GREEN}current${RESET}`;
+  if (status === 'missing') return `${RED}missing${RESET}`;
+  return `${RED}too_large${RESET}`;
+}
+
+function renderSummary(items: ScanItem[]): string {
+  if (items.length === 0) {
+    return `${DIM}Reviewed-script scan — no scripts discovered in Hermes/OpenClaw cron jobs.${RESET}`;
+  }
+  const count = (s: ScanStatus): number => items.filter((i) => i.status === s).length;
+  const lines: string[] = [
+    `${BOLD}Reviewed-script scan${RESET} — ${items.length} script(s) discovered: ` +
+      `${count('current')} current · ${count('new')} new · ${count('changed')} changed · ` +
+      `${count('missing')} missing · ${count('too_large')} too large`,
+    '',
+  ];
+  for (const i of items) {
+    const notes: string[] = [i.sources.join(', ')];
+    if (i.sha256) notes.push(`sha256 ${i.sha256.slice(0, 12)}…`);
+    if (i.status === 'changed' && i.pinnedSha256) notes.push(`pinned ${i.pinnedSha256.slice(0, 12)}…`);
+    if (i.status === 'missing') notes.push('path does not resolve — cannot pin');
+    if (i.status === 'too_large') notes.push('>256KB — never folded, nothing to exempt');
+    if (i.networkHint) notes.push(`${YELLOW}network?${RESET}`);
+    lines.push(`  ${statusPaint(i.status)}  ${BOLD}${i.path}${RESET}`);
+    lines.push(`     ${DIM}${notes.join(' · ')}${RESET}`);
+  }
+  return lines.join('\n');
+}
+
+function renderReviewItem(item: ScanItem, index: number, total: number): string {
+  const lines: string[] = [
+    '',
+    `${BOLD}── ${index}/${total} · ${item.status === 'changed' ? 'CHANGED' : 'NEW'} · ${item.path}${RESET}`,
+  ];
+  const meta: string[] = [`sha256 ${(item.sha256 ?? '').slice(0, 16)}…`];
+  if (item.status === 'changed' && item.pinnedSha256) meta.push(`was ${item.pinnedSha256.slice(0, 16)}…`);
+  meta.push(`sources: ${item.sources.join(', ')}`);
+  if (item.networkHint) meta.push(`${YELLOW}network calls likely (advisory sniff)${RESET}`);
+  lines.push(`   ${DIM}${meta.join(' · ')}${RESET}`);
+  if (item.preview) {
+    lines.push(`   ${DIM}┄┄ first ${PREVIEW_MAX_LINES} lines ┄┄${RESET}`);
+    for (const l of item.preview.split('\n')) lines.push(`   ${DIM}│${RESET} ${l}`);
+    lines.push(`   ${DIM}┄┄${RESET}`);
+  }
+  return lines.join('\n');
+}
+
+// ── Interactive review ──────────────────────────────────────
+
+async function ttyPrompt(question: string): Promise<string> {
+  const { createInterface } = await import('node:readline/promises');
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await rl.question(question);
+  } finally {
+    rl.close();
+  }
+}
+
+export interface ReviewResult {
+  pinned: number;
+  skipped: number;
+  failed: number;
+  quit: boolean;
+}
+
+/**
+ * Per-item human review of every `new`/`changed` item. TTY-gated HERE, not
+ * only in the CLI wrapper, so no caller (update hook included) can reach a
+ * write without a human at the keyboard.
+ */
+export async function reviewScanItems(items: ScanItem[], deps: ScanDeps = {}): Promise<ReviewResult> {
+  const log = deps.log ?? ((m: string) => console.log(m));
+  const err = deps.error ?? ((m: string) => console.error(m));
+  const result: ReviewResult = { pinned: 0, skipped: 0, failed: 0, quit: false };
+
+  const reviewable = items.filter((i) => i.status === 'new' || i.status === 'changed');
+  if (reviewable.length === 0) return result;
+
+  const interactive = deps.interactive ?? isInteractive();
+  if (!interactive) {
+    err('shieldcortex allowlist scan review must be run by a human in an interactive terminal.');
+    err('Refusing: stdin/stdout are not TTYs, so this could be the agent pinning its own payload as "reviewed".');
+    return result;
+  }
+
+  const ask = deps.prompt ?? ttyPrompt;
+  for (let i = 0; i < reviewable.length; i++) {
+    const item = reviewable[i];
+    log(renderReviewItem(item, i + 1, reviewable.length));
+    const answer = (await ask(`  [y] pin / [n] skip / [q] quit > `)).trim().toLowerCase();
+    if (answer === 'q' || answer === 'quit') {
+      result.quit = true;
+      log(`${DIM}Stopped — ${result.pinned} pinned this run stay pinned; the rest fold as usual.${RESET}`);
+      break;
+    }
+    if (answer !== 'y' && answer !== 'yes') {
+      result.skipped += 1;
+      continue;
+    }
+    const note = (await ask('  note (optional, why is this trusted): ')).trim() || undefined;
+    const pin = pinReviewedScript(item.path, note, deps);
+    if (pin.ok) {
+      result.pinned += 1;
+      log(`  ${GREEN}✓${RESET} Pinned ${BOLD}${pin.entry.path}${RESET} — any edit re-gates it.`);
+    } else {
+      result.failed += 1;
+      err(`  ✗ ${pin.error}`);
+    }
+  }
+  return result;
+}
+
+// ── CLI entry ───────────────────────────────────────────────
+
+const SCAN_USAGE = 'Usage: shieldcortex allowlist scan [--json] [--yes] [--glob pat ...] [--hermes-cron p] [--openclaw-cron p]';
+
+/**
+ * Exit codes: 0 nothing needs review (or review completed), 3 new/changed
+ * found but not reviewable here (non-interactive — automation's "a human
+ * should look" signal), 1 hard error.
+ */
+export async function runAllowlistScan(argv: string[], deps: ScanDeps = {}): Promise<number> {
+  const log = deps.log ?? ((m: string) => console.log(m));
+  const err = deps.error ?? ((m: string) => console.error(m));
+
+  const globs = [...(deps.globs ?? [])];
+  let json = false;
+  let yes = false;
+  let hermesCronPath = deps.hermesCronPath;
+  let openclawCronPath = deps.openclawCronPath;
+
+  const args = argv.filter((a) => a !== '--');
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--json') json = true;
+    else if (a === '--yes') yes = true;
+    else if (a === '--glob' || a === '--hermes-cron' || a === '--openclaw-cron') {
+      const value = args[i + 1];
+      if (!value || value.startsWith('-')) {
+        err(`${a} expects a value. ${SCAN_USAGE}`);
+        return 1;
+      }
+      if (a === '--glob') globs.push(value);
+      else if (a === '--hermes-cron') hermesCronPath = value;
+      else openclawCronPath = value;
+      i += 1;
+    } else {
+      err(`Unknown option "${a}". ${SCAN_USAGE}`);
+      return 1;
+    }
+  }
+
+  const interactive = deps.interactive ?? isInteractive();
+  if (yes && !interactive) {
+    err('shieldcortex allowlist scan --yes must be run by a human in an interactive terminal.');
+    err('Refusing: stdin/stdout are not TTYs, so this could be the agent batch-pinning its own payloads as "reviewed".');
+    return 1;
+  }
+
+  const scanDeps: ScanDeps = { ...deps, hermesCronPath, openclawCronPath, globs };
+  let items: ScanItem[];
+  try {
+    const readEntries = deps.readEntries ?? getReviewedScriptsRaw;
+    items = classifyScripts(discoverScripts(scanDeps), readEntries());
+  } catch (e) {
+    err(`Scan failed: ${e instanceof Error ? e.message : String(e)}`);
+    return 1;
+  }
+
+  const needsReview = items.filter((i) => i.status === 'new' || i.status === 'changed');
+
+  if (json) {
+    log(
+      JSON.stringify(
+        {
+          counts: {
+            current: items.filter((i) => i.status === 'current').length,
+            new: items.filter((i) => i.status === 'new').length,
+            changed: items.filter((i) => i.status === 'changed').length,
+            missing: items.filter((i) => i.status === 'missing').length,
+            too_large: items.filter((i) => i.status === 'too_large').length,
+          },
+          items: items.map((i) => ({
+            path: i.path,
+            status: i.status,
+            sha256: i.sha256 ?? null,
+            pinnedSha256: i.pinnedSha256 ?? null,
+            networkHint: i.networkHint,
+            sources: i.sources,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+    return needsReview.length > 0 ? 3 : 0;
+  }
+
+  log(renderSummary(items));
+  if (needsReview.length === 0) return 0;
+
+  if (!interactive) {
+    log('');
+    log(`${needsReview.length} new/changed need human review — run: ${BOLD}shieldcortex allowlist scan${RESET} in an interactive terminal.`);
+    return 3;
+  }
+
+  if (yes) {
+    const ask = deps.prompt ?? ttyPrompt;
+    const answer = (
+      await ask(`\nType ${BOLD}approve${RESET} to pin ALL ${needsReview.length} new/changed script(s) listed above, anything else to cancel: `)
+    )
+      .trim()
+      .toLowerCase();
+    if (answer !== 'approve') {
+      log(`${DIM}Cancelled — nothing pinned. Re-run without --yes for per-item review.${RESET}`);
+      return 0;
+    }
+    let failed = 0;
+    for (const item of needsReview) {
+      const pin = pinReviewedScript(item.path, undefined, deps);
+      if (pin.ok) {
+        log(`${GREEN}✓${RESET} Pinned ${BOLD}${pin.entry.path}${RESET}`);
+      } else {
+        err(`✗ ${pin.error}`);
+        failed += 1;
+      }
+    }
+    return failed > 0 ? 1 : 0;
+  }
+
+  const result = await reviewScanItems(items, scanDeps);
+  return result.failed > 0 ? 1 : 0;
+}
+
+// ── `shieldcortex update` hook ──────────────────────────────
+
+/**
+ * Called near the end of `runUpdate`. Interactive terminals get the same
+ * per-item review the CLI offers; headless runs get ONE dim pointer line and
+ * no writes. Never throws — an update must not fail because a cron file was
+ * strange.
+ */
+export async function maybeReviewAllowlistAfterUpdate(deps: ScanDeps = {}): Promise<void> {
+  const log = deps.log ?? ((m: string) => console.log(m));
+  try {
+    const readEntries = deps.readEntries ?? getReviewedScriptsRaw;
+    const items = classifyScripts(discoverScripts(deps), readEntries());
+    const needsReview = items.filter((i) => i.status === 'new' || i.status === 'changed');
+    if (needsReview.length === 0) return;
+
+    const interactive = deps.interactive ?? isInteractive();
+    if (!interactive) {
+      log(`${DIM}reviewed-script scan: ${needsReview.length} new/changed — run: shieldcortex allowlist scan${RESET}`);
+      return;
+    }
+    log(renderSummary(items));
+    await reviewScanItems(items, deps);
+  } catch (e) {
+    log(`${DIM}reviewed-script scan skipped — ${e instanceof Error ? e.message : String(e)}${RESET}`);
+  }
+}

--- a/src/cli/allowlist-scan.ts
+++ b/src/cli/allowlist-scan.ts
@@ -6,8 +6,10 @@
  * Hermes cron jobs (`~/.hermes/cron/jobs.json`), OpenClaw cron jobs
  * (`~/.openclaw/cron/jobs.json`), and any explicit `--glob` patterns — and
  * diffs every resolvable script against `actionGuard.reviewedScripts` by
- * content hash. Missing files never throw; a cron store we cannot read is an
- * empty discovery source, not an error.
+ * content hash. An **absent** cron store is empty-ok. A store that **exists
+ * but is unreadable or invalid JSON is incomplete discovery** — `scan`
+ * exits 1 so automation cannot treat "we could not look" as "all clear".
+ * Relative script names are not extracted (absolute or `~/` + extension only).
  *
  * Trust surface discipline, same #118 threat model as `allowlist add`:
  *   - Non-interactive runs LIST ONLY. They exit 3 when there is something a

--- a/src/cli/allowlist.ts
+++ b/src/cli/allowlist.ts
@@ -105,6 +105,12 @@ export interface PinDeps {
   now?: number;
   readEntries?: () => unknown[];
   writeEntries?: (entries: Array<Record<string, unknown>>) => void;
+  /**
+   * When set (scan review / batch --yes), the on-disk content at pin time MUST
+   * still hash to this value. Closes the TOCTOU where an agent rewrites the
+   * file after the human saw the preview and before `y`/`approve`.
+   */
+  expectedSha256?: string;
 }
 
 export type PinResult = { ok: true; entry: ReviewedScriptEntry } | { ok: false; error: string };
@@ -138,6 +144,14 @@ export function pinReviewedScript(target: string, note: string | undefined, deps
   }
 
   const sha256 = hashScriptSource(content);
+  if (deps.expectedSha256 && deps.expectedSha256 !== sha256) {
+    return {
+      ok: false,
+      error:
+        `Content changed since review (expected ${deps.expectedSha256.slice(0, 12)}…, now ${sha256.slice(0, 12)}…). ` +
+        `Nothing pinned — re-run scan and review the new bytes.`,
+    };
+  }
   const entries = normaliseReviewedScripts(readEntries());
   const kept = entries.filter((e) => e.path !== canonical);
   const entry: ReviewedScriptEntry = { path: canonical, sha256, addedAt: now, ...(note ? { note } : {}) };

--- a/src/cli/allowlist.ts
+++ b/src/cli/allowlist.ts
@@ -6,6 +6,7 @@
  *   shieldcortex allowlist add <path> [--note "why"]
  *   shieldcortex allowlist remove <path>
  *   shieldcortex allowlist verify                # exit 1 if any entry drifted
+ *   shieldcortex allowlist scan                  # #309 cron discovery + TTY batch review
  *
  * `add` pins a script by ABSOLUTE CANONICAL PATH + CONTENT HASH so the Action
  * Guard stops folding its source into the scan surface. This is the standing
@@ -38,7 +39,7 @@ const RESET = '\x1b[0m';
 
 /** Matches the resolver's fold cap — a file the guard would refuse to fold
  *  cannot meaningfully be "exempt from folding". */
-const MAX_REVIEWABLE_BYTES = 262_144;
+export const MAX_REVIEWABLE_BYTES = 262_144;
 
 export interface AllowlistDeps {
   now?: number;
@@ -100,7 +101,55 @@ function toRecords(entries: ReviewedScriptEntry[]): Array<Record<string, unknown
   }));
 }
 
-export function runAllowlist(argv: string[], deps: AllowlistDeps = {}): number {
+export interface PinDeps {
+  now?: number;
+  readEntries?: () => unknown[];
+  writeEntries?: (entries: Array<Record<string, unknown>>) => void;
+}
+
+export type PinResult = { ok: true; entry: ReviewedScriptEntry } | { ok: false; error: string };
+
+/**
+ * The ONE write path for pinning a script as reviewed — `allowlist add` and
+ * the scan review flow (#309) both come through here, so canonicalisation,
+ * the size cap, and replace-on-same-path can never drift apart. NOT TTY-gated
+ * itself: every caller must gate on `isInteractive()` before invoking, the
+ * same way `add` does.
+ */
+export function pinReviewedScript(target: string, note: string | undefined, deps: PinDeps = {}): PinResult {
+  const now = deps.now ?? Date.now();
+  const readEntries = deps.readEntries ?? getReviewedScriptsRaw;
+  const writeEntries = deps.writeEntries ?? setReviewedScripts;
+
+  let canonical: string;
+  let content: string;
+  try {
+    canonical = realpathSync(isAbsolute(target) ? target : resolvePath(process.cwd(), target));
+    const st = statSync(canonical);
+    if (!st.isFile()) {
+      return { ok: false, error: `Not a regular file: ${canonical}` };
+    }
+    if (st.size > MAX_REVIEWABLE_BYTES) {
+      return { ok: false, error: `File exceeds the guard's 256KB fold cap — it is never folded, so there is nothing to exempt.` };
+    }
+    content = readFileSync(canonical, 'utf8');
+  } catch (e) {
+    return { ok: false, error: `Cannot read ${target}: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  const sha256 = hashScriptSource(content);
+  const entries = normaliseReviewedScripts(readEntries());
+  const kept = entries.filter((e) => e.path !== canonical);
+  const entry: ReviewedScriptEntry = { path: canonical, sha256, addedAt: now, ...(note ? { note } : {}) };
+  try {
+    writeEntries(toRecords([...kept, entry]));
+  } catch (e) {
+    return { ok: false, error: `Could not write the allowlist: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  return { ok: true, entry };
+}
+
+export function runAllowlist(argv: string[], deps: AllowlistDeps = {}): number | Promise<number> {
   const now = deps.now ?? Date.now();
   const log = deps.log ?? ((m: string) => console.log(m));
   const err = deps.error ?? ((m: string) => console.error(m));
@@ -109,6 +158,13 @@ export function runAllowlist(argv: string[], deps: AllowlistDeps = {}): number {
 
   const args = argv.filter((a) => a !== '--');
   const sub = args[0];
+
+  // Scan (#309) dispatches before the entries read: it does its own read, and
+  // the dynamic import keeps the module edge one-directional (scan imports
+  // `pinReviewedScript` from here statically).
+  if (sub === 'scan') {
+    return import('./allowlist-scan.js').then((m) => m.runAllowlistScan(args.slice(1), deps));
+  }
 
   const entries = normaliseReviewedScripts(readEntries());
 
@@ -146,37 +202,14 @@ export function runAllowlist(argv: string[], deps: AllowlistDeps = {}): number {
     }
     if (!requireHuman(deps, err, 'add')) return 1;
 
-    let canonical: string;
-    let content: string;
-    try {
-      canonical = realpathSync(isAbsolute(target) ? target : resolvePath(process.cwd(), target));
-      const st = statSync(canonical);
-      if (!st.isFile()) {
-        err(`Not a regular file: ${canonical}`);
-        return 1;
-      }
-      if (st.size > MAX_REVIEWABLE_BYTES) {
-        err(`File exceeds the guard's 256KB fold cap — it is never folded, so there is nothing to exempt.`);
-        return 1;
-      }
-      content = readFileSync(canonical, 'utf8');
-    } catch (e) {
-      err(`Cannot read ${target}: ${e instanceof Error ? e.message : String(e)}`);
+    const pin = pinReviewedScript(target, note, { now, readEntries, writeEntries });
+    if (!pin.ok) {
+      err(pin.error);
       return 1;
     }
 
-    const sha256 = hashScriptSource(content);
-    const kept = entries.filter((e) => e.path !== canonical);
-    const entry: ReviewedScriptEntry = { path: canonical, sha256, addedAt: now, ...(note ? { note } : {}) };
-    try {
-      writeEntries(toRecords([...kept, entry]));
-    } catch (e) {
-      err(`Could not write the allowlist: ${e instanceof Error ? e.message : String(e)}`);
-      return 1;
-    }
-
-    log(`${GREEN}✓${RESET} Pinned ${BOLD}${canonical}${RESET} as reviewed.`);
-    log(`  sha256 ${sha256.slice(0, 16)}… — the guard stops folding this file's source.`);
+    log(`${GREEN}✓${RESET} Pinned ${BOLD}${pin.entry.path}${RESET} as reviewed.`);
+    log(`  sha256 ${pin.entry.sha256.slice(0, 16)}… — the guard stops folding this file's source.`);
     log(`${DIM}  You are vouching for this file's CONTENT. Any edit re-gates it; the command line`);
     log(`  that invokes it is still scanned in full. Remove with: shieldcortex allowlist remove <path>${RESET}`);
     return 0;
@@ -213,6 +246,6 @@ export function runAllowlist(argv: string[], deps: AllowlistDeps = {}): number {
     return 0;
   }
 
-  err(`Unknown subcommand "${sub}". Usage: shieldcortex allowlist [list|add|remove|verify]`);
+  err(`Unknown subcommand "${sub}". Usage: shieldcortex allowlist [list|add|remove|verify|scan]`);
   return 1;
 }

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -767,6 +767,19 @@ export async function runUpdate(): Promise<void> {
     }
     process.stdout.write('\n');
   }
+
+  // #309 — after the package is current, surface new/changed cron-referenced
+  // scripts for TTY batch review. Headless updates only print a pointer line;
+  // never auto-pin and never fail the update if discovery is weird.
+  try {
+    const { maybeReviewAllowlistAfterUpdate } = await import('./allowlist-scan.js');
+    await maybeReviewAllowlistAfterUpdate({
+      log: (m: string) => process.stdout.write(`  ${paint('gray', m)}\n`),
+    });
+  } catch {
+    /* update must not fail on allowlist scan */
+  }
+
   maybePrint411Notice(currentVersion, mainUpdated);
   await maybePrintDashboardHint();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -643,8 +643,10 @@ ${bold}COMMANDS${reset}
   ${cyan}sessions${reset} prune        Delete old session-capture events (dry-run; --days N, --execute)
   ${cyan}approve${reset} [hash]        Grant a one-shot Action Guard approval for one exact
                         command (no hash = list recent refusals; --ttl N minutes)
-  ${cyan}allowlist${reset} [add|remove|verify]  Pin a human-reviewed script (path + content hash)
-                        so the guard stops folding its source; any edit re-gates it
+  ${cyan}allowlist${reset} [add|remove|verify|scan]
+                        Pin a human-reviewed script (path + content hash)
+                        so the guard stops folding its source; any edit re-gates it.
+                        scan = discover cron-referenced scripts and TTY-batch-review new/changed
   ${cyan}quickstart${reset} [target]    Detect integrations and guide/install setup
   ${cyan}config${reset} [options]      Configure cloud sync and settings
   ${cyan}cloud${reset} sync --full     Backfill local memories + graph to ShieldCortex Cloud
@@ -864,7 +866,8 @@ ${bold}DOCS${reset}
   // approve/deny above are one-shot. TTY-gated on every mutating verb.
   if (process.argv[2] === 'allowlist') {
     const { runAllowlist } = await import('./cli/allowlist.js');
-    process.exitCode = runAllowlist(process.argv.slice(3));
+    // scan is async (TTY prompts); add/list/verify stay sync.
+    process.exitCode = await Promise.resolve(runAllowlist(process.argv.slice(3)));
     return;
   }
 


### PR DESCRIPTION
## Summary
Closes the discovery grind from #309: cron-referenced scripts are found and diffed against `reviewedScripts` by content hash; humans pin them in a TTY batch flow.

## What
- `shieldcortex allowlist scan` — Hermes + OpenClaw cron discovery, optional `--glob`, `--json`, path overrides for tests
- Classification: `current` / `changed` / `new` / `missing` / `too_large`
- **TTY-only** per-item pin via shared `pinReviewedScript` (same path+hash as `add`)
- Non-interactive: report only, **exit 3** when new/changed exist, **never writes**
- `--yes` refused without TTY; with TTY requires typing `approve`
- `shieldcortex update` calls `maybeReviewAllowlistAfterUpdate` (interactive review / headless pointer; never fails update)

## Security invariants
- No headless auto-approve
- No env escape hatch
- No change to runtime guard match rules or approval cards (#310 separate)

## Test plan
- [x] `npm test -- --runInBand src/cli/__tests__/allowlist.test.ts src/cli/__tests__/allowlist-scan.test.ts` → **32/32**
- [x] `npm run build:ts` clean

Closes #309