### PR TITLE
chore(release): v4.52.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.52.4] - 2026-08-15
+
+**Patch — `allowlist scan` + update-time batch review for cron scripts (#309).**
+
+Turns the ad-hoc discovery grind (regex over cron prompts, mislabeled paths, network-script misses) into a first-class TTY tool. Hosts on `shieldcortex update` get an interactive review when a terminal is present, or one pointer line headless.
+
+### Added
+
+- **`shieldcortex allowlist scan`** — discovers scripts named by Hermes/OpenClaw cron jobs (absolute or `~/` + script extension) plus optional `--glob`; classifies `current` / `new` / `changed` / `missing` / `too_large` against `actionGuard.reviewedScripts` by content hash.
+- **TTY batch pin** through the same `pinReviewedScript` path as `allowlist add` (canonical path + content hash). Non-interactive runs never write (exit 3 when review needed).
+- **`shieldcortex update` hook** — interactive terminals get the same review; headless prints one dim pointer and never fails the update.
+
+### Security
+
+- Pin binds **`expectedSha256`** from the reviewed preview (TOCTOU refuse on rewrite).
+- Cron sources report `absent|ok|unreadable|invalid_json`; unreadable/invalid → exit 1 (not empty-ok).
+- Preview CSI/C0 sanitised against TTY spoofing.
+- `--yes` requires a TTY + typed word `approve`, and shows per-item previews first.
+
+### Notes
+
+- Closes #309 via PR #311. Dual-reviewed APPROVE_WITH_NITS (Grok 4.6 + SOL), blockers empty. CI green Node 20/22 + macOS.
+- No SDK/client API change — TS SDK and PyPI stay on 0.3.0.
+- Hosts pick this up with `shieldcortex update`.
+
 ## [4.52.3] - 2026-08-15
 
 **Patch — Hermes Action Guard: malformed 200 is unavailable, not allow.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.52.3",
+  "version": "4.52.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.52.3",
+      "version": "4.52.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.52.3",
+  "version": "4.52.4",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.52.3",
+  "version": "4.52.4",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.52.3",
+  "version": "4.52.4",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.52.3
+  version: 4.52.4
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Summary
Release vehicle for #311 / #309 — `shieldcortex allowlist scan` + update-time batch review on npm `@latest`.

## Surfaces
- Core + OpenClaw plugin + ClawHub skill meta → **4.52.4**
- No SDK/PyPI API change (stay **0.3.0**)
- Cloud + websites follow after tag/publish

## Test plan
- [x] #311 already CI green + dual-reviewed + merged
- [ ] This PR CI (version/sync only)