### PR TITLE
feat(attestation): attest the .mjs hook plane behind an allowlist clamp (Phase 2)

### DIFF
--- a/scripts/lib/recall-defence.mjs
+++ b/scripts/lib/recall-defence.mjs
@@ -121,6 +121,9 @@ export function emitRecallAudit(logAudit, { memoryId, action, layer, reason, pro
       reason: `recall-withheld: ${reason ?? layer ?? 'policy'}`,
       fragmentation_score: null,
       pipeline_duration_ms: 0,
+      // hook:recall-defence is a literal in this shipped file — attested by
+      // construction, so withheld-recall BLOCKs can accrue to the channel.
+      source_attested: 1,
     });
   } catch {
     // best-effort

--- a/scripts/lib/save-memory.mjs
+++ b/scripts/lib/save-memory.mjs
@@ -28,6 +28,16 @@ const DEDUP_TITLE_JACCARD = pickNumber('SHIELDCORTEX_DEDUP_TITLE_JACCARD', 0.6);
 const DEDUP_COMBINED = pickNumber('SHIELDCORTEX_DEDUP_COMBINED', 0.5);
 const DEDUP_CANDIDATE_LIMIT = 200; // bound the candidate scan per write
 
+// Hook identities shipped IN THIS PACKAGE — string literals at the three hook
+// call sites (session-end/pre-compact/stop) plus the JSDoc'd default. These are
+// attested by construction: no transcript content or hook stdin can reach the
+// field. The clamp exists because this module is importable by any same-user
+// process — a free opts.source must NOT mint attested rows under an arbitrary
+// name. Out-of-allowlist sources still scan and store, but land UNDEFINED →
+// source_attested NULL (never `false`→0: an explicit 0 under a real key is the
+// mute lever risk.ts's latest-non-null attestation resolution hands out).
+const KNOWN_HOOK_SOURCES = new Set(['session-end-hook', 'pre-compact-hook', 'stop-hook', 'hook']);
+
 /**
  * Insert an auto-extracted memory into the SC database, routed through the
  * full defence pipeline.
@@ -65,7 +75,9 @@ export async function saveAutoExtractedMemory(db, memory, project, opts = {}) {
 
   let result;
   try {
-    result = defence.runDefencePipeline(memory.content, memory.title, source, undefined, project ?? undefined);
+    result = defence.runDefencePipeline(memory.content, memory.title, source, undefined, project ?? undefined, {
+      sourceAttested: KNOWN_HOOK_SOURCES.has(sourceIdentifier) ? true : undefined,
+    });
   } catch (err) {
     const msg = err && typeof err === 'object' && 'message' in err ? String(err.message) : String(err);
     writeFallbackAudit(db, memory, project, sourceIdentifier, `pipeline_error: ${msg}`);
@@ -212,6 +224,12 @@ function insertQuarantineRow(db, memory, project, source, result) {
 
 function writeFallbackAudit(db, memory, project, sourceIdentifier, reason) {
   // Synthetic audit row for cases where the pipeline could not run.
+  //
+  // source_attested is DELIBERATELY absent (schema default NULL): both call
+  // sites are self-inflicted states (dist build missing / pipeline threw), and
+  // an attested BLOCK here would accrue full-weight risk against the hook's
+  // own identity for a packaging problem, not an attack. Leave NULL — do not
+  // "fix" this into an accruing row.
   try {
     db.prepare(`
       INSERT INTO defence_audit (

--- a/src/__tests__/hook-attestation.test.ts
+++ b/src/__tests__/hook-attestation.test.ts
@@ -1,0 +1,154 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import Database from 'better-sqlite3';
+// @ts-expect-error -- importing a .mjs hook util
+import { saveAutoExtractedMemory } from '../../scripts/lib/save-memory.mjs';
+// @ts-expect-error -- importing a .mjs hook util
+import { emitRecallAudit } from '../../scripts/lib/recall-defence.mjs';
+
+/**
+ * Phase 2 of the attestation gap: the .mjs hook plane.
+ *
+ * On a real install the TOP audit source is hook:session-end-hook (5,973 rows)
+ * — every one source_attested NULL, so the biggest single writer never accrues.
+ * The hook identity is a string literal in package-shipped hook code, which is
+ * attested by construction — but ONLY behind an allowlist clamp, because
+ * saveAutoExtractedMemory is an importable shipped module whose opts.source is
+ * otherwise a free string that would mint attested rows under any name.
+ *
+ * Polarity rule (the Phase 1 mute-lever lesson): out-of-allowlist sources get
+ * undefined → NULL, NEVER false → 0. An explicit 0 under a real key is the
+ * mute lever risk.ts's latest-non-null resolution hands to whoever writes it.
+ */
+describe('hook plane attestation', () => {
+  const thisFile = fileURLToPath(import.meta.url);
+  const repoRoot = path.resolve(path.dirname(thisFile), '..', '..');
+  const schemaPath = path.join(repoRoot, 'src', 'database', 'schema.sql');
+
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shieldcortex-hook-attest-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function freshDb(name: string): Database.Database {
+    const db = new Database(path.join(tempDir, name));
+    db.exec(fs.readFileSync(schemaPath, 'utf-8'));
+    return db;
+  }
+
+  it('a known hook source writes an ATTESTED audit row', async () => {
+    const db = freshDb('known.db');
+    try {
+      await saveAutoExtractedMemory(db, {
+        title: 'Decision: chose Drizzle for the SaaS schema',
+        content: 'After comparing Prisma and Kysely we decided Drizzle for the SaaS layer.',
+        category: 'architecture',
+        salience: 0.45,
+        tags: ['auto-extracted'],
+      }, 'shieldcortex', { source: 'session-end-hook' });
+
+      const row = db.prepare(
+        "SELECT source_attested FROM defence_audit WHERE source_identifier = 'session-end-hook' ORDER BY id DESC LIMIT 1",
+      ).get() as { source_attested: number | null } | undefined;
+      expect(row?.source_attested).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('every shipped hook identifier is allowlisted (session-end, pre-compact, stop, default)', async () => {
+    for (const source of ['session-end-hook', 'pre-compact-hook', 'stop-hook', undefined]) {
+      const db = freshDb(`each-${source ?? 'default'}.db`);
+      try {
+        await saveAutoExtractedMemory(db, {
+          title: `Decision: fact for ${source ?? 'default'}`,
+          content: 'A perfectly benign auto-extracted engineering fact for the allowlist sweep.',
+          category: 'learning',
+          salience: 0.4,
+          tags: ['auto-extracted'],
+        }, 'shieldcortex', source === undefined ? {} : { source });
+
+        const row = db.prepare(
+          'SELECT source_identifier, source_attested FROM defence_audit ORDER BY id DESC LIMIT 1',
+        ).get() as { source_identifier: string; source_attested: number | null } | undefined;
+        expect(row?.source_identifier).toBe(source ?? 'hook');
+        expect(row?.source_attested).toBe(1);
+      } finally {
+        db.close();
+      }
+    }
+  });
+
+  it('an out-of-allowlist opts.source lands NULL — never 0, never 1', async () => {
+    // saveAutoExtractedMemory ships in the package and is importable by any
+    // same-user process; a free opts.source must not mint attested rows under
+    // an arbitrary name (→ not 1), and must not write an explicit 0 that could
+    // mute a real key via latest-non-null (→ not 0). NULL only.
+    const db = freshDb('rogue.db');
+    try {
+      await saveAutoExtractedMemory(db, {
+        title: 'Decision: rogue importer fact',
+        content: 'Content written through the shipped module by an arbitrary importer.',
+        category: 'learning',
+        salience: 0.4,
+        tags: ['auto-extracted'],
+      }, 'shieldcortex', { source: 'victim-hook-name' });
+
+      const row = db.prepare(
+        "SELECT source_attested FROM defence_audit WHERE source_identifier = 'victim-hook-name' ORDER BY id DESC LIMIT 1",
+      ).get() as { source_attested: number | null } | undefined;
+      expect(row).toBeDefined();
+      expect(row?.source_attested).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('the fallback audit rows stay NULL deliberately (source pin)', () => {
+    // writeFallbackAudit fires when the pipeline could not run (dist missing /
+    // pipeline throw) — self-inflicted states that must not accrue full-weight
+    // risk against the hook's own identity. Its INSERT must NOT include
+    // source_attested (schema default NULL). Textual pin on the shipped .mjs.
+    const src = fs.readFileSync(path.join(repoRoot, 'scripts', 'lib', 'save-memory.mjs'), 'utf-8');
+    const fnStart = src.indexOf('function writeFallbackAudit');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = src.slice(fnStart, src.indexOf('\n}', fnStart));
+    // The INSERT itself must not carry the column (comments may discuss it).
+    const insertStart = fnBody.indexOf('INSERT INTO defence_audit');
+    expect(insertStart).toBeGreaterThan(-1);
+    const insertStmt = fnBody.slice(insertStart, fnBody.indexOf(').run(', insertStart));
+    expect(insertStmt).not.toContain('source_attested');
+    // And the deliberate-NULL decision is documented where the next editor
+    // will see it, so it isn't "fixed" into an accruing row later.
+    expect(fnBody).toMatch(/DELIBERATELY absent/);
+  });
+
+  it('emitRecallAudit stamps attested=1 (hook:recall-defence is a code literal)', () => {
+    const captured: Array<Record<string, unknown>> = [];
+    const fakeLogAudit = jest.fn((entry: Record<string, unknown>) => {
+      captured.push(entry);
+      return 1;
+    });
+    emitRecallAudit(fakeLogAudit, {
+      memoryId: 7,
+      action: 'withheld',
+      layer: 'trust',
+      reason: 'below floor',
+      project: 'shieldcortex',
+    });
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toMatchObject({
+      source_type: 'hook',
+      source_identifier: 'recall-defence',
+      source_attested: 1,
+    });
+  });
+});

--- a/src/__tests__/hook-attestation.test.ts
+++ b/src/__tests__/hook-attestation.test.ts
@@ -103,10 +103,17 @@ describe('hook plane attestation', () => {
       }, 'shieldcortex', { source: 'victim-hook-name' });
 
       const row = db.prepare(
-        "SELECT source_attested FROM defence_audit WHERE source_identifier = 'victim-hook-name' ORDER BY id DESC LIMIT 1",
-      ).get() as { source_attested: number | null } | undefined;
-      expect(row).toBeDefined();
-      expect(row?.source_attested).toBeNull();
+        "SELECT source_attested, firewall_result FROM defence_audit WHERE source_identifier = 'victim-hook-name' ORDER BY id DESC LIMIT 1",
+      ).get() as { source_attested: number | null; firewall_result: string } | undefined;
+      // firewall_result ALLOW + a stored memories row prove the REAL pipeline
+      // ran — the writeFallbackAudit path (dist missing / pipeline throw) also
+      // writes a NULL row, but as a BLOCK with nothing stored, so without
+      // these two assertions this test passes vacuously off the fallback.
+      expect(row).toMatchObject({ firewall_result: 'ALLOW', source_attested: null });
+      const stored = db.prepare(
+        "SELECT COUNT(*) AS c FROM memories WHERE source = 'hook:victim-hook-name'",
+      ).get() as { c: number };
+      expect(stored.c).toBe(1);
     } finally {
       db.close();
     }


### PR DESCRIPTION
## What

**Phase 2 of the attestation gap: the `.mjs` hook plane** — the biggest single writer on a real install (`hook:session-end-hook`, 5,973 NULL rows).

The hook identity is a string literal in package-shipped hook code (session-end / pre-compact / stop all converge on `saveAutoExtractedMemory` with literal `opts.source` values) — attested by construction, **but only behind an allowlist clamp**: `save-memory.mjs` is an importable shipped module whose `opts.source` is otherwise a free string that would mint attested rows under any name.

## Polarity — the #308 mute-lever lesson, applied

Out-of-allowlist sources land `undefined` → NULL, **never** `false` → 0. An explicit 0 under a real key is the mute lever `risk.ts`'s latest-non-null resolution hands to whoever writes it. The clamp is `KNOWN_HOOK_SOURCES.has(id) ? true : undefined`.

## Changes

- `save-memory.mjs`: `KNOWN_HOOK_SOURCES` = the four shipped identifiers; the pipeline call gains the attestation option.
- `writeFallbackAudit` rows stay NULL **deliberately** (documented in place): both call sites are self-inflicted states (dist missing / pipeline threw); an attested BLOCK would accrue full-weight risk against the hook's own identity for a packaging problem, not an attack.
- `recall-defence.mjs` `emitRecallAudit` → `source_attested: 1` (`hook:recall-defence` is a shipped-file literal); withheld-recall BLOCKs can now accrue.

## Tests

`hook-attestation.test.ts`, through the **real dist pipeline** on a temp DB: known source → 1; all four shipped identifiers allowlisted; rogue importer source → NULL (not 0, not 1); fallback INSERT pinned column-free with the decision documented; `emitRecallAudit` stamps 1.

Full suite: **455 suites / 5,694 green (serial)**.

Known residual (pre-existing, unchanged): `runDefencePipeline` + `sourceAttested` is exported via `shieldcortex/lib`, so any same-user local importer can already assert attested directly — the allowlist is defence-in-depth for this module's identity minting, not a process boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
