### PR TITLE
chore(release): v4.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.53.0] - 2026-08-15
+
+**Minor — attestation write-path + allowlist batch review + threat-graph projector heal on upgrade.**
+
+Four landings since 4.52.3, published together so hosts on `shieldcortex update` get a coherent train:
+
+1. **Threat-graph projector un-stall (#304)** — upgraded installs where the projector cursor advanced but modern lease runs died no longer sit silent forever. The projector heals itself; doctor surfaces stall/never-ran/error instead of a clean bill of health on a dead graph. **Headline behaviour change on every upgraded install: the graph starts moving again.**
+2. **Attestation Phase 1 (#308)** — `source_attested` plumbed through the write surface (MCP / read / delete / tool-response / iron-dome). NULL-preserving and backward-compatible; unattested history stays NULL, not false.
+3. **Attestation Phase 2 (#313)** — the `.mjs` hook plane is attested behind an allowlist clamp. Rogue importers do not get a free attested stamp.
+4. **Allowlist scan + update-time batch review (#311 / #309)** — `shieldcortex allowlist scan` discovers Hermes/OpenClaw cron scripts, classifies vs `reviewedScripts` by content hash, and TTY-pins through the same path as `allowlist add`. `shieldcortex update` offers interactive review or one headless pointer line.
+
+### Behaviour / ops notes (read before flipping knobs)
+
+- **`threatGraph.trustModifier` stays advisory by default.** Do **not** flip to `enforce` in or after this cut. Until now enforce was inert everywhere because the ledger was all-NULL. After 4.53.0, attested rows start accruing real risk — and the #182 lesson says a fleet's own infra (session-end-hook especially) will top the risk list first. **Advisory soak until the FP picture is measured.**
+- No SDK / client API change — TS SDK and PyPI stay on **0.3.0**.
+- Hosts pick this up with `shieldcortex update`.
+
+### Added
+
+- **`shieldcortex allowlist scan`** (+ `--json` / `--glob` / cron path flags / TTY `--yes` requiring typed `approve`).
+- **`source_attested` write-path** across MCP, read, delete, hook, tool-response, and iron-dome surfaces (NULL-preserving).
+- **Hook-plane attestation allowlist clamp** (Phase 2) so only approved hook importers stamp attested.
+- **Doctor threat-graph stall detection** — never-ran backlog, stalled-upgrade cursor, last projector error.
+
+### Fixed
+
+- **Threat-graph projector on upgraded installs** — un-stall / self-heal so the graph moves again (#304).
+- **Allowlist pin TOCTOU** — scan/yes bind `expectedSha256` from the reviewed preview; content rewrite refuses the write.
+- **Incomplete cron discovery** — unreadable/invalid cron JSON exits 1 (not empty-ok).
+- **TTY preview spoofing** — CSI/C0 sanitised in allowlist scan previews.
+
+### Security
+
+- Attested stamps are host-path / allowlist derived, not caller-supplied free labels.
+- Allowlist batch review keeps the #118 TTY gate: non-interactive never writes; headless update never auto-approves.
+
+### PRs
+
+- #304 threat-graph un-stall + doctor visibility
+- #308 attestation Phase 1 write-path
+- #311 / #309 allowlist scan + update hook
+- #313 attestation Phase 2 hook allowlist clamp
+
 ## [4.52.3] - 2026-08-15
 
 **Patch — Hermes Action Guard: malformed 200 is unavailable, not allow.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.52.3",
+  "version": "4.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.52.3",
+      "version": "4.53.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.52.3",
+  "version": "4.53.0",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.52.3",
+  "version": "4.53.0",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.52.3",
+  "version": "4.53.0",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.52.3
+  version: 4.53.0
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Summary
Coordinated **minor** cut after main absorbed:
- **#304** threat-graph projector un-stall + doctor stall visibility (headline upgrade behaviour)
- **#308** attestation Phase 1 — `source_attested` write-path (NULL-preserving)
- **#313** attestation Phase 2 — hook plane allowlist clamp
- **#311 / #309** allowlist scan + update-time batch review

Supersedes closed #312 (`v4.52.4` was stale and only documented #311).

## Explicit non-goals
- **Do not** flip `threatGraph.trustModifier` to `enforce` — stays advisory soak (#182 lesson).
- No SDK/PyPI API bump (remain 0.3.0).

## Test plan
- [x] #304/#308/#311/#313 already on main
- [ ] This PR CI (version sync + changelog only)
- [ ] After merge: tag `v4.53.0` → publish.yml → cloud → websites verify matrix