### PR TITLE
feat(attestation): record-only attestation on the OpenClaw realtime plane (Phase 4)

### DIFF
--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -2373,6 +2373,11 @@ export async function scanLlmInput(event: LlmInputEvent, _ctx: AgentCtx): Promis
           // lets the threat graph attribute taint-raising events). Metadata
           // only — no content, same as the fields above.
           tainted: trust.mayTaint,
+          // Writer-side attestation (attestation Phase 4): the hook identity
+          // above is a hardcoded literal — no conversation content can reach
+          // it. RECORD-ONLY at the reader (attribution metadata); the JSONL
+          // has no integrity, so this claim never feeds risk accrual.
+          attested: true,
           ts: new Date().toISOString(),
         };
         await auditLog(entry);
@@ -2978,6 +2983,10 @@ export async function handleBeforeAgentRun(
       decisionRowPersisted = await auditLog({
         type: decision.outcome === 'unavailable' ? 'scan_unavailable' : 'threat',
         hook: 'before_agent_run',
+        // Writer-side attestation (attestation Phase 4): hook is a literal;
+        // record-only at the reader, never an accrual input. Stamps the
+        // scan_unavailable variant too (same object) — harmless, same claim.
+        attested: true,
         eventId,
         sessionId,
         model,

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -650,7 +650,17 @@ function xrayMemoryGuard(content: string, title?: string): XRayGuardResult {
 // Field paths verified against src/defence/types.ts: trust.score (TrustScore.score),
 // sensitivity.level (SensitivityClassification.level), fragmentation.score
 // (FragmentationAnalysis.score; fragmentation itself is nullable).
-type PipelineRunner = (content: string, title: string, source: { type: string; identifier: string }) => {
+type PipelineRunner = (
+  content: string,
+  title: string,
+  source: { type: string; identifier: string },
+  // Optional trailing params of the real runDefencePipeline (config, project,
+  // options). Only options.sourceAttested is used here: the agent:openclaw
+  // identity below is a plugin-code literal, attested by construction.
+  config?: unknown,
+  project?: string,
+  options?: { sourceAttested?: boolean },
+) => {
   allowed: boolean;
   firewall: {
     result: 'ALLOW' | 'BLOCK' | 'QUARANTINE';
@@ -1363,7 +1373,10 @@ export function createInterceptor(
 
     try {
       const pipelineStart = Date.now();
-      const result = pipeline(content, title, { type: 'agent', identifier: 'openclaw' });
+      // Identity is a plugin-code literal → attested by construction. Hostile
+      // CONTENT that BLOCKs accrues to agent:openclaw — the channel, same
+      // conduit-accrual model as the hooks; advisory soak absorbs it.
+      const result = pipeline(content, title, { type: 'agent', identifier: 'openclaw' }, undefined, undefined, { sourceAttested: true });
       pipelineDurationMs = Date.now() - pipelineStart;
       severity = mapSeverity(result.firewall);
       firewallResult = result.firewall.result;

--- a/src/__tests__/realtime-attestation.test.ts
+++ b/src/__tests__/realtime-attestation.test.ts
@@ -90,6 +90,27 @@ describe('phase 4 — realtime attestation is record-only', () => {
     }
   });
 
+  it('a literal null / non-object JSONL line cannot wedge the projection', () => {
+    // JSON.parse('null') SUCCEEDS, so the malformed-JSON catch never fired and
+    // `row.type` then threw outside it — rolling back the transaction, leaving
+    // the cursor unadvanced, and permanently wedging the realtime projection
+    // on one hostile or accidental line (this file is same-user-writable).
+    // Non-object parses must count as malformed and be skipped like bad JSON.
+    fs.writeFileSync(
+      path.join(dir, 'realtime-2026-08-16.jsonl'),
+      ['null', '42', '"threat"', '[]', JSON.stringify({ ...base })].join('\n') + '\n',
+    );
+    const result = projectRealtimeLedger({ dir });
+    // The real row after the garbage still projects…
+    expect(result.eventNodes).toBe(1);
+    // …the garbage is recorded as malformed…
+    expect(result.errors.filter(e => e.includes('malformed')).length).toBe(4);
+    // …and the cursor is PAST the garbage (no permanent wedge).
+    expect(result.cursor).toBe('realtime-2026-08-16.jsonl:5');
+    // A second run is dry — nothing re-processes.
+    expect(projectRealtimeLedger({ dir }).processed).toBe(0);
+  });
+
   it('the risk model never reads event-attr attestation (source pin)', () => {
     // attrs.attested (row-level writer claim on event nodes) and
     // source_risk.attested (sweep-derived from defence_audit) are DIFFERENT

--- a/src/__tests__/realtime-attestation.test.ts
+++ b/src/__tests__/realtime-attestation.test.ts
@@ -1,0 +1,140 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { closeDatabase, getDatabase, initDatabase } from '../database/init.js';
+import { projectRealtimeLedger } from '../threat-graph/realtime-ledger.js';
+import { PROJECTOR_VERSION } from '../threat-graph/projector.js';
+import { runRiskSweep } from '../threat-graph/risk.js';
+
+const __dirname = path.join(fileURLToPath(import.meta.url), '..');
+const repoRoot = path.join(__dirname, '..', '..');
+
+/**
+ * Phase 4 of the attestation gap: the OpenClaw realtime plane — RECORD-ONLY.
+ *
+ * The gateway's writers stamp a literal `attested: true` on their threat rows
+ * (the identity is a hardcoded hook literal; no conversation content can reach
+ * the field), and the reader surfaces it into event-node attrs. What it must
+ * NEVER do is feed accrual: the JSONL transport has no integrity — any
+ * same-user process can append forged rows — so `attrs.attested` is a
+ * writer-side claim for attribution/display, structurally firewalled from
+ * `source_risk.attested` (sweep-derived from defence_audit, a different fact).
+ */
+describe('phase 4 — realtime attestation is record-only', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    initDatabase(':memory:');
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-rt-attest-'));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeRows(rows: Array<Record<string, unknown>>): void {
+    fs.writeFileSync(
+      path.join(dir, 'realtime-2026-08-16.jsonl'),
+      rows.map(r => JSON.stringify(r)).join('\n') + '\n',
+    );
+  }
+
+  function eventAttrs(line: number): Record<string, unknown> {
+    const row = getDatabase()
+      .prepare("SELECT attrs FROM threat_nodes WHERE kind = 'event' AND key = ?")
+      .get(`rt:realtime-2026-08-16.jsonl:${line}`) as { attrs: string } | undefined;
+    expect(row).toBeDefined();
+    return JSON.parse(row!.attrs) as Record<string, unknown>;
+  }
+
+  const base = {
+    type: 'threat', hook: 'llm_input', sessionId: 's1', model: 'm',
+    reason: 'detector tripped', chars: 10, ts: '2026-08-16T10:00:00.000Z',
+  };
+
+  it('surfaces attested: true into event attrs (strict === true only)', () => {
+    writeRows([
+      { ...base, attested: true },        // line 1 → surfaced
+      { ...base, attested: 'true' },      // line 2 → hostile-influenceable file: string is NOT true
+      { ...base, attested: 1 },           // line 3 → not true
+      { ...base, attested: false },       // line 4 → not surfaced
+      { ...base },                        // line 5 → old row, absent
+    ]);
+    const result = projectRealtimeLedger({ dir });
+    expect(result.eventNodes).toBe(5);
+
+    expect(eventAttrs(1).attested).toBe(true);
+    expect(eventAttrs(2).attested).toBeUndefined();
+    expect(eventAttrs(3).attested).toBeUndefined();
+    expect(eventAttrs(4).attested).toBeUndefined();
+    expect(eventAttrs(5).attested).toBeUndefined();
+  });
+
+  it('an attested realtime row NEVER accrues risk (record-only firewall)', () => {
+    // A forged `attested: true` in the JSONL must buy an attacker nothing on
+    // the risk model: realtime rows are not accrual inputs, and the sweep's
+    // attestation is derived from defence_audit only.
+    writeRows([{ ...base, attested: true }]);
+    projectRealtimeLedger({ dir });
+    runRiskSweep({ nowMs: Date.parse('2026-08-16T11:00:00.000Z') });
+
+    const risk = getDatabase()
+      .prepare("SELECT risk, attested FROM source_risk WHERE source_key = 'conversation:llm_input'")
+      .get() as { risk: number; attested: number } | undefined;
+    if (risk) {
+      expect(risk.risk).toBe(0);
+      expect(risk.attested).not.toBe(1);
+    }
+  });
+
+  it('the risk model never reads event-attr attestation (source pin)', () => {
+    // attrs.attested (row-level writer claim on event nodes) and
+    // source_risk.attested (sweep-derived from defence_audit) are DIFFERENT
+    // facts. The sweep/model must never conflate them.
+    for (const rel of ['src/threat-graph/risk.ts', 'src/threat-graph/projector.ts']) {
+      const src = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+      expect(src).not.toContain('attrs.attested');
+    }
+  });
+
+  it('PROJECTOR_VERSION is bumped to 6 (attrs are in the determinism contract)', () => {
+    // Event-node attrs are inside the canonicalDump determinism contract, so
+    // existing graphs must rebuild to surface the new field.
+    expect(PROJECTOR_VERSION).toBe(6);
+  });
+
+  describe('gateway writers stamp the literal (source pins on plugin code)', () => {
+    // plugins/ cannot import src/ (build boundary), so the stamp is a plain
+    // JSON field on the row objects — pinned here the same way `tainted` is
+    // shipped. Identity provenance: the hook names are hardcoded literals at
+    // the write sites; no conversation content can reach the field.
+    const pluginSrc = () => fs.readFileSync(path.join(repoRoot, 'plugins', 'openclaw', 'index.ts'), 'utf8');
+
+    it('the llm_input threat entry carries attested: true', () => {
+      const src = pluginSrc();
+      const at = src.indexOf('type: "threat", hook: "llm_input"');
+      expect(at).toBeGreaterThan(-1);
+      const entry = src.slice(at, src.indexOf('};', at));
+      expect(entry).toMatch(/attested:\s*true/);
+    });
+
+    it('the before_agent_run decision row carries attested: true', () => {
+      const src = pluginSrc();
+      const at = src.indexOf("hook: 'before_agent_run'");
+      expect(at).toBeGreaterThan(-1);
+      const entry = src.slice(Math.max(0, at - 200), src.indexOf('});', at));
+      expect(entry).toMatch(/attested:\s*true/);
+    });
+
+    it('the interceptor pipeline call passes sourceAttested: true (literal identity)', () => {
+      const src = fs.readFileSync(path.join(repoRoot, 'plugins', 'openclaw', 'interceptor.ts'), 'utf8');
+      const at = src.indexOf("pipeline(content, title, { type: 'agent', identifier: 'openclaw' }");
+      expect(at).toBeGreaterThan(-1);
+      const call = src.slice(at, src.indexOf(');', at));
+      expect(call).toMatch(/sourceAttested:\s*true/);
+    });
+  });
+});

--- a/src/threat-graph/projector.ts
+++ b/src/threat-graph/projector.ts
@@ -638,6 +638,11 @@ export async function runProjectorWithLease(options?: LeaseRunOptions): Promise<
     const stored = (db.prepare('SELECT projector_version FROM threat_graph_state WHERE id = 1')
       .get() as { projector_version: number }).projector_version;
     if (stored !== PROJECTOR_VERSION) {
+      // KNOWN GAP (#320): unlike rebuildThreatGraph, this path has no risk
+      // snapshot/reseed, so risk from retention-purged evidence lapses on a
+      // version bump (bounded by decay — ~1% on default retention). Not fixed
+      // inline: the batched cross-tick replay below makes a post-replay reseed
+      // double-count; see the issue for the design options.
       clearGraph();
     }
 

--- a/src/threat-graph/projector.ts
+++ b/src/threat-graph/projector.ts
@@ -79,8 +79,10 @@ import {
  *  src_type/src_id attrs, and risk_reset review-row consumption.
  *  v3 (Phase C): quarantine_decision consumption → operator allowance edges.
  *  v4 (Phase D): realtime `tainted` attr on conversation event nodes.
- *  v5 (Phase E): relation-channel conflict detection + triple provenance. */
-export const PROJECTOR_VERSION = 5;
+ *  v5 (Phase E): relation-channel conflict detection + triple provenance.
+ *  v6 (attestation Phase 4): realtime `attested` attr on conversation event
+ *  nodes — record-only writer claim, never an accrual input. */
+export const PROJECTOR_VERSION = 6;
 
 export interface ProjectorOptions {
   /** Rows per claim-and-advance batch. */

--- a/src/threat-graph/realtime-ledger.ts
+++ b/src/threat-graph/realtime-ledger.ts
@@ -209,6 +209,13 @@ export function projectRealtimeLedger(options: RealtimeLedgerOptions): RealtimeR
       // this detection tainted the session, so attribution can distinguish a
       // taint-raising event. Forward-compatible — absent on older rows.
       if (typeof row.tainted === 'boolean') attrs.tainted = row.tainted;
+      // Writer-side attestation claim (attestation Phase 4) — RECORD-ONLY.
+      // Strict === true: this file is same-user-writable (hostile-influenceable),
+      // so truthiness is not acceptable, and the claim must NEVER feed accrual —
+      // attrs.attested is attribution metadata, a DIFFERENT fact from
+      // source_risk.attested (sweep-derived from defence_audit). Absent or any
+      // non-true value ⇒ unattested. Old rows lack the field (compat: unattested).
+      if (row.attested === true) attrs.attested = true;
       db.prepare('UPDATE threat_nodes SET attrs = ? WHERE id = ?').run(JSON.stringify(attrs), eventId);
 
       const sourceId = upsertNode('source', `conversation:${hook}`, ts);

--- a/src/threat-graph/realtime-ledger.ts
+++ b/src/threat-graph/realtime-ledger.ts
@@ -187,7 +187,16 @@ export function projectRealtimeLedger(options: RealtimeLedgerOptions): RealtimeR
 
       let row: Record<string, unknown>;
       try {
-        row = JSON.parse(item.raw) as Record<string, unknown>;
+        const parsed: unknown = JSON.parse(item.raw);
+        // JSON.parse('null') / '42' / '"x"' / '[]' all SUCCEED — a non-object
+        // line used to throw on `row.type` OUTSIDE this catch, rolling back
+        // the transaction with the cursor unadvanced and permanently wedging
+        // the projection on one hostile or accidental line (this file is
+        // same-user-writable). Non-objects are malformed rows: record + skip.
+        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error('non-object row');
+        }
+        row = parsed as Record<string, unknown>;
       } catch {
         result.errors.push(`${item.file}:${item.line}: malformed JSON`);
         continue;


### PR DESCRIPTION
## What

**Phase 4 of the attestation gap: the OpenClaw realtime plane — record-only by design.**

The gateway's realtime writers now stamp a literal `attested: true` on their threat rows, and the projector's reader surfaces it into event-node attrs. What it deliberately does **not** do is feed accrual.

## Why record-only is the design, not a limitation

The realtime JSONL transport has no integrity — any same-user process can append forged rows. So a writer-side `attested` claim can serve attribution/display, but must never reach the risk model. `attrs.attested` (row-level writer claim on conversation event nodes) and `source_risk.attested` (sweep-derived from `defence_audit`) are **different facts**, and the firewall between them is pinned twice: textually (`risk.ts`/`projector.ts` contain no `attrs.attested` read) and behaviourally (a forged attested realtime row projects but accrues nothing).

## Changes

- **`plugins/openclaw/index.ts`** — literal `attested: true` on the `llm_input` threat entry and the `before_agent_run` decision row. Hook identities are hardcoded literals; no conversation content can reach the field. Plain JSON fields (respects the plugins/-cannot-import-src boundary, same shipping pattern as `tainted`).
- **`src/threat-graph/realtime-ledger.ts`** — reader accepts **strict `=== true` only** (hostile-influenceable file; truthiness unacceptable). Absent / `false` / `'true'` / `1` all read as unattested; old rows are compat-unattested.
- **`PROJECTOR_VERSION` 5 → 6** — event-node attrs sit inside the canonicalDump determinism contract; existing graphs rebuild to surface the field.
- **`plugins/openclaw/interceptor.ts`** — `PipelineRunner` gains the real pipeline's optional trailing params; the scan call passes `{ sourceAttested: true }`. `agent:openclaw` is a plugin-code literal; hostile content that BLOCKs accrues to the channel — conduit-accrual, same model as the hooks, absorbed by the advisory soak.

## Deliberately out of scope (documented in code)

Realtime rows as accrual inputs (needs an authenticated channel that doesn't exist); deriving attested from the #224 binding fields (schema-checkable but mintable); `session_summary` rows (the reader already skips all non-threat types).

## Tests

Strict-`===` reader semantics across 5 row shapes; the record-only firewall behaviourally + textually; `PROJECTOR_VERSION` pin; source pins on both plugin writers + the interceptor call.

Full suite: **458 suites / 5,719 green (serial)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
