### PR TITLE
feat(attestation): end-to-end sentinel + doctor coverage metric (Phase 5)

### DIFF
--- a/src/__tests__/attestation-sentinel.test.ts
+++ b/src/__tests__/attestation-sentinel.test.ts
@@ -1,0 +1,161 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { closeDatabase, getDatabase, initDatabase } from '../database/init.js';
+import { runDefencePipeline } from '../defence/pipeline.js';
+import { scoreSource } from '../defence/trust/source-scorer.js';
+import { runProjectorWithLease } from '../threat-graph/projector.js';
+import { checkAttestationCoverage } from '../cli/doctor.js';
+import type { DefenceSource } from '../defence/types.js';
+
+const __dirname = path.join(fileURLToPath(import.meta.url), '..');
+const repoRoot = path.join(__dirname, '..', '..');
+
+/**
+ * Phase 5 of the attestation gap: the DONE-criteria.
+ *
+ * The sentinel is the one test that walks the whole chain the previous four
+ * phases built, through the PRODUCTION tick path: an attested BLOCK lands in
+ * the ledger → the lease runner projects and sweeps → source_risk carries
+ * {risk>0, attested=1} → the very next scan for that source records a non-zero
+ * risk_modifier (computed-not-applied in advisory; subtracted in enforce).
+ * If any link regresses — a writer stops attesting, the accrual gate breaks,
+ * the sweep stops deriving, the hot-path read drifts — this fails.
+ */
+describe('phase 5 — end-to-end attestation sentinel', () => {
+  const attacker: DefenceSource = { type: 'agent', identifier: 'sentinel-attacker' };
+  // Deterministic BLOCK: a cleartext test credential trips the credential-leak
+  // detector regardless of trust (same fixture class as memory-file-scanner).
+  const hostile = 'Temporary test fixture token: sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  beforeEach(() => {
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  it('attested BLOCK → lease tick → risk accrues → next scan records the modifier', async () => {
+    // 1. The attested BLOCK (as the resolver-vouched write path produces).
+    const blocked = runDefencePipeline(hostile, 'note', attacker, undefined, 'test', { sourceAttested: true });
+    expect(blocked.firewall.result).toBe('BLOCK');
+
+    // 2. One PRODUCTION worker tick (lease acquisition, projection, sweep).
+    const tick = await runProjectorWithLease({ now: Date.now() });
+    expect(tick.ran).toBe(true);
+
+    // 3. The risk model saw it.
+    const risk = getDatabase()
+      .prepare("SELECT risk, attested FROM source_risk WHERE source_key = 'agent:sentinel-attacker'")
+      .get() as { risk: number; attested: number } | undefined;
+    expect(risk).toBeDefined();
+    expect(risk!.risk).toBeGreaterThan(0);
+    expect(risk!.attested).toBe(1);
+
+    // 4a. Advisory (the shipped default): the modifier is RECORDED on the next
+    // scan's audit row but NOT applied — trust unchanged.
+    const base = scoreSource(attacker).score;
+    const advisory = runDefencePipeline('a perfectly benign follow-up note', 'note', attacker, undefined, 'test', {
+      trustModifierMode: 'advisory',
+    });
+    expect(advisory.trust.score).toBe(base);
+    const advisoryRow = getDatabase()
+      .prepare('SELECT risk_modifier FROM defence_audit ORDER BY id DESC LIMIT 1')
+      .get() as { risk_modifier: number | null };
+    expect(advisoryRow.risk_modifier).toBeGreaterThan(0);
+
+    // 4b. Enforce: the same modifier is SUBTRACTED (additive-tightening only).
+    const enforce = runDefencePipeline('a perfectly benign follow-up note', 'note', attacker, undefined, 'test', {
+      trustModifierMode: 'enforce',
+    });
+    expect(enforce.trust.score).toBeLessThan(base);
+    expect(enforce.trust.score).toBeCloseTo(base - advisoryRow.risk_modifier!, 5);
+  });
+
+  it('the sentinel chain stays dead for an UNATTESTED block (the gate is the point)', async () => {
+    runDefencePipeline(hostile, 'note', attacker, undefined, 'test'); // NULL attestation
+    await runProjectorWithLease({ now: Date.now() });
+
+    const risk = getDatabase()
+      .prepare("SELECT risk, attested FROM source_risk WHERE source_key = 'agent:sentinel-attacker'")
+      .get() as { risk: number; attested: number } | undefined;
+    if (risk) {
+      expect(risk.risk).toBe(0);
+      expect(risk.attested).not.toBe(1);
+    }
+    const next = runDefencePipeline('benign', 'note', attacker, undefined, 'test', { trustModifierMode: 'enforce' });
+    expect(next.trust.score).toBe(scoreSource(attacker).score);
+  });
+});
+
+describe('phase 5 — doctor attestation-coverage metric', () => {
+  const NOW = Date.parse('2026-08-16T12:00:00.000Z');
+
+  beforeEach(() => {
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  function seedRow(daysAgo: number, attested: number | null): void {
+    getDatabase().prepare(`
+      INSERT INTO defence_audit (
+        memory_id, project, timestamp, source_type, source_identifier,
+        trust_score, sensitivity_level, firewall_result,
+        anomaly_score, threat_indicators, blocked_patterns,
+        reason, fragmentation_score, pipeline_duration_ms, source_attested
+      ) VALUES (NULL, 'test', ?, 'cli', 'seed', 0.9, 'PUBLIC', 'ALLOW', 0, '[]', '[]', NULL, NULL, 0, ?)
+    `).run(new Date(NOW - daysAgo * 86_400_000).toISOString(), attested);
+  }
+
+  it('reports the window percentage with the attested/unattested/unplumbed split', async () => {
+    seedRow(1, 1);
+    seedRow(2, 1);
+    seedRow(3, 0);
+    seedRow(4, null);
+    seedRow(40, null); // outside the 28-day window — excluded
+    const result = await checkAttestationCoverage({ nowMs: NOW });
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('75%'); // 3 of 4 in-window rows non-NULL
+    expect(result.message).toContain('2 attested');
+    expect(result.message).toContain('1 explicitly unattested');
+    expect(result.message).toContain('1 unplumbed');
+  });
+
+  it('warns when a busy install has ZERO attested rows (stale long-running processes)', async () => {
+    for (let i = 0; i < 60; i++) seedRow(1, null);
+    const result = await checkAttestationCoverage({ nowMs: NOW });
+    expect(result.status).toBe('warn');
+    expect(result.message.toLowerCase()).toContain('no audit row');
+    expect(result.fix ?? '').toMatch(/restart/i);
+  });
+
+  it('a quiet window is informational, not a fault', async () => {
+    const result = await checkAttestationCoverage({ nowMs: NOW });
+    expect(result.status).toBe('info');
+  });
+
+  it('is wired into the doctor run registry (source pin)', () => {
+    const src = fs.readFileSync(path.join(repoRoot, 'src', 'cli', 'doctor.ts'), 'utf8');
+    const registry = src.slice(src.indexOf('checkDefenceCanary,'));
+    expect(registry).toContain('checkAttestationCoverage,');
+  });
+});
+
+describe('phase 5 — the no-backfill decision is recorded and enforced', () => {
+  it('no migration ever writes source_attested values (source pin)', () => {
+    // NULL→1 on historic rows is a trust-elevation hole; NULL→0 is a
+    // behavioural no-op that only adds mute-lever surface. The consumption
+    // side reads NULL conservatively, so history stays NULL, forever. This
+    // pin stops a future session from "tidying" the NULL backlog.
+    const src = fs.readFileSync(
+      path.join(fileURLToPath(import.meta.url), '..', '..', 'database', 'migrations.ts'), 'utf8');
+    expect(src).not.toMatch(/UPDATE\s+defence_audit\s+SET\s+source_attested/i);
+    // And the decision is documented at the column's migration site.
+    expect(src).toMatch(/never backfill/i);
+  });
+});

--- a/src/__tests__/attestation-sentinel.test.ts
+++ b/src/__tests__/attestation-sentinel.test.ts
@@ -101,15 +101,18 @@ describe('phase 5 — doctor attestation-coverage metric', () => {
     closeDatabase();
   });
 
-  function seedRow(daysAgo: number, attested: number | null): void {
+  function seedRow(daysAgo: number, attested: number | null, source: { type?: string; identifier?: string } = {}): void {
     getDatabase().prepare(`
       INSERT INTO defence_audit (
         memory_id, project, timestamp, source_type, source_identifier,
         trust_score, sensitivity_level, firewall_result,
         anomaly_score, threat_indicators, blocked_patterns,
         reason, fragmentation_score, pipeline_duration_ms, source_attested
-      ) VALUES (NULL, 'test', ?, 'cli', 'seed', 0.9, 'PUBLIC', 'ALLOW', 0, '[]', '[]', NULL, NULL, 0, ?)
-    `).run(new Date(NOW - daysAgo * 86_400_000).toISOString(), attested);
+      ) VALUES (NULL, 'test', ?, ?, ?, 0.9, 'PUBLIC', 'ALLOW', 0, '[]', '[]', NULL, NULL, 0, ?)
+    `).run(
+      new Date(NOW - daysAgo * 86_400_000).toISOString(),
+      source.type ?? 'cli', source.identifier ?? 'seed', attested,
+    );
   }
 
   it('reports the window percentage with the attested/unattested/unplumbed split', async () => {
@@ -126,12 +129,36 @@ describe('phase 5 — doctor attestation-coverage metric', () => {
     expect(result.message).toContain('1 unplumbed');
   });
 
-  it('warns when a busy install has ZERO attested rows (stale long-running processes)', async () => {
-    for (let i = 0; i < 60; i++) seedRow(1, null);
+  it('warns when KNOWN-HOOK rows are all unattested (the stale-process discriminator)', async () => {
+    // Hook rows come from writers this build ships and pins as attesting, so
+    // an all-NULL hook window is a sharp signal: still-running pre-upgrade
+    // processes are writing them.
+    for (let i = 0; i < 60; i++) seedRow(1, null, { type: 'hook', identifier: 'session-end-hook' });
     const result = await checkAttestationCoverage({ nowMs: NOW });
     expect(result.status).toBe('warn');
-    expect(result.message.toLowerCase()).toContain('no audit row');
+    expect(result.message.toLowerCase()).toContain('hook');
     expect(result.fix ?? '').toMatch(/restart/i);
+  });
+
+  it('does NOT warn on a healthy never-attest-only install (adversarially confirmed false-warn)', async () => {
+    // The confirmed Phase 5 review finding: a box used exclusively through the
+    // deliberately-never-attested surfaces (REST scan API, langchain guard,
+    // universal bridge — pinned NULL forever per the #308 mute-lever rule)
+    // accrues 50+ all-NULL rows while perfectly healthy. That must be a PASS
+    // with 0% coverage, not a permanent un-clearable warn whose "restart"
+    // diagnosis is affirmatively wrong.
+    for (let i = 0; i < 60; i++) seedRow(1, null, { type: 'api', identifier: 'rest-scan' });
+    for (let i = 0; i < 20; i++) seedRow(1, null, { type: 'cli', identifier: 'langchain-guard' });
+    const result = await checkAttestationCoverage({ nowMs: NOW });
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('0%');
+  });
+
+  it('a single attested hook row clears the stale-process warn', async () => {
+    for (let i = 0; i < 60; i++) seedRow(2, null, { type: 'hook', identifier: 'session-end-hook' });
+    seedRow(1, 1, { type: 'hook', identifier: 'session-end-hook' }); // post-restart row
+    const result = await checkAttestationCoverage({ nowMs: NOW });
+    expect(result.status).toBe('pass');
   });
 
   it('a quiet window is informational, not a fault', async () => {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -487,10 +487,14 @@ async function checkDatabase(): Promise<CheckResult> {
  * split. Lets an operator WATCH coverage climb after upgrading instead of
  * inferring the writers' state from risk_modifier zeros.
  *
- * A busy window with ZERO non-NULL rows warns: the doctor binary shipping this
- * check also ships plumbed writers, so an all-NULL recent ledger means the
- * rows are coming from still-running pre-upgrade processes (MCP server,
- * gateway, dashboard) that need a restart to pick up the new dist.
+ * The stale-process warn keys on KNOWN-HOOK rows only (adversarially
+ * confirmed, PR #322 review): overall-zero coverage is NOT a fault signal,
+ * because this same build deliberately ships never-attest writers (REST scan
+ * API, langchain guard, universal bridge — pinned NULL forever per the #308
+ * mute-lever rule), so a box used exclusively through those surfaces is
+ * healthy at 0%. Hook rows are the sharp discriminator: their writers ship in
+ * this package and are pinned as attesting, so a busy all-NULL hook window
+ * means still-running pre-upgrade processes are writing them — restart.
  */
 export async function checkAttestationCoverage(
   opts: { nowMs?: number; windowDays?: number; minRowsForWarn?: number } = {},
@@ -541,12 +545,23 @@ export async function checkAttestationCoverage(
     const nonNull = attested + unattested;
     const pct = Math.round((nonNull / total) * 100);
 
-    if (nonNull === 0 && total >= minRowsForWarn) {
+    // Stale-process discriminator: only the shipped hook writers (pinned as
+    // attesting in this build) can prove staleness. Overall-zero coverage is
+    // healthy on a never-attest-only box — see the docblock.
+    const hookCounts = db.prepare(`
+      SELECT COUNT(*) AS total,
+             SUM(CASE WHEN source_attested IS NOT NULL THEN 1 ELSE 0 END) AS nonNull
+      FROM defence_audit
+      WHERE timestamp >= ?
+        AND source_type = 'hook'
+        AND source_identifier IN ('session-end-hook', 'pre-compact-hook', 'stop-hook', 'hook', 'recall-defence')
+    `).get(since) as { total: number; nonNull: number | null };
+    if (hookCounts.total >= minRowsForWarn && (hookCounts.nonNull ?? 0) === 0) {
       return {
         label,
         status: 'warn',
-        message: `${total} audit rows in the last ${windowDays} days and no audit row carries attestation — ` +
-          'the rows are likely written by still-running pre-upgrade processes',
+        message: `${hookCounts.total} hook-captured audit rows in the last ${windowDays} days and none carries attestation — ` +
+          'these writers attest in the current build, so still-running pre-upgrade processes are writing them',
         fix: 'restart long-running ShieldCortex processes (MCP server, OpenClaw gateway, dashboard) so they load the current build',
       };
     }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -480,6 +480,93 @@ async function checkDatabase(): Promise<CheckResult> {
  * Uses the initialised singleton when present (tests); otherwise opens the
  * DB file read-only like every other doctor check.
  */
+/**
+ * Attestation coverage (attestation Phase 5) — the rollout observability the
+ * plumbing phases need: % of recent defence_audit rows carrying a non-NULL
+ * source_attested, with the attested / explicitly-unattested / unplumbed
+ * split. Lets an operator WATCH coverage climb after upgrading instead of
+ * inferring the writers' state from risk_modifier zeros.
+ *
+ * A busy window with ZERO non-NULL rows warns: the doctor binary shipping this
+ * check also ships plumbed writers, so an all-NULL recent ledger means the
+ * rows are coming from still-running pre-upgrade processes (MCP server,
+ * gateway, dashboard) that need a restart to pick up the new dist.
+ */
+export async function checkAttestationCoverage(
+  opts: { nowMs?: number; windowDays?: number; minRowsForWarn?: number } = {},
+): Promise<CheckResult> {
+  const label = 'Attestation coverage';
+  const windowDays = opts.windowDays ?? 28;
+  const minRowsForWarn = opts.minRowsForWarn ?? 50;
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const Database = require('better-sqlite3');
+  let db: any = null;
+  let opened = false;
+  try {
+    const { isDatabaseInitialized, getDatabase } = await import('../database/init.js');
+    if (isDatabaseInitialized()) {
+      db = getDatabase();
+    } else {
+      const dbPath = getDbPath();
+      const gate = databasePrerequisite(label, dbPath);
+      if (gate) return gate;
+      db = new Database(dbPath, { readonly: true });
+      opened = true;
+    }
+
+    const hasCol = (db.prepare('PRAGMA table_info(defence_audit)').all() as Array<{ name: string }>)
+      .some((c) => c.name === 'source_attested');
+    if (!hasCol) {
+      return { label, status: 'info', message: 'source_attested column not present yet (created on next init after upgrade)' };
+    }
+
+    const nowMs = opts.nowMs ?? Date.now();
+    const since = new Date(nowMs - windowDays * 86_400_000).toISOString();
+    const counts = db.prepare(`
+      SELECT COUNT(*) AS total,
+             SUM(CASE WHEN source_attested = 1 THEN 1 ELSE 0 END) AS attested,
+             SUM(CASE WHEN source_attested = 0 THEN 1 ELSE 0 END) AS unattested,
+             SUM(CASE WHEN source_attested IS NULL THEN 1 ELSE 0 END) AS unplumbed
+      FROM defence_audit WHERE timestamp >= ?
+    `).get(since) as { total: number; attested: number | null; unattested: number | null; unplumbed: number | null };
+
+    const total = counts.total;
+    if (total === 0) {
+      return { label, status: 'info', message: `no audit rows in the last ${windowDays} days — nothing to measure yet` };
+    }
+    const attested = counts.attested ?? 0;
+    const unattested = counts.unattested ?? 0;
+    const unplumbed = counts.unplumbed ?? 0;
+    const nonNull = attested + unattested;
+    const pct = Math.round((nonNull / total) * 100);
+
+    if (nonNull === 0 && total >= minRowsForWarn) {
+      return {
+        label,
+        status: 'warn',
+        message: `${total} audit rows in the last ${windowDays} days and no audit row carries attestation — ` +
+          'the rows are likely written by still-running pre-upgrade processes',
+        fix: 'restart long-running ShieldCortex processes (MCP server, OpenClaw gateway, dashboard) so they load the current build',
+      };
+    }
+
+    return {
+      label,
+      status: 'pass',
+      message: `${pct}% of the last ${windowDays} days' ${total} audit rows carry attestation ` +
+        `(${attested} attested / ${unattested} explicitly unattested / ${unplumbed} unplumbed)`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { label, status: 'warn', message: `could not measure: ${msg}` };
+  } finally {
+    if (opened && db) {
+      try { db.close(); } catch { /* readonly close is best-effort */ }
+    }
+  }
+}
+
 export async function checkThreatGraph(
   opts: { lagWarnThreshold?: number; enabled?: boolean; nowMs?: number; sweepStaleMs?: number } = {},
 ): Promise<CheckResult> {
@@ -4029,6 +4116,7 @@ export async function runDoctor(
     checkDefenceCanary,
     checkActionGuard,
     checkThreatGraph,
+    checkAttestationCoverage,
     checkClaudeCodeVersion,
     checkModelCache,
   ];

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -838,6 +838,13 @@ export function runMigrations(database: Database.Database): void {
       // (NULL on legacy rows and unplumbed paths); risk_modifier = the
       // advisory trust modifier computed for this scan (NULL until the
       // modifier ships/fires). Local-only until declared as egress.
+      //
+      // NEVER BACKFILL source_attested on historic rows (decision recorded
+      // 2026-08-16, attestation Phase 5, pinned by test): NULL→1 is a
+      // trust-elevation hole (attesting identities nothing derived), and
+      // NULL→0 is a behavioural no-op that only adds mute-lever surface via
+      // risk.ts's latest-non-null resolution. The consumption side reads NULL
+      // conservatively; history stays NULL, forever.
       if (!auditColNames.has('source_attested')) {
         database.exec('ALTER TABLE defence_audit ADD COLUMN source_attested INTEGER');
       }


### PR DESCRIPTION
## What

**Phase 5 of the attestation gap — the DONE-criteria.** The phase that keeps the other four honest.

### The sentinel

One test walks the whole chain through the **production tick path**: an attested BLOCK lands in the ledger → `runProjectorWithLease` projects and sweeps → `source_risk` carries `{risk>0, attested=1}` → the very next scan for that source records a non-zero `risk_modifier` (computed-not-applied in advisory, subtracted in enforce, cross-checked against each other). Its inverse pins the gate itself: an **unattested** block accrues nothing and moves no trust. If any link regresses — a writer stops attesting, the accrual gate breaks, the sweep stops deriving, the hot-path read drifts — one of these fails.

### Doctor: `Attestation coverage`

% of the last 28 days' `defence_audit` rows carrying non-NULL attestation, with the attested / explicitly-unattested / unplumbed split — so operators **watch coverage climb** after upgrading instead of inferring writer state from `risk_modifier` zeros. A busy window (≥50 rows) with zero non-NULL rows warns with the real cause: still-running pre-upgrade processes needing a restart. Quiet window → info.

### No-backfill, recorded and enforced

The decision that history stays NULL is written at the migration site (NULL→1 is a trust-elevation hole; NULL→0 only adds mute-lever surface via latest-non-null) and pinned by a test that fails if any migration ever writes `source_attested` values.

## Live verification (operator install, read-only)

48h after v4.53.0: `hook:session-end-hook` is **51/51 attested** — Phase 2 working in production — with `stop-hook` mid-transition (21/39), exactly the coverage picture this doctor check exists to show. `cli:shieldcortex-scan` runs ~300 scans/day at 0 attested — that becomes attested when Phase 3 (#315) ships in the next release.

Full suite: **459 suites / 5,727 green (serial)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
