### PR TITLE
fix(trust): stop caller-supplied notes minting user: provenance (#305 #306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- **Caller-supplied `user:` identity (#305 / #306)** — quarantine / risk-reset / conflict review rows no longer stamp MCP `notes` or dashboard `reviewedBy` as a `user:` provenance identity. The row uses the inferred runtime source; the caller string stays annotation. REST `/v1/scan` now coerces `type: 'user'` to `api`, matching the MCP reject.
+
 ## [4.54.0] - 2026-08-16
 
 **Minor — attestation Phases 3–5: remaining callers, OpenClaw realtime record-only, sentinel + doctor coverage.**

--- a/src/__tests__/threat-graph-conflict-resolve.test.ts
+++ b/src/__tests__/threat-graph-conflict-resolve.test.ts
@@ -221,6 +221,23 @@ describe('Phase E — conflict resolution', () => {
     expect(row(tb2).valid_to).toBeTruthy(); // re-suspended by replay
   });
 
+  it('#305: the resolution review row carries host-derived identity; operator is annotation only', () => {
+    const a = entity('deploy-305');
+    const good = entity('good-305');
+    const evil = entity('evil-305');
+    triple(a, 'uses', good, 'cli:m', 0.95);
+    triple(a, 'uses', evil, 'agent:x', 0.3);
+    detectRelationConflicts({ nowMs: NOW });
+    resolveConflict({ subjectId: a, predicate: 'uses', resolution: 'keep_both' }, 'victim-name', { nowMs: NOW + 1000 });
+
+    const audit = getDatabase().prepare(
+      "SELECT source_type, source_identifier, reason FROM defence_audit WHERE operation = 'review' ORDER BY id DESC LIMIT 1",
+    ).get() as { source_type: string; source_identifier: string; reason: string };
+    expect(audit.source_type).not.toBe('user');
+    expect(audit.source_identifier).not.toBe('victim-name');
+    expect((JSON.parse(audit.reason) as { reviewed_by?: string }).reviewed_by).toBe('victim-name');
+  });
+
   it('keep_one rejects a kept object that is not on the channel', () => {
     const a = entity('svc3');
     const b = entity('b3');

--- a/src/__tests__/threat-graph-decision-ledger.test.ts
+++ b/src/__tests__/threat-graph-decision-ledger.test.ts
@@ -144,6 +144,24 @@ describe('quarantine decision ledger', () => {
     expect(d.patterns.sort()).toEqual(['credential_exfil', 'instruction_injection']);
   });
 
+  it('#305: the review row identity is host-derived — caller notes cannot mint a user: row', () => {
+    const qid = seedQuarantine({ sourceIdentifier: 'jarvis' });
+    // MCP quarantine_review passes caller-controlled `notes` as reviewedBy.
+    approveQuarantineItem(qid, 'victim-name');
+
+    const audit = getDatabase().prepare(
+      "SELECT source_type, source_identifier, reason FROM defence_audit WHERE operation = 'review' ORDER BY id DESC LIMIT 1"
+    ).get() as { source_type: string; source_identifier: string; reason: string };
+    expect(audit.source_type).not.toBe('user');
+    expect(audit.source_identifier).not.toBe('victim-name');
+
+    // The allowance payload is untouched: source_key stays the QUARANTINED
+    // item's identity, and the notes survive only as the reviewed_by annotation.
+    const d = decisionRows()[0]!;
+    expect(d.source_key).toBe('agent:jarvis');
+    expect((JSON.parse(audit.reason) as { reviewed_by?: string }).reviewed_by).toBe('victim-name');
+  });
+
   it('the exemplar hash binds the title (same content + different title → different hash)', () => {
     const db = getDatabase();
     const mk = (title: string) => {

--- a/src/__tests__/threat-graph-decision-ledger.test.ts
+++ b/src/__tests__/threat-graph-decision-ledger.test.ts
@@ -154,12 +154,25 @@ describe('quarantine decision ledger', () => {
     ).get() as { source_type: string; source_identifier: string; reason: string };
     expect(audit.source_type).not.toBe('user');
     expect(audit.source_identifier).not.toBe('victim-name');
+    expect(audit.source_type.length).toBeGreaterThan(0);
+    expect(audit.source_identifier.length).toBeGreaterThan(0);
 
     // The allowance payload is untouched: source_key stays the QUARANTINED
     // item's identity, and the notes survive only as the reviewed_by annotation.
     const d = decisionRows()[0]!;
     expect(d.source_key).toBe('agent:jarvis');
     expect((JSON.parse(audit.reason) as { reviewed_by?: string }).reviewed_by).toBe('victim-name');
+  });
+
+  it('#305: empty reviewedBy still cannot mint a user: row', () => {
+    const qid = seedQuarantine({ sourceIdentifier: 'jarvis' });
+    approveQuarantineItem(qid, '');
+    const audit = getDatabase().prepare(
+      "SELECT source_type, source_identifier, reason FROM defence_audit WHERE operation = 'review' ORDER BY id DESC LIMIT 1"
+    ).get() as { source_type: string; source_identifier: string; reason: string };
+    expect(audit.source_type).not.toBe('user');
+    expect(audit.source_identifier).not.toBe('');
+    expect((JSON.parse(audit.reason) as { reviewed_by?: string }).reviewed_by).toBe('');
   });
 
   it('the exemplar hash binds the title (same content + different title → different hash)', () => {

--- a/src/__tests__/threat-graph-reset-doctor.test.ts
+++ b/src/__tests__/threat-graph-reset-doctor.test.ts
@@ -52,13 +52,16 @@ describe('resetSourceRisk', () => {
       .get() as { s: number | null };
     expect(node.s ?? 0).toBe(0);
 
-    // Recorded as an operator review event.
+    // Recorded as an operator review event with a host-derived identity (#305):
+    // the caller-supplied reviewedBy string is annotation, never a user: row.
     const audit = db.prepare(
       "SELECT operation, source_type, source_identifier, reason FROM defence_audit WHERE operation = 'review' ORDER BY id DESC LIMIT 1"
     ).get() as { operation: string; source_type: string; source_identifier: string; reason: string };
     expect(audit.operation).toBe('review');
-    expect(audit.source_identifier).toBe('michael');
+    expect(audit.source_type).not.toBe('user');
+    expect(audit.source_identifier).not.toBe('michael');
     expect(audit.reason).toContain('agent:jarvis');
+    expect((JSON.parse(audit.reason) as { reviewed_by?: string }).reviewed_by).toBe('michael');
   });
 
   it('reports not-found for an unknown source without writing risk state', () => {

--- a/src/api/__tests__/scan-route-source.test.ts
+++ b/src/api/__tests__/scan-route-source.test.ts
@@ -148,7 +148,9 @@ describe('Fix #13 — /api/v1/scan source normalisation + tamper audit', () => {
       expect(rows[0].source_type).toBe('api');
 
       // No audit row was minted under the caller-claimed user identity.
-      expect(queryAuditLogs({ source: 'user', limit: 50 }).length).toBe(0);
+      const spoofed = queryAuditLogs({ source: 'user', limit: 50 })
+        .filter(row => row.source_identifier === 'victim-name');
+      expect(spoofed.length).toBe(0);
     });
 
     it('truncates oversize source.identifier in the audit row', () => {

--- a/src/api/__tests__/scan-route-source.test.ts
+++ b/src/api/__tests__/scan-route-source.test.ts
@@ -53,6 +53,12 @@ describe('Fix #13 — /api/v1/scan source normalisation + tamper audit', () => {
       }
     });
 
+    it('#306: coerces caller-declared type "user" to "api" (user is host-attested only)', () => {
+      const result = normaliseDefenceSource({ type: 'user', identifier: 'victim-name' });
+      expect(result.type).toBe('api');
+      expect(result.identifier).toBe('victim-name');
+    });
+
     it('normalises unknown type to "api"', () => {
       const result = normaliseDefenceSource({ type: 'attacker', identifier: 'mallory' });
       expect(result.type).toBe('api');
@@ -123,6 +129,26 @@ describe('Fix #13 — /api/v1/scan source normalisation + tamper audit', () => {
       // the audit table.
       const attackerRows = queryAuditLogs({ source: 'attacker' as never, limit: 50 });
       expect(attackerRows.length).toBe(0);
+    });
+
+    it('#306: audits a type "user" claim as source_type api, never user', () => {
+      const { res } = createResponseMock();
+      handleV1Scan(
+        makeReq({
+          content: 'hello world',
+          title: 'Test',
+          source: { type: 'user', identifier: 'victim-name' },
+        }),
+        res,
+      );
+
+      const rows = queryAuditLogs({ source: 'api', limit: 50 })
+        .filter(row => row.source_identifier === 'victim-name');
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      expect(rows[0].source_type).toBe('api');
+
+      // No audit row was minted under the caller-claimed user identity.
+      expect(queryAuditLogs({ source: 'user', limit: 50 }).length).toBe(0);
     });
 
     it('truncates oversize source.identifier in the audit row', () => {

--- a/src/api/visualization-server.ts
+++ b/src/api/visualization-server.ts
@@ -59,13 +59,16 @@ import { classifySqlQuery } from './sql-classifier.js';
 
 const PORT = process.env.PORT || 3001;
 
-// ── Defence source whitelist (Fix #13) ──────────────────────────────────────
+// ── Defence source whitelist (Fix #13 / #306) ───────────────────────────────
 // The DefenceSource.type field is part of the threat-model surface — caller-
 // controlled `source.type` values pollute Iron Dome dashboards and audit
 // queries. Normalise unknown values to 'api' silently (defence in depth) and
 // cap identifier length to avoid log-explosion attacks.
+//
+// `user` is intentionally omitted: it is the top of the trust ladder and must
+// never be self-declarable. MCP already rejects it; REST used to honour it.
 const ALLOWED_DEFENCE_SOURCE_TYPES: ReadonlyArray<DefenceSource['type']> = [
-  'user', 'cli', 'hook', 'email', 'web', 'agent', 'file', 'api', 'tool_response',
+  'cli', 'hook', 'email', 'web', 'agent', 'file', 'api', 'tool_response',
 ] as const;
 const MAX_SOURCE_IDENTIFIER_LENGTH = 200;
 

--- a/src/threat-graph/conflict.ts
+++ b/src/threat-graph/conflict.ts
@@ -24,6 +24,7 @@
 import type { Database } from 'better-sqlite3';
 import { getDatabase } from '../database/init.js';
 import { logAudit } from '../defence/audit/logger.js';
+import { inferSourceFromEnvironment } from '../defence/trust/env-detector.js';
 
 /**
  * Single-valued predicates: a subject should have exactly one of these. A
@@ -131,6 +132,8 @@ export interface ConflictResolution {
   resolution: 'keep_one' | 'keep_both' | 'reject_both';
   kept_object_id?: number;
   covered_object_ids: number[];
+  /** Annotation only — never the audit-row identity (#305). */
+  reviewed_by?: string;
 }
 
 export function parseConflictResolution(reason: string | null | undefined): ConflictResolution | null {
@@ -462,14 +465,17 @@ export function resolveConflict(
       resolution: input.resolution,
       kept_object_id: input.resolution === 'keep_one' ? input.keptObjectId : undefined,
       covered_object_ids: covered,
+      reviewed_by: operator,
     };
     try {
+      // #305 — operator string is annotation; row identity is host-derived.
+      const reviewer = inferSourceFromEnvironment().source;
       logAudit({
         memory_id: null,
         project: null,
         timestamp: nowIso,
-        source_type: 'user',
-        source_identifier: operator,
+        source_type: reviewer.type,
+        source_identifier: reviewer.identifier,
         trust_score: 0.9,
         sensitivity_level: 'INTERNAL',
         firewall_result: 'ALLOW',

--- a/src/threat-graph/decision.ts
+++ b/src/threat-graph/decision.ts
@@ -8,6 +8,7 @@
 import { createContentHash } from '../defence/audit/logger.js';
 import { logAudit } from '../defence/audit/logger.js';
 import { getDatabase } from '../database/init.js';
+import { inferSourceFromEnvironment } from '../defence/trust/env-detector.js';
 import { sourceKey } from './keys.js';
 
 export interface QuarantineDecision {
@@ -138,12 +139,16 @@ export function recordQuarantineDecision(input: DecisionInput): void {
     bulk: input.bulk,
   };
   try {
+    // #305 — reviewer identity is host-derived. `reviewedBy` is caller notes
+    // (MCP `notes`, dashboard free text) and must stay annotation, never a
+    // user: provenance row. Allowance consumes payload.source_key.
+    const reviewer = inferSourceFromEnvironment().source;
     logAudit({
       memory_id: null,
       project: input.project,
       timestamp: new Date().toISOString(),
-      source_type: 'user',
-      source_identifier: input.reviewedBy,
+      source_type: reviewer.type,
+      source_identifier: reviewer.identifier,
       trust_score: 0.9,
       sensitivity_level: 'INTERNAL',
       firewall_result: 'ALLOW',
@@ -151,7 +156,7 @@ export function recordQuarantineDecision(input: DecisionInput): void {
       anomaly_score: 0,
       threat_indicators: '[]',
       blocked_patterns: '[]',
-      reason: JSON.stringify(payload),
+      reason: JSON.stringify({ ...payload, reviewed_by: input.reviewedBy }),
       fragmentation_score: null,
       pipeline_duration_ms: null,
     });

--- a/src/threat-graph/risk.ts
+++ b/src/threat-graph/risk.ts
@@ -22,6 +22,7 @@
 import { getDatabase, isDatabaseInitialized } from '../database/init.js';
 import type { DefenceSource } from '../defence/types.js';
 import { logAudit } from '../defence/audit/logger.js';
+import { inferSourceFromEnvironment } from '../defence/trust/env-detector.js';
 import { cachedStmt } from './shared.js';
 import { sourceKey } from './keys.js';
 
@@ -333,12 +334,14 @@ export function resetSourceRisk(key: string, opts: { reviewedBy: string }): Rese
   if (!found) return { found: false };
 
   try {
+    // #305 — reviewedBy is annotation; the row identity is host-derived.
+    const reviewer = inferSourceFromEnvironment().source;
     logAudit({
       memory_id: null,
       project: null,
       timestamp: nowIso,
-      source_type: 'user',
-      source_identifier: opts.reviewedBy,
+      source_type: reviewer.type,
+      source_identifier: reviewer.identifier,
       trust_score: 0.9,
       sensitivity_level: 'INTERNAL',
       firewall_result: 'ALLOW',


### PR DESCRIPTION
## What broke

`user` is the top of the trust ladder (`scoreSource` = 1.0) and is not caller-suppliable on MCP. Two writers still let a caller mint it:

- **#305** — `recordQuarantineDecision` (and the sibling risk-reset / conflict review writers) stamped `source_type: 'user'` + `source_identifier: reviewedBy`. MCP `quarantine_review` passes `notes` as `reviewedBy`. `notes: "victim-name"` minted a `user:victim-name` decision-ledger row.
- **#306** — REST `POST /v1/scan` honoured `source.type: 'user'` via `ALLOWED_DEFENCE_SOURCE_TYPES`. MCP already rejects that type.

## What changed

- Review-row identity comes from `inferSourceFromEnvironment()`. Caller `reviewedBy` / `notes` / operator string stays a `reviewed_by` annotation in the payload JSON.
- Allowance / projector still consume `operation='review'` + payload `source_key`. Identity change does not move the quarantined source.
- REST drops `user` from the allowlist; unknown/`user` coerce to `api` (existing Fix #13 contract, no 400).
- `user:approved` on the promote-to-memory path is a **code constant**, left alone.

## Tests

New cases fail before the fix (5 failures) and pass after:

```
npm test -- src/__tests__/threat-graph-decision-ledger.test.ts \
  src/api/__tests__/scan-route-source.test.ts \
  src/__tests__/threat-graph-reset-doctor.test.ts \
  src/__tests__/threat-graph-conflict-resolve.test.ts \
  src/defence/quarantine/__tests__/promote-rescan.test.ts --runInBand
```

41/41. Nearby allowance + attestation suites 63/63. `npm run build:ts` clean.

## Not done

- #320 version-bump risk amnesty — design (persisted snapshot vs sync upgrade tick), not this patch.
- #321 stays draft/HOLD (disclosure).
- #317 Mac doctor UNKNOWN — separate.

Do not merge automatically.
