### PR TITLE
fix(guard): shred-device ignores fd redirects (#303)

### DIFF
--- a/src/defence/iron-dome/__tests__/guard-tune-91-89.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-tune-91-89.test.ts
@@ -130,4 +130,24 @@ describe('#89 remainder — shred anchored to command position', () => {
     expect(v.decision).toBe('block');
     expect(v.signals).toContain('shred-device');
   });
+
+  it.each([
+    ['shred file with stdout discard', 'shred -n 3 secret.txt >/dev/null'],
+    ['shred file with stderr discard', 'shred secret.txt 2>/dev/null'],
+    ['wipe file with stdout discard', 'wipe old.key >/dev/null'],
+    ['shred file with /dev/stdout', 'shred secret.txt >/dev/stdout'],
+    ['shred file with /dev/stderr', 'shred secret.txt >/dev/stderr'],
+  ])('#303 does not treat fd redirects as devices: %s', (_name, cmd) => {
+    const v = verdict(cmd);
+    expect(v.signals).not.toContain('shred-device');
+  });
+
+  it.each([
+    ['nvme', 'shred /dev/nvme0n1'],
+    ['wipe sdb', 'wipe /dev/sdb'],
+  ])('#303 still blocks real block devices: %s', (_name, cmd) => {
+    const v = verdict(cmd);
+    expect(v.decision).toBe('block');
+    expect(v.signals).toContain('shred-device');
+  });
 });

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -272,7 +272,7 @@ const CATASTROPHIC: Pattern[] = [
   // verb and the /dev/ target in ONE statement — mirroring recursive-force-delete
   // above — so `export PATH=/opt/wipe/bin; echo /dev/null` no longer collides two
   // unrelated statements into a false catastrophic block (issue #89).
-  { re: /\b(?:shred|wipe)\b[^|;&\n]*\/dev\//i, signal: 'shred-device' },
+  { re: /\b(?:shred|wipe)\b[^|;&\n]*\/dev\/(?!null\b|stdout\b|stderr\b|fd\/\d)/i, signal: 'shred-device' },
 ];
 
 /**


### PR DESCRIPTION
Closes #303.

`shred file.txt >/dev/null` (and stdout/stderr/fd/N) no longer matches `shred-device`.
`shred /dev/sda`, `shred /dev/nvme0n1`, `wipe /dev/sdb` still catastrophic-block.

#89 remainder stays: shred as a mention is not file-delete.