### PR TITLE
fix(doctor): Mac running-version UNKNOWN is a log-channel gap (#317)

### DIFF
--- a/src/cli/__tests__/doctor-running-plugin-version.test.ts
+++ b/src/cli/__tests__/doctor-running-plugin-version.test.ts
@@ -113,6 +113,33 @@ describe('checkOpenClawRunningPluginVersion', () => {
     expect(r.message).toMatch(/running version UNKNOWN/i);
   });
 
+  it('#317 passes UNKNOWN log gap when roster-confirmed matches disk', async () => {
+    installOnDisk('4.53.0');
+    const r = await checkOpenClawRunningPluginVersion(home, {
+      readGatewayJournal: () => ({
+        text: 'Jul 21 09:00:01 host openclaw-gateway[123]: starting gateway\n',
+        preBounded: true,
+      }),
+      readGatewayProcessStartMs: () => 1_700_000_000_000,
+      readRosterConfirmedVersion: () => '4.53.0',
+    });
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/roster-confirmed/i);
+    expect(r.message).toMatch(/log line unavailable/i);
+    expect(r.message).not.toMatch(/UNKNOWN/i);
+  });
+
+  it('#317 does not let roster compose override a FRESH stale log line (#94)', async () => {
+    installOnDisk('4.53.0');
+    const r = await checkOpenClawRunningPluginVersion(home, {
+      readGatewayJournal: () => ({ text: journalWith('4.47.8'), preBounded: true }),
+      readGatewayProcessStartMs: () => 1_700_000_000_000,
+      readRosterConfirmedVersion: () => '4.53.0',
+    });
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/stale/i);
+  });
+
   it('skips (info) when OpenClaw is present but the realtime plugin is not installed', async () => {
     fs.mkdirSync(path.join(home, '.openclaw'), { recursive: true });
     const r = await checkOpenClawRunningPluginVersion(home, { readGatewayJournal: () => ({ text: journalWith('4.47.13'), preBounded: true }), readGatewayProcessStartMs: () => 1_700_000_000_000 });

--- a/src/cli/__tests__/doctor-startup-intent-156.test.ts
+++ b/src/cli/__tests__/doctor-startup-intent-156.test.ts
@@ -44,6 +44,30 @@ describe('#156 readPluginStartupIntent', () => {
   it('returns null when no installed manifest exists', () => {
     expect(readPluginStartupIntent(home)).toBeNull();
   });
+
+  it('#317 reads the npm-projects install path, not only extensions/', () => {
+    const pkg = path.join(
+      home,
+      '.openclaw',
+      'npm',
+      'projects',
+      'drakon-systems-shieldcortex-shieldcortex-realtime-abc',
+      'node_modules',
+      '@drakon-systems',
+      'shieldcortex-realtime',
+    );
+    fs.mkdirSync(pkg, { recursive: true });
+    fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify({ version: '4.53.0' }));
+    fs.writeFileSync(
+      path.join(pkg, 'openclaw.plugin.json'),
+      JSON.stringify({ id: 'shieldcortex-realtime', activation: { onStartup: true, onCapabilities: ['hook'] } }),
+    );
+    const intent = readPluginStartupIntent(home);
+    expect(intent).not.toBeNull();
+    expect(intent!.onStartup).toBe(true);
+    expect(intent!.hookCapability).toBe(true);
+    expect(intent!.source).toContain('npm/projects');
+  });
 });
 
 describe('#156 doctor startup-intent check', () => {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3539,6 +3539,13 @@ export interface RunningPluginVersionDeps {
   readGatewayProcessStartMs: () => number | null;
   /** #214 — running gateway pid, so a CLI registration line is not quoted as the gateway. */
   readGatewayPid?: () => number | null;
+  /**
+   * #317 — version proven loaded by the live gateway roster (same evidence as
+   * "plugin loaded: roster-confirmed"). Used only when the log channel has no
+   * fresh `[shieldcortex] … registered` line. A FRESH stale log line still wins
+   * (the #94 class).
+   */
+  readRosterConfirmedVersion?: () => string | null;
 }
 
 /**
@@ -3650,6 +3657,17 @@ export function realRunningPluginVersionDeps(home: string = os.homedir()): Runni
     },
     readGatewayProcessStartMs: (): number | null => readRunningGatewayProcess(home)?.startedAtMs ?? null,
     readGatewayPid: (): number | null => readRunningGatewayProcess(home)?.pid ?? null,
+    readRosterConfirmedVersion: (): string | null => {
+      try {
+        const verdict = reconcilePluginState(gatherReconcileInput(home, { expectedVersion: pkg.version }));
+        if (verdict.loadedInLiveRoster === true) {
+          return readInstalledRealtimePluginVersion(home);
+        }
+      } catch {
+        // roster unreadable — log path stays the only proof
+      }
+      return null;
+    },
   };
 }
 
@@ -3701,13 +3719,26 @@ export async function checkOpenClawRunningPluginVersion(
     : parseRunningPluginVersionSince(journal.text, processStartMs, gatewayPid);
   if (!running) {
     const historic = journal.preBounded ? null : parseRunningPluginVersion(journal.text);
+    const roster = deps.readRosterConfirmedVersion?.() ?? null;
+    if (roster && roster === diskVersion) {
+      return {
+        label,
+        status: 'pass',
+        message:
+          `running v${roster} matches on-disk v${diskVersion} (roster-confirmed; ` +
+          `log line unavailable on this platform)`,
+      };
+    }
     return {
       label,
       status: 'info',
       message:
         `running version UNKNOWN — no \`[shieldcortex] … registered\` line since the running gateway ` +
         `started (${new Date(processStartMs).toISOString()}); on-disk v${diskVersion}.` +
-        (historic ? ` An older line exists (v${historic}) but predates this process and proves nothing about it` : ''),
+        (historic ? ` An older line exists (v${historic}) but predates this process and proves nothing about it` : '') +
+        (process.platform === 'darwin'
+          ? ' On macOS LaunchAgent hosts this is usually a log-channel gap, not an unload — see `openclaw gateway restart` / `launchctl print gui/$(id -u)/ai.openclaw.gateway`'
+          : ''),
     };
   }
 
@@ -3745,6 +3776,16 @@ export function readPluginStartupIntent(home: string = os.homedir()): {
   const candidates = [
     path.join(home, '.openclaw', 'extensions', 'shieldcortex-realtime', 'openclaw.plugin.json'),
   ];
+  // #317 — modern npm-projects layout (same ground-truth path as on-disk version).
+  try {
+    const install = resolveRealtimePluginInstallPath(home);
+    if (install) {
+      candidates.push(path.join(install, 'openclaw.plugin.json'));
+      candidates.push(path.join(install, 'dist', 'openclaw.plugin.json'));
+    }
+  } catch {
+    // ignore
+  }
   for (const file of candidates) {
     try {
       if (!fs.existsSync(file)) continue;

--- a/src/setup/gateway-restart-command.ts
+++ b/src/setup/gateway-restart-command.ts
@@ -72,3 +72,14 @@ export function gatewayRestartCommand(
 export function gatewayRestartAdvice(platform: RestartPlatform = process.platform): string {
   return gatewayRestartCommand(platform).advice;
 }
+
+/** How to inspect the running gateway boot line — not journalctl on Darwin. */
+export function gatewayBootLogAdvice(platform: RestartPlatform = process.platform): string {
+  if (platform === 'darwin') {
+    return 'openclaw gateway restart   # then: launchctl print gui/$(id -u)/ai.openclaw.gateway';
+  }
+  if (platform === 'linux') {
+    return 'journalctl --user -u openclaw-gateway | grep "http server listening"';
+  }
+  return 'inspect the OpenClaw gateway process log for a boot/"http server listening" line';
+}

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -17,6 +17,7 @@ import { waitForGatewayReady } from './gateway-readiness.js';
 import { summariseRepair, renderRepairHeadline } from './repair-verdict.js';
 import { resolveRepairConsent } from './repair-consent.js';
 import { summariseCommandOutput } from '../integrations/child-output.js';
+import { gatewayBootLogAdvice } from './gateway-restart-command.js';
 
 /**
  * The #74 metadata reconciler orchestrator.
@@ -458,7 +459,7 @@ export function formatReconcileReport(result: ReconcileExecResult): string[] {
       lines.push(
         verdict.loadedInLiveRoster === true
           ? '✓ realtime plugin healthy: enabled, loaded on the running gateway roster, versions agree.'
-          : '⚠ realtime plugin installed and enabled, versions agree — NOT proven loaded: the running gateway boot roster could not be read. Restart the gateway, then re-run, or check `journalctl --user -u openclaw-gateway | grep "http server listening"` yourself.',
+          : `⚠ realtime plugin installed and enabled, versions agree — NOT proven loaded: the running gateway boot roster could not be read. Restart the gateway, then re-run, or check \`${gatewayBootLogAdvice()}\` yourself.`,
       );
       return lines;
     }

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import os from 'os';
 import { execSync, spawnSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { gatewayRestartAdvice } from './gateway-restart-command.js';
+import { gatewayRestartAdvice, gatewayBootLogAdvice } from './gateway-restart-command.js';
 import {
   resolveRealtimePluginInstallPath,
   resolveRealtimeProjectDir,
@@ -1711,7 +1711,7 @@ export async function installOpenClawHook(options: OpenClawInstallOptions = {}):
         // an unreadable log is the #142 false alarm; say what we actually know.
         console.warn('✗ Honest-state self-check INCONCLUSIVE: could not read the running gateway\'s boot roster,');
         console.warn('  so the plugin is not PROVEN loaded — this is unproven, not known-broken. Check it yourself with:');
-        console.warn('    journalctl --user -u openclaw-gateway | grep "http server listening"');
+        console.warn(`    ${gatewayBootLogAdvice()}`);
         process.exitCode = 1;
       } else if (!check.versionProof) {
         console.warn('✗ Honest-state self-check FAILED: the loaded plugin version is OLDER than expected (silent downgrade, #74).');
@@ -1870,7 +1870,7 @@ async function reportLoadAndEnforcement(): Promise<void> {
     } else {
       console.log('  Loaded: UNPROVEN — could not read the running gateway\'s boot roster');
       console.log('    This is unproven, not known-broken. Check it directly:');
-      console.log('      journalctl --user -u openclaw-gateway | grep "http server listening"');
+      console.log(`      ${gatewayBootLogAdvice()}`);
     }
 
     if (check.canaryProof) {


### PR DESCRIPTION
Closes #317.

- Roster-confirmed + on-disk match → PASS even without a fresh \`[shieldcortex] vX registered\` line
- Fresh stale register line still WARNs (#94)
- Darwin honest-state/repair copy uses LaunchAgent advice, not journalctl
- Startup intent reads the npm-projects install path

Do not treat historic pre-process-start lines as running (#150).