### PR TITLE
fix(graph): overflowed sources no longer get silent 0 risk (#307)

### DIFF
--- a/src/__tests__/threat-graph-modifier.test.ts
+++ b/src/__tests__/threat-graph-modifier.test.ts
@@ -69,6 +69,29 @@ describe('computeRiskModifier', () => {
     const r = computeRiskModifier({ type: 'agent', identifier: longId }, 'enforce');
     expect(r.modifier).toBeCloseTo(RISK_TRUST_CAP, 6);
   });
+
+  it('#307 overflowed attested source uses overflow risk, not silent 0', () => {
+    seedRisk(0.8, 1, 'overflow');
+    getDatabase().prepare(`
+      INSERT INTO defence_audit (
+        memory_id, project, timestamp, source_type, source_identifier,
+        trust_score, sensitivity_level, firewall_result,
+        anomaly_score, threat_indicators, blocked_patterns,
+        reason, fragmentation_score, pipeline_duration_ms, source_attested
+      ) VALUES (NULL, 'test', '2026-08-16T00:00:00.000Z', 'agent', 'overflowed-attacker',
+        0.1, 'PUBLIC', 'BLOCK', 0, '[]', '[]', NULL, NULL, 0, 1)
+    `).run();
+    const r = computeRiskModifier({ type: 'agent', identifier: 'overflowed-attacker' }, 'enforce');
+    expect(r.modifier).toBeGreaterThan(0);
+    expect(r.applied).toBe(true);
+  });
+
+  it('#307 overflowed unattested source stays 0', () => {
+    seedRisk(0.8, 1, 'overflow');
+    const r = computeRiskModifier({ type: 'agent', identifier: 'overflowed-unattested' }, 'enforce');
+    expect(r.modifier).toBe(0);
+    expect(r.applied).toBe(false);
+  });
 });
 
 describe('pipeline integration', () => {

--- a/src/threat-graph/risk.ts
+++ b/src/threat-graph/risk.ts
@@ -151,8 +151,31 @@ export function computeRiskModifier(source: DefenceSource, mode: TrustModifierMo
 
   try {
     const key = sourceKey(source.type, source.identifier);
-    const row = cachedStmt('SELECT risk, attested FROM source_risk WHERE source_key = ?')
+    let row = cachedStmt('SELECT risk, attested FROM source_risk WHERE source_key = ?')
       .get(key) as { risk: number; attested: number } | undefined;
+
+    // #307 — overflowed identities have no own source_risk row. Use the overflow
+    // bucket's risk, but THIS source's latest-non-null attestation (unattested
+    // overflow traffic must not tighten).
+    if (!row) {
+      const ownNode = cachedStmt("SELECT 1 AS ok FROM threat_nodes WHERE kind = 'source' AND key = ?")
+        .get(key) as { ok: number } | undefined;
+      if (!ownNode) {
+        const overflow = cachedStmt("SELECT risk FROM source_risk WHERE source_key = 'overflow'")
+          .get() as { risk: number } | undefined;
+        if (overflow && overflow.risk > 0) {
+          const attestRow = cachedStmt(`
+            SELECT source_attested FROM defence_audit
+            WHERE source_type = ? AND source_identifier = ? AND source_attested IS NOT NULL
+            ORDER BY id DESC LIMIT 1
+          `).get(source.type, source.identifier) as { source_attested: number } | undefined;
+          if (attestRow?.source_attested === 1) {
+            row = { risk: overflow.risk, attested: 1 };
+          }
+        }
+      }
+    }
+
     if (!row || row.attested !== 1 || row.risk <= 0) return { modifier: 0, applied: false };
 
     const modifier = Math.min(row.risk * RISK_TRUST_SCALE, RISK_TRUST_CAP);
@@ -194,7 +217,7 @@ export function runRiskSweep(options: RiskSweepOptions): RiskSweepResult {
   const windowStartIso = new Date(options.nowMs - COUNTER_WINDOW_MS).toISOString();
 
   const nodes = db.prepare(
-    "SELECT key, attrs FROM threat_nodes WHERE kind = 'source' AND key != 'overflow'"
+    "SELECT key, attrs FROM threat_nodes WHERE kind = 'source'"
   ).all() as SourceNodeRow[];
 
   const upsert = cachedStmt(`


### PR DESCRIPTION
Closes #307. Overflow bucket now has source_risk; overflowed attested identities use that risk. Unattested overflowed sources stay 0.