### PR TITLE
fix(guard): Face 1 deny surface no longer claims a missing sink (#284)

### DIFF
--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -766,9 +766,9 @@ function redactedActionSurface(toolName, toolInput) {
   const keys = ['command', 'script', 'file_path', 'path', 'url', 'pattern'];
   const present = keys.filter((k) => toolInput?.[k] !== undefined && toolInput?.[k] !== null);
   const suffix = present.length > 0 ? ` fields=${present.join(',')}` : ' no command field';
-  // #284 Face 1 — name the verified sink. denials.jsonl is a summary; unredacted
-  // command lives in ~/.shieldcortex/audit/realtime-YYYY-MM-DD.jsonl.
-  return `${safeToolName(toolName)}: [redacted action surface; unredacted command in ~/.shieldcortex/audit/realtime-*.jsonl]${suffix}`;
+  // #284 Face 1 — denials.jsonl / notify carry a redacted surface only.
+  // Do not claim the raw command lives in realtime-*.jsonl; that pointer was a lie.
+  return `${safeToolName(toolName)}: [redacted action surface; command not persisted to notify or denials.jsonl preview]${suffix}`;
 }
 
 function redactedAuditArgs(toolName, toolInput) {

--- a/src/__tests__/pre-tool-hook.test.ts
+++ b/src/__tests__/pre-tool-hook.test.ts
@@ -428,4 +428,12 @@ describe('pre-tool hook — WS1 enforce-by-default on Claude Code', () => {
       fs.rmSync(emptyDist, { recursive: true, force: true });
     }
   });
+
+  it('#284 Face 1 does not claim the raw command lives in realtime-*.jsonl', () => {
+    const src = fs.readFileSync(HOOK_PATH, 'utf8');
+    expect(src).toMatch(/redacted action surface/i);
+    expect(src).not.toMatch(/unredacted command in ~\/\.shieldcortex\/audit\/realtime-/);
+    const surface = src.match(/redacted action surface[^`]*/)?.[0] ?? '';
+    expect(surface.toLowerCase()).not.toContain('realtime-');
+  });
 });

--- a/src/defence/iron-dome/__tests__/deny-path-forensics-284.test.ts
+++ b/src/defence/iron-dome/__tests__/deny-path-forensics-284.test.ts
@@ -74,8 +74,10 @@ describe('#284 deny-path forensics', () => {
     expect(row.signals).toEqual(expect.arrayContaining(['recursive-force-delete']));
     expect(row.signals).not.toEqual(['redacted-signal']);
 
-    // Face 1 wording — points at realtime audit, not vague "local audit"
-    expect(String(row.surface)).toMatch(/realtime-\*\.jsonl/);
+    // Face 1 wording — do not claim a sink that does not hold the command
+    expect(String(row.surface)).toMatch(/redacted action surface/i);
+    expect(String(row.surface)).not.toMatch(/realtime-\*\.jsonl/);
+    expect(String(row.surface)).toMatch(/not persisted/i);
 
     // Face 2 — origin on auto_deny/critical
     expect(row.origin).toBe('claude-code-hook');


### PR DESCRIPTION
Partial #284 (Face 1 honesty). Stops the false realtime-*.jsonl pointer. Does not put raw command back into notify.