### PR TITLE
feat(guard): loud DNP digest (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **#331 loud DNP digest** — host-local time-window rollup for `denied_no_prompt_surface` notifies. First DNP in the window pages; later ones coalesce. `actionGuard.notify.dnpDigestWindowMs` (default 15m, `0` = legacy every-event). Payload / `permission_mode` never mute. #310 stays design (no approval cards).
+
 ## [4.54.1] - 2026-08-16
 
 **Patch — board grind + instruction-floor GHSA.**

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -335,9 +335,9 @@ async function loadNotify(rawNotifyConfig) {
     }
   };
   try {
-    const [notifyConfigMod, notifyMod, webhookMod, openclawMod] = await Promise.all([
+    const [notifyConfigMod, notifyMod, webhookMod, openclawMod, digestMod] = await Promise.all([
       load('notify-config.js'), load('operator-notify.js'), load('webhook-notify-channel.js'),
-      load('openclaw-approval-channel.js'),
+      load('openclaw-approval-channel.js'), load('dnp-digest.js'),
     ]);
     if (typeof notifyConfigMod?.normaliseNotifyConfig !== 'function') return null;
     if (typeof notifyMod?.requestOperatorApproval !== 'function') return null;
@@ -396,6 +396,9 @@ async function loadNotify(rawNotifyConfig) {
         : null,
       buildActionGuardOutcomeNotification: typeof notifyMod.buildActionGuardOutcomeNotification === 'function'
         ? notifyMod.buildActionGuardOutcomeNotification
+        : null,
+      formatDnpDigestText: typeof digestMod?.formatDnpDigestText === 'function'
+        ? digestMod.formatDnpDigestText
         : null,
       /** Where a denial goes when the primary channel cannot carry one. Null
        *  means an openclaw-only install: the denial reaches no channel, which
@@ -901,6 +904,14 @@ function recordLocalGuardOutcome(outcome) {
 
 function classifyNotifyStatus(notifyMod, result) {
   // #284 Face 4 — distinguish not_configured / no_channel / delivered / error.
+  // #331 — coalesced is a successful volume decision, not a delivery failure.
+  if (result?.coalesced === true) {
+    return {
+      status: 'coalesced',
+      deliveredVia: null,
+      digestCount: typeof result.digestCount === 'number' ? result.digestCount : undefined,
+    };
+  }
   if (!notifyMod) {
     return { status: 'not_configured', deliveredVia: null };
   }
@@ -946,13 +957,67 @@ async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict
   }
 
   let deliveryResult = null;
-  if (
+  // #331 — DNP volume control. Always record forensics; outbound notify is
+  // at most once per host window. Payload never decides mute.
+  let digestDecision = null;
+  if (outcome === 'denied_no_prompt_surface' && notify) {
+    try {
+      const dig = await import(
+        pathToFileURL(resolve(process.env.SHIELDCORTEX_DIST_ROOT ?? resolve(here, '..', 'dist'), 'defence', 'iron-dome', 'dnp-digest.js')).href
+      );
+      if (typeof dig.recordDnpDigestEvent === 'function') {
+        const context = notificationContext(sessionKey, id);
+        digestDecision = dig.recordDnpDigestEvent(
+          {
+            actionId: id,
+            sessionId: context.sessionId,
+            tool: safeToolName(toolName),
+            signals: safeSignalList(verdict?.signals),
+            severity: String(verdict?.severity ?? 'unknown'),
+          },
+          {
+            home: homedir(),
+            windowMs: notify.config?.dnpDigestWindowMs,
+          },
+        );
+      }
+    } catch {
+      digestDecision = null;
+    }
+  }
+
+  if (digestDecision?.action === 'coalesce') {
+    deliveryResult = {
+      deliveredVia: null,
+      coalesced: true,
+      digestCount: digestDecision.summary?.count,
+      attempts: [],
+    };
+  } else if (
     notify?.denialChannel &&
     typeof notify.deliverOperatorNotification === 'function' &&
     typeof notify.buildActionGuardOutcomeNotification === 'function'
   ) {
     try {
-      const notification = notify.buildActionGuardOutcomeNotification(pendingRow);
+      let notification = notify.buildActionGuardOutcomeNotification(pendingRow);
+      // Enrich first-of-window DNP with digest text when builder supports it.
+      if (
+        digestDecision?.action === 'notify' &&
+        digestDecision.summary &&
+        typeof notify.formatDnpDigestText === 'function'
+      ) {
+        notification = {
+          ...notification,
+          digestText: notify.formatDnpDigestText(digestDecision.summary),
+          digestCount: digestDecision.summary.count,
+        };
+      } else if (digestDecision?.action === 'notify' && digestDecision.summary) {
+        // Inline fallback so older dist still gets a rolled-up reason line.
+        notification = {
+          ...notification,
+          reason: `${notification.reason} [digest: ${digestDecision.summary.count} DNP in window]`,
+        };
+      }
       deliveryResult = await notify.deliverOperatorNotification(notification, {
         channels: [notify.denialChannel],
         timeoutMs: notify.config?.timeoutMs,

--- a/src/__tests__/prompt-surface-deny.test.ts
+++ b/src/__tests__/prompt-surface-deny.test.ts
@@ -463,6 +463,30 @@ describe('Action Guard hook — prompt-surface rule', () => {
         expect(after).toEqual(before);
       });
     });
+
+    it('#331 coalesces later DNPs in the host window (one outbound page)', async () => {
+      writeNotifyConfig({ dnpDigestWindowMs: 900_000 });
+      const r1 = await runHook(call(DANGEROUS_COMMAND, 'bypassPermissions'));
+      expect(decisionOf(r1.stdout).permissionDecision).toBe('deny');
+      expect(deliveries).toHaveLength(1);
+      const body1 = JSON.parse(deliveries[0].body) as Record<string, unknown>;
+      expect(body1.outcome).toBe('denied_no_prompt_surface');
+      // Digest text preferred when present
+      expect(String(body1.text)).toMatch(/DNP digest|denied_no_prompt_surface|BLOCKED/i);
+
+      const r2 = await runHook(call(DANGEROUS_COMMAND, 'bypassPermissions'));
+      expect(decisionOf(r2.stdout).permissionDecision).toBe('deny');
+      // Still one webhook delivery — second DNP was coalesced.
+      expect(deliveries).toHaveLength(1);
+
+      const denialsPath = path.join(tempHome, '.shieldcortex', 'denials.jsonl');
+      expect(fs.existsSync(denialsPath)).toBe(true);
+      const rows = fs.readFileSync(denialsPath, 'utf8').trim().split('\n').map((l) => JSON.parse(l) as Record<string, unknown>);
+      const finals = rows.filter((r) => r.outcome === 'denied_no_prompt_surface' && r.notify && (r.notify as { status?: string }).status !== 'pending');
+      expect(finals.length).toBeGreaterThanOrEqual(2);
+      expect(finals.some((r) => (r.notify as { status?: string }).status === 'delivered')).toBe(true);
+      expect(finals.some((r) => (r.notify as { status?: string }).status === 'coalesced')).toBe(true);
+    });
   });
 
   describe('degraded guard (WS2 fallback) follows the same rule', () => {

--- a/src/defence/iron-dome/__tests__/dnp-digest-331.test.ts
+++ b/src/defence/iron-dome/__tests__/dnp-digest-331.test.ts
@@ -1,0 +1,136 @@
+/**
+ * #331 — DNP digest unit tests.
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  DEFAULT_DNP_DIGEST_WINDOW_MS,
+  formatDnpDigestText,
+  normaliseDnpDigestWindowMs,
+  recordDnpDigestEvent,
+} from '../dnp-digest.js';
+
+describe('normaliseDnpDigestWindowMs', () => {
+  it('defaults junk to 15m', () => {
+    expect(normaliseDnpDigestWindowMs(undefined)).toBe(DEFAULT_DNP_DIGEST_WINDOW_MS);
+    expect(normaliseDnpDigestWindowMs('nope')).toBe(DEFAULT_DNP_DIGEST_WINDOW_MS);
+    expect(normaliseDnpDigestWindowMs(-1)).toBe(DEFAULT_DNP_DIGEST_WINDOW_MS);
+    expect(normaliseDnpDigestWindowMs(99)).toBe(DEFAULT_DNP_DIGEST_WINDOW_MS);
+  });
+
+  it('allows 0 to disable', () => {
+    expect(normaliseDnpDigestWindowMs(0)).toBe(0);
+  });
+
+  it('honours in-range override', () => {
+    expect(normaliseDnpDigestWindowMs(120_000)).toBe(120_000);
+  });
+});
+
+describe('recordDnpDigestEvent', () => {
+  let dir: string;
+  let statePath: string;
+  const t0 = 1_700_000_000_000;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-dnp-'));
+    statePath = path.join(dir, 'dnp-digest.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('passthrough when windowMs is 0', () => {
+    const d = recordDnpDigestEvent(
+      { actionId: 'act-0123456789abcdef', tool: 'Bash', signals: ['secret-egress'] },
+      { statePath, windowMs: 0, nowMs: t0 },
+    );
+    expect(d.action).toBe('passthrough');
+  });
+
+  it('notifies on the first DNP in a window', () => {
+    const d = recordDnpDigestEvent(
+      {
+        actionId: 'act-0123456789abcdef',
+        sessionId: 'sc-0123456789abcdef',
+        tool: 'Bash',
+        signals: ['secret-egress', 'recursive-force-delete'],
+      },
+      { statePath, windowMs: 900_000, nowMs: t0 },
+    );
+    expect(d.action).toBe('notify');
+    expect(d.summary?.count).toBe(1);
+    expect(d.summary?.bySignal['secret-egress']).toBe(1);
+    expect(d.summary?.lastActionIds).toEqual(['act-0123456789abcdef']);
+    expect(fs.existsSync(statePath)).toBe(true);
+  });
+
+  it('coalesces later DNPs in the same window', () => {
+    recordDnpDigestEvent(
+      { actionId: 'act-0123456789abcdef', tool: 'Bash', signals: ['secret-egress'] },
+      { statePath, windowMs: 900_000, nowMs: t0 },
+    );
+    const d2 = recordDnpDigestEvent(
+      { actionId: 'act-1123456789abcdef', tool: 'Bash', signals: ['secret-egress'] },
+      { statePath, windowMs: 900_000, nowMs: t0 + 60_000 },
+    );
+    expect(d2.action).toBe('coalesce');
+    expect(d2.summary?.count).toBe(2);
+    expect(d2.summary?.coalescedAfterNotify).toBe(true);
+    expect(d2.summary?.lastActionIds).toEqual([
+      'act-0123456789abcdef',
+      'act-1123456789abcdef',
+    ]);
+  });
+
+  it('opens a new window after windowMs elapses', () => {
+    recordDnpDigestEvent(
+      { actionId: 'act-0123456789abcdef', tool: 'Bash', signals: ['a'] },
+      { statePath, windowMs: 60_000, nowMs: t0 },
+    );
+    const d2 = recordDnpDigestEvent(
+      { actionId: 'act-2223456789abcdef', tool: 'Edit', signals: ['b'] },
+      { statePath, windowMs: 60_000, nowMs: t0 + 60_000 },
+    );
+    expect(d2.action).toBe('notify');
+    expect(d2.summary?.count).toBe(1);
+    expect(d2.summary?.byTool.Edit).toBe(1);
+  });
+
+  it('does not let a junk actionId or permission-shaped field mute anything', () => {
+    const d = recordDnpDigestEvent(
+      {
+        actionId: 'bypassPermissions',
+        tool: 'Bash',
+        signals: ['x'.repeat(200), 'secret-egress'],
+      },
+      { statePath, windowMs: 900_000, nowMs: t0 },
+    );
+    expect(d.action).toBe('notify');
+    expect(d.summary?.lastActionIds).toEqual([]);
+    expect(d.summary?.bySignal['secret-egress']).toBe(1);
+  });
+});
+
+describe('formatDnpDigestText', () => {
+  it('never includes a raw command and names the window', () => {
+    const text = formatDnpDigestText({
+      count: 3,
+      windowMs: 900_000,
+      windowStartMs: 0,
+      bySignal: { 'secret-egress': 2 },
+      byTool: { Bash: 3 },
+      lastActionIds: ['act-0123456789abcdef'],
+      lastSessionIds: [],
+      coalescedAfterNotify: false,
+    });
+    expect(text).toMatch(/BLOCKED \(DNP digest\)/i);
+    expect(text).toMatch(/3 denied_no_prompt_surface/);
+    expect(text).toMatch(/15m/);
+    expect(text).not.toMatch(/rm -rf/);
+    expect(text).toMatch(/denials\.jsonl/);
+  });
+});

--- a/src/defence/iron-dome/__tests__/notify-config.test.ts
+++ b/src/defence/iron-dome/__tests__/notify-config.test.ts
@@ -117,6 +117,14 @@ describe('normaliseNotifyConfig — timeoutMs bounds', () => {
     expect(normaliseNotifyConfig({ enabled: true, timeoutMs: NaN }).timeoutMs).toBe(DEFAULT_NOTIFY_CONFIG.timeoutMs);
   });
 
+  it('#331 defaults dnpDigestWindowMs to 15m and accepts 0 disable', () => {
+    expect(normaliseNotifyConfig({ enabled: true }).dnpDigestWindowMs).toBe(DEFAULT_NOTIFY_CONFIG.dnpDigestWindowMs);
+    expect(normaliseNotifyConfig({ enabled: true, dnpDigestWindowMs: 0 }).dnpDigestWindowMs).toBe(0);
+    expect(normaliseNotifyConfig({ enabled: true, dnpDigestWindowMs: 120_000 }).dnpDigestWindowMs).toBe(120_000);
+    expect(normaliseNotifyConfig({ enabled: true, dnpDigestWindowMs: 'bypassPermissions' }).dnpDigestWindowMs)
+      .toBe(DEFAULT_NOTIFY_CONFIG.dnpDigestWindowMs);
+  });
+
   it('honours an in-range override', () => {
     expect(normaliseNotifyConfig({ enabled: true, timeoutMs: 3_000 }).timeoutMs).toBe(3_000);
   });

--- a/src/defence/iron-dome/dnp-digest.ts
+++ b/src/defence/iron-dome/dnp-digest.ts
@@ -1,0 +1,270 @@
+/**
+ * #331 — host-local DNP (denied_no_prompt_surface) digest.
+ *
+ * Volume control for loud terminal denials. Primary key is a time window on
+ * THIS host. Payload / permission_mode never appear here — they must not
+ * select silence (same class as #283/#287/#288).
+ *
+ * Contract:
+ *  - Every DNP still writes denials.jsonl (caller responsibility).
+ *  - At most one outbound notify per window (first event opens + notifies).
+ *  - Later DNPs in the same window return `coalesced` so the hook skips send.
+ *  - windowMs === 0 disables digest (legacy: every DNP notifies).
+ *  - State lives under ~/.shieldcortex so concurrent hook processes share it.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+export const DEFAULT_DNP_DIGEST_WINDOW_MS = 15 * 60 * 1000;
+export const MIN_DNP_DIGEST_WINDOW_MS = 60 * 1000;
+export const MAX_DNP_DIGEST_WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_ACTION_IDS = 5;
+const MAX_SIGNAL_KEYS = 25;
+const MAX_TOOL_KEYS = 15;
+
+export interface DnpDigestEvent {
+  actionId?: string;
+  sessionId?: string;
+  tool?: string;
+  signals?: string[];
+  severity?: string;
+  atMs?: number;
+}
+
+export interface DnpDigestState {
+  windowStartMs: number;
+  windowMs: number;
+  count: number;
+  bySignal: Record<string, number>;
+  byTool: Record<string, number>;
+  lastActionIds: string[];
+  lastSessionIds: string[];
+  /** True once an outbound notify was attempted for this window. */
+  notifiedForWindow: boolean;
+}
+
+export type DnpDigestDecision =
+  | {
+      action: 'notify';
+      state: DnpDigestState;
+      /** Human + structured summary for the outbound channel. */
+      summary: DnpDigestSummary;
+    }
+  | {
+      action: 'coalesce';
+      state: DnpDigestState;
+      summary: DnpDigestSummary;
+    }
+  | {
+      /** Digest disabled (windowMs === 0) — caller sends per-event as before. */
+      action: 'passthrough';
+      state: null;
+      summary: null;
+    };
+
+export interface DnpDigestSummary {
+  count: number;
+  windowMs: number;
+  windowStartMs: number;
+  bySignal: Record<string, number>;
+  byTool: Record<string, number>;
+  lastActionIds: string[];
+  lastSessionIds: string[];
+  coalescedAfterNotify: boolean;
+}
+
+export interface DnpDigestOptions {
+  home?: string;
+  windowMs?: number;
+  nowMs?: number;
+  /** Injected for tests. */
+  statePath?: string;
+}
+
+function clampWindowMs(raw: unknown): number {
+  if (raw === 0) return 0;
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return DEFAULT_DNP_DIGEST_WINDOW_MS;
+  if (raw < MIN_DNP_DIGEST_WINDOW_MS || raw > MAX_DNP_DIGEST_WINDOW_MS) {
+    return DEFAULT_DNP_DIGEST_WINDOW_MS;
+  }
+  return Math.floor(raw);
+}
+
+export function normaliseDnpDigestWindowMs(raw: unknown): number {
+  return clampWindowMs(raw);
+}
+
+function safeId(v: unknown, re: RegExp): string | undefined {
+  const t = String(v ?? '').trim();
+  return re.test(t) ? t : undefined;
+}
+
+function safeTool(v: unknown): string {
+  const t = String(v ?? '').trim();
+  if (!t || t.length > 64) return 'tool';
+  if (!/^[A-Za-z][A-Za-z0-9._-]{0,63}$/.test(t)) return 'tool';
+  return t;
+}
+
+function safeSignals(signals: unknown): string[] {
+  if (!Array.isArray(signals)) return [];
+  const out: string[] = [];
+  for (const s of signals) {
+    const t = String(s ?? '').trim();
+    if (!t || t.length > 64) continue;
+    if (!/^[a-z0-9][a-z0-9._-]{0,63}$/i.test(t)) continue;
+    if (!out.includes(t)) out.push(t);
+    if (out.length >= 10) break;
+  }
+  return out;
+}
+
+function emptyState(windowStartMs: number, windowMs: number): DnpDigestState {
+  return {
+    windowStartMs,
+    windowMs,
+    count: 0,
+    bySignal: {},
+    byTool: {},
+    lastActionIds: [],
+    lastSessionIds: [],
+    notifiedForWindow: false,
+  };
+}
+
+function bumpMap(map: Record<string, number>, key: string, maxKeys: number): void {
+  if (map[key] !== undefined) {
+    map[key] += 1;
+    return;
+  }
+  if (Object.keys(map).length >= maxKeys) {
+    map._other = (map._other ?? 0) + 1;
+    return;
+  }
+  map[key] = 1;
+}
+
+function pushRing(list: string[], value: string | undefined, max: number): void {
+  if (!value) return;
+  if (list[list.length - 1] === value) return;
+  list.push(value);
+  while (list.length > max) list.shift();
+}
+
+export function defaultDnpDigestStatePath(home: string = os.homedir()): string {
+  return path.join(home, '.shieldcortex', 'dnp-digest.json');
+}
+
+function readState(file: string): DnpDigestState | null {
+  try {
+    const raw = fs.readFileSync(file, 'utf8');
+    const j = JSON.parse(raw) as Partial<DnpDigestState>;
+    if (typeof j.windowStartMs !== 'number' || typeof j.windowMs !== 'number') return null;
+    if (typeof j.count !== 'number' || j.count < 0) return null;
+    return {
+      windowStartMs: j.windowStartMs,
+      windowMs: j.windowMs,
+      count: j.count,
+      bySignal: j.bySignal && typeof j.bySignal === 'object' ? j.bySignal as Record<string, number> : {},
+      byTool: j.byTool && typeof j.byTool === 'object' ? j.byTool as Record<string, number> : {},
+      lastActionIds: Array.isArray(j.lastActionIds) ? j.lastActionIds.map(String).slice(-MAX_ACTION_IDS) : [],
+      lastSessionIds: Array.isArray(j.lastSessionIds) ? j.lastSessionIds.map(String).slice(-MAX_ACTION_IDS) : [],
+      notifiedForWindow: j.notifiedForWindow === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeStateAtomic(file: string, state: DnpDigestState): void {
+  const dir = path.dirname(file);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(state)}\n`, { encoding: 'utf8', mode: 0o600 });
+  fs.renameSync(tmp, file);
+}
+
+function toSummary(state: DnpDigestState, coalescedAfterNotify: boolean): DnpDigestSummary {
+  return {
+    count: state.count,
+    windowMs: state.windowMs,
+    windowStartMs: state.windowStartMs,
+    bySignal: { ...state.bySignal },
+    byTool: { ...state.byTool },
+    lastActionIds: [...state.lastActionIds],
+    lastSessionIds: [...state.lastSessionIds],
+    coalescedAfterNotify,
+  };
+}
+
+/**
+ * Record one DNP and decide whether the caller should send an outbound notify.
+ * Synchronous + file-backed so one-shot hook processes share the window.
+ */
+export function recordDnpDigestEvent(
+  event: DnpDigestEvent,
+  opts: DnpDigestOptions = {},
+): DnpDigestDecision {
+  const windowMs = clampWindowMs(opts.windowMs ?? DEFAULT_DNP_DIGEST_WINDOW_MS);
+  if (windowMs === 0) {
+    return { action: 'passthrough', state: null, summary: null };
+  }
+
+  const nowMs = typeof opts.nowMs === 'number' && Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
+  const atMs = typeof event.atMs === 'number' && Number.isFinite(event.atMs) ? event.atMs : nowMs;
+  const file = opts.statePath ?? defaultDnpDigestStatePath(opts.home);
+  let state = readState(file);
+  if (!state || state.windowMs !== windowMs || atMs - state.windowStartMs >= windowMs) {
+    state = emptyState(atMs, windowMs);
+  }
+
+  state.count += 1;
+  const tool = safeTool(event.tool);
+  bumpMap(state.byTool, tool, MAX_TOOL_KEYS);
+  for (const sig of safeSignals(event.signals)) {
+    bumpMap(state.bySignal, sig, MAX_SIGNAL_KEYS);
+  }
+  pushRing(state.lastActionIds, safeId(event.actionId, /^(?:act|sc)-[a-f0-9]{16}$/), MAX_ACTION_IDS);
+  pushRing(state.lastSessionIds, safeId(event.sessionId, /^sc-[a-f0-9]{16}$/), MAX_ACTION_IDS);
+
+  if (!state.notifiedForWindow) {
+    state.notifiedForWindow = true;
+    writeStateAtomic(file, state);
+    return { action: 'notify', state, summary: toSummary(state, false) };
+  }
+
+  writeStateAtomic(file, state);
+  return { action: 'coalesce', state, summary: toSummary(state, true) };
+}
+
+/** Operator-facing one-liner / multi-line body. Never includes raw command. */
+export function formatDnpDigestText(summary: DnpDigestSummary): string {
+  const mins = Math.max(1, Math.round(summary.windowMs / 60_000));
+  const topSignals = Object.entries(summary.bySignal)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .map(([k, v]) => `${k}×${v}`)
+    .join(', ') || 'none';
+  const topTools = Object.entries(summary.byTool)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 4)
+    .map(([k, v]) => `${k}×${v}`)
+    .join(', ') || 'none';
+  const lastActs = summary.lastActionIds.slice(-3).join(', ') || 'none';
+  const lines = [
+    '🛡️ ShieldCortex — Action Guard BLOCKED (DNP digest)',
+    '',
+    `Count:     ${summary.count} denied_no_prompt_surface in this ${mins}m window`,
+    `Tools:     ${topTools}`,
+    `Signals:   ${topSignals}`,
+    `Last act:  ${lastActs}`,
+    '',
+    summary.coalescedAfterNotify
+      ? 'This event was coalesced into the open window (no extra page).'
+      : 'First DNP in this window. Further DNPs in the window are coalesced.',
+    'Full forensics: ~/.shieldcortex/denials.jsonl — the raw command is deliberately NOT included in this alert.',
+    'Chat buttons are not a TTY review (#310). This is visibility only (#331).',
+  ];
+  return lines.join('\n');
+}

--- a/src/defence/iron-dome/notify-config.ts
+++ b/src/defence/iron-dome/notify-config.ts
@@ -19,6 +19,11 @@
  * degrades to "no configured channel" rather than a spoofed one.
  */
 
+import {
+  DEFAULT_DNP_DIGEST_WINDOW_MS,
+  normaliseDnpDigestWindowMs,
+} from './dnp-digest.js';
+
 export interface NotifyConfig {
   /** Master switch. FALSE by default — the whole transport is opt-in. */
   enabled: boolean;
@@ -44,6 +49,14 @@ export interface NotifyConfig {
    *  truthy-but-not-true value must read as "not opted in".
    *  See openclaw-approval-channel.ts. */
   openclaw: boolean;
+  /**
+   * #331 — host-local DNP digest window (ms).
+   * - default 15m
+   * - `0` disables digest (every DNP notifies, legacy volume)
+   * - only finite values in [60s, 24h] accepted; junk → default
+   * Payload / permission_mode never appear here and never mute.
+   */
+  dnpDigestWindowMs: number;
 }
 
 const TIMEOUT_MIN_MS = 500;
@@ -59,6 +72,7 @@ export const DEFAULT_NOTIFY_CONFIG: NotifyConfig = {
   enabled: false,
   timeoutMs: 10_000,
   openclaw: false,
+  dnpDigestWindowMs: DEFAULT_DNP_DIGEST_WINDOW_MS,
 };
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
@@ -136,6 +150,9 @@ export function normaliseNotifyConfig(raw: unknown): NotifyConfig {
     // Strict true for the same reason as `enabled`: this arms a channel that
     // raises native gateway approval cards. Junk degrades to "not opted in".
     openclaw: raw.openclaw === true,
+    // #331 — volume window. Explicit 0 disables. Junk → default 15m.
+    // Never derived from permission_mode or any payload field.
+    dnpDigestWindowMs: normaliseDnpDigestWindowMs(raw.dnpDigestWindowMs),
   };
 
   const webhookUrl = normaliseWebhookUrl(raw.webhookUrl);

--- a/src/defence/iron-dome/operator-notify.ts
+++ b/src/defence/iron-dome/operator-notify.ts
@@ -579,6 +579,10 @@ export function formatConversationThreatNotification(n: ConversationThreatNotifi
 }
 
 export function formatActionGuardOutcomeNotification(n: ActionGuardOutcomeNotification): string {
+  const extra = n as ActionGuardOutcomeNotification & { digestText?: string; digestCount?: number };
+  if (typeof extra.digestText === 'string' && extra.digestText.trim()) {
+    return truncate(extra.digestText, 4_000);
+  }
   const denied = n.event === 'action_guard_denial';
   const lines = [
     denied
@@ -592,6 +596,9 @@ export function formatActionGuardOutcomeNotification(n: ActionGuardOutcomeNotifi
     `Outcome:   ${n.outcome}`,
     `Reason:    ${n.reason}`,
   ];
+  if (typeof extra.digestCount === 'number') {
+    lines.push(`Digest:    ${extra.digestCount} DNP in current host window`);
+  }
   if (n.origin) lines.push(`Origin:    ${n.origin}`);
   if (n.actionId) lines.push(`Action:    ${n.actionId}`);
   if (n.sessionId) lines.push(`Session:   ${n.sessionId}`);


### PR DESCRIPTION
Closes #331. Related: #310 ADR locked (no approval cards).

## What
Host-local time-window digest for `denied_no_prompt_surface`:
- first DNP in window → outbound notify (webhook denial channel)
- later DNPs in window → `notify.status=coalesced` (still in denials.jsonl)
- config: `actionGuard.notify.dnpDigestWindowMs` (default 15m, `0` disables)
- payload / `permission_mode` never select silence

## Not in this PR
- OpenClaw Telegram approval cards (#310 design lock)
- minting/spending `reviewedScripts` from chat taps

## Tests
Local after `build:ts`: **124** focused green (digest unit + notify-config + prompt-surface + #143 notify + operator-notify).