### PR TITLE
chore(release): 4.54.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.54.2] - 2026-08-16
+
+**Patch — loud DNP digest.**
+
+Operator visibility for headless `denied_no_prompt_surface` without spam. `threatGraph.trustModifier` stays **advisory**. SDK / PyPI stay **0.3.0**.
+
 ### Added
 
 - **#331 loud DNP digest** — host-local time-window rollup for `denied_no_prompt_surface` notifies. First DNP in the window pages; later ones coalesce. `actionGuard.notify.dnpDigestWindowMs` (default 15m, `0` = legacy every-event). Payload / `permission_mode` never mute. #310 stays design (no approval cards).
+
+### References
+
+- #331 #333
 
 ## [4.54.1] - 2026-08-16
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.1",
+  "version": "4.54.2",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.54.1",
+  "version": "4.54.2",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.54.1",
+  "version": "4.54.2",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.54.1
+  version: 4.54.2
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Release 4.54.2

Contents since 4.54.1:
- **#331 / #333** — loud host-local DNP digest (`actionGuard.notify.dnpDigestWindowMs`)

Not included:
- #310 design remains open (no approval cards)
- SDK/PyPI stay **0.3.0**
- `trustModifier` stays **advisory**

Coordinated surfaces after merge/tag: npm core+plugin, GH Release, ClawHub, cloud, websites.