### PR TITLE
feat(doctor): mobile/tmux attention-first report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Doctor mobile/tmux report** — default output is attention-first: failures and warnings with Why + `$` command lines; passes collapsed; duplicate warning themes (e.g. conversation scanning) merged with `xN`. `shieldcortex doctor --verbose` restores the full pass list. Check logic and exit codes unchanged.
+
 ## [4.54.2] - 2026-08-16
 
 **Patch — loud DNP digest.**

--- a/src/cli/__tests__/doctor-report-mobile.test.ts
+++ b/src/cli/__tests__/doctor-report-mobile.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Mobile/tmux doctor report renderer — pure unit tests.
+ */
+import { describe, expect, it } from '@jest/globals';
+import {
+  collapseKey,
+  extractFixCommands,
+  formatDoctorReport,
+  oneLineWhy,
+  themeForLabel,
+  wrapLine,
+  type DoctorReportItem,
+} from '../doctor-report.js';
+
+const EDITH: DoctorReportItem[] = [
+  { label: 'Database', status: 'pass', message: 'healthy (47.5 MB, WAL 2.0 MB)' },
+  { label: 'Schema', status: 'pass', message: 'up to date' },
+  { label: 'Hooks', status: 'pass', message: '4/4 installed and resolving' },
+  {
+    label: 'Project keys',
+    status: 'warn',
+    message: '1 legacy/canonical collision(s): workspace ↔ edith-vitaetpax-edith-workspace',
+    fix: 'Run shieldcortex doctor --fix-project-keys to auto-repair, or shieldcortex memories repair-project-keys --map workspace=edith-vitaetpax-edith-workspace --include-stm (dry-run by default; add --execute to apply)',
+  },
+  {
+    label: 'OpenClaw plugin loaded',
+    status: 'warn',
+    message:
+      'realtime plugin loaded (roster-confirmed, v4.54.2); enforcement not probed here — prove it live with: SHIELDCORTEX_ALLOW_GATEWAY_CANARY=1 shieldcortex openclaw status. NOTE: conversation-hook access is NOT granted, so the gateway refuses this plugin\'s llm_input/llm_output hooks — tool-call gating is live; conversation scanning is NOT live',
+    fix: 'Add "hooks": { "allowConversationAccess": true } to plugins.entries["shieldcortex-realtime"] in ~/.openclaw/openclaw.json, then restart the gateway. Conversation content is sensitive — this is your call, and leaving it ungranted is a valid choice.',
+  },
+  {
+    label: 'Conversation scanning',
+    status: 'warn',
+    message:
+      'conversation scanning INACTIVE — OpenClaw drops llm_input/llm_output at registration because plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess is not true; no conversation content is being scanned on this host',
+    fix: 'Add "hooks": { "allowConversationAccess": true } to plugins.entries["shieldcortex-realtime"] in ~/.openclaw/openclaw.json, then restart the gateway. Conversation content is sensitive — this is your call, and leaving it ungranted is a valid choice.',
+  },
+  {
+    label: 'Action guard config',
+    status: 'warn',
+    message:
+      'Action Guard runs in warn-mode (`actionGuard.enforce: false`) on both surfaces — dangerous ops log but are not gated (catastrophic still blocks)',
+    fix: 'Run `shieldcortex config --action-guard-enforce` to gate dangerous ops — the CLI writes a signed config; hand-editing config.json invalidates its integrity signature.',
+  },
+  {
+    label: 'Attestation coverage',
+    status: 'warn',
+    message:
+      '7666 hook-captured audit rows in the last 28 days and none carries attestation — these writers attest in the current build, so still-running pre-upgrade processes are writing them',
+    fix: 'restart long-running ShieldCortex processes (MCP server, OpenClaw gateway, dashboard) so they load the current build',
+  },
+  { label: 'Defence canary', status: 'pass', message: 'caught (14ms, pattern: defence_canary)' },
+  {
+    label: 'Dashboard',
+    status: 'info',
+    message: 'not running (optional on headless/OpenClaw-only setups)',
+  },
+];
+
+describe('themeForLabel / collapseKey', () => {
+  it('maps Edith labels to short themes', () => {
+    expect(themeForLabel('Project keys')).toBe('KEY');
+    expect(themeForLabel('Conversation scanning')).toBe('SCAN');
+    expect(themeForLabel('Action guard config')).toBe('GUARD');
+    expect(themeForLabel('Attestation coverage')).toBe('ATTEST');
+  });
+
+  it('collapses the two conversation-related warnings', () => {
+    const a = EDITH.find((r) => r.label === 'OpenClaw plugin loaded')!;
+    const b = EDITH.find((r) => r.label === 'Conversation scanning')!;
+    expect(collapseKey(a)).toBe(collapseKey(b));
+    expect(collapseKey(a)).toBe('warn:SCAN');
+  });
+});
+
+describe('extractFixCommands', () => {
+  it('pulls backticked shieldcortex commands', () => {
+    expect(extractFixCommands(EDITH.find((r) => r.label === 'Action guard config')!.fix)).toEqual([
+      'shieldcortex config --action-guard-enforce',
+    ]);
+  });
+
+  it('surfaces allowConversationAccess guidance', () => {
+    const cmds = extractFixCommands(EDITH.find((r) => r.label === 'Conversation scanning')!.fix);
+    expect(cmds.some((c) => c.includes('allowConversationAccess'))).toBe(true);
+  });
+});
+
+describe('wrapLine / oneLineWhy', () => {
+  it('never exceeds width', () => {
+    const long = 'word '.repeat(40).trim();
+    for (const line of wrapLine(long, 40, 4, 6)) {
+      expect(line.length).toBeLessThanOrEqual(40);
+    }
+  });
+
+  it('ellipsizes why to width', () => {
+    expect(oneLineWhy('a'.repeat(100), 40).length).toBeLessThanOrEqual(40);
+  });
+});
+
+describe('formatDoctorReport — Edith case', () => {
+  it('default: collapses SCAN x2, hides passes, ranks attention first', () => {
+    const lines = formatDoctorReport(EDITH, {
+      version: '4.54.2',
+      target: 'edith',
+      width: 48,
+      color: false,
+      verbose: false,
+    });
+    const text = lines.join('\n');
+
+    expect(text).toMatch(/ShieldCortex Doctor\s+v4\.54\.2/);
+    expect(text).toMatch(/target\s+edith/);
+    // raw tally keeps 5 warn even if themes collapse
+    expect(text).toMatch(/5 warn/);
+    expect(text).toMatch(/0 fail/);
+    expect(text).toMatch(/4 pass/);
+
+    expect(text).toMatch(/NEEDS ATTENTION/);
+    // collapsed conversation theme
+    expect(text).toMatch(/SCAN/);
+    expect(text).toMatch(/x2/);
+    expect(text).toMatch(/Conversation scanning|conversation scanning/i);
+    expect(text).toMatch(/GUARD/);
+    expect(text).toMatch(/ATTEST/);
+    expect(text).toMatch(/KEY/);
+
+    // commands on own lines
+    expect(text).toMatch(/\$ shieldcortex config --action-guard-enforce/);
+    expect(text).toMatch(/\$ shieldcortex doctor --fix-project-keys/);
+    expect(text).toMatch(/allowConversationAccess/);
+    expect(text).toMatch(/\$ /);
+
+    // passes collapsed
+    expect(text).toMatch(/4 pass hidden/);
+    expect(text).toMatch(/doctor --verbose/);
+    expect(text).not.toMatch(/\[ok\].*Database/);
+
+    // no old bottom wall header
+    expect(text).not.toMatch(/Suggested fixes:/);
+
+    // every line fits 48
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(48);
+    }
+  });
+
+  it('verbose: lists passes and does not hide them', () => {
+    const lines = formatDoctorReport(EDITH, {
+      version: '4.54.2',
+      width: 80,
+      color: false,
+      verbose: true,
+    });
+    const text = lines.join('\n');
+    expect(text).toMatch(/HEALTHY/);
+    expect(text).toMatch(/\[ok\].*Database|DB\s+Database/);
+    expect(text).not.toMatch(/pass hidden/);
+  });
+
+  it('all-pass host prints All clear', () => {
+    const lines = formatDoctorReport(
+      [
+        { label: 'Database', status: 'pass', message: 'healthy' },
+        { label: 'Hooks', status: 'pass', message: 'ok' },
+      ],
+      { width: 40, color: false },
+    );
+    expect(lines.join('\n')).toMatch(/All clear/);
+  });
+
+  it('failures section precedes warnings', () => {
+    const lines = formatDoctorReport(
+      [
+        { label: 'Hooks', status: 'warn', message: 'missing', fix: '`shieldcortex install`' },
+        { label: 'Database', status: 'fail', message: 'corrupt', fix: '`shieldcortex repair`' },
+      ],
+      { width: 60, color: false },
+    );
+    const text = lines.join('\n');
+    expect(text.indexOf('FAILURES')).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf('FAILURES')).toBeLessThan(text.indexOf('NEEDS ATTENTION'));
+    expect(text).toMatch(/\$ shieldcortex repair/);
+  });
+});

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -1,0 +1,514 @@
+/**
+ * Mobile/tmux-friendly doctor report renderer.
+ *
+ * Pure display layer only — does not change check logic, exit codes, or
+ * severity. Default output collapses passes and duplicate warning themes so a
+ * 40-col phone SSH pane shows what matters first.
+ */
+
+export type DoctorStatus = 'pass' | 'warn' | 'fail' | 'info';
+
+/** Minimal input shape — matches CheckResult fields the renderer needs. */
+export interface DoctorReportItem {
+  label: string;
+  status: DoctorStatus;
+  message: string;
+  fix?: string;
+}
+
+export interface FormatDoctorReportOpts {
+  /** Show every pass line and do not collapse themes. */
+  verbose?: boolean;
+  /** Hard line budget. Default 80. Use 40 for phone landscape. */
+  width?: number;
+  /** Package version string, e.g. 4.54.2 */
+  version?: string;
+  /** Optional host/target label (hostname). */
+  target?: string;
+  /** Colourise when true (TTY). Tests leave false. */
+  color?: boolean;
+  /**
+   * ANSI helpers. Injected so tests can assert plain text without importing
+   * doctor.ts colour constants.
+   */
+  style?: DoctorReportStyle;
+}
+
+export interface DoctorReportStyle {
+  bold: string;
+  reset: string;
+  green: string;
+  yellow: string;
+  red: string;
+  cyan: string;
+  dim: string;
+}
+
+const NO_STYLE: DoctorReportStyle = {
+  bold: '',
+  reset: '',
+  green: '',
+  yellow: '',
+  red: '',
+  cyan: '',
+  dim: '',
+};
+
+const STATUS_MARK: Record<DoctorStatus, string> = {
+  fail: '[x]',
+  warn: '[!]',
+  info: '[i]',
+  pass: '[ok]',
+};
+
+const STATUS_ORDER: Record<DoctorStatus, number> = {
+  fail: 0,
+  warn: 1,
+  info: 2,
+  pass: 3,
+};
+
+/** Theme codes kept short for 40-col panes. */
+export function themeForLabel(label: string): string {
+  const l = label.toLowerCase();
+  if (l.includes('project key')) return 'KEY';
+  if (l.includes('conversation')) return 'SCAN';
+  if (l.includes('plugin loaded') && l.includes('openclaw')) return 'LOAD';
+  if (l.includes('action guard') && l.includes('config')) return 'GUARD';
+  if (l.includes('action guard') && l.includes('notify')) return 'NOTIFY';
+  if (l.includes('action guard')) return 'GUARD';
+  if (l.includes('attestation')) return 'ATTEST';
+  if (l.includes('threat graph')) return 'GRAPH';
+  if (l.includes('database') || l === 'schema' || l.includes('write path')) return 'DB';
+  if (l.includes('hook')) return 'HOOK';
+  if (l.includes('openclaw config')) return 'OC-CFG';
+  if (l.includes('openclaw residue')) return 'OC-RES';
+  if (l.includes('plugin version') || l.includes('running version')) return 'PLUGIN';
+  if (l.includes('skill')) return 'SKILL';
+  if (l.includes('disk')) return 'DISK';
+  if (l.includes('lock')) return 'LOCK';
+  if (l.includes('dashboard')) return 'UI';
+  if (l.includes('api server')) return 'API';
+  if (l.includes('brain')) return 'BRAIN';
+  if (l.includes('defence') || l.includes('defense') || l.includes('canary')) return 'DEF';
+  if (l.includes('claude')) return 'CLAUDE';
+  if (l.includes('embedding') || l.includes('model')) return 'MODEL';
+  if (l.includes('permission') || l.includes('state permission')) return 'PERM';
+  if (l.includes('approval')) return 'APPROVE';
+  if (l.includes('memory')) return 'MEM';
+  // fallback: first word upper, max 6
+  const word = label.replace(/[^A-Za-z0-9]+/g, ' ').trim().split(/\s+/)[0] || 'CHK';
+  return word.slice(0, 6).toUpperCase();
+}
+
+/**
+ * Collapse key for duplicate themes. Conversation scanning often emits two
+ * checks that are one operator decision — collapse them.
+ */
+export function collapseKey(item: DoctorReportItem): string {
+  const theme = themeForLabel(item.label);
+  // Same posture decision, two check sites.
+  if (theme === 'SCAN' || /conversation scanning/i.test(item.label) || /conversation scanning/i.test(item.message)) {
+    return `${item.status}:SCAN`;
+  }
+  if (theme === 'LOAD' && /conversation/i.test(item.message)) {
+    return `${item.status}:SCAN`;
+  }
+  // Same fix text = same root cause.
+  if (item.fix) return `${item.status}:fix:${normaliseFixKey(item.fix)}`;
+  return `${item.status}:${theme}:${item.label}`;
+}
+
+function normaliseFixKey(fix: string): string {
+  return fix
+    .toLowerCase()
+    .replace(/[`'"]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 160);
+}
+
+/** Pull copy-pasteable commands out of a free-form fix string. */
+export function extractFixCommands(fix: string | undefined): string[] {
+  if (!fix) return [];
+  const cmds: string[] = [];
+  const re = /`([^`]+)`/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(fix)) !== null) {
+    const c = m[1].trim();
+    if (!c) continue;
+    // Prefer real shell-ish snippets
+    if (
+      /^(shieldcortex|openclaw|claude|npm|node|systemctl|launchctl|sudo|chown|chmod|rm|mkdir)\b/i.test(c) ||
+      c.startsWith('SHIELDCORTEX_') ||
+      c.includes('allowConversationAccess') ||
+      c.includes('~/.shieldcortex')
+    ) {
+      cmds.push(c);
+    }
+  }
+  if (cmds.length > 0) return unique(cmds);
+
+  // Bare shieldcortex/openclaw multi-word commands without backticks.
+  // Stop before English glue words so we don't swallow the rest of the sentence.
+  const bareRe = /\b((?:shieldcortex|openclaw)(?:\s+(?:--?[\w-]+(?:=[\w./:@+=,-]+)?|[\w./:@+=,-]+))+)/g;
+  const stop = new Set([
+    'to', 'and', 'or', 'then', 'so', 'for', 'while', 'the', 'a', 'an', 'on', 'in',
+    'with', 'from', 'after', 'before', 'because', 'if', 'when', 'this', 'that',
+    'auto-repair', 'migrate', 'please',
+  ]);
+  let bm: RegExpExecArray | null;
+  while ((bm = bareRe.exec(fix)) !== null) {
+    const parts = bm[1].trim().split(/\s+/);
+    const kept: string[] = [parts[0]];
+    for (let i = 1; i < parts.length; i++) {
+      const p = parts[i].replace(/[.,;:]+$/, '');
+      if (stop.has(p.toLowerCase())) break;
+      if (/^\(/.test(p)) break;
+      kept.push(p);
+    }
+    const c = kept.join(' ').replace(/[.,;:]+$/, '').trim();
+    if (c.split(/\s+/).length >= 2 && !cmds.includes(c)) cmds.push(c);
+  }
+  if (cmds.length > 0) return unique(cmds);
+
+  // Config JSON snippet guidance
+  if (/allowConversationAccess/i.test(fix)) {
+    return [
+      'set allowConversationAccess=true on shieldcortex-realtime hooks',
+      'restart OpenClaw gateway',
+    ];
+  }
+
+  // Restart guidance without a single binary
+  if (/restart long-running/i.test(fix)) {
+    return ['restart MCP server / OpenClaw gateway / dashboard'];
+  }
+
+  // JSON/config path instructions — keep short first sentence as guidance
+  const firstPart = fix.split(/[.\u2014]/)[0];
+  const first = typeof firstPart === 'string' ? firstPart.trim() : '';
+  if (first && first.length <= 100) return [first];
+  return [ellipsize(fix.replace(/\s+/g, ' ').trim(), 96)];
+}
+
+function unique(xs: string[]): string[] {
+  const out: string[] = [];
+  for (const x of xs) if (!out.includes(x)) out.push(x);
+  return out;
+}
+
+export function oneLineWhy(message: string, width: number): string {
+  const cleaned = message
+    .replace(/\s+/g, ' ')
+    .replace(/`/g, '')
+    .trim();
+  // Prefer text before em-dash / "—" explanation tail if very long
+  return ellipsize(cleaned, Math.max(12, width - 4));
+}
+
+export function ellipsize(s: string, max: number): string {
+  if (s.length <= max) return s;
+  if (max <= 1) return '…';
+  return `${s.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+/** Soft-wrap at spaces; hanging indent on continuation. Never split mid-token if possible. */
+export function wrapLine(text: string, width: number, indent = 0, hang = 0): string[] {
+  const budget = Math.max(8, width - indent);
+  const words = text.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [' '.repeat(indent)];
+  const lines: string[] = [];
+  let cur = '';
+  const push = () => {
+    if (cur) lines.push(`${' '.repeat(lines.length === 0 ? indent : hang)}${cur}`);
+    cur = '';
+  };
+  for (const w of words) {
+    if (!cur) {
+      if (w.length > budget) {
+        // hard-split long tokens (URLs/paths) rather than overflow
+        let rest = w;
+        while (rest.length > budget) {
+          lines.push(`${' '.repeat(lines.length === 0 ? indent : hang)}${rest.slice(0, budget)}`);
+          rest = rest.slice(budget);
+        }
+        cur = rest;
+      } else {
+        cur = w;
+      }
+      continue;
+    }
+    if (`${cur} ${w}`.length <= budget) {
+      cur = `${cur} ${w}`;
+    } else {
+      push();
+      if (w.length > budget) {
+        let rest = w;
+        while (rest.length > budget) {
+          lines.push(`${' '.repeat(hang)}${rest.slice(0, budget)}`);
+          rest = rest.slice(budget);
+        }
+        cur = rest;
+      } else {
+        cur = w;
+      }
+    }
+  }
+  push();
+  return lines.length ? lines : [' '.repeat(indent)];
+}
+
+interface ThemeGroup {
+  status: DoctorStatus;
+  theme: string;
+  what: string;
+  why: string;
+  fixCommands: string[];
+  count: number;
+  labels: string[];
+}
+
+function groupItems(items: DoctorReportItem[], collapse: boolean): ThemeGroup[] {
+  if (!collapse) {
+    return items.map((it) => ({
+      status: it.status,
+      theme: themeForLabel(it.label),
+      what: shortWhat(it),
+      why: it.message.replace(/\s+/g, ' ').trim(),
+      fixCommands: extractFixCommands(it.fix),
+      count: 1,
+      labels: [it.label],
+    }));
+  }
+
+  const map = new Map<string, ThemeGroup>();
+  const order: string[] = [];
+  for (const it of items) {
+    const key = collapseKey(it);
+    const existing = map.get(key);
+    if (!existing) {
+      const g: ThemeGroup = {
+        status: it.status,
+        theme: themeForLabel(it.label),
+        what: shortWhat(it),
+        why: it.message.replace(/\s+/g, ' ').trim(),
+        fixCommands: extractFixCommands(it.fix),
+        count: 1,
+        labels: [it.label],
+      };
+      // Prefer SCAN theme when collapsing conversation-related load warnings
+      if (key.endsWith(':SCAN')) g.theme = 'SCAN';
+      map.set(key, g);
+      order.push(key);
+    } else {
+      existing.count += 1;
+      if (!existing.labels.includes(it.label)) existing.labels.push(it.label);
+      // Prefer a non-empty fix
+      const cmds = extractFixCommands(it.fix);
+      for (const c of cmds) if (!existing.fixCommands.includes(c)) existing.fixCommands.push(c);
+      // Prefer the dedicated conversation-scanning label over plugin-loaded note
+      if (/conversation scanning/i.test(it.label) && !/conversation scanning/i.test(existing.what)) {
+        existing.what = shortWhat(it);
+        existing.why = it.message.replace(/\s+/g, ' ').trim();
+      } else if (it.message.length > existing.why.length && !/conversation scanning/i.test(existing.labels.join(' '))) {
+        existing.why = it.message.replace(/\s+/g, ' ').trim();
+        existing.what = shortWhat(it);
+      }
+    }
+  }
+  return order.map((k) => map.get(k)!);
+}
+
+function shortWhat(it: DoctorReportItem): string {
+  // Label is the "what"; strip redundant prefixes
+  return it.label.replace(/^Action guard\s+/i, 'Action Guard ').trim();
+}
+
+function statusColor(status: DoctorStatus, s: DoctorReportStyle): string {
+  switch (status) {
+    case 'fail': return s.red;
+    case 'warn': return s.yellow;
+    case 'info': return s.cyan;
+    case 'pass': return s.green;
+  }
+}
+
+function renderIssueBlock(g: ThemeGroup, width: number, style: DoctorReportStyle): string[] {
+  const mark = STATUS_MARK[g.status];
+  const col = statusColor(g.status, style);
+  const xN = g.count > 1 ? `  x${g.count}` : '';
+  const head = `${col}${mark}${style.reset} ${g.theme.padEnd(6)} ${g.what}${xN}`;
+  const lines: string[] = [];
+  // Head may need wrap — keep mark+theme on first line when possible
+  lines.push(...wrapLine(stripAnsiForWrap(head, style), width, 0, 4).map((ln, i) => {
+    if (i === 0) {
+      // re-colour first line only
+      return `${col}${mark}${style.reset} ${g.theme.padEnd(6)} ${ellipsize(`${g.what}${xN}`, Math.max(8, width - 12))}`;
+    }
+    return ln;
+  }));
+  // Why
+  const why = oneLineWhy(g.why, width);
+  lines.push(...wrapLine(why, width, 4, 4).map((l) => `${style.dim}${l}${style.reset}`));
+  // Fix commands
+  if (g.fixCommands.length === 0) {
+    lines.push(`${style.dim}    $ (see message — no single command)${style.reset}`);
+  } else {
+    for (const cmd of g.fixCommands.slice(0, 3)) {
+      const prefixed = `$ ${cmd}`;
+      for (const wl of wrapLine(prefixed, width, 4, 6)) {
+        lines.push(`${style.bold}${wl}${style.reset}`);
+      }
+    }
+  }
+  return lines;
+}
+
+/** Strip style codes we just added if wrap helper sees them — head path avoids this. */
+function stripAnsiForWrap(s: string, style: DoctorReportStyle): string {
+  if (!style.reset) return s;
+  return s
+    .split(style.bold).join('')
+    .split(style.reset).join('')
+    .split(style.green).join('')
+    .split(style.yellow).join('')
+    .split(style.red).join('')
+    .split(style.cyan).join('')
+    .split(style.dim).join('');
+}
+
+function renderPassLine(it: DoctorReportItem, width: number, style: DoctorReportStyle): string[] {
+  const head = `${style.green}${STATUS_MARK.pass}${style.reset} ${themeForLabel(it.label).padEnd(6)} ${it.label}`;
+  const msg = oneLineWhy(it.message, Math.max(12, width - 4));
+  return [
+    `${style.green}${STATUS_MARK.pass}${style.reset} ${themeForLabel(it.label).padEnd(6)} ${ellipsize(it.label, Math.max(8, width - 12))}`,
+    ...wrapLine(msg, width, 4, 4).map((l) => `${style.dim}${l}${style.reset}`),
+  ];
+}
+
+/**
+ * Format a full doctor report as lines (no trailing newline on last join —
+ * caller prints with console.log per line or join('\\n')).
+ */
+export function formatDoctorReport(
+  results: DoctorReportItem[],
+  opts: FormatDoctorReportOpts = {},
+): string[] {
+  const width = clampWidth(opts.width ?? detectWidth());
+  const verbose = opts.verbose === true;
+  const style = opts.color ? (opts.style ?? defaultColorStyle()) : (opts.style ?? NO_STYLE);
+  const version = opts.version?.trim() || '';
+  const target = opts.target?.trim() || '';
+
+  const fails = results.filter((r) => r.status === 'fail');
+  const warns = results.filter((r) => r.status === 'warn');
+  const infos = results.filter((r) => r.status === 'info');
+  const passes = results.filter((r) => r.status === 'pass');
+
+  const failGroups = groupItems(fails, !verbose);
+  const warnGroups = groupItems(warns, !verbose);
+  const infoGroups = groupItems(infos, !verbose);
+
+  // Sort groups: keep original relative order (stable from groupItems)
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`${style.bold}ShieldCortex Doctor${style.reset}${version ? `  v${version}` : ''}`);
+  if (target) lines.push(`target  ${target}`);
+  lines.push('');
+
+  // Tally — use raw counts (operator expects Edith-style 5 warnings, not collapsed)
+  const tally = [
+    `${style.red}${fails.length} fail${style.reset}`,
+    `${style.yellow}${warns.length} warn${style.reset}`,
+    `${style.green}${passes.length} pass${style.reset}`,
+    infos.length ? `${style.cyan}${infos.length} info${style.reset}` : '',
+  ].filter(Boolean);
+  lines.push(tally.join('  '));
+  lines.push('');
+
+  const emitGroups = (groups: ThemeGroup[], title: string) => {
+    if (groups.length === 0) return;
+    lines.push(`${style.bold}${title}${style.reset}`);
+    for (let i = 0; i < groups.length; i++) {
+      lines.push(...renderIssueBlock(groups[i], width, style));
+      if (i !== groups.length - 1) lines.push('');
+    }
+    lines.push('');
+  };
+
+  emitGroups(failGroups, 'FAILURES');
+  emitGroups(warnGroups, 'NEEDS ATTENTION');
+  if (verbose) {
+    emitGroups(infoGroups, 'INFO');
+  } else if (infoGroups.length > 0) {
+    // Compact info: one line each, no big section unless verbose
+    lines.push(`${style.bold}INFO${style.reset}`);
+    for (const g of infoGroups) {
+      const bit = `${STATUS_MARK.info} ${g.theme} ${g.what}${g.count > 1 ? ` x${g.count}` : ''}`;
+      lines.push(...wrapLine(bit, width, 0, 4).map((l, idx) => (idx === 0 ? `${style.cyan}${STATUS_MARK.info}${style.reset} ${g.theme.padEnd(6)} ${ellipsize(`${g.what}${g.count > 1 ? ` x${g.count}` : ''}`, Math.max(8, width - 12))}` : `${style.dim}${l}${style.reset}`)));
+      lines.push(...wrapLine(oneLineWhy(g.why, width), width, 4, 4).map((l) => `${style.dim}${l}${style.reset}`));
+      lines.push('');
+    }
+  }
+
+  if (verbose) {
+    if (passes.length > 0) {
+      lines.push(`${style.bold}HEALTHY${style.reset}`);
+      for (const p of passes) {
+        lines.push(...renderPassLine(p, width, style));
+      }
+      lines.push('');
+    }
+  } else if (passes.length > 0) {
+    const labels = passes.map((p) => themeForLabel(p.label));
+    const uniq = unique(labels).slice(0, 10);
+    const more = unique(labels).length > 10 ? '…' : '';
+    const summary = `${passes.length} pass hidden — ${uniq.join(' · ')}${more}`;
+    lines.push(...wrapLine(summary, width, 0, 2).map((l) => `${style.dim}${l}${style.reset}`));
+    lines.push(`${style.dim}rerun: shieldcortex doctor --verbose${style.reset}`);
+    lines.push('');
+  }
+
+  // All clear
+  if (fails.length === 0 && warns.length === 0) {
+    lines.push(`${style.green}All clear.${style.reset}`);
+    lines.push('');
+  }
+
+  // Drop trailing blank
+  while (lines.length && lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+function clampWidth(w: number): number {
+  if (!Number.isFinite(w) || w < 40) return 40;
+  if (w > 120) return 120;
+  return Math.floor(w);
+}
+
+function detectWidth(): number {
+  const cols = Number(process.env.COLUMNS || process.stdout?.columns || 80);
+  return clampWidth(cols || 80);
+}
+
+function defaultColorStyle(): DoctorReportStyle {
+  return {
+    bold: '\x1b[1m',
+    reset: '\x1b[0m',
+    green: '\x1b[32m',
+    yellow: '\x1b[33m',
+    red: '\x1b[31m',
+    cyan: '\x1b[36m',
+    dim: '\x1b[2m',
+  };
+}
+
+/** True when stdout looks like a TTY and NO_COLOR is unset. */
+export function shouldColorDoctor(env: NodeJS.ProcessEnv = process.env, stdoutIsTTY = !!process.stdout?.isTTY): boolean {
+  if (env.NO_COLOR != null && env.NO_COLOR !== '') return false;
+  if (env.FORCE_COLOR === '0') return false;
+  if (env.FORCE_COLOR) return true;
+  return stdoutIsTTY;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -61,6 +61,11 @@ import { validateOpenClawConfig } from '../integrations/openclaw-config-validate
 import type { OpenClawConfigVerdict, ValidateDeps } from '../integrations/openclaw-config-validate.js';
 import type { ModelInvoker } from '../defence/iron-dome/approval-judge.js';
 import type { DoctorExplainerOutcome } from '../defence/iron-dome/doctor-explainer.js';
+import {
+  formatDoctorReport,
+  shouldColorDoctor,
+  type DoctorReportStyle,
+} from './doctor-report.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../../package.json');
@@ -4132,7 +4137,9 @@ export async function runDoctor(
   // runDoctorAiSection() resolves the real pool-inherited CLI transport.
   deps: { aiInvoke?: ModelInvoker | null } = {},
 ): Promise<DoctorSummary> {
-  console.log(`\n${bold}ShieldCortex Doctor${reset} v${pkg.version}\n`);
+  // Title is emitted by formatDoctorReport (mobile layout). Keep a single
+  // leading blank so piped/cron capture still starts cleanly.
+  console.log('');
 
   const results: CheckResult[] = [];
 
@@ -4252,38 +4259,32 @@ export async function runDoctor(
   // the same single fact already reported by the Database line (#129).
   const { visible, suppressed } = partitionUninitialisedSkips(gated);
 
-  // Print results
-  for (const r of visible) {
-    console.log(`  ${icon(r.status)} ${bold}${r.label}:${reset} ${r.message}`);
-  }
-  if (suppressed.length > 0) {
-    console.log(`  ${dim}(${suppressed.map(r => r.label).join(', ')} checked once the database exists)${reset}`);
-  }
-
-  // Summary
+  // Summary counts stay on the RAW visible set (exit codes / CI gates).
   const passed = visible.filter(r => r.status === 'pass').length;
   const warnings = visible.filter(r => r.status === 'warn').length;
   const failures = visible.filter(r => r.status === 'fail').length;
   const infos = visible.filter(r => r.status === 'info').length;
   const total = visible.length;
 
-  console.log('');
-  const parts: string[] = [];
-  parts.push(`${passed}/${total} checks passed`);
-  if (warnings > 0) parts.push(`${yellow}${warnings} warning${warnings !== 1 ? 's' : ''}${reset}`);
-  if (failures > 0) parts.push(`${red}${failures} failure${failures !== 1 ? 's' : ''}${reset}`);
-  if (infos > 0) parts.push(`${infos} info`);
-  console.log(`  ${parts.join(', ')}`);
+  // Mobile/tmux report (render-only). Default collapses passes + duplicate
+  // warning themes; --verbose restores the full pass list. Exit codes and
+  // check logic are unchanged.
+  const verbose = args.includes('--verbose') || args.includes('--debug');
+  const style: DoctorReportStyle = { bold, reset, green, yellow, red, cyan, dim };
+  const reportLines = formatDoctorReport(visible, {
+    verbose,
+    version: String(pkg.version ?? ''),
+    target: (() => {
+      try { return os.hostname(); } catch { return ''; }
+    })(),
+    color: shouldColorDoctor(),
+    style,
+    width: Number(process.env.COLUMNS || process.stdout?.columns || 80) || 80,
+  });
+  for (const line of reportLines) console.log(line);
 
-  // Suggested fixes. Deduplicated: one root cause can fail several checks at
-  // once (a root-owned ~/.shieldcortex fails Database, Disk and Lock), and
-  // printing the same remedy three times reads as three separate problems.
-  const fixes = [...new Set(visible.filter(r => r.fix).map(r => r.fix as string))];
-  if (fixes.length > 0) {
-    console.log(`\n  ${bold}Suggested fixes:${reset}`);
-    for (const f of fixes) {
-      console.log(`  ${dim}\u2192${reset} ${f}`);
-    }
+  if (suppressed.length > 0) {
+    console.log(`${dim}(${suppressed.map(r => r.label).join(', ')} checked once the database exists)${reset}`);
   }
 
   // (The Pro upsell footer that used to render here was removed with the
@@ -4313,7 +4314,7 @@ export async function runDoctor(
     const reason = failures > 0
       ? `${failures} failed check${failures !== 1 ? 's' : ''}`
       : `${warnings} warning${warnings !== 1 ? 's' : ''} (--strict)`;
-    console.log(`  ${dim}exit ${exitCode} \u2014 ${reason}${reset}`);
+    console.log(`${dim}exit ${exitCode} \u2014 ${reason}${reset}`);
   }
 
   console.log('');


### PR DESCRIPTION
## Why
`shieldcortex doctor` dumped 30+ long one-liners. On mobile SSH/tmux (Edith), five real warnings were unreadable and the fix wall did not explain *why* or put commands on their own lines.

## What
Render-only redesign (Grok design lock):
- **Default:** failures → warnings → compact info → collapsed passes
- Each issue: `[!] THEME  what` / why / `$ command`
- Duplicate themes collapse with `xN` (conversation scanning ×2)
- `doctor --verbose` restores full pass list
- **No** check-logic or exit-code changes

### Edith-shaped sample (48 cols)
```
$(cat /tmp/doctor-ux/edith-sample.txt)
```

## Tests
Local after `build:ts`: **79** focused green (mobile report + permission-denied + fresh-install + action-guard + project-keys).