### PR TITLE
chore(release): 4.54.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.54.3] - 2026-08-16
+
+**Patch — doctor mobile/tmux report.**
+
+Readable attention-first doctor output for phone SSH and tmux. `threatGraph.trustModifier` stays **advisory**. SDK / PyPI stay **0.3.0**.
+
 ### Changed
 
-- **Doctor mobile/tmux report** — default output is attention-first: failures and warnings with Why + `$` command lines; passes collapsed; duplicate warning themes (e.g. conversation scanning) merged with `xN`. `shieldcortex doctor --verbose` restores the full pass list. Check logic and exit codes unchanged.
+- **Doctor mobile/tmux report (#335)** — default output is attention-first: failures and warnings with Why + `$` command lines; passes collapsed; duplicate warning themes (e.g. conversation scanning) merged with `xN`. `shieldcortex doctor --verbose` restores the full pass list. Check logic and exit codes unchanged.
+
+### References
+
+- #335
 
 ## [4.54.2] - 2026-08-16
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.2",
+  "version": "4.54.3",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.54.2",
+  "version": "4.54.3",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.54.2",
+  "version": "4.54.3",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.54.2
+  version: 4.54.3
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Release 4.54.3

Contents since 4.54.2:
- **#335** — doctor mobile/tmux attention-first report

Not included:
- #310 design (no cards)
- SDK/PyPI stay **0.3.0**
- `trustModifier` stays **advisory**

Coordinated surfaces after merge/tag: npm core+plugin, GH Release, ClawHub, cloud, websites.