### PR TITLE
fix(doctor): $ restart must be openclaw gateway restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Doctor `$` lines are real commands** — gateway restart prints `openclaw gateway restart`, never English `restart OpenClaw gateway`.
+
 ## [4.54.3] - 2026-08-16
 
 **Patch — doctor mobile/tmux report.**

--- a/src/cli/__tests__/doctor-report-mobile.test.ts
+++ b/src/cli/__tests__/doctor-report-mobile.test.ts
@@ -81,9 +81,17 @@ describe('extractFixCommands', () => {
     ]);
   });
 
-  it('surfaces allowConversationAccess guidance', () => {
+  it('surfaces allowConversationAccess as a note plus openclaw gateway restart', () => {
     const cmds = extractFixCommands(EDITH.find((r) => r.label === 'Conversation scanning')!.fix);
-    expect(cmds.some((c) => c.includes('allowConversationAccess'))).toBe(true);
+    expect(cmds).toEqual(['openclaw gateway restart']);
+    expect(cmds.join(' ')).not.toMatch(/^restart /);
+  });
+
+  it('never treats English restart prose as a command', () => {
+    expect(extractFixCommands('restart OpenClaw gateway')).toEqual(['openclaw gateway restart']);
+    expect(extractFixCommands('restart long-running ShieldCortex processes')).toEqual([
+      'openclaw gateway restart',
+    ]);
   });
 });
 
@@ -130,7 +138,10 @@ describe('formatDoctorReport — Edith case', () => {
     // commands on own lines
     expect(text).toMatch(/\$ shieldcortex config --action-guard-enforce/);
     expect(text).toMatch(/\$ shieldcortex doctor --fix-project-keys/);
+    expect(text).toMatch(/\$ openclaw gateway restart/);
     expect(text).toMatch(/allowConversationAccess/);
+    expect(text).not.toMatch(/\$ restart OpenClaw/);
+    expect(text).not.toMatch(/\$ restart MCP/);
     expect(text).toMatch(/\$ /);
 
     // passes collapsed

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -139,10 +139,8 @@ export function extractFixCommands(fix: string | undefined): string[] {
     if (!c) continue;
     // Prefer real shell-ish snippets
     if (
-      /^(shieldcortex|openclaw|claude|npm|node|systemctl|launchctl|sudo|chown|chmod|rm|mkdir)\b/i.test(c) ||
-      c.startsWith('SHIELDCORTEX_') ||
-      c.includes('allowConversationAccess') ||
-      c.includes('~/.shieldcortex')
+      /^(?:[\w.-]+\s+)?(?:shieldcortex|openclaw|claude|npm|node|systemctl|launchctl|chown|chmod)\b/i.test(c) ||
+      c.startsWith('SHIELDCORTEX_')
     ) {
       cmds.push(c);
     }
@@ -172,24 +170,13 @@ export function extractFixCommands(fix: string | undefined): string[] {
   }
   if (cmds.length > 0) return unique(cmds);
 
-  // Config JSON snippet guidance
-  if (/allowConversationAccess/i.test(fix)) {
-    return [
-      'set allowConversationAccess=true on shieldcortex-realtime hooks',
-      'restart OpenClaw gateway',
-    ];
+  // Config / restart guidance. Only emit a real binary — never English
+  // that a phone user will copy after `$`.
+  if (/allowConversationAccess/i.test(fix) || /restart.{0,40}gateway/i.test(fix) || /restart long-running/i.test(fix)) {
+    return ['openclaw gateway restart'];
   }
 
-  // Restart guidance without a single binary
-  if (/restart long-running/i.test(fix)) {
-    return ['restart MCP server / OpenClaw gateway / dashboard'];
-  }
-
-  // JSON/config path instructions — keep short first sentence as guidance
-  const firstPart = fix.split(/[.\u2014]/)[0];
-  const first = typeof firstPart === 'string' ? firstPart.trim() : '';
-  if (first && first.length <= 100) return [first];
-  return [ellipsize(fix.replace(/\s+/g, ' ').trim(), 96)];
+  return [];
 }
 
 function unique(xs: string[]): string[] {
@@ -352,14 +339,23 @@ function renderIssueBlock(g: ThemeGroup, width: number, style: DoctorReportStyle
   const why = oneLineWhy(g.why, width);
   lines.push(...wrapLine(why, width, 4, 4).map((l) => `${style.dim}${l}${style.reset}`));
   // Fix commands
+  // Fix lines: `$` only on a real binary. English notes stay notes.
   if (g.fixCommands.length === 0) {
-    lines.push(`${style.dim}    $ (see message — no single command)${style.reset}`);
+    lines.push(`${style.dim}    (no single copy-paste command)${style.reset}`);
   } else {
     for (const cmd of g.fixCommands.slice(0, 3)) {
-      const prefixed = `$ ${cmd}`;
+      const runnable = /^(?:[\w.-]+\s+)?(?:shieldcortex|openclaw|claude|npm|node|systemctl|launchctl|chown|chmod)\b/i.test(cmd)
+        || cmd.startsWith('SHIELDCORTEX_');
+      const prefixed = runnable ? `$ ${cmd}` : cmd;
       for (const wl of wrapLine(prefixed, width, 4, 6)) {
-        lines.push(`${style.bold}${wl}${style.reset}`);
+        lines.push(runnable ? `${style.bold}${wl}${style.reset}` : `${style.dim}${wl}${style.reset}`);
       }
+    }
+  }
+  if (g.theme === 'SCAN') {
+    const note = 'also set allowConversationAccess=true in ~/.openclaw/openclaw.json';
+    if (!g.fixCommands.some((c) => /allowConversationAccess/i.test(c))) {
+      lines.push(...wrapLine(note, width, 4, 4).map((l) => `${style.dim}${l}${style.reset}`));
     }
   }
   return lines;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -567,7 +567,7 @@ export async function checkAttestationCoverage(
         status: 'warn',
         message: `${hookCounts.total} hook-captured audit rows in the last ${windowDays} days and none carries attestation — ` +
           'these writers attest in the current build, so still-running pre-upgrade processes are writing them',
-        fix: 'restart long-running ShieldCortex processes (MCP server, OpenClaw gateway, dashboard) so they load the current build',
+        fix: 'These writers attest in the current build — still-running pre-upgrade processes are writing them. Run `openclaw gateway restart` and restart MCP / dashboard so they load the current build',
       };
     }
 

--- a/src/integrations/openclaw-conversation-access.ts
+++ b/src/integrations/openclaw-conversation-access.ts
@@ -83,7 +83,7 @@ export function readConversationAccess(home: string, pluginId: string): Conversa
  * plugin's startup line and the tests cannot drift apart.
  */
 export function conversationAccessFix(pluginId: string): string {
-  return `Add "hooks": { "allowConversationAccess": true } to plugins.entries["${pluginId}"] in ~/.openclaw/openclaw.json, then restart the gateway. Conversation content is sensitive — this is your call, and leaving it ungranted is a valid choice.`;
+  return `Add "hooks": { "allowConversationAccess": true } to plugins.entries["${pluginId}"] in ~/.openclaw/openclaw.json, then run \`openclaw gateway restart\`. Conversation content is sensitive — this is your call, and leaving it ungranted is a valid choice.`;
 }
 
 /**


### PR DESCRIPTION
## Bug
Edith copied this from doctor and the shell said command not found:

```
$ restart OpenClaw gateway
```

That was English, not a command.

## Fix
- `$` only prefixes a real binary
- gateway restart is **`openclaw gateway restart`**
- config grant stays a note (not a fake `$ set ...` command)

Check logic / exit codes unchanged.