### PR TITLE
chore(release): 4.54.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.54.4] - 2026-08-17
+
+**Patch — doctor `$` lines are real commands.**
+
+`threatGraph.trustModifier` stays **advisory**. SDK / PyPI stay **0.3.0**.
+
 ### Fixed
 
-- **Doctor `$` lines are real commands** — gateway restart prints `openclaw gateway restart`, never English `restart OpenClaw gateway`.
+- **Doctor `$` lines are real commands (#337)** — gateway restart prints `openclaw gateway restart`, never English `restart OpenClaw gateway`. `$` is only prefixed on a real binary.
+
+### References
+
+- #337
 
 ## [4.54.3] - 2026-08-16
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.3",
+  "version": "4.54.4",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.54.3",
+  "version": "4.54.4",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.54.3",
+  "version": "4.54.4",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.54.3
+  version: 4.54.4
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Release 4.54.4

Contents since 4.54.3:
- **#337** — doctor `$` lines are real commands (`openclaw gateway restart`)

Not included:
- #310 design (no cards)
- SDK/PyPI stay **0.3.0**
- `trustModifier` stays **advisory**

Coordinated surfaces after merge/tag: npm core+plugin, GH Release, ClawHub, cloud, websites.