### PR TITLE
fix(guard): resolve delete confinement before /tmp exemption (#339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- **Action Guard temp-root exemption is proven, not spelled (#339)** — lexical `/tmp/...` is no longer treated as confined when the path is a symlink out of the tree, a Darwin `/private/tmp` spelling of the same tree, or a relative target after `cd /`. Same-line `ln -s` / `cp -s` into a later delete dest fails closed. Workspace `dist` / `cd dashboard && … .next` relief from #170 is unchanged.
+
 ## [4.54.4] - 2026-08-17
 
 **Patch — doctor `$` lines are real commands.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
-- **Action Guard temp-root exemption is proven, not spelled (#339)** — lexical `/tmp/...` is no longer treated as confined when the path is a symlink out of the tree, a Darwin `/private/tmp` spelling of the same tree, or a relative target after `cd /`. Same-line `ln -s` / `cp -s` into a later delete dest fails closed. Workspace `dist` / `cd dashboard && … .next` relief from #170 is unchanged.
+- **Action Guard temp-root exemption is proven, not spelled (#339)** — lexical `/tmp/...` is no longer treated as confined when the path is a symlink out of the tree, a Darwin `/private/tmp` spelling of the same tree, or a relative target after `cd /`. Same-line `ln -s` / `cp -s` into a later delete dest fails closed. Wrapper/subshell/`bash -c`/`builtin`/`command` cd is walked the same way. Workspace `dist` / `cd dashboard && … .next` relief from #170 is unchanged.
 
 ## [4.54.4] - 2026-08-17
 

--- a/src/defence/iron-dome/__tests__/guard-tmp-confine-339.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-tmp-confine-339.test.ts
@@ -41,6 +41,18 @@ function verdict(command: string) {
   return evaluateToolCall('Bash', { command });
 }
 
+/** POSIX single-quote a word, so a nested program text survives one more level. */
+function singleQuote(word: string): string {
+  return `'${word.split("'").join("'\\''")}'`;
+}
+
+/** `inline('cd / && rm -rf x', 3)` → three `bash -c` levels around that program. */
+function inline(program: string, levels: number): string {
+  let out = program;
+  for (let i = 0; i < levels; i++) out = `bash -c ${singleQuote(out)}`;
+  return out;
+}
+
 describe('#339 — Darwin alias parity', () => {
   it('/private/tmp and /tmp are the same tree, so both are confined', () => {
     expect(verdict(`${RMRF} /tmp/sc339-missing`).decision).toBe('allow');
@@ -155,6 +167,24 @@ describe('#339 — a symlink minted on the same line is not a proof of confineme
     expect(verdict(`ln -s ${ETC} ${dollar}TARGET && ${RMRF} /tmp/sc339-x`).decision).toBe('block');
   });
 
+  it('a wrapper in front of the mint does not hide it', () => {
+    const mint = `ln -s ${ETC} /tmp/sc339-x`;
+    const del = `${RMRF} /tmp/sc339-x`;
+    for (const prefix of ['command', 'env', 'env SC339=1', 'exec']) {
+      expect(verdict(`${prefix} ${mint} && ${del}`).decision).toBe('block');
+    }
+  });
+
+  it('a path-qualified mint does not hide it', () => {
+    const del = `${RMRF} /tmp/sc339-x`;
+    expect(verdict(`/bin/ln -s ${ETC} /tmp/sc339-x && ${del}`).decision).toBe('block');
+    expect(verdict(`/usr/bin/cp -s ${ETC}/passwd /tmp/sc339-x && ${del}`).decision).toBe('block');
+  });
+
+  it('a wrapper LOOKUP is not a mint', () => {
+    expect(verdict(`command -v bash && ${RMRF} dist`).decision).toBe('allow');
+  });
+
   it('a symlink minted somewhere else does not cost an unrelated delete', () => {
     expect(verdict(`ln -s ../shared/node_modules node_modules && ${RMRF} dist`).decision).toBe('allow');
   });
@@ -181,6 +211,20 @@ describe('#339 — wrapper / subshell cd is still a cwd change', () => {
   it('builtin/command wrappers around cd still move cwd', () => {
     expect(verdict(`builtin cd / && ${RMRF} relative-target`).decision).toBe('block');
     expect(verdict(`command cd / && ${RMRF} relative-target`).decision).toBe('block');
+  });
+
+  it('nesting past the recursion budget fails closed instead of skipping', () => {
+    const escape = `cd / && ${RMRF} relative-target`;
+    for (const levels of [1, 2, 3, 4]) {
+      expect(verdict(inline(escape, levels)).decision).toBe('block');
+    }
+  });
+
+  it('the exhausted budget is fail-CLOSED, so a deep nest costs the exemption', () => {
+    const confined = `cd dashboard && ${RMRF} .next`;
+    expect(verdict(inline(confined, 1)).decision).toBe('allow');
+    expect(verdict(inline(confined, 2)).decision).toBe('allow');
+    expect(verdict(inline(confined, 3)).decision).not.toBe('allow');
   });
 
   it('#170 relief still holds inside wrappers that stay in the workspace', () => {

--- a/src/defence/iron-dome/__tests__/guard-tmp-confine-339.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-tmp-confine-339.test.ts
@@ -21,6 +21,15 @@
  * re-asserted alongside every tightening: a security fix that takes the honest
  * build commands back down with it has not made anyone safer.
  *
+ * The same-line symlink MINT rule that closed (2) had two of its own, found in
+ * review: the destination was compared as WRITTEN, so a dot segment renamed a
+ * link out of its own taint (`ln -s /etc ./x` did not taint `x/child`), and the
+ * destination was read as the last positional, so `ln -s -t /tmp /etc` recorded
+ * the SOURCE and left the real link under the temp root untainted. Both are
+ * fail-open. Destinations are now canonicalised and placed against the cwd at
+ * the mint statement, argv is parsed rather than guessed, and an option shape
+ * the parser cannot place costs the exemption instead of being ignored.
+ *
  * Fixtures are assembled at runtime (the #196 house style) so no attack-shaped
  * literal sits on disk. Nothing here deletes anything: the live-filesystem
  * cases build a sandbox under the OS temp root, ask `evaluateToolCall` what it
@@ -191,6 +200,89 @@ describe('#339 — a symlink minted on the same line is not a proof of confineme
 
   it('a hard link is not a directory traversal and costs nothing', () => {
     expect(verdict(`ln a b && ${RMRF} dist`).decision).toBe('allow');
+  });
+
+  // The mint dest used to be compared AS WRITTEN, so a dot segment renamed a
+  // link out of its own taint while naming the very same file. Each case pairs
+  // with the same delete minus the mint, which is the #170 relief — so the
+  // assertion is that the MINT moved the decision, not the delete's spelling.
+  it('a dot segment does not rename a mint out of its own taint', () => {
+    expect(verdict(`ln -s ${ETC} ./sc339-x && ${RMRF} sc339-x/passwd`).decision).toBe('block');
+    expect(verdict(`ln -s ${ETC} /tmp/./sc339-x && ${RMRF} /tmp/sc339-x/passwd`).decision).toBe('block');
+    expect(verdict(`ln -s ${ETC} /tmp/sc339-x/ && ${RMRF} /tmp/sc339-x/passwd`).decision).toBe('block');
+    expect(verdict(`${RMRF} sc339-x/passwd`).decision).toBe('allow');
+    expect(verdict(`${RMRF} /tmp/sc339-x/passwd`).decision).toBe('allow');
+  });
+
+  it('a relative mint dest is placed against the cwd at the MINT statement', () => {
+    expect(verdict(`cd /tmp && ln -s ${ETC} ./sc339-x && ${RMRF} /tmp/sc339-x/passwd`).decision)
+      .toBe('block');
+    expect(verdict(`cd /tmp && ${RMRF} /tmp/sc339-x/passwd`).decision).toBe('allow');
+  });
+
+  it('a relative mint dest under a cwd this walk lost costs the exemption', () => {
+    const dollar = '$';
+    expect(verdict(`cd ${dollar}HOME && ln -s ${ETC} ./sc339-x && ${RMRF} /tmp/sc339-y`).decision)
+      .toBe('block');
+    expect(verdict(`ln -s ${ETC} ../sc339-x && ${RMRF} /tmp/sc339-y`).decision).toBe('block');
+    expect(verdict(`cd ${dollar}HOME && ${RMRF} /tmp/sc339-y`).decision).toBe('allow');
+  });
+
+  // `-t DIR SRC` puts the link at DIR/basename(SRC). Reading the last positional
+  // as the destination recorded the SOURCE instead, and left the real link — the
+  // one under the temp root — with no taint on it at all.
+  it('`-t DIR` names the link DIR/basename(SRC), not the source', () => {
+    const forms = [
+      '-s -t /tmp', '-s -t/tmp', '-st /tmp',
+      '-s --target-directory /tmp', '-s --target-directory=/tmp',
+    ];
+    for (const form of forms) {
+      const v = verdict(`ln ${form} ${ETC} && ${RMRF} /tmp/etc/passwd`);
+      expect(v.decision).toBe('block');
+      expect(v.signals).toContain('recursive-force-delete');
+    }
+    expect(verdict(`cp -s -t /tmp ${ETC}/passwd && ${RMRF} /tmp/passwd/x`).decision).toBe('block');
+    expect(verdict(`${RMRF} /tmp/passwd/x`).decision).toBe('allow');
+  });
+
+  it('every source of a `-t` mint gets its own destination', () => {
+    expect(verdict(`ln -s -t /tmp ${ETC} ${ETC}/hosts && ${RMRF} /tmp/hosts/x`).decision).toBe('block');
+    expect(verdict(`${RMRF} /tmp/hosts/x`).decision).toBe('allow');
+  });
+
+  it('a value flag does not donate its value as a destination', () => {
+    expect(verdict(`ln -s -S .bak ${ETC} /tmp/sc339-x && ${RMRF} /tmp/sc339-x/passwd`).decision)
+      .toBe('block');
+  });
+
+  it('`--` ends the options without losing the destination', () => {
+    expect(verdict(`ln -s -- ${ETC} /tmp/sc339-x && ${RMRF} /tmp/sc339-x/passwd`).decision)
+      .toBe('block');
+  });
+
+  it('a one-operand mint links basename(SRC) into the cwd', () => {
+    expect(verdict(`ln -s ${ETC}/sc339-x && ${RMRF} sc339-x/child`).decision).toBe('block');
+    expect(verdict(`${RMRF} sc339-x/child`).decision).toBe('allow');
+  });
+
+  it('a mint option shape this parser cannot place costs the exemption', () => {
+    const unplaceable = [
+      `-s ${ETC} -t`,                 // a value flag with nothing after it
+      `-s --sc339-unknown /tmp ${ETC}`, // an unknown long option, which may eat the next word
+      `-sQ ${ETC} /tmp/sc339-x`,      // an unknown letter in the bundle
+      `-s -t /tmp -t /var/tmp ${ETC}`, // two target dirs, so neither is provable
+    ];
+    for (const args of unplaceable) {
+      expect(verdict(`ln ${args} && ${RMRF} /tmp/sc339-y`).decision).toBe('block');
+    }
+    // The same delete under a mint this parser CAN place is untouched.
+    expect(verdict(`ln -s ${ETC} /tmp/sc339-x && ${RMRF} /tmp/sc339-y`).decision).toBe('allow');
+  });
+
+  it('a placed `-t` mint leaves an unrelated delete alone (#170 relief holds)', () => {
+    expect(verdict(`ln -s -t /tmp ${ETC} && ${RMRF} dist`).decision).toBe('allow');
+    expect(verdict(`ln -s ${ETC} /tmp/./sc339-x && ${RMRF} dist`).decision).toBe('allow');
+    expect(verdict(`ln -s ${ETC} ./sc339-x && ${RMRF} dist`).decision).toBe('allow');
   });
 });
 

--- a/src/defence/iron-dome/__tests__/guard-tmp-confine-339.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-tmp-confine-339.test.ts
@@ -164,6 +164,32 @@ describe('#339 — a symlink minted on the same line is not a proof of confineme
   });
 });
 
+describe('#339 — wrapper / subshell cd is still a cwd change', () => {
+  it('a subshell cd to root is not workspace-confined', () => {
+    expect(verdict(`(cd / && ${RMRF} relative-target)`).decision).toBe('block');
+  });
+
+  it('a brace-group cd to root is not workspace-confined', () => {
+    expect(verdict(`{ cd /; ${RMRF} relative-target; }`).decision).toBe('block');
+  });
+
+  it('an inline shell program that cds to root is not workspace-confined', () => {
+    expect(verdict(`bash -c 'cd / && ${RMRF} relative-target'`).decision).toBe('block');
+    expect(verdict(`sh -c "cd / && ${RMRF} relative-target"`).decision).toBe('block');
+  });
+
+  it('builtin/command wrappers around cd still move cwd', () => {
+    expect(verdict(`builtin cd / && ${RMRF} relative-target`).decision).toBe('block');
+    expect(verdict(`command cd / && ${RMRF} relative-target`).decision).toBe('block');
+  });
+
+  it('#170 relief still holds inside wrappers that stay in the workspace', () => {
+    expect(verdict(`bash -c 'cd dashboard && ${RMRF} .next'`).decision).toBe('allow');
+    expect(verdict(`(cd dashboard && ${RMRF} .next)`).decision).toBe('allow');
+    expect(verdict(`{ cd dashboard; ${RMRF} .next; }`).decision).toBe('allow');
+  });
+});
+
 describe('#339 — mixed and multi-target lines', () => {
   it('a confined target next to a system target still blocks', () => {
     expect(verdict(`${RMRF} /tmp/sc339-a ${SYSTEM_TARGET}`).decision).toBe('block');

--- a/src/defence/iron-dome/__tests__/guard-tmp-confine-339.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-tmp-confine-339.test.ts
@@ -1,0 +1,244 @@
+/**
+ * #339 — the temp-root exemption must be PROVEN, not spelled.
+ *
+ * #170 made danger a property of the delete TARGET rather than the verb, and
+ * #196 stopped that exemption being laundered by an unexamined statement. Both
+ * left the temp-root arm of the test purely lexical: a token that *looked* like
+ * `/tmp/...` was confined, full stop. Three ways out of that, all measured on
+ * 4.54.4:
+ *
+ *   1. `/private/tmp/x` is the SAME directory as `/tmp/x` on Darwin and was
+ *      blocked, while `/tmp/x` was allowed — the guard disagreed with itself
+ *      about one path, which is how an operator learns to route around it.
+ *   2. `/tmp/link/subdir` is only confined if `/tmp/link` is not a symlink out
+ *      of the tree. Lexically it always was.
+ *   3. `cd / && rm -rf relative-target` has a relative token, and relative
+ *      tokens were assumed workspace-confined with no cwd tracking at all.
+ *
+ * (1) is a false positive, (2) and (3) are fail-OPEN — the quiet direction.
+ *
+ * Both directions are pinned here. The #170 relief this file must NOT undo is
+ * re-asserted alongside every tightening: a security fix that takes the honest
+ * build commands back down with it has not made anyone safer.
+ *
+ * Fixtures are assembled at runtime (the #196 house style) so no attack-shaped
+ * literal sits on disk. Nothing here deletes anything: the live-filesystem
+ * cases build a sandbox under the OS temp root, ask `evaluateToolCall` what it
+ * WOULD do, and unlink/rmdir what they made.
+ */
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, mkdirSync, symlinkSync, unlinkSync, rmdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { evaluateToolCall } from '../tool-action-guard.js';
+
+/** Assembled at runtime so the fixtures are not attack-shaped literals on disk. */
+const RMRF = ['rm', '-rf'].join(' ');
+const ETC = ['/', 'etc'].join('');
+const SYSTEM_TARGET = `${ETC}/foo`;
+
+function verdict(command: string) {
+  return evaluateToolCall('Bash', { command });
+}
+
+describe('#339 — Darwin alias parity', () => {
+  it('/private/tmp and /tmp are the same tree, so both are confined', () => {
+    expect(verdict(`${RMRF} /tmp/sc339-missing`).decision).toBe('allow');
+    expect(verdict(`${RMRF} /private/tmp/sc339-missing`).decision).toBe('allow');
+  });
+
+  it('/private/var/tmp and /var/tmp are the same tree, so both are confined', () => {
+    expect(verdict(`${RMRF} /var/tmp/sc339-missing`).decision).toBe('allow');
+    expect(verdict(`${RMRF} /private/var/tmp/sc339-missing`).decision).toBe('allow');
+  });
+
+  it('both spellings of the per-user temp root are confined', () => {
+    expect(verdict(`${RMRF} /private/var/folders/xx/yyyy/T/sc339`).decision).toBe('allow');
+    expect(verdict(`${RMRF} /var/folders/xx/yyyy/T/sc339`).decision).toBe('allow');
+  });
+
+  it('the temp ROOT itself is not a confined subdirectory', () => {
+    for (const root of ['/tmp', '/private/tmp', '/var/tmp', '/private/var/tmp', '/tmp/']) {
+      expect(verdict(`${RMRF} ${root}`).decision).not.toBe('allow');
+    }
+  });
+
+  it('a lookalike sibling of the temp root is not confined', () => {
+    expect(verdict(`${RMRF} /tmpfoo/x`).decision).toBe('block');
+    expect(verdict(`${RMRF} /private/tmpfoo/x`).decision).toBe('block');
+  });
+});
+
+describe('#339 — confinement is resolved, not spelled (symlink escape)', () => {
+  let sandbox = '';
+  const escape = () => join(sandbox, 'escape-link');
+  const real = () => join(sandbox, 'real-dir');
+
+  beforeAll(() => {
+    sandbox = mkdtempSync(join(tmpdir(), 'sc339-'));
+    mkdirSync(real());
+    symlinkSync(ETC, escape());
+  });
+
+  afterAll(() => {
+    // Unlink/rmdir only — this suite never runs a recursive delete of its own.
+    for (const f of [() => unlinkSync(escape()), () => rmdirSync(real()), () => rmdirSync(sandbox)]) {
+      try { f(); } catch { /* best effort */ }
+    }
+  });
+
+  it('a real directory under the temp root stays confined (#170 relief holds)', () => {
+    expect(verdict(`${RMRF} ${real()}`).decision).toBe('allow');
+  });
+
+  it('a temp-root path that is a symlink OUT of the tree is not confined', () => {
+    expect(verdict(`${RMRF} ${escape()}`).decision).toBe('block');
+  });
+
+  it('a path THROUGH a symlinked parent is not confined even when it does not exist', () => {
+    expect(verdict(`${RMRF} ${escape()}/child`).decision).toBe('block');
+  });
+
+  it('a path that does not exist at all is judged lexically and stays confined', () => {
+    expect(verdict(`${RMRF} ${join(sandbox, 'never-created')}`).decision).toBe('allow');
+  });
+
+  it('one escaping target costs the exemption for the whole line', () => {
+    expect(verdict(`${RMRF} ${real()} ${escape()}`).decision).toBe('block');
+  });
+});
+
+describe('#339 — cwd tracking for relative targets', () => {
+  it('a relative target after `cd /` is a ROOT-level target', () => {
+    expect(verdict(`cd / && ${RMRF} relative-target`).decision).toBe('block');
+  });
+
+  it('a relative target after `cd` into a system directory is not confined', () => {
+    expect(verdict(`cd ${ETC} && ${RMRF} foo`).decision).toBe('block');
+  });
+
+  it('a relative target after `cd` into the temp root is confined', () => {
+    expect(verdict(`cd /tmp && ${RMRF} sc339-missing`).decision).toBe('allow');
+    expect(verdict(`cd /private/tmp && ${RMRF} sc339-missing`).decision).toBe('allow');
+  });
+
+  it('a cd the parser cannot analyse costs the exemption for later relative targets', () => {
+    const dollar = '$';
+    const dests = [`${dollar}HOME`, '~', '-', '', '..', `${dollar}(pwd)`, '/tmp /etc'];
+    for (const dest of dests) {
+      expect(verdict(`cd ${dest} && ${RMRF} foo`).decision).not.toBe('allow');
+    }
+    expect(verdict(`pushd /tmp && ${RMRF} foo`).decision).not.toBe('allow');
+  });
+
+  it('an uncertain branch after a cd costs the exemption for later relative targets', () => {
+    expect(verdict(`cd /tmp || cd ${ETC}; ${RMRF} foo`).decision).not.toBe('allow');
+  });
+
+  it('the implicit workspace cwd keeps ordinary build deletes allowed (#170 relief holds)', () => {
+    expect(verdict(`${RMRF} dist`).decision).toBe('allow');
+    expect(verdict(`cd dashboard && ${RMRF} .next && npm run build`).decision).toBe('allow');
+    expect(verdict(`cd dashboard && cd .. && ${RMRF} .next`).decision).not.toBe('allow');
+  });
+});
+
+describe('#339 — a symlink minted on the same line is not a proof of confinement', () => {
+  it('`ln -s` into the temp root taints that destination', () => {
+    expect(verdict(`ln -s ${ETC} /tmp/sc339-x && ${RMRF} /tmp/sc339-x`).decision).toBe('block');
+    expect(verdict(`ln -sf ${ETC} /tmp/sc339-x && ${RMRF} /tmp/sc339-x/child`).decision).toBe('block');
+    expect(verdict(`ln --symbolic ${ETC} /tmp/sc339-x && ${RMRF} /tmp/sc339-x`).decision).toBe('block');
+    expect(verdict(`cp -s ${ETC}/passwd /tmp/sc339-x && ${RMRF} /tmp/sc339-x`).decision).toBe('block');
+  });
+
+  it('a mint whose destination cannot be read costs the exemption', () => {
+    const dollar = '$';
+    expect(verdict(`ln -s ${ETC} ${dollar}TARGET && ${RMRF} /tmp/sc339-x`).decision).toBe('block');
+  });
+
+  it('a symlink minted somewhere else does not cost an unrelated delete', () => {
+    expect(verdict(`ln -s ../shared/node_modules node_modules && ${RMRF} dist`).decision).toBe('allow');
+  });
+
+  it('a hard link is not a directory traversal and costs nothing', () => {
+    expect(verdict(`ln a b && ${RMRF} dist`).decision).toBe('allow');
+  });
+});
+
+describe('#339 — mixed and multi-target lines', () => {
+  it('a confined target next to a system target still blocks', () => {
+    expect(verdict(`${RMRF} /tmp/sc339-a ${SYSTEM_TARGET}`).decision).toBe('block');
+  });
+
+  it('a confined statement never launders an unconfined one', () => {
+    expect(verdict(`${RMRF} /tmp/sc339-a && ${RMRF} ${SYSTEM_TARGET}`).decision).toBe('block');
+  });
+});
+
+describe('#339 — #170 / #196 invariants still hold', () => {
+  it('an unconfined recursive delete is still catastrophic', () => {
+    expect(verdict(`${RMRF} ${SYSTEM_TARGET}`).decision).toBe('block');
+  });
+
+  it('`rm` inside a path or identifier costs the exemption nothing', () => {
+    expect(verdict(`${RMRF} build/rm-cache`).decision).toBe('allow');
+    expect(verdict(`${RMRF} src/rm/generated`).decision).toBe('allow');
+  });
+
+  it('a scan that truncates never exempts what it could not read', () => {
+    const filler = Array.from({ length: 70 }, (_, i) => `${RMRF} build${i}`).join(' && ');
+    expect(verdict(`${filler} && ${RMRF} ${SYSTEM_TARGET}`).decision).toBe('block');
+  });
+
+  it('a command substitution is command position, and is examined', () => {
+    expect(verdict(`${RMRF} dist && out=$(${RMRF} ${SYSTEM_TARGET})`).decision).toBe('block');
+  });
+
+  it('an rm the splitter cannot account for keeps the gate for the whole line', () => {
+    expect(verdict(`${RMRF} dist && find . -name "*.log" -exec ${RMRF} {} +`).decision)
+      .not.toBe('allow');
+  });
+
+  it('a glob under the temp root is still not confined', () => {
+    expect(verdict(`cd /tmp && ${RMRF} *`).decision).toBe('block');
+  });
+});
+
+describe('#339 — Vision probe rows', () => {
+  const rows: Array<[string, string, 'allow' | 'block']> = [
+    ['tmp-name', `${RMRF} /tmp/friday-guard-probe`, 'allow'],
+    ['private-tmp', `${RMRF} /private/tmp/friday-guard-probe`, 'allow'],
+    ['tmp-link-subdir', `${RMRF} /tmp/sc339-no-such-link/subdir`, 'allow'],
+    ['home-nontmp', `${RMRF} /home/ubuntu/friday/guard-probe-nontmp`, 'block'],
+    ['cd-root-relative', `cd / && ${RMRF} relative-target`, 'block'],
+    ['var-tmp', `${RMRF} /var/tmp/x`, 'allow'],
+    ['private-var-folders', `${RMRF} /private/var/folders/xx/yyyy/T/z`, 'allow'],
+    ['workspace-next', `cd dashboard && ${RMRF} .next && npm run build`, 'allow'],
+    ['workspace-dist', `${RMRF} dist`, 'allow'],
+    ['etc-foo', `${RMRF} ${SYSTEM_TARGET}`, 'block'],
+    ['tmp-glob', `cd /tmp && ${RMRF} *`, 'block'],
+  ];
+  for (const [label, command, expected] of rows) {
+    it(`${label} → ${expected}`, () => {
+      expect(verdict(command).decision).toBe(expected);
+    });
+  }
+});
+
+describe('#339 — the write-content scanner uses the same proof', () => {
+  it('a confined delete authored into a script is not a catastrophic payload', () => {
+    const v = evaluateToolCall('Write', {
+      file_path: 'scripts/clean.sh',
+      content: `#!/bin/sh\n${RMRF} dist\n${RMRF} /tmp/sc339-missing\n`,
+    });
+    expect(v.signals).not.toContain('write-content-catastrophic');
+  });
+
+  it('a relative delete after `cd /` authored into a script IS a catastrophic payload', () => {
+    const v = evaluateToolCall('Write', {
+      file_path: 'scripts/clean.sh',
+      content: `#!/bin/sh\ncd / && ${RMRF} relative-target\n`,
+    });
+    expect(v.decision).toBe('block');
+    expect(v.signals).toContain('write-content-catastrophic');
+  });
+});

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -1111,6 +1111,21 @@ function normalizeDarwinTempAliases(p: string): string {
     .replace(/\/{2,}/g, '/');
 }
 
+/**
+ * Lexical canonical form: `.` segments and duplicate slashes collapsed, no
+ * trailing slash, Darwin temp aliases applied. One path has one spelling here,
+ * so `./x`, `x`, `x/` and `/tmp/./x` vs `/tmp/x` stop being different strings.
+ *
+ * `..` is deliberately NOT resolved: a parent segment only means what the
+ * filesystem says it means once a symlink is in the path. Callers treat a
+ * token containing one as unreadable rather than pretending this walk read it.
+ */
+function canonicalisePathLexically(p: string): string {
+  const absolute = p.startsWith('/');
+  const body = p.split('/').filter(seg => seg !== '' && seg !== '.').join('/');
+  return normalizeDarwinTempAliases(absolute ? `/${body}` : body);
+}
+
 /** A confined temp child, never the temp root itself. */
 function isConfinedAbsolute(p: string): boolean {
   const n = normalizeDarwinTempAliases(p).replace(/\/+$/, '');
@@ -1296,31 +1311,166 @@ function effectiveDeleteTarget(tok: string, cwd: ConfinedCwd): string | 'uncerta
  * same lesson as #188/#193, so it uses the same tokenising machinery rather
  * than a longer list of spellings. `command -v ln` resolves to `ln` but carries
  * no `-s`, so a lookup is still not a mint.
+ *
+ * The destination is READ OFF THE ARGV, not off the last positional: `ln -s -t
+ * DIR SRC` puts the link at `DIR/SRC`, and `-t`'s value is not an operand at
+ * all, so the last-positional rule recorded the SOURCE as the destination and
+ * left the real link untainted. It is then placed against the cwd in effect at
+ * the mint STATEMENT (the same `cwdBefore` walk the deletes use), because
+ * `cd /tmp && ln -s … ./x` and `ln -s … /tmp/x` mint the same link. An option
+ * shape this walk cannot place is not a proof of anything: fail closed (#339,
+ * Athena review).
  */
+// The ln / cp option surface, split by whether an option eats the argv word
+// after it. Everything outside these tables is a shape this walk cannot place,
+// and an unplaced option is what turns a source into a "destination" — so the
+// parse fails closed rather than guessing. Long options carrying an OPTIONAL
+// value (`--backup`, `--preserve`, `--reflink`, `--update`, `--context`) only
+// ever take it as `--name=VALUE`, so they belong with the no-arg forms.
+const MINT_LONG_NO_ARG = new Set([
+  'symbolic', 'symbolic-link', 'force', 'interactive', 'logical', 'physical',
+  'dereference', 'no-dereference', 'no-target-directory', 'relative', 'verbose',
+  'directory', 'archive', 'attributes-only', 'copy-contents', 'link', 'no-clobber',
+  'parents', 'recursive', 'remove-destination', 'strip-trailing-slashes',
+  'one-file-system', 'backup', 'preserve', 'no-preserve', 'reflink', 'sparse',
+  'update', 'context', 'help', 'version',
+]);
+/** Long options whose value is the next argv word when written without `=`. */
+const MINT_LONG_ARG = new Set(['target-directory', 'suffix']);
+/** Short option letters that take no value, so they bundle in any order. */
+const MINT_SHORT_NO_ARG = 'abcdfFhHiLlnpPrRsTuvwxXZ';
+/** Short letters whose value is the rest of the bundle, else the next word. */
+const MINT_SHORT_ARG = 'tS';
+
+type MintArgv = { targetDir: string | null; positional: string[] };
+
+/**
+ * getopt for the mint verbs: operands separated from options, `-t` / `-S`
+ * values consumed rather than mistaken for operands. Returns 'unreadable' for
+ * every shape it cannot prove — an unknown option (which may or may not eat
+ * the next word), a value flag with nothing after it, a second `-t`.
+ */
+function parseMintArgv(args: readonly string[]): MintArgv | 'unreadable' {
+  const positional: string[] = [];
+  let targetDir: string | null = null;
+  let optionsEnded = false;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (optionsEnded || arg === '-' || !arg.startsWith('-')) { positional.push(arg); continue; }
+    if (arg === '--') { optionsEnded = true; continue; }
+    if (arg.startsWith('--')) {
+      const eq = arg.indexOf('=');
+      const name = (eq < 0 ? arg.slice(2) : arg.slice(2, eq)).toLowerCase();
+      if (MINT_LONG_ARG.has(name)) {
+        const value = eq < 0 ? args[++i] : arg.slice(eq + 1);
+        if (value === undefined) return 'unreadable';
+        if (name === 'target-directory') {
+          if (targetDir !== null) return 'unreadable';
+          targetDir = value;
+        }
+        continue;
+      }
+      if (!MINT_LONG_NO_ARG.has(name)) return 'unreadable';
+      continue;
+    }
+    for (let k = 1; k < arg.length; k++) {
+      const letter = arg[k]!;
+      if (MINT_SHORT_ARG.includes(letter)) {
+        const value = k + 1 < arg.length ? arg.slice(k + 1) : args[++i];
+        if (value === undefined) return 'unreadable';
+        if (letter === 't') {
+          if (targetDir !== null) return 'unreadable';
+          targetDir = value;
+        }
+        break;
+      }
+      if (!MINT_SHORT_NO_ARG.includes(letter)) return 'unreadable';
+    }
+  }
+  return { targetDir, positional };
+}
+
+/** The paths a parsed mint creates, as written — 'unreadable' if it cannot say. */
+function mintDestSpellings(argv: MintArgv): string[] | 'unreadable' {
+  const { targetDir, positional } = argv;
+  if (positional.length === 0) return 'unreadable';
+  // Two or more operands and no `-t`: the last one names the link. When it is
+  // an existing DIRECTORY the link lands underneath it instead, which the
+  // prefix test in `mintTaintsTarget` already covers — so the operand as
+  // written is the safe over-approximation, and no stat is needed.
+  if (targetDir === null && positional.length >= 2) {
+    return [positional[positional.length - 1]!];
+  }
+  // `-t DIR SRC…`, and the one-operand form whose DIR is the cwd: every source
+  // is linked as DIR/basename(SRC).
+  const dir = targetDir ?? '.';
+  const out: string[] = [];
+  for (const source of positional) {
+    const name = commandBaseName(source.replace(/\/+$/, ''));
+    if (!name || name === '.' || /[$`*?~]/.test(name)) return 'unreadable';
+    out.push(joinPathParts(dir, name));
+  }
+  return out;
+}
+
+/**
+ * A mint destination in the frame the delete targets are judged in: absolute
+ * where it can be, workspace-relative while the cwd walk is still in the
+ * workspace, 'uncertain' where it cannot be placed at all. A relative dest
+ * under a cwd this walk lost is NOT assumed to be in the workspace.
+ */
+function resolveMintDest(dest: string, cwd: ConfinedCwd): string | 'uncertain' {
+  if (!dest || /[$`*?~]/.test(dest) || dest.includes('..')) return 'uncertain';
+  const lexical = canonicalisePathLexically(dest);
+  if (!lexical) return 'uncertain';
+  if (lexical.startsWith('/')) return lexical;
+  if (cwd.kind === 'uncertain') return 'uncertain';
+  if (cwd.kind === 'abs') return canonicalisePathLexically(joinPathParts(cwd.path, lexical));
+  return canonicalisePathLexically(cwd.rel ? joinPathParts(cwd.rel, lexical) : lexical);
+}
+
 function symlinkMintTaint(text: string): { all: boolean; dests: string[] } {
   const dests: string[] = [];
   let all = false;
-  for (const raw of quoteAwareStatements(text)) {
-    const tokens = tokeniseStatement(raw);
+  for (const stmt of quoteAwareStatementSpans(text)) {
+    const tokens = tokeniseStatement(stmt.text);
     const cmd = commandWordIndex(tokens);
     const base = commandBaseName(tokens[cmd] ?? '').toLowerCase();
     if (base !== 'ln' && base !== 'cp') continue;
     const args = tokens.slice(cmd + 1);
-    const flags = args.filter(a => a.startsWith('-'));
-    const positional = args.filter(a => !a.startsWith('-'));
-    const symbolic = flags.some(f =>
-      f === '--symbolic' || (!f.startsWith('--') && f.includes('s')));
+    // Superset test, deliberately loose: it decides only whether this
+    // invocation is a mint AT ALL, so a `cp` with no `-s` never pays for the
+    // strict parse below. `--symbolic-link` is cp's spelling of `--symbolic`.
+    const symbolic = args.some(a => a.startsWith('--')
+      ? /^--symbolic(?:-link)?$/.test(a)
+      : a.startsWith('-') && a.includes('s'));
     if (!symbolic) continue;
-    const dest = positional[positional.length - 1] ?? '';
-    if (!dest || /[$`*?~]/.test(dest)) { all = true; continue; }
-    dests.push(dest);
+    const argv = parseMintArgv(args);
+    if (argv === 'unreadable') { all = true; continue; }
+    const spellings = mintDestSpellings(argv);
+    if (spellings === 'unreadable') { all = true; continue; }
+    const cwd = cwdBefore(text, stmt.index);
+    for (const spelled of spellings) {
+      const resolved = resolveMintDest(spelled, cwd);
+      if (resolved === 'uncertain') { all = true; continue; }
+      dests.push(resolved);
+    }
   }
   return { all, dests };
 }
 
+/**
+ * Does a delete of `target` reach through the minted `dest`?
+ *
+ * Both sides are canonicalised first. Comparing the spellings as WRITTEN meant
+ * a mint could be renamed out of its own taint by a dot segment — `./x` did
+ * not taint `x/child`, `/tmp/./x` did not taint `/tmp/x/child` — while naming
+ * the very same link (#339, Athena review).
+ */
 function mintTaintsTarget(target: string, dest: string): boolean {
-  const a = normalizeDarwinTempAliases(target);
-  const b = normalizeDarwinTempAliases(dest);
+  const a = canonicalisePathLexically(target);
+  const b = canonicalisePathLexically(dest);
+  if (!a || !b) return false;
   return a === b || a.startsWith(b.endsWith('/') ? b : `${b}/`);
 }
 
@@ -1404,26 +1554,45 @@ function installsAreContainerConfined(text: string): boolean {
  * Kept local so the fail-safe splitter stays exactly as it is.
  */
 function quoteAwareStatements(text: string): string[] {
-  const out: string[] = [];
+  return quoteAwareStatementSpans(text).map(s => s.text);
+}
+
+/**
+ * The same split, keeping each statement's OFFSET in the original text. The
+ * mint rule needs it: "which directory was this `ln` run from" is a question
+ * about the statement's position, and `cwdBefore` answers it by walking the
+ * prefix (#339).
+ */
+function quoteAwareStatementSpans(text: string): Array<{ text: string; index: number }> {
+  const out: Array<{ text: string; index: number }> = [];
   let cur = '';
+  let start = 0;
   let quote: string | null = null;
+  const take = (at: number, part: string): void => {
+    if (!cur) start = at;
+    cur += part;
+  };
+  const flush = (): void => {
+    if (cur.trim()) out.push({ text: cur, index: start });
+    cur = '';
+  };
   for (let i = 0; i < text.length; i++) {
-    const c = text[i];
-    if (c === '\\' && quote !== "'" && i + 1 < text.length) { cur += c + text[++i]; continue; }
+    const c = text[i]!;
+    if (c === '\\' && quote !== "'" && i + 1 < text.length) {
+      take(i, c + text[i + 1]!);
+      i++;
+      continue;
+    }
     if (quote) {
-      cur += c;
+      take(i, c);
       if (c === quote) quote = null;
       continue;
     }
-    if (c === '"' || c === "'") { quote = c; cur += c; continue; }
-    if (c === ';' || c === '&' || c === '|' || c === '\n' || c === '\r') {
-      if (cur.trim()) out.push(cur);
-      cur = '';
-      continue;
-    }
-    cur += c;
+    if (c === '"' || c === "'") { quote = c; take(i, c); continue; }
+    if (c === ';' || c === '&' || c === '|' || c === '\n' || c === '\r') { flush(); continue; }
+    take(i, c);
   }
-  if (cur.trim()) out.push(cur);
+  flush();
   return out;
 }
 

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -1285,20 +1285,29 @@ function effectiveDeleteTarget(tok: string, cwd: ConfinedCwd): string | 'uncerta
   return cwd.rel ? joinPathParts(cwd.rel, tok) : tok;
 }
 
-/** Same-line ln -s / cp -s destinations. Unreadable dest taints the whole line. */
+/**
+ * Same-line ln -s / cp -s destinations. Unreadable dest taints the whole line.
+ *
+ * The mint is identified by ARGV, not by the statement's leading literal: the
+ * command word is located with the shared `commandWordIndex` walk, so a
+ * path-qualified (`/bin/ln`) or wrapper-fronted (`command ln`, `env FOO=1 ln`,
+ * `exec ln`) mint taints exactly like a bare `ln`. Matching the first word made
+ * one wrapper word enough to carry a mint straight past this rule (#339) — the
+ * same lesson as #188/#193, so it uses the same tokenising machinery rather
+ * than a longer list of spellings. `command -v ln` resolves to `ln` but carries
+ * no `-s`, so a lookup is still not a mint.
+ */
 function symlinkMintTaint(text: string): { all: boolean; dests: string[] } {
   const dests: string[] = [];
   let all = false;
   for (const raw of quoteAwareStatements(text)) {
-    const stmt = raw.trim();
-    const isLn = /^ln\b/i.test(stmt);
-    const isCp = /^cp\b/i.test(stmt);
-    if (!isLn && !isCp) continue;
-    const args = stmt.split(/\s+/).slice(1);
+    const tokens = tokeniseStatement(raw);
+    const cmd = commandWordIndex(tokens);
+    const base = commandBaseName(tokens[cmd] ?? '').toLowerCase();
+    if (base !== 'ln' && base !== 'cp') continue;
+    const args = tokens.slice(cmd + 1);
     const flags = args.filter(a => a.startsWith('-'));
-    const positional = args
-      .filter(a => !a.startsWith('-'))
-      .map(a => a.replace(/^[\"']|[\"']$/g, ''));
+    const positional = args.filter(a => !a.startsWith('-'));
     const symbolic = flags.some(f =>
       f === '--symbolic' || (!f.startsWith('--') && f.includes('s')));
     if (!symbolic) continue;
@@ -1322,14 +1331,18 @@ function hasStandaloneRmStatement(text: string): boolean {
 }
 
 function deleteTargetsAreWorkspaceConfined(text: string, depth = 0): boolean {
-  if (depth < 2) {
-    const nested = nestedDeleteSurfaces(text);
-    if (nested.unreadable) return false;
-    for (const body of nested.bodies) {
-      if (hasStandaloneRmStatement(body) && !deleteTargetsAreWorkspaceConfined(body, depth + 1)) {
-        return false;
-      }
-    }
+  const nested = nestedDeleteSurfaces(text);
+  if (nested.unreadable) return false;
+  for (const body of nested.bodies) {
+    if (!hasStandaloneRmStatement(body)) continue;
+    // Budget exhausted. The `bash -c` statement holding this body is exempt
+    // from the cd-uncertainty rule (`isInlineShellStatement`) precisely BECAUSE
+    // the recursion reads the body — so abandoning the recursion here handed
+    // that exemption to a delete nobody analysed, and a third nested `bash -c`
+    // could hide `cd /` plus a relative recursive delete (#339). A delete this
+    // walk cannot reach is not a proof of confinement: fail closed.
+    if (depth >= MAX_INLINE_RECURSION) return false;
+    if (!deleteTargetsAreWorkspaceConfined(body, depth + 1)) return false;
   }
   const mint = symlinkMintTaint(text);
   if (mint.all) return false;

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -1171,6 +1171,66 @@ function applyCdDest(cwd: ConfinedCwd, dest: string): ConfinedCwd {
   return { kind: 'workspace', rel: cwd.rel ? joinPathParts(cwd.rel, dest) : dest };
 }
 
+/**
+ * A statement stripped of the shell furniture that hides a `cd` from a
+ * leading-anchor test: the grouping characters a subshell / brace group leaves
+ * on the ends (`(cd /`, `{ cd /`) and the two wrappers that still leave `cd`
+ * the real command (`builtin cd /`, `command cd /`).
+ *
+ * Measured on the #339 build: every one of those spellings walked straight past
+ * `^cd\b`, so a root-level relative delete kept the workspace cwd and the
+ * exemption ALLOWED it — the fail-open direction, one wrapper away from the
+ * case #339 had just closed.
+ */
+function unwrapCdStatement(stmt: string): string {
+  let s = stmt.replace(/^[\s(){}]+/, '').replace(/[\s(){}]+$/, '');
+  for (let prev = ''; s !== prev; ) {
+    prev = s;
+    s = s.replace(/^(?:builtin|command)\s+/i, '');
+  }
+  return s;
+}
+
+function isInlineShellStatement(s: string): boolean {
+  return /^(?:(?:builtin|command|env|nohup|exec)\s+)*(?:bash|sh|zsh|ksh|dash|ash)\b/i.test(s);
+}
+
+/**
+ * Nested surfaces a relative delete can hide in: unquoted `(…)` / `$(…)` /
+ * backticks, plus `bash -c '…'` (and friends). Missing `-c` program text is
+ * unreadable — fail closed. Depth is owned by the caller.
+ */
+function nestedDeleteSurfaces(text: string): { bodies: string[]; unreadable: boolean } {
+  const bodies = collectExecutableBodies(text);
+  let unreadable = false;
+  for (const stmt of disposerStatements(text)) {
+    const tokens = tokeniseStatement(stmt);
+    for (let i = 0; i < tokens.length; i++) {
+      const base = commandBaseName(tokens[i]!);
+      if (!/^(?:bash|sh|zsh|ksh|dash|ash)$/.test(base)) continue;
+      for (let j = i + 1; j < tokens.length; j++) {
+        if (isInlineProgramFlag(base, tokens[j]!)) {
+          const prog = tokens[j + 1];
+          if (!prog) unreadable = true;
+          else bodies.push(prog);
+          break;
+        }
+        if (BASH_VALUE_OPTION.test(tokens[j]!)) { j++; continue; }
+        if (!tokens[j]!.startsWith('-')) break;
+      }
+    }
+  }
+  return { bodies, unreadable };
+}
+
+// A `cd` / `pushd` / `popd` ANYWHERE in a statement the cd parser could not
+// read as a clean destination (`eval "cd /"`, `foo=$(cd /)`, a shell whose
+// program is quoted). The directory may have moved and this walk cannot say
+// where, so the only honest answer is "uncertain" — which costs the exemption
+// rather than betting the cwd is still the workspace. Hyphen excluded from the
+// boundary so a hyphenated identifier (`docker-cd-helper`) is not a cd (#188).
+const CD_WORD_RE = /(?<![\w-])(?:cd|pushd|popd)(?![\w-])/i;
+
 /** Cwd in effect just before `end`, walking cd / pushd and failing closed on ||. */
 function cwdBefore(text: string, end: number): ConfinedCwd {
   const slice = text.slice(0, end);
@@ -1178,7 +1238,7 @@ function cwdBefore(text: string, end: number): ConfinedCwd {
   let quote: string | null = null;
   let stmt = '';
   const flush = (sep: string): void => {
-    const s = stmt.trim();
+    const s = unwrapCdStatement(stmt);
     stmt = '';
     if (!s) return;
     if (/^pushd\b|^popd\b/i.test(s)) {
@@ -1186,6 +1246,8 @@ function cwdBefore(text: string, end: number): ConfinedCwd {
     } else if (/^cd\b/i.test(s)) {
       const dest = parseCdDest(s);
       cwd = dest === 'bad' ? { kind: 'uncertain' } : applyCdDest(cwd, dest);
+    } else if (CD_WORD_RE.test(s) && !isInlineShellStatement(s)) {
+      cwd = { kind: 'uncertain' };
     }
     if (sep === '||' || sep === '|') cwd = { kind: 'uncertain' };
   };
@@ -1209,6 +1271,10 @@ function cwdBefore(text: string, end: number): ConfinedCwd {
     }
     stmt += c;
   }
+  // The leftover statement, with no separator of its own. `rm` is at command
+  // position after openers cwdBefore does not split on (`` ` ``, `$(`, `(`), so
+  // dropping the tail dropped the `cd` in ``cd / `rm -rf x` `` entirely.
+  flush('');
   return cwd;
 }
 
@@ -1255,7 +1321,16 @@ function hasStandaloneRmStatement(text: string): boolean {
   return RM_STATEMENT_RE.test(text);
 }
 
-function deleteTargetsAreWorkspaceConfined(text: string): boolean {
+function deleteTargetsAreWorkspaceConfined(text: string, depth = 0): boolean {
+  if (depth < 2) {
+    const nested = nestedDeleteSurfaces(text);
+    if (nested.unreadable) return false;
+    for (const body of nested.bodies) {
+      if (hasStandaloneRmStatement(body) && !deleteTargetsAreWorkspaceConfined(body, depth + 1)) {
+        return false;
+      }
+    }
+  }
   const mint = symlinkMintTaint(text);
   if (mint.all) return false;
   RM_STATEMENT_RE.lastIndex = 0;

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -25,6 +25,7 @@
  * user's `autoApprove` list.
  */
 
+import { lstatSync, realpathSync } from 'node:fs';
 import type { IronDomeConfig } from './config.js';
 import { forEachWindow } from '../scan-windows.js';
 
@@ -1085,55 +1086,205 @@ const RM_STATEMENT_RE = /(^|[;&|(){}`\n]|\$\()\s*(?:sudo\s+)?rm\b([^;&|(){}`\n]*
 // (`build/rm-cache`, `src/rm/x`), which is not a delete verb at all and must
 // not cost the exemption.
 const RM_WORD_RE = /(?<![\w./-])rm(?![\w./-])/gi;
-const CONFINED_TEMP_TARGET_RE = /^(?:\/tmp|\/var\/tmp|\/private\/var\/folders)\/[^\s]+$/i;
-/** Beyond this many `rm` statements the line is not analysable — never exempt. */
+/** Beyond this many standalone delete statements the line is not analysable. */
 const RM_STATEMENT_SCAN_LIMIT = 64;
 
-/** At least one statement on the line begins with a standalone `rm`. */
+type ConfinedCwd =
+  | { kind: 'workspace'; rel: string }
+  | { kind: 'abs'; path: string }
+  | { kind: 'uncertain' };
+
+function joinPathParts(base: string, child: string): string {
+  const left = base.replace(/\/+$/, '');
+  const right = child.replace(/^\/+/, '');
+  if (!left) return `/${right}`;
+  if (!right) return left;
+  return `${left}/${right}`;
+}
+
+/** Darwin /private/tmp is /tmp; /private/var/tmp is /var/tmp. */
+function normalizeDarwinTempAliases(p: string): string {
+  return p
+    .replace(/^\/private\/tmp(?=\/|$)/i, '/tmp')
+    .replace(/^\/private\/var\/tmp(?=\/|$)/i, '/var/tmp')
+    .replace(/^\/private\/var\/folders(?=\/|$)/i, '/var/folders')
+    .replace(/\/{2,}/g, '/');
+}
+
+/** A confined temp child, never the temp root itself. */
+function isConfinedAbsolute(p: string): boolean {
+  const n = normalizeDarwinTempAliases(p).replace(/\/+$/, '');
+  const lower = n.toLowerCase();
+  return ['/tmp/', '/var/tmp/', '/var/folders/'].some(prefix => lower.startsWith(prefix));
+}
+
+/**
+ * Resolve existing components (so a symlink parent is followed) and append
+ * any missing tail lexically. Returns null on ELOOP / EACCES / special files.
+ */
+function resolveExistingPrefix(p: string): string | null {
+  const trimmed = p.length > 1 ? p.replace(/\/+$/, '') : p;
+  const parts = trimmed.split('/').filter(Boolean);
+  let current = '';
+  for (let i = 0; i < parts.length; i++) {
+    const next = `${current}/${parts[i]}`;
+    try {
+      const st = lstatSync(next);
+      if (st.isSymbolicLink()) {
+        try { current = realpathSync(next); }
+        catch { return null; }
+        continue;
+      }
+      if (!st.isDirectory() && !st.isFile()) return null;
+      try { current = realpathSync(next); }
+      catch { current = next; }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code === 'ENOENT') {
+        const rest = parts.slice(i).join('/');
+        return current ? `${current}/${rest}` : `/${rest}`;
+      }
+      return null;
+    }
+  }
+  return current || trimmed;
+}
+
+function parseCdDest(stmt: string): string | 'bad' {
+  const m = stmt.match(/^\s*cd\b(.*)$/i);
+  if (!m) return 'bad';
+  const rest = (m[1] ?? '').trim();
+  if (!rest) return 'bad';
+  const positional = rest.split(/\s+/)
+    .map(t => t.replace(/^[\"']|[\"']$/g, ''))
+    .filter(t => t && !t.startsWith('-'));
+  if (positional.length !== 1) return 'bad';
+  const dest = positional[0]!;
+  if (dest === '-' || /[$`*?~]/.test(dest) || dest.includes('..')) return 'bad';
+  return dest;
+}
+
+function applyCdDest(cwd: ConfinedCwd, dest: string): ConfinedCwd {
+  if (cwd.kind === 'uncertain') return cwd;
+  if (dest.startsWith('/')) return { kind: 'abs', path: dest };
+  if (cwd.kind === 'abs') return { kind: 'abs', path: joinPathParts(cwd.path, dest) };
+  return { kind: 'workspace', rel: cwd.rel ? joinPathParts(cwd.rel, dest) : dest };
+}
+
+/** Cwd in effect just before `end`, walking cd / pushd and failing closed on ||. */
+function cwdBefore(text: string, end: number): ConfinedCwd {
+  const slice = text.slice(0, end);
+  let cwd: ConfinedCwd = { kind: 'workspace', rel: '' };
+  let quote: string | null = null;
+  let stmt = '';
+  const flush = (sep: string): void => {
+    const s = stmt.trim();
+    stmt = '';
+    if (!s) return;
+    if (/^pushd\b|^popd\b/i.test(s)) {
+      cwd = { kind: 'uncertain' };
+    } else if (/^cd\b/i.test(s)) {
+      const dest = parseCdDest(s);
+      cwd = dest === 'bad' ? { kind: 'uncertain' } : applyCdDest(cwd, dest);
+    }
+    if (sep === '||' || sep === '|') cwd = { kind: 'uncertain' };
+  };
+  for (let i = 0; i < slice.length; i++) {
+    const c = slice[i]!;
+    if (c === '\\' && quote !== "'" && i + 1 < slice.length) {
+      stmt += c + slice[++i];
+      continue;
+    }
+    if (quote) {
+      stmt += c;
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") { quote = c; stmt += c; continue; }
+    if (c === ';' || c === '&' || c === '|' || c === '\n' || c === '\r') {
+      let sep = c;
+      if ((c === '&' || c === '|') && slice[i + 1] === c) { sep = c + c; i++; }
+      flush(sep);
+      continue;
+    }
+    stmt += c;
+  }
+  return cwd;
+}
+
+function effectiveDeleteTarget(tok: string, cwd: ConfinedCwd): string | 'uncertain' {
+  if (tok.startsWith('/')) return tok;
+  if (cwd.kind === 'uncertain') return 'uncertain';
+  if (cwd.kind === 'abs') return joinPathParts(cwd.path, tok);
+  return cwd.rel ? joinPathParts(cwd.rel, tok) : tok;
+}
+
+/** Same-line ln -s / cp -s destinations. Unreadable dest taints the whole line. */
+function symlinkMintTaint(text: string): { all: boolean; dests: string[] } {
+  const dests: string[] = [];
+  let all = false;
+  for (const raw of quoteAwareStatements(text)) {
+    const stmt = raw.trim();
+    const isLn = /^ln\b/i.test(stmt);
+    const isCp = /^cp\b/i.test(stmt);
+    if (!isLn && !isCp) continue;
+    const args = stmt.split(/\s+/).slice(1);
+    const flags = args.filter(a => a.startsWith('-'));
+    const positional = args
+      .filter(a => !a.startsWith('-'))
+      .map(a => a.replace(/^[\"']|[\"']$/g, ''));
+    const symbolic = flags.some(f =>
+      f === '--symbolic' || (!f.startsWith('--') && f.includes('s')));
+    if (!symbolic) continue;
+    const dest = positional[positional.length - 1] ?? '';
+    if (!dest || /[$`*?~]/.test(dest)) { all = true; continue; }
+    dests.push(dest);
+  }
+  return { all, dests };
+}
+
+function mintTaintsTarget(target: string, dest: string): boolean {
+  const a = normalizeDarwinTempAliases(target);
+  const b = normalizeDarwinTempAliases(dest);
+  return a === b || a.startsWith(b.endsWith('/') ? b : `${b}/`);
+}
+
+/** At least one statement on the line begins with a standalone delete verb. */
 function hasStandaloneRmStatement(text: string): boolean {
   RM_STATEMENT_RE.lastIndex = 0;
   return RM_STATEMENT_RE.test(text);
 }
 
 function deleteTargetsAreWorkspaceConfined(text: string): boolean {
+  const mint = symlinkMintTaint(text);
+  if (mint.all) return false;
   RM_STATEMENT_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
   let sawTarget = false;
   let statements = 0;
   while ((m = RM_STATEMENT_RE.exec(text)) !== null) {
-    // Truncating the scan used to fall out of the loop and return the verdict
-    // built from the statements already seen — so a long enough command was
-    // exempted on the strength of its first 64 deletes (measured, #196). An
-    // unanalysable line is never downgraded.
     if (++statements > RM_STATEMENT_SCAN_LIMIT) return false;
+    const cwd = cwdBefore(text, m.index);
     const args = m[2] ?? '';
     for (const raw of args.split(/\s+/)) {
       const tok = raw.trim().replace(/^["']|["']$/g, '');
-      if (!tok || tok.startsWith('-')) continue;          // flags, not targets
+      if (!tok || tok.startsWith('-')) continue;
       sawTarget = true;
-      // Never gamble on anything that can expand or climb.
       if (/[$`*?~]/.test(tok)) return false;
       if (tok.includes('..')) return false;
-      // The WHOLE current directory is not an innocuous confined subdir — it is
-      // every entry in cwd (`.git`, source, uncommitted work), the same blast
-      // radius as `./*`. Any token that is only dots and slashes normalises to
-      // cwd (`.`, `./`, `./.`, `.//`, `././`) — and the quote strip above means
-      // `'.'` / `"."` reach here as `.`. A NAMED relative dir (`.next`, `./build`)
-      // has a non-dot/slash char and stays confined. (#182 residual — Grok.)
       if (/^\.[.\/]*$/.test(tok)) return false;
-      if (tok.startsWith('/')) {
-        if (!CONFINED_TEMP_TARGET_RE.test(tok)) return false;
-        continue;
+      const effective = effectiveDeleteTarget(tok, cwd);
+      if (effective === 'uncertain') return false;
+      if (mint.dests.some(d => mintTaintsTarget(effective, d) || mintTaintsTarget(tok, d))) {
+        return false;
       }
-      // Relative and non-climbing — a workspace path.
+      if (!effective.startsWith('/')) continue;
+      const resolved = resolveExistingPrefix(effective);
+      if (resolved === null) return false;
+      if (!isConfinedAbsolute(resolved)) return false;
     }
   }
   if (!sawTarget) return false;
-  // Every `rm` on the line must have been one of the statements just examined.
-  // If the splitter could not account for one — `find … -exec rm -rf {} +`,
-  // `xargs rm`, any shape not yet understood — its target was never checked,
-  // and an unexamined delete must not inherit the exemption its neighbours
-  // earned. Fail-safe by construction rather than by enumeration.
   RM_WORD_RE.lastIndex = 0;
   const occurrences = (text.match(RM_WORD_RE) ?? []).length;
   return occurrences === statements;


### PR DESCRIPTION
## Summary

Closes #339. Action Guard no longer treats a lexical temp-root spelling as proof of confinement.

Vision reproduced on 4.54.4 via `evaluateToolCall` only (no live delete):

- a temp-root path that is a symlink out of the tree was allowed
- Darwin `/private/tmp/...` (same tree as `/tmp/...`) was blocked
- `cd /` plus a relative target was allowed because relative tokens were assumed workspace-confined

## Change

- Resolve existing path components (`lstat` / `realpath`) or fail closed
- Treat `/private/tmp` and `/private/var/tmp` as the Darwin spellings of `/tmp` and `/var/tmp`
- Track `cd` before relative delete targets; unanalysable `cd` / `pushd` / `||` fail closed
- Same-line symbolic-link mint is identified by argv (`commandWordIndex` + basename), so `command ln`, `env ln`, `exec ln`, `/bin/ln` taint like bare `ln -s` / `cp -s`
- Nested `bash -c` / friends are inspected up to `MAX_INLINE_RECURSION`; exhausted budget + a still-unanalysed standalone delete fails closed
- #170 / #196 workspace relief unchanged at analysed depth (`dist`, `cd dashboard && .next`, one- and two-level workspace nests)

## Residual — name it, do not overclaim

This PR closes the **shell-syntax confinement path**. It does **not** make the `/tmp` confine complete.

Interpreter-language deletes never become shell statements. Isolated `evaluateToolCall` on this head still **allows**:

- `python3 -c "import os,shutil; os.chdir('/'); shutil.rmtree('relative-target')"`
- `node -e "process.chdir('/'); require('fs').rmSync('relative-target',{recursive:true,force:true})"`

`perl -e '... system("rm -rf ...")'` blocks only because the payload still contains the shell verb. A future wrapper list will not cover this class. Track separately; do not read #339-closed as "escape closed."

Also still named (unchanged): workspace-relative `dist` / `.next` are allowed by #170 design, not because they were proven confined to a temp root.

## Verification

- `guard-tmp-confine-339.test.ts`: 51 passed
- `#196` + `#170` nearby: 15 passed
- Isolated `evaluateToolCall` replay: Athena mint-wrapper + third-nest cases now block; Veronica Tier 1 (other shells / eval / exec / timeout / env / nice / stdbuf / xargs / find -exec) block; Tier 2 python/node still allow

## Out of scope

- #310 stays design (no approval cards)
- No version bump / cut
- No interpreter AST / `python -c` / `node -e` confinement in this PR

## Test plan

- [x] Focused confinement + #196 + #170 suites
- [ ] CI on this head
- [ ] Independent re-review of **36206b5** (Athena CHANGES_REQUESTED was on 7973f07)
