### PR TITLE
fix(doctor): full-screen fail/warn text no longer ellipsized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Doctor fail/warn text wraps in full on wide terminals — no mid-sentence ellipsis; width ceiling raised to 240.
+
 ### Security
 
 - **Action Guard temp-root exemption is proven, not spelled (#339)** — lexical `/tmp/...` is no longer treated as confined when the path is a symlink out of the tree, a Darwin `/private/tmp` spelling of the same tree, or a relative target after `cd /`. Same-line `ln -s` / `cp -s` into a later delete dest fails closed. Wrapper/subshell/`bash -c`/`builtin`/`command` cd is walked the same way. Workspace `dist` / `cd dashboard && … .next` relief from #170 is unchanged.

--- a/src/cli/__tests__/doctor-report-mobile.test.ts
+++ b/src/cli/__tests__/doctor-report-mobile.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, expect, it } from '@jest/globals';
 import {
+  cleanWhy,
   collapseKey,
   extractFixCommands,
   formatDoctorReport,
@@ -103,8 +104,13 @@ describe('wrapLine / oneLineWhy', () => {
     }
   });
 
-  it('ellipsizes why to width', () => {
+  it('ellipsizes why to width (compact info/pass path only)', () => {
     expect(oneLineWhy('a'.repeat(100), 40).length).toBeLessThanOrEqual(40);
+  });
+
+  it('cleanWhy collapses whitespace and strips backticks without ellipsizing', () => {
+    const long = 'x'.repeat(200);
+    expect(cleanWhy(`a  \`b\`\n c ${long}`)).toBe(`a b c ${long}`);
   });
 });
 
@@ -194,5 +200,56 @@ describe('formatDoctorReport — Edith case', () => {
     expect(text.indexOf('FAILURES')).toBeGreaterThanOrEqual(0);
     expect(text.indexOf('FAILURES')).toBeLessThan(text.indexOf('NEEDS ATTENTION'));
     expect(text).toMatch(/\$ shieldcortex repair/);
+  });
+});
+
+describe('formatDoctorReport — full-screen terminals', () => {
+  const LONG_TOKEN = 'FULLY_VISIBLE_WHY_TOKEN_THAT_MUST_NOT_BE_CUT_BY_ELLIPSIS';
+  const LONG_FAIL: DoctorReportItem = {
+    label: 'Database',
+    status: 'fail',
+    message:
+      'integrity check failed on three tables and the write-ahead log cannot be replayed; ' +
+      'the previous backup completed four hours ago so restoring from it loses recent captures — ' +
+      `full details are recorded in the audit log under ${LONG_TOKEN}`,
+    fix: '`shieldcortex repair`',
+  };
+
+  it.each([120, 200])('long fail why appears in full at width %d — no mid-sentence ellipsis', (width) => {
+    const lines = formatDoctorReport([LONG_FAIL], { width, color: false });
+    const text = lines.join('\n');
+    expect(text).toContain(LONG_TOKEN);
+    expect(text).not.toContain('…');
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(width);
+    }
+  });
+
+  it('width 200 is not clamped down to 120 — long single token stays on one line', () => {
+    const token = 'A'.repeat(170);
+    const lines = formatDoctorReport(
+      [{ label: 'Database', status: 'fail', message: `token ${token} end`, fix: '`shieldcortex repair`' }],
+      { width: 200, color: false },
+    );
+    // If width were clamped to 120, wrapLine would hard-split the 170-char
+    // token across lines and no single line would contain it whole.
+    expect(lines.some((l) => l.includes(token))).toBe(true);
+  });
+
+  it('shows all fix commands for a fail item, not just the first three', () => {
+    const fix =
+      'Run `shieldcortex repair`, then `shieldcortex doctor --fix-project-keys`, ' +
+      '`shieldcortex config --action-guard-enforce`, `openclaw gateway restart`, ' +
+      'and `shieldcortex memories repair-project-keys --execute`';
+    const lines = formatDoctorReport(
+      [{ label: 'Database', status: 'fail', message: 'corrupt', fix }],
+      { width: 100, color: false },
+    );
+    const text = lines.join('\n');
+    expect(text).toContain('$ shieldcortex repair');
+    expect(text).toContain('$ shieldcortex doctor --fix-project-keys');
+    expect(text).toContain('$ shieldcortex config --action-guard-enforce');
+    expect(text).toContain('$ openclaw gateway restart');
+    expect(text).toContain('$ shieldcortex memories repair-project-keys --execute');
   });
 });

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -3,7 +3,8 @@
  *
  * Pure display layer only — does not change check logic, exit codes, or
  * severity. Default output collapses passes and duplicate warning themes so a
- * 40-col phone SSH pane shows what matters first.
+ * 40-col phone SSH pane shows what matters first. Fail/warn text is never
+ * truncated mid-sentence via ellipsis — it wraps in full at any width.
  */
 
 export type DoctorStatus = 'pass' | 'warn' | 'fail' | 'info';
@@ -185,13 +186,17 @@ function unique(xs: string[]): string[] {
   return out;
 }
 
-export function oneLineWhy(message: string, width: number): string {
-  const cleaned = message
+/** Collapse whitespace and strip backticks — never ellipsizes. */
+export function cleanWhy(message: string): string {
+  return message
     .replace(/\s+/g, ' ')
     .replace(/`/g, '')
     .trim();
-  // Prefer text before em-dash / "—" explanation tail if very long
-  return ellipsize(cleaned, Math.max(12, width - 4));
+}
+
+/** Compact one-liner — used only for the INFO compact path and pass lines. */
+export function oneLineWhy(message: string, width: number): string {
+  return ellipsize(cleanWhy(message), Math.max(12, width - 4));
 }
 
 export function ellipsize(s: string, max: number): string {
@@ -325,25 +330,28 @@ function renderIssueBlock(g: ThemeGroup, width: number, style: DoctorReportStyle
   const mark = STATUS_MARK[g.status];
   const col = statusColor(g.status, style);
   const xN = g.count > 1 ? `  x${g.count}` : '';
-  const head = `${col}${mark}${style.reset} ${g.theme.padEnd(6)} ${g.what}${xN}`;
   const lines: string[] = [];
-  // Head may need wrap — keep mark+theme on first line when possible
-  lines.push(...wrapLine(stripAnsiForWrap(head, style), width, 0, 4).map((ln, i) => {
+  // Title: wrap in full — never ellipsize fail/warn headings mid-label.
+  const titlePlain = `${mark} ${g.theme.padEnd(6)} ${g.what}${xN}`;
+  const titleWrapped = wrapLine(titlePlain, width, 0, 4);
+  for (let i = 0; i < titleWrapped.length; i++) {
+    const ln = titleWrapped[i]!;
     if (i === 0) {
-      // re-colour first line only
-      return `${col}${mark}${style.reset} ${g.theme.padEnd(6)} ${ellipsize(`${g.what}${xN}`, Math.max(8, width - 12))}`;
+      // Re-apply colour to mark only; body stays plain after theme.
+      const rest = ln.replace(mark, '').replace(/^\s*/, '');
+      lines.push(`${col}${mark}${style.reset} ${rest}`);
+    } else {
+      lines.push(ln);
     }
-    return ln;
-  }));
-  // Why
-  const why = oneLineWhy(g.why, width);
+  }
+  // Why: full text, wrapped. Ellipsis here is what made full-screen doctor look "cut off".
+  const why = cleanWhy(g.why);
   lines.push(...wrapLine(why, width, 4, 4).map((l) => `${style.dim}${l}${style.reset}`));
-  // Fix commands
-  // Fix lines: `$` only on a real binary. English notes stay notes.
+  // Fix commands — all of them. `$` only on a real binary. English notes stay notes.
   if (g.fixCommands.length === 0) {
     lines.push(`${style.dim}    (no single copy-paste command)${style.reset}`);
   } else {
-    for (const cmd of g.fixCommands.slice(0, 3)) {
+    for (const cmd of g.fixCommands) {
       const runnable = /^(?:[\w.-]+\s+)?(?:shieldcortex|openclaw|claude|npm|node|systemctl|launchctl|chown|chmod)\b/i.test(cmd)
         || cmd.startsWith('SHIELDCORTEX_');
       const prefixed = runnable ? `$ ${cmd}` : cmd;
@@ -359,19 +367,6 @@ function renderIssueBlock(g: ThemeGroup, width: number, style: DoctorReportStyle
     }
   }
   return lines;
-}
-
-/** Strip style codes we just added if wrap helper sees them — head path avoids this. */
-function stripAnsiForWrap(s: string, style: DoctorReportStyle): string {
-  if (!style.reset) return s;
-  return s
-    .split(style.bold).join('')
-    .split(style.reset).join('')
-    .split(style.green).join('')
-    .split(style.yellow).join('')
-    .split(style.red).join('')
-    .split(style.cyan).join('')
-    .split(style.dim).join('');
 }
 
 function renderPassLine(it: DoctorReportItem, width: number, style: DoctorReportStyle): string[] {
@@ -480,7 +475,8 @@ export function formatDoctorReport(
 
 function clampWidth(w: number): number {
   if (!Number.isFinite(w) || w < 40) return 40;
-  if (w > 120) return 120;
+  // Full-screen terminals are often 160–200+; 120 forced mid-sentence cutoffs.
+  if (w > 240) return 240;
   return Math.floor(w);
 }
 


### PR DESCRIPTION
## Summary
Doctor on a **full-screen** terminal was still cutting fail/warn text mid-sentence.

### Cause
1. `oneLineWhy` **ellipsized** before wrap on every issue block
2. Width hard-capped at **120**
3. Fix commands capped at **3**

### Fix
- Fail/warn: wrap **full** why + title; all fix commands
- Width ceiling **240**
- Ellipsis kept only for compact info/pass paths
- Tests: full-screen suite (width 120/200, all fixes)

## Test plan
- [x] `doctor-report-mobile.test.ts` 16/16
- [ ] CI