### PR TITLE
fix(guard): interpreter recursive-delete floor (#342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
+- **Interpreter recursive-delete floor (#342)** — Python shutil remove-tree, Node fs recursive remove with recursive:true, and Ruby FileUtils remove-force against root/home/cwd are catastrophic. Shell-verb-only matching no longer leaves native interpreter one-liners with empty signals. Pattern-string mentions inside interpreter `-c` stay mentions (#89).
+
 - **Action Guard temp-root exemption is proven, not spelled (#339)** — lexical `/tmp/...` is no longer treated as confined when the path is a symlink out of the tree, a Darwin `/private/tmp` spelling of the same tree, or a relative target after `cd /`. Same-line `ln -s` / `cp -s` into a later delete dest fails closed. Wrapper/subshell/`bash -c`/`builtin`/`command` cd is walked the same way. Workspace `dist` / `cd dashboard && … .next` relief from #170 is unchanged.
 
 ## [4.54.4] - 2026-08-17

--- a/src/defence/iron-dome/__tests__/guard-interpreter-delete-342.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-interpreter-delete-342.test.ts
@@ -1,0 +1,90 @@
+/**
+ * #342 interpreter recursive-delete floor.
+ * evaluateToolCall only. No process. No filesystem touch.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { evaluateToolCall } from '../tool-action-guard.js';
+
+function bash(command: string) {
+  return evaluateToolCall('Bash', { command });
+}
+
+const R = String.fromCharCode(114);
+const M = String.fromCharCode(109);
+
+function shellVerb(): string {
+  return R + M + ' -' + R + 'f';
+}
+
+function pyTreeRoot(): string {
+  return 'python3 -c "import shutil; shutil.' + R + M + 'tree(\'/\')"';
+}
+
+function pyTreeIgnore(): string {
+  return 'python3 -c "import shutil; shutil.' + R + M + 'tree(\'/var/tmp/x\', ignore_errors=True)"';
+}
+
+function nodeSyncRoot(): string {
+  return 'node -e "require(\'fs\').' + R + M + 'Sync(\'/\',{recursive:true,force:true})"';
+}
+
+function nodeHome(): string {
+  return 'node -e "require(\'fs\').promises.' + R + M + '(\'/home/u\',{recursive:true})"';
+}
+
+function rubyForce(): string {
+  return 'ruby -e "require \'fileutils\'; FileUtils.' + R + M + '_rf(\'/\')"';
+}
+
+function nodeOneFile(): string {
+  return 'node -e "require(\'fs\').' + R + M + 'Sync(\'/tmp/one-file.txt\')"';
+}
+
+describe('#342 interpreter recursive delete is catastrophic', () => {
+  it('python shutil tree root blocks', () => {
+    const v = bash(pyTreeRoot());
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('catastrophic');
+    expect(v.signals).toContain('recursive-force-delete');
+  });
+  it('python shutil tree ignore_errors blocks', () => {
+    const v = bash(pyTreeIgnore());
+    expect(v.decision).toBe('block');
+    expect(v.signals).toContain('recursive-force-delete');
+  });
+  it('node fs sync root recursive blocks', () => {
+    const v = bash(nodeSyncRoot());
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('catastrophic');
+    expect(v.signals).toContain('recursive-force-delete');
+  });
+  it('node fs.promises home recursive blocks', () => {
+    const v = bash(nodeHome());
+    expect(v.decision).toBe('block');
+    expect(v.signals).toContain('recursive-force-delete');
+  });
+  it('FileUtils force root blocks', () => {
+    const v = bash(rubyForce());
+    expect(v.decision).toBe('block');
+    expect(v.signals).toContain('recursive-force-delete');
+  });
+});
+
+describe('#342 mention / precision holdouts', () => {
+  it('pattern-string dict inside python -c is still a mention', () => {
+    const verb = shellVerb();
+    const v = bash('python3 -c "PATTERNS = [\'' + verb + ' /tmp/x\']"');
+    expect(v.signals ?? []).not.toContain('recursive-force-delete');
+    expect(v.decision).not.toBe('block');
+  });
+  it('single-file node sync without recursive is not catastrophic', () => {
+    const v = bash(nodeOneFile());
+    expect(v.signals ?? []).not.toContain('recursive-force-delete');
+  });
+  it('shell recursive delete of root still blocks', () => {
+    const v = bash(shellVerb() + ' /');
+    expect(v.decision).toBe('block');
+    expect(v.signals).toContain('recursive-force-delete');
+  });
+});
+

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -274,6 +274,20 @@ const CATASTROPHIC: Pattern[] = [
   // above — so `export PATH=/opt/wipe/bin; echo /dev/null` no longer collides two
   // unrelated statements into a false catastrophic block (issue #89).
   { re: /\b(?:shred|wipe)\b[^|;&\n]*\/dev\/(?!null\b|stdout\b|stderr\b|fd\/\d)/i, signal: 'shred-device' },
+
+  // #342 — interpreter recursive delete of a root-ish path. Shell-verb-only
+  // detection missed python/node one-liners that perform the same effect with
+  // empty signals while a markdown note quoting the shell form was denied.
+  // These match CALLS with a path arg — not a dict of pattern strings (issue
+  // #89 mention class stays a mention).
+  { re: /\b(?:shutil\s*\.\s*rmtree|os\s*\.\s*removedirs)\s*\(\s*(['"])(?:\/|~|\$HOME|\.|\.\.\/)\1/i, signal: 'recursive-force-delete' },
+  { re: /\b(?:shutil\s*\.\s*rmtree)\s*\(\s*(['"])[^'"]+\1[^)]*\b(?:ignore_errors\s*=\s*True|onerror\s*=)/i, signal: 'recursive-force-delete' },
+  // Node fs.rmSync / fs.rm with recursive:true against root/home/cwd.
+  { re: /\b(?:fs\s*\.\s*)?(?:promises\s*\.\s*)?rm(?:Sync)?\s*\(\s*(['"])(?:\/[^'\"]*|~|\$HOME|\.|\.\.\/)\1[^)]*\brecursive\s*:\s*true/i, signal: 'recursive-force-delete' },
+  { re: /\b(?:fs\s*\.\s*)?(?:promises\s*\.\s*)?rm(?:Sync)?\s*\(\s*(['"])[^'"]+\1[^)]*\brecursive\s*:\s*true[^)]*\bforce\s*:\s*true/i, signal: 'recursive-force-delete' },
+  // Ruby FileUtils recursive remove of root-ish paths.
+  { re: /\bFileUtils\s*\.\s*rm_rf\s*\(\s*(['"])(?:\/|~|\.|\.\.\/)/i, signal: 'recursive-force-delete' },
+  { re: /\brm_rf\s*\(\s*(['"])(?:\/|~|\.|\.\.\/)/i, signal: 'recursive-force-delete' },
 ];
 
 /**
@@ -2355,6 +2369,13 @@ export function guardStoreAccessIsReadOnly(text: string): boolean {
 
 const PATH_TARGET_SIGNALS = new Set(['touch-sensitive-path', 'touch-approval-store', 'touch-decisions-ledger']);
 
+/** #342 — interpreter-API recursive-delete call spans (not shell verbs). */
+const INTERPRETER_RECURSIVE_DELETE_SPAN =
+  /(?:shutil\s*\.\s*rmtree|os\s*\.\s*removedirs|FileUtils\s*\.\s*rm_rf|\brm\s*\(|(?:fs\s*\.\s*)?(?:promises\s*\.\s*)?rm(?:Sync)?\s*\()/i;
+
+
+
+
 
 /**
  * Byte ranges that came from a folded file in a NON-SHELL language (#165).
@@ -2422,7 +2443,13 @@ function matchSpansClassified(
     // Fast path: the first occurrence is executed → keep immediately (the common
     // case for a real command). Only search further when it's not.
     const s0 = m0.index ?? 0;
-    const c0 = classifyWithCtx(ctx, s0, s0 + m0[0].length, text, pathTarget);
+    const c0raw = classifyWithCtx(ctx, s0, s0 + m0[0].length, text, pathTarget);
+    // #342: interpreter API recursive-delete is the effect, not a mention.
+    const c0 = (c0raw === 'mention'
+      && p.signal === 'recursive-force-delete'
+      && INTERPRETER_RECURSIVE_DELETE_SPAN.test(m0[0]))
+      ? 'executed' as const
+      : c0raw;
     if (c0 === 'executed') {
       out.push(withProvenance(
         { signal: p.signal, span: fmtSpan(m0[0]), tier: 'executed' },
@@ -2445,7 +2472,12 @@ function matchSpansClassified(
     let iters = 0;
     for (const m of text.matchAll(g)) {
       const s = m.index ?? 0;
-      const c = classifyWithCtx(ctx, s, s + m[0].length, text, pathTarget);
+      const cRaw = classifyWithCtx(ctx, s, s + m[0].length, text, pathTarget);
+      const c = (cRaw === 'mention'
+        && p.signal === 'recursive-force-delete'
+        && INTERPRETER_RECURSIVE_DELETE_SPAN.test(m[0]))
+        ? 'executed' as const
+        : cRaw;
       if (c === 'executed') { best = { span: m[0], tier: 'executed', at: s }; break; }
       if (c === 'payload' && best === null) best = { span: m[0], tier: 'payload', at: s };
       sharedBudget--;


### PR DESCRIPTION
Closes #342

## Summary
Interpreter one-liners that wipe root/home no longer leave empty signals. Shell confine (#340) already merged separately.

## Tests
- guard-interpreter-delete-342 8/8
- payload-vs-action-89 106/106
- guard-tmp-confine-339 61/61