### PR TITLE
fix(guard): memory markdown forensic quotes (#341 Face 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
+- **#341 Face 1 — memory markdown forensic quotes** — inline backticks and fenced blocks in MEMORY.md / `.claude/memory` writes are neutralized before the write-content danger scan so incident notes can quote ops forms without a promptless deny. Script-like targets still scan raw bytes. Face 2 (false realtime pointer) already shipped in 4.54.x (#284).
+
 - **Action Guard temp-root exemption is proven, not spelled (#339)** — lexical `/tmp/...` is no longer treated as confined when the path is a symlink out of the tree, a Darwin `/private/tmp` spelling of the same tree, or a relative target after `cd /`. Same-line `ln -s` / `cp -s` into a later delete dest fails closed. Wrapper/subshell/`bash -c`/`builtin`/`command` cd is walked the same way. Workspace `dist` / `cd dashboard && … .next` relief from #170 is unchanged.
 
 ## [4.54.4] - 2026-08-17

--- a/src/defence/iron-dome/__tests__/guard-forensic-md-341.test.ts
+++ b/src/defence/iron-dome/__tests__/guard-forensic-md-341.test.ts
@@ -1,0 +1,47 @@
+/** #341 Face 1 */
+import { describe, expect, it } from '@jest/globals';
+import { evaluateToolCall, neutralizeMarkdownCommandMentions } from '../tool-action-guard.js';
+
+const U = 'sys' + 'tem' + 'ctl';
+const V = 'st' + 'op';
+const SSH = 'ss' + 'h ' + 'ro' + 'ot@host uptime';
+
+describe('#341 Face 1 neutralize', () => {
+  it('strips fences and backticks', () => {
+    const out = neutralizeMarkdownCommandMentions('seen `foo` and\n```\nbaz\n```\nend');
+    expect(out).not.toContain('foo');
+    expect(out).not.toContain('baz');
+    expect(out).toContain('seen');
+  });
+});
+
+describe('#341 Face 1 memory md', () => {
+  it('MEMORY.md quoting ops forms allows', () => {
+    const quoted = '`' + U + ' ' + V + ' nginx`';
+    const sshq = '`' + SSH + '`';
+    const v = evaluateToolCall('Edit', {
+      file_path: 'MEMORY.md',
+      old_string: 'x',
+      new_string: 'Incident: ' + quoted + ' and ' + sshq,
+    });
+    expect(v.decision).toBe('allow');
+    expect(v.signals ?? []).not.toContain('write-content-dangerous');
+  });
+  it('claude memory fence allows', () => {
+    const fence = '```\n' + U + ' ' + V + ' nginx\n```';
+    const v = evaluateToolCall('Edit', {
+      file_path: '/home/u/.claude/memory/facts.md',
+      old_string: 'x',
+      new_string: 'Forensics:\n' + fence,
+    });
+    expect(v.decision).toBe('allow');
+  });
+  it('script shebang still gates', () => {
+    const v = evaluateToolCall('Write', {
+      file_path: 'util.sh',
+      content: '#!/bin/bash\n' + U + ' ' + V + ' nginx\n',
+    });
+    expect(v.decision).not.toBe('allow');
+  });
+});
+

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -191,6 +191,20 @@ export function writeContentLooksExecutable(content: string): boolean {
   return /^\uFEFF?\s*#!/.test(String(content || ''));
 }
 
+/**
+ * #341 Face 1 — memory/markdown writes re-read as prose. Quoted forensic
+ * evidence (inline backticks, fenced blocks) is a mention, not a command to
+ * run. Strip those spans before the write-content danger scan so incident
+ * notes can cite shell/ops forms without a promptless deny.
+ * Script-like targets never use this — their bytes are programs.
+ */
+export function neutralizeMarkdownCommandMentions(content: string): string {
+  let s = String(content || '');
+  s = s.replace(/```[\s\S]*?```/g, ' ');
+  s = s.replace(/`[^`\n]+`/g, ' ');
+  return s;
+}
+
 // ── Danger detection ─────────────────────────────────────────────────────────
 
 interface Pattern { re: RegExp; signal: string; }
@@ -3866,8 +3880,13 @@ export function evaluateToolCall(
         || isMemoryWritePath(path)
         || writeContentLooksExecutable(writeContent));
     if (scanThisWrite) {
-      const hits = scanWriteContentPayload(writeContent);
       const memory = isMemoryWritePath(path);
+      // #341: memory markdown is instruction prose — neutralize quoted mentions
+      // before the command-pattern scan. Scripts keep raw bytes.
+      const scanBody = (memory && /\.md$/i.test(path) && !writeContentLooksExecutable(writeContent))
+        ? neutralizeMarkdownCommandMentions(writeContent)
+        : writeContent;
+      const hits = scanWriteContentPayload(scanBody);
       if (hits.catastrophic.length > 0) {
         const signals = ['write-content-catastrophic', ...hits.catastrophic.map(m => m.signal)];
         const span = hits.catastrophic[0]?.span;


### PR DESCRIPTION
Partial close for #341 Face 1.

## Face 1
MEMORY.md / `.claude/memory` Edit content with backtick/fenced ops quotes no longer promptless-denies. Scripts still gate.

## Face 2
False `realtime-*.jsonl` unredacted pointer already fixed in #284 / 4.54.x — hosts need upgrade to ≥4.54.4.

## Tests
- guard-forensic-md-341 4/4
- write-content-scan-93 20/20