### PR TITLE
feat(memory): Track D LongMemEval-S harness (fetch/convert/honest ingest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - **Memory SOTA Track C:** capture distill provider (OpenAI-compatible + Anthropic), fail-closed extract path on stop/session-end, L1 salience cap, no silent regex fallback (#350 / epic #347).
 - **Memory SOTA Track C (OAuth):** distill resolves Hermes OAuth on disk (xai-oauth → openai-codex) when no API key is set — fleet hosts reuse existing login; `SHIELDCORTEX_DISTILL_OAUTH=0` disables.
 - **Memory SOTA Track C (defaults):** distill defaults to cheap models (`grok-4.3` on xAI OAuth, not main chat `grok-4.6`); zero-config when Hermes is already logged in.
+- **Memory SOTA Track D:** LongMemEval-S fetch script, upstream→harness convertor, loader accepts official Turn[][] sessions; honesty docs.
 - **Memory SOTA Track D kickoff:** LongMemEval-S honesty harness design + residual A/B host checklist.
 - **Memory SOTA Track C.2 (OpenClaw):** session extract uses optional L1 distill via OpenClaw auth/env (primary model family first); regex L0 fallback; gateway-safe (no DB in hook).
 - **Memory SOTA Track C (multi-provider zero-config):** distill on-disk auth chain covers Hermes active provider, xai/codex/qwen/minimax/nous OAuth, API-key pools (anthropic/openai/gemini/…), and Claude Max OAuth; cheap model per family.

--- a/benchmark/longmemeval/README.md
+++ b/benchmark/longmemeval/README.md
@@ -71,3 +71,31 @@ public-by-default.
   diverge from the academic dataset.
 - Not gated CI — the workflow is a transparency tool, not a regression
   gate. Per-PR perf checks belong in the unit-test suite.
+
+## Track D — full / labeled LongMemEval-S (honesty)
+
+Dataset is **not** in git. Fetch the cleaned S release, convert if needed, run:
+
+```bash
+# 1) download (HF; ~respect upstream license)
+npm run bench:fetch-s
+# → ~/.shieldcortex/benchmark/longmemeval/longmemeval_s_cleaned.json
+
+# 2) convert official → harness JSONL (optional if using load.ts upstream support)
+npm run bench:convert --   --in ~/.shieldcortex/benchmark/longmemeval/longmemeval_s_cleaned.json   --out ~/.shieldcortex/benchmark/longmemeval/longmemeval-s.jsonl
+
+# labeled subset (deterministic, cite as subset not full-S)
+npm run bench:convert --   --in ~/.shieldcortex/benchmark/longmemeval/longmemeval_s_cleaned.json   --out ~/.shieldcortex/benchmark/longmemeval/longmemeval-s-subset50.jsonl   --limit 50 --seed 42
+
+# 3) measure (writes SCORECARD.md + report.json)
+npm run bench -- --dataset ~/.shieldcortex/benchmark/longmemeval/longmemeval-s.jsonl
+# or embeddings-off smoke-scale:
+SHIELDCORTEX_SKIP_EMBEDDINGS=1 npm run bench -- --dataset ~/.shieldcortex/benchmark/longmemeval/longmemeval-s-subset50.jsonl
+```
+
+**Honesty rules**
+
+- Toy fixture ≠ LongMemEval-S.
+- Subset-50 must be labeled **subset** in SCORECARD / epic comments.
+- agentmemory 95.2% is reference-only, different corpus run.
+- Not a merge gate.

--- a/benchmark/longmemeval/ingest.ts
+++ b/benchmark/longmemeval/ingest.ts
@@ -3,18 +3,21 @@
  *
  * One memory per turn. `metadata.session_id` is the bridge that lets
  * the runner map retrieved memories back to their source sessions for
- * recall scoring. Project is held constant per question so memories
- * from different questions don't pollute each other when the harness
- * reuses an in-memory DB across questions.
+ * recall scoring.
+ *
+ * Defence stays ON (product-honest). Turns blocked by the firewall are
+ * skipped and counted — they never enter the ranker's corpus, same as prod.
  */
 
 import type { Memory } from '../../src/memory/types.js';
-import { addMemory } from '../../src/memory/store.js';
+import { addMemory, MemoryBlockedError } from '../../src/memory/store.js';
 import type { LongMemEvalQuestion } from './types.js';
 
 export interface IngestResult {
   /** Number of memories actually written to the DB. */
   ingested: number;
+  /** Turns skipped because defence blocked them. */
+  blocked: number;
   /** Memory id → session_id, for fast lookups during scoring. */
   memoryToSession: Map<number, string>;
 }
@@ -25,31 +28,42 @@ export function ingestQuestion(
 ): IngestResult {
   const memoryToSession = new Map<number, string>();
   let ingested = 0;
+  let blocked = 0;
 
   for (const session of question.haystack_sessions) {
     for (const turn of session.turns) {
       const title = buildTitle(turn.role, turn.content);
-      const memory: Memory = addMemory({
-        title,
-        content: turn.content,
-        category: 'note',
-        project,
-        type: 'long_term',
-        // Salience kept moderate so memories stay above the default
-        // salienceThreshold (0.2) and are eligible for recall.
-        salience: 0.5,
-        metadata: {
-          session_id: session.session_id,
-          role: turn.role,
-          ts: turn.ts ?? null,
-        },
-      });
-      memoryToSession.set(memory.id, session.session_id);
-      ingested++;
+      try {
+        const memory: Memory = addMemory({
+          title,
+          content: turn.content,
+          category: 'note',
+          project,
+          type: 'long_term',
+          // Salience kept moderate so memories stay above the default
+          // salienceThreshold (0.2) and are eligible for recall.
+          salience: 0.5,
+          metadata: {
+            session_id: session.session_id,
+            role: turn.role,
+            ts: turn.ts ?? null,
+            sourceType: 'benchmark',
+            capture_layer: 'L0',
+          },
+        });
+        memoryToSession.set(memory.id, session.session_id);
+        ingested++;
+      } catch (err) {
+        if (err instanceof MemoryBlockedError) {
+          blocked++;
+          continue;
+        }
+        throw err;
+      }
     }
   }
 
-  return { ingested, memoryToSession };
+  return { ingested, blocked, memoryToSession };
 }
 
 function buildTitle(role: string, content: string): string {

--- a/benchmark/longmemeval/load.ts
+++ b/benchmark/longmemeval/load.ts
@@ -98,9 +98,31 @@ function normaliseQuestion(
       path,
     );
   }
-  const haystack_sessions: HaystackSession[] = haystackRaw.map((s, sIdx) =>
-    normaliseSession(s, question_id, sIdx, path),
-  );
+
+  // Official LongMemEval: haystack_sessions is Turn[][] parallel to haystack_session_ids.
+  // Harness shape: { session_id, turns }[]. Accept both.
+  const idList = Array.isArray(obj.haystack_session_ids)
+    ? (obj.haystack_session_ids as unknown[]).map(String)
+    : [];
+  const dateList = Array.isArray(obj.haystack_dates)
+    ? (obj.haystack_dates as unknown[]).map(String)
+    : [];
+
+  const haystack_sessions: HaystackSession[] = haystackRaw.map((s, sIdx) => {
+    if (Array.isArray(s)) {
+      // Official Turn[] form
+      const session_id = idList[sIdx] || `${question_id}-sess-${sIdx}`;
+      const turns: HaystackTurn[] = s.map((t, tIdx) => {
+        const turn = normaliseTurn(t, session_id, tIdx, path);
+        if (!turn.ts && dateList[sIdx]) {
+          return { ...turn, ts: `${dateList[sIdx]}#${tIdx}` };
+        }
+        return turn;
+      });
+      return { session_id, turns };
+    }
+    return normaliseSession(s, question_id, sIdx, path);
+  });
 
   return { question_id, question, answer_session_ids, haystack_sessions };
 }

--- a/benchmark/longmemeval/scorecard.ts
+++ b/benchmark/longmemeval/scorecard.ts
@@ -29,6 +29,20 @@ export function renderScorecard(report: BenchmarkReport): string {
   lines.push('> 2. The `agentmemory` reference line below is `rohitg00/agentmemory`\'s **published** result on the full LongMemEval-S corpus. ShieldCortex has not been evaluated against that corpus yet; we cite the number only to identify the algorithm (Reciprocal Rank Fusion, Cormack et al. 2009) that both implementations use.');
   lines.push('> 3. To reproduce: `npm run bench` from the repo root regenerates this file. Full-suite numbers against LongMemEval-S are on the roadmap; see <https://shieldcortex.ai/security> for status.');
   lines.push('');
+  const ds = report.dataset_path || '';
+  const isToy = /toy-dataset/i.test(ds);
+  const isSubset = /subset/i.test(ds);
+  const isFullS = /longmemeval-s\.jsonl$/i.test(ds) && !isSubset;
+  if (isToy) {
+    lines.push('> 4. **THIS RUN = TOY FIXTURE ONLY** (5 questions). Do not quote as LongMemEval-S.');
+  } else if (isSubset) {
+    lines.push('> 4. **THIS RUN = LABELED SUBSET** (not full 500). Cite as subset with seed/limit from convert stats. Not comparable to full-S or agentmemory.');
+  } else if (isFullS) {
+    lines.push('> 4. **THIS RUN = full LongMemEval-S harness JSONL (500)** after local convert. Still retrieval-only; not a generation score. agentmemory line remains reference-only.');
+  } else {
+    lines.push('> 4. Dataset path did not match toy/subset/full heuristics — read the path and question count before quoting.');
+  }
+  lines.push('> 5. Defence firewall stays ON during ingest; blocked turns are skipped (product-honest corpus).');
   lines.push(`- Dataset: \`${report.dataset_path}\``);
   lines.push(`- Top-k: ${report.k_top}`);
   lines.push(`- Generated: ${report.generated_at}`);

--- a/benchmark/longmemeval/scripts/convert-upstream.ts
+++ b/benchmark/longmemeval/scripts/convert-upstream.ts
@@ -1,0 +1,228 @@
+/**
+ * Convert upstream LongMemEval JSON (cleaned HF release) → harness JSONL.
+ *
+ * Upstream shape (per README):
+ *   question_id, question, answer_session_ids,
+ *   haystack_session_ids: string[],
+ *   haystack_sessions: Turn[][]   // parallel to ids; each session is turns[]
+ *   haystack_dates?: string[]
+ *
+ * Harness shape (types.ts):
+ *   question_id, question, answer_session_ids,
+ *   haystack_sessions: { session_id, turns: {role,content,ts?}[] }[]
+ *
+ * Does NOT download data (license: fetch separately). See fetch-longmemeval-s.sh.
+ *
+ * Usage:
+ *   npx tsx benchmark/longmemeval/scripts/convert-upstream.ts \
+ *     --in ~/.shieldcortex/benchmark/longmemeval/longmemeval_s_cleaned.json \
+ *     --out ~/.shieldcortex/benchmark/longmemeval/longmemeval-s.jsonl \
+ *     [--limit N] [--seed 42]
+ */
+import { createHash } from 'crypto';
+import { createReadStream, createWriteStream, existsSync, readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { createInterface } from 'readline';
+
+interface Cli {
+  inPath: string;
+  outPath: string;
+  limit: number | null;
+  seed: number;
+  statsPath: string | null;
+}
+
+function parseArgs(argv: string[]): Cli {
+  const cli: Cli = {
+    inPath: '',
+    outPath: '',
+    limit: null,
+    seed: 42,
+    statsPath: null,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--in' && argv[i + 1]) { cli.inPath = resolve(argv[++i]); }
+    else if (a === '--out' && argv[i + 1]) { cli.outPath = resolve(argv[++i]); }
+    else if (a === '--limit' && argv[i + 1]) { cli.limit = Number.parseInt(argv[++i], 10); }
+    else if (a === '--seed' && argv[i + 1]) { cli.seed = Number.parseInt(argv[++i], 10); }
+    else if (a === '--stats' && argv[i + 1]) { cli.statsPath = resolve(argv[++i]); }
+    else if (a === '--help' || a === '-h') {
+      console.log(`Usage: convert-upstream.ts --in <upstream.json|jsonl> --out <harness.jsonl> [--limit N] [--seed 42]`);
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown arg: ${a}`);
+    }
+  }
+  if (!cli.inPath || !cli.outPath) throw new Error('--in and --out required');
+  return cli;
+}
+
+/** Mulberry32 PRNG for deterministic subset sampling. */
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6D2B79F5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function loadUpstream(path: string): unknown[] {
+  if (!existsSync(path)) throw new Error(`input not found: ${path}`);
+  const raw = readFileSync(path, 'utf-8');
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) throw new Error('JSON root is not an array');
+    return parsed;
+  }
+  // JSONL
+  return trimmed.split(/\r?\n/).filter(Boolean).map((line, i) => {
+    try { return JSON.parse(line); }
+    catch (e) { throw new Error(`JSONL line ${i + 1}: ${(e as Error).message}`); }
+  });
+}
+
+function isTurn(x: unknown): x is { role: string; content: string; ts?: string; has_answer?: boolean } {
+  return !!x && typeof x === 'object' && typeof (x as any).role === 'string' && typeof (x as any).content === 'string';
+}
+
+/**
+ * Convert one upstream question object to harness form.
+ * Accepts both already-normalised harness objects and official LongMemEval.
+ */
+export function convertQuestion(raw: unknown, index: number): {
+  question_id: string;
+  question: string;
+  answer_session_ids: string[];
+  haystack_sessions: { session_id: string; turns: { role: 'user' | 'assistant'; content: string; ts?: string }[] }[];
+} {
+  if (!raw || typeof raw !== 'object') throw new Error(`item ${index} not object`);
+  const o = raw as Record<string, unknown>;
+  const question_id = String(o.question_id || o.questionId || `q-${index}`);
+  const question = String(o.question || '');
+  if (!question) throw new Error(`${question_id}: empty question`);
+
+  const answer_session_ids = Array.isArray(o.answer_session_ids)
+    ? (o.answer_session_ids as unknown[]).map(String)
+    : [];
+
+  // Already harness-shaped?
+  if (Array.isArray(o.haystack_sessions) && o.haystack_sessions[0]
+    && typeof o.haystack_sessions[0] === 'object'
+    && !Array.isArray(o.haystack_sessions[0])
+    && 'session_id' in (o.haystack_sessions[0] as object)
+    && 'turns' in (o.haystack_sessions[0] as object)) {
+    return {
+      question_id,
+      question,
+      answer_session_ids,
+      haystack_sessions: (o.haystack_sessions as any[]).map((s) => ({
+        session_id: String(s.session_id),
+        turns: (s.turns || []).filter(isTurn).map((t: any) => ({
+          role: t.role === 'assistant' ? 'assistant' as const : 'user' as const,
+          content: String(t.content),
+          ...(typeof t.ts === 'string' ? { ts: t.ts } : {}),
+        })),
+      })),
+    };
+  }
+
+  // Official: parallel arrays haystack_session_ids + haystack_sessions (Turn[][])
+  const ids = Array.isArray(o.haystack_session_ids)
+    ? (o.haystack_session_ids as unknown[]).map(String)
+    : [];
+  const sessionsRaw = Array.isArray(o.haystack_sessions) ? (o.haystack_sessions as unknown[]) : [];
+  const dates = Array.isArray(o.haystack_dates) ? (o.haystack_dates as unknown[]).map(String) : [];
+
+  if (sessionsRaw.length === 0) {
+    throw new Error(`${question_id}: no haystack_sessions`);
+  }
+
+  const haystack_sessions = sessionsRaw.map((sess, sIdx) => {
+    const session_id = ids[sIdx] || `${question_id}-sess-${sIdx}`;
+    const turnsSrc = Array.isArray(sess) ? sess : (sess && typeof sess === 'object' && Array.isArray((sess as any).turns) ? (sess as any).turns : []);
+    const turns = (turnsSrc as unknown[]).filter(isTurn).map((t, tIdx) => {
+      const role = t.role === 'assistant' ? 'assistant' as const : 'user' as const;
+      const content = String(t.content || '');
+      const ts = typeof (t as any).ts === 'string'
+        ? (t as any).ts
+        : (dates[sIdx] ? `${dates[sIdx]}#${tIdx}` : undefined);
+      return ts ? { role, content, ts } : { role, content };
+    }).filter((t) => t.content.length > 0);
+    return { session_id, turns };
+  }).filter((s) => s.turns.length > 0);
+
+  if (haystack_sessions.length === 0) {
+    throw new Error(`${question_id}: all sessions empty after convert`);
+  }
+
+  return { question_id, question, answer_session_ids, haystack_sessions };
+}
+
+function main(): void {
+  const cli = parseArgs(process.argv.slice(2));
+  const items = loadUpstream(cli.inPath);
+  console.log(`[convert] loaded ${items.length} upstream item(s) from ${cli.inPath}`);
+
+  let selected = items.map((it, i) => ({ it, i }));
+  if (cli.limit != null && cli.limit > 0 && cli.limit < selected.length) {
+    const rnd = mulberry32(cli.seed);
+    // Fisher-Yates partial shuffle for deterministic subset
+    for (let i = selected.length - 1; i > 0; i--) {
+      const j = Math.floor(rnd() * (i + 1));
+      [selected[i], selected[j]] = [selected[j], selected[i]];
+    }
+    selected = selected.slice(0, cli.limit);
+    console.log(`[convert] sampled limit=${cli.limit} seed=${cli.seed}`);
+  }
+
+  mkdirSync(dirname(cli.outPath), { recursive: true });
+  const out = createWriteStream(cli.outPath, { encoding: 'utf-8' });
+  let ok = 0;
+  let fail = 0;
+  const typeCounts: Record<string, number> = {};
+  for (const { it, i } of selected) {
+    try {
+      const q = convertQuestion(it, i);
+      const qtype = typeof (it as any)?.question_type === 'string' ? (it as any).question_type : 'unknown';
+      typeCounts[qtype] = (typeCounts[qtype] || 0) + 1;
+      out.write(JSON.stringify(q) + '\n');
+      ok++;
+    } catch (e) {
+      fail++;
+      console.warn(`[convert] skip index=${i}: ${(e as Error).message}`);
+    }
+  }
+  out.end();
+
+  const stats = {
+    source: cli.inPath,
+    out: cli.outPath,
+    source_count: items.length,
+    written: ok,
+    skipped: fail,
+    limit: cli.limit,
+    seed: cli.seed,
+    question_types: typeCounts,
+    sha256_note: 'hash after write via sha256sum',
+  };
+  console.log(`[convert] wrote ${ok} questions (${fail} skipped) → ${cli.outPath}`);
+  console.log(`[convert] types`, typeCounts);
+  if (cli.statsPath) {
+    writeFileSync(cli.statsPath, JSON.stringify(stats, null, 2));
+    console.log(`[convert] stats → ${cli.statsPath}`);
+  }
+}
+
+const isDirect = typeof process.argv[1] === 'string' && /convert-upstream\.ts$/.test(process.argv[1]);
+if (isDirect) {
+  try {
+    main();
+  } catch (e) {
+    console.error(`[convert] fatal: ${(e as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/benchmark/longmemeval/scripts/fetch-longmemeval-s.sh
+++ b/benchmark/longmemeval/scripts/fetch-longmemeval-s.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Fetch LongMemEval-S (cleaned) from Hugging Face — NOT redistributed in-repo.
+# License: respect upstream (xiaowu0162/longmemeval-cleaned).
+#
+# Usage:
+#   bash benchmark/longmemeval/scripts/fetch-longmemeval-s.sh
+#   OUT_DIR=~/.shieldcortex/benchmark/longmemeval bash benchmark/longmemeval/scripts/fetch-longmemeval-s.sh
+set -euo pipefail
+
+OUT_DIR="${OUT_DIR:-${HOME}/.shieldcortex/benchmark/longmemeval}"
+mkdir -p "${OUT_DIR}"
+cd "${OUT_DIR}"
+
+BASE="https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/main"
+FILE="longmemeval_s_cleaned.json"
+
+if [[ -f "${FILE}" ]]; then
+  echo "[fetch] already present: ${OUT_DIR}/${FILE} ($(wc -c < "${FILE}") bytes)"
+else
+  echo "[fetch] downloading ${FILE} → ${OUT_DIR}/"
+  curl -L --fail --retry 3 -o "${FILE}.tmp" "${BASE}/${FILE}"
+  mv "${FILE}.tmp" "${FILE}"
+  echo "[fetch] done ($(wc -c < "${FILE}") bytes)"
+fi
+
+echo "[fetch] next:"
+echo "  npx tsx benchmark/longmemeval/scripts/convert-upstream.ts \\"
+echo "    --in ${OUT_DIR}/${FILE} \\"
+echo "    --out ${OUT_DIR}/longmemeval-s.jsonl"
+echo "  # labeled subset (honest, non-full):"
+echo "  npx tsx benchmark/longmemeval/scripts/convert-upstream.ts \\"
+echo "    --in ${OUT_DIR}/${FILE} \\"
+echo "    --out ${OUT_DIR}/longmemeval-s-subset50.jsonl --limit 50 --seed 42"
+echo "  npm run bench -- --dataset ${OUT_DIR}/longmemeval-s.jsonl"

--- a/docs/design/2026-08-18-memory-sota-track-d-longmemeval.md
+++ b/docs/design/2026-08-18-memory-sota-track-d-longmemeval.md
@@ -63,3 +63,32 @@ npm run bench:smoke
 
 D runs **after** C merge is fine; does not block host enablement or A/B
 contract work.
+
+
+## First measured run (TARS, 2026-08-18)
+
+| Field | Value |
+|---|---|
+| Dataset | LongMemEval-S **labeled subset-50** (seed=42) from `longmemeval_s_cleaned` HF |
+| Convert | `convert-upstream.ts --limit 50 --seed 42` |
+| Embeddings | **OFF** (`SHIELDCORTEX_SKIP_EMBEDDINGS=1`) |
+| Defence | **ON** (blocked turns skipped) |
+| Engines | rrf, legacy |
+
+### Headline (subset-50, no embeddings)
+
+| Engine | R@5 | R@10 | MRR | Duration |
+|---|---|---|---|---|
+| rrf | **4.00%** | 4.00% | 0.0400 | ~101s |
+| legacy | **0.00%** | 0.00% | 0.0000 | ~100s |
+
+### What this means (honesty)
+
+- **Not** a full-S number. **Not** comparable to agentmemory 95.2%.
+- Without embeddings, retrieval is FTS-only over large multi-session haystacks — weak by design.
+- Defence-on ingest means some gold turns never enter the store (product-honest).
+- Value of this run: harness + convert + fetch path **proven end-to-end** on real upstream data.
+- Next measurement upgrade: subset-50 **with** embeddings, then optional full-500 (still non-gating).
+
+Artifacts (host-local, not in git):
+`~/.shieldcortex/benchmark/longmemeval/runs/subset50/{SCORECARD.md,report.json}`

--- a/package.json
+++ b/package.json
@@ -84,7 +84,10 @@
     "release:clawhub": "node scripts/clawhub-sync.mjs",
     "release:clawhub:check": "node scripts/clawhub-sync.mjs --check",
     "version": "node scripts/sync-plugin-version.mjs && git add plugins/openclaw/package.json plugins/openclaw/openclaw.plugin.json skills/shieldcortex/SKILL.md",
-    "prepublishOnly": "node scripts/sync-plugin-version.mjs --check && npm run build && npm run test:dist"
+    "prepublishOnly": "node scripts/sync-plugin-version.mjs --check && npm run build && npm run test:dist",
+    "bench:fetch-s": "bash benchmark/longmemeval/scripts/fetch-longmemeval-s.sh",
+    "bench:convert": "tsx benchmark/longmemeval/scripts/convert-upstream.ts",
+    "bench:subset": "tsx benchmark/longmemeval/run.ts --dataset ${HOME}/.shieldcortex/benchmark/longmemeval/longmemeval-s-subset50.jsonl"
   },
   "keywords": [
     "ai-memory",

--- a/src/memory/__tests__/longmemeval-convert-d.test.ts
+++ b/src/memory/__tests__/longmemeval-convert-d.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from '@jest/globals';
+import { convertQuestion } from '../../../benchmark/longmemeval/scripts/convert-upstream.ts';
+import { loadDataset } from '../../../benchmark/longmemeval/load.ts';
+import { writeFileSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('LongMemEval Track D convert/load', () => {
+  const upstream = {
+    question_id: 'u1',
+    question: 'What DB did we pick?',
+    question_type: 'single-session-user',
+    answer_session_ids: ['sess-a'],
+    haystack_session_ids: ['sess-a', 'sess-b'],
+    haystack_dates: ['2024-01-01', '2024-01-02'],
+    haystack_sessions: [
+      [
+        { role: 'user', content: 'Which database?' },
+        { role: 'assistant', content: 'PostgreSQL with JSONB.', has_answer: true },
+      ],
+      [
+        { role: 'user', content: 'Frontend?' },
+        { role: 'assistant', content: 'React.' },
+      ],
+    ],
+  };
+
+  it('convertQuestion maps official Turn[][] to harness sessions', () => {
+    const q = convertQuestion(upstream, 0);
+    expect(q.question_id).toBe('u1');
+    expect(q.answer_session_ids).toEqual(['sess-a']);
+    expect(q.haystack_sessions).toHaveLength(2);
+    expect(q.haystack_sessions[0].session_id).toBe('sess-a');
+    expect(q.haystack_sessions[0].turns[1].content).toContain('PostgreSQL');
+  });
+
+  it('loadDataset accepts official shape without pre-convert', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'lme-d-'));
+    const path = join(dir, 'one.jsonl');
+    writeFileSync(path, JSON.stringify(upstream) + '\n');
+    const qs = loadDataset(path);
+    expect(qs).toHaveLength(1);
+    expect(qs[0].haystack_sessions[0].session_id).toBe('sess-a');
+    expect(qs[0].haystack_sessions[1].turns[0].role).toBe('user');
+  });
+
+  it('loadDataset still loads toy fixture', () => {
+    const qs = loadDataset('benchmark/longmemeval/fixtures/toy-dataset.jsonl');
+    expect(qs.length).toBeGreaterThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## Summary
Track D for epic #347 / #351.

- `bench:fetch-s` — download cleaned LongMemEval-S from HF (not in git)
- `convert-upstream.ts` — official → harness JSONL; `--limit/--seed` for labeled subsets
- `load.ts` accepts official `Turn[][]` + `haystack_session_ids`
- Ingest keeps **defence ON**; blocked turns skipped (product-honest)
- Scorecard labels toy / subset / full-S paths

## Not in this PR
- Redistributed dataset files
- Merge gate on R@k
- Generation QA scores

## Test plan
- [x] unit: convert + load
- [x] `npm run bench:smoke`
- [ ] subset-50 run (in progress on TARS) → SCORECARD under `~/.shieldcortex/benchmark/.../runs/subset50`
- [ ] optional full-500 run later