### PR TITLE
fix(memory): map distill categories to schema valid_category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - **Memory SOTA Track C:** capture distill provider (OpenAI-compatible + Anthropic), fail-closed extract path on stop/session-end, L1 salience cap, no silent regex fallback (#350 / epic #347).
 - **Memory SOTA Track C (OAuth):** distill resolves Hermes OAuth on disk (xai-oauth → openai-codex) when no API key is set — fleet hosts reuse existing login; `SHIELDCORTEX_DISTILL_OAUTH=0` disables.
 - **Memory SOTA Track C (defaults):** distill defaults to cheap models (`grok-4.3` on xAI OAuth, not main chat `grok-4.6`); zero-config when Hermes is already logged in.
+- **Capture distill:** map decision/bug/fact/procedure onto schema `valid_category` values (fixes silent CHECK failures on admit).
 - **Memory SOTA Track D (embeddings run):** bench awaits async embedding writes before search; preload MiniLM when embeddings enabled.
 - **Memory SOTA Track D:** LongMemEval-S fetch script, upstream→harness convertor, loader accepts official Turn[][] sessions; honesty docs.
 - **Memory SOTA Track D kickoff:** LongMemEval-S honesty harness design + residual A/B host checklist.

--- a/scripts/lib/capture-distill.mjs
+++ b/scripts/lib/capture-distill.mjs
@@ -23,17 +23,29 @@ export const DISTILL_MAX_INPUT_CHARS = 24_000;
 export const DISTILL_TIMEOUT_MS = 12_000;
 
 const ALLOWED_CATEGORIES = new Set([
-  'note',
-  'decision',
-  'preference',
+  // Must match memories.valid_category CHECK constraint.
   'architecture',
-  'bug',
+  'pattern',
+  'preference',
+  'error',
+  'context',
   'learning',
-  'fact',
-  'procedure',
-  'error-fix',
-  'important-note',
+  'todo',
+  'note',
+  'relationship',
+  'custom',
 ]);
+
+/** Map common distill labels → schema categories. */
+const CATEGORY_ALIASES = {
+  decision: 'architecture',
+  bug: 'error',
+  fact: 'note',
+  procedure: 'pattern',
+  pref: 'preference',
+  fix: 'error',
+  ops: 'context',
+};
 
 /**
  * @param {unknown} mode
@@ -73,6 +85,7 @@ export function failClosedDistill(errOrNull, memories) {
     if (salience > L1_SALIENCE_CAP) salience = L1_SALIENCE_CAP;
     if (salience < 0) salience = 0;
     let category = typeof m.category === 'string' ? m.category.trim().toLowerCase() : 'note';
+    if (CATEGORY_ALIASES[category]) category = CATEGORY_ALIASES[category];
     if (!ALLOWED_CATEGORIES.has(category)) category = 'note';
     cleaned.push({
       title: title.slice(0, 200),
@@ -517,7 +530,7 @@ export function buildDistillPrompt(conversationText) {
   return {
     system:
       'You extract durable agent memories from a conversation transcript. '
-      + 'Return ONLY valid JSON: {"memories":[{"title":"...","content":"...","category":"note|decision|preference|architecture|bug|learning|fact|procedure","salience":0.0-0.7}]}. '
+      + 'Return ONLY valid JSON: {"memories":[{"title":"...","content":"...","category":"architecture|pattern|preference|error|context|learning|todo|note|relationship|custom","salience":0.0-0.7}]}. '
       + 'Rules: facts only (no instructions to the agent); no secrets/tokens/passwords; max 8 memories; '
       + 'prefer decisions, preferences, architecture, fixes, standing procedures; skip chit-chat; '
       + 'salience <= 0.7; content under 500 words each; title under 80 chars.',

--- a/src/memory/__tests__/capture-distill-sota.test.ts
+++ b/src/memory/__tests__/capture-distill-sota.test.ts
@@ -9,6 +9,7 @@ import {
   resolveProviderPreference,
   resolveClaudeCodeOAuthProvider,
   parseDistillResponseText,
+  // category path covered below
   extractCaptureMemories,
   buildDistillPrompt,
 } from '../../../scripts/lib/capture-distill.mjs';
@@ -186,4 +187,17 @@ describe('extractCaptureMemories', () => {
     expect(r.path).toBe('skip');
     expect(r.memories).toEqual([]);
   });
+
+  it('maps distill decision/bug categories onto schema-valid labels', () => {
+    const parsed = parseDistillResponseText(JSON.stringify({
+      memories: [
+        { title: 'Dec', content: 'We decided X', category: 'decision', salience: 0.5 },
+        { title: 'Bug', content: 'Fixed Y', category: 'bug', salience: 0.5 },
+      ],
+    }));
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].category).toBe('architecture');
+    expect(parsed[1].category).toBe('error');
+  });
+
 });

--- a/src/memory/__tests__/capture-distill-sota.test.ts
+++ b/src/memory/__tests__/capture-distill-sota.test.ts
@@ -189,15 +189,15 @@ describe('extractCaptureMemories', () => {
   });
 
   it('maps distill decision/bug categories onto schema-valid labels', () => {
-    const parsed = parseDistillResponseText(JSON.stringify({
-      memories: [
-        { title: 'Dec', content: 'We decided X', category: 'decision', salience: 0.5 },
-        { title: 'Bug', content: 'Fixed Y', category: 'bug', salience: 0.5 },
-      ],
-    }));
-    expect(parsed).toHaveLength(2);
-    expect(parsed[0].category).toBe('architecture');
-    expect(parsed[1].category).toBe('error');
+    const raw = [
+      { title: 'Dec', content: 'We decided X', category: 'decision', salience: 0.5 },
+      { title: 'Bug', content: 'Fixed Y', category: 'bug', salience: 0.5 },
+    ];
+    const res = failClosedDistill(null, raw);
+    expect(res.ok).toBe(true);
+    expect(res.memories).toHaveLength(2);
+    expect(res.memories[0].category).toBe('architecture');
+    expect(res.memories[1].category).toBe('error');
   });
 
 });


### PR DESCRIPTION
## Summary
TARS live-loop proof found L1 distill admitting only ~2/6 memories: others failed `valid_category` CHECK (`decision`, etc.).

Map common distill labels onto schema categories and constrain the prompt.

## Proof
Session-end after fix: **5/5** L1 saves. Session-start inject pack included new rows with `hostId=tars` / `agentId=hermes-primary`.

## Test plan
- [x] unit: decision→architecture, bug→error
- [x] live TARS session-end + session-start loop