### PR TITLE
fix(doctor): notify.openclaw alone is not a DNP denial sink (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 > **Coverage note**: 49 v4 versions are documented below — typically every minor (`X.Y.0`) plus significant patches. Many small patch releases between 4.0.0 and 4.20.x are not individually documented (~50 versions, mostly behaviour-preserving fixes). For a specific diff between adjacent npm versions, see `git log vX.Y.Z..vX.Y.W` or compare tarballs. Audited and reconciled 2026-05-27 — gap is intentional, not a sign of release-note drift going forward.
 
+## Unreleased
+
+- **Doctor / Action Guard (#354):** `notify.openclaw` alone no longer satisfies the unattended-notify check. DNP/headless denials need `notify.webhookUrl` (denial-capable sink). OpenClaw cards remain interactive-only per #310.
+
 ## [Unreleased]
 
 ### Added

--- a/src/cli/__tests__/doctor-action-guard.test.ts
+++ b/src/cli/__tests__/doctor-action-guard.test.ts
@@ -205,10 +205,27 @@ describe('doctor — Action Guard notify channel (#242)', () => {
     expect(results.find((r) => /webhookUrl|notify channel/i.test(r.message))).toBeUndefined();
   });
 
-  it('does not warn when notify.openclaw is the configured channel', async () => {
+  it('warns when notify.openclaw alone is set — not a DNP denial sink (#354)', async () => {
     writeConfig({ actionGuard: { notify: { enabled: true, openclaw: true } } });
     const results = await checkActionGuard();
-    expect(results.find((r) => /webhookUrl|notify channel/i.test(r.message))).toBeUndefined();
+    const warn = results.find((r) => r.status === 'warn' && /notify/i.test(r.label));
+    expect(warn).toBeDefined();
+    expect(warn!.message).toMatch(/openclaw only|denial-capable|webhookUrl/i);
+    expect(warn!.message).not.toMatch(/native OpenClaw approval card reaches a human/i);
+  });
+
+  it('does not warn when webhook denial sink is configured even if openclaw is also on', async () => {
+    writeConfig({
+      actionGuard: {
+        notify: {
+          enabled: true,
+          openclaw: true,
+          webhookUrl: 'https://hooks.example.invalid/sc',
+        },
+      },
+    });
+    const results = await checkActionGuard();
+    expect(results.find((r) => r.status === 'warn' && /notify/i.test(r.label))).toBeUndefined();
   });
 
   it('does not warn about notify when the guard is not enforcing', async () => {
@@ -234,7 +251,8 @@ describe('doctor — Action Guard notify fix is a signed CLI command (#275)', ()
     writeConfig({});
     const warn = await findNotifyWarn();
     expect(warn).toBeDefined();
-    expect(warn!.fix).toMatch(/shieldcortex config --action-guard-notify-(webhook|openclaw)/);
+    // #354: webhook is the denial sink; openclaw is not prescribed as the unattended fix.
+    expect(warn!.fix).toMatch(/shieldcortex config --action-guard-notify-webhook/);
     // The bare key-path prescription must no longer lead the fix.
     expect(warn!.fix).not.toMatch(/Set `actionGuard\.notify/);
   });
@@ -250,14 +268,15 @@ describe('doctor — Action Guard notify fix is a signed CLI command (#275)', ()
     expect(warn!.fix).not.toMatch(/(^|\.\s)(Edit|Add|Set)\b/);
   });
 
-  it('warn clears when the OpenClaw channel is enabled via the CLI (signed write)', async () => {
+  it('openclaw-only CLI enable does NOT clear the unattended-notify warn (#354)', async () => {
     fs.rmSync(configPath(), { force: true });
     fs.rmSync(legacySigPath(), { force: true });
     clearCloudConfigCache();
     jest.spyOn(console, 'log').mockImplementation(() => {});
     handleCloudConfig(['--action-guard-notify-openclaw']);
     const warn = await findNotifyWarn();
-    expect(warn).toBeUndefined();
+    expect(warn).toBeDefined();
+    expect(warn!.message).toMatch(/openclaw only|denial-capable|webhookUrl/i);
     const onDisk = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
     expect(typeof onDisk._sig).toBe('string');
   });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2278,22 +2278,34 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
     // vanished for eight days while lastRunStatus stayed ok. WARN, never fail
     // — a missing webhook is a misconfiguration, not a broken evaluator.
     // OpenClaw lastRunStatus is not ours to write (#242 Defect A / #260).
+    //
+    // #354 / #310: `notify.openclaw` is NOT a DNP denial sink. It arms interactive
+    // held-approval cards only. Headless denials are `denied_no_prompt_surface`
+    // and travel via webhookUrl → denialChannel (or loud DNP digest on that sink).
+    // Doctor must not treat openclaw:true alone as "unattended notify configured".
     if (effective.enabled && effective.enforce) {
       const notify = isBlock(merged.notify) ? merged.notify : {};
       const notifyOn = notify.enabled === true;
       const webhook = typeof notify.webhookUrl === 'string' ? notify.webhookUrl.trim() : '';
       const openclaw = notify.openclaw === true;
-      if (!(notifyOn && (webhook || openclaw))) {
+      // Denial-capable sink for unattended/DNP path = enabled notify + webhook URL.
+      const denialSink = notifyOn && webhook.length > 0;
+      if (!denialSink) {
+        const openclawOnly = notifyOn && openclaw && !webhook;
         results.push({
           label: `${label} notify`,
           status: 'warn',
-          message:
-            `Action Guard is enforcing with no notify channel (actionGuard.notify.webhookUrl unset` +
-            `${notifyOn ? '' : ', notify.enabled is not true'}) — unattended denials stay in the ` +
-            `audit log and session-guard index only. The #242 cron incidents were this shape.`,
+          message: openclawOnly
+            ? `Action Guard is enforcing with notify.openclaw only — that arms interactive approval cards, ` +
+              `not unattended denial delivery. Headless denials (denied_no_prompt_surface / cron) stay local ` +
+              `unless actionGuard.notify.webhookUrl is set as the denial-capable sink (#354 / #310).`
+            : `Action Guard is enforcing with no denial-capable notify sink (actionGuard.notify.webhookUrl unset` +
+              `${notifyOn ? '' : ', notify.enabled is not true'}) — unattended denials stay in the ` +
+              `audit log and session-guard index only. The #242 cron incidents were this shape.`,
           fix:
-            'Run `shieldcortex config --action-guard-notify-webhook <https-url>` (or `shieldcortex config ' +
-            '--action-guard-notify-openclaw` for a native OpenClaw approval card) so a denied cron reaches a human. ' +
+            'Run `shieldcortex config --action-guard-notify-webhook <https-url>` so denied/unattended actions ' +
+            'reach a human via a denial-capable webhook sink. `notify.openclaw` is separate (interactive cards ' +
+            'for live require_approval holds) and does not replace the webhook for DNP. ' +
             'The CLI writes a signed config — hand-editing config.json invalidates its integrity signature and ' +
             'forces strict mode. OpenClaw lastRunStatus is not ShieldCortex\'s to write.',
         });


### PR DESCRIPTION
## Summary
Closes the **actionable** part of #354 (doctor honesty), not the #310 card redesign.

`notify.openclaw: true` arms **interactive** OpenClaw approval cards for live `require_approval` holds. It is **not** a denial-capable sink for headless `denied_no_prompt_surface` / cron denials. Doctor previously treated `openclaw:true` alone as “unattended notify configured,” which is a false green.

## Change
- Unattended-notify warn clears only when `notify.enabled` **and** `notify.webhookUrl` are set
- `openclaw`-only configs get an explicit warn explaining the distinction
- Fix text prescribes `--action-guard-notify-webhook`, not openclaw-as-DNP
- Tests updated (#242 / #275 / #354)

## Out of scope (still #310)
- Turning DNP into tappable approval cards
- Telegram tap ≠ TTY allowlist review
- Sink probe A/B protocol (future ADR)

## Test plan
- [x] `doctor-action-guard.test.ts` — 28 passed
- [ ] CI green