### PR TITLE
fix(openclaw): unknown scan summary must not taint sessions (#361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **Action Guard / conversation scan (#361):** bare `unknown` scan summaries no longer taint sessions or escalate Action Guard. Dirty non-injection scans keep an honest multi-layer THREAT summary instead of defaulting risk to `unknown`.
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/plugins/openclaw/__tests__/unknown-taint-361.test.ts
+++ b/plugins/openclaw/__tests__/unknown-taint-361.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  isTaintingScanSummary,
+  severityFromScanSummary,
+} from '../scan-taint-policy.js';
+
+/**
+ * #361 — unknown / uncertain scan results must not taint sessions.
+ * Production: benign support thread → reason "unknown" → tainted → AG escalate
+ * → broker unavailable → fail-closed deny on action_lease.py.
+ */
+describe('#361 isTaintingScanSummary', () => {
+  it('rejects bare unknown / none / empty', () => {
+    expect(isTaintingScanSummary('unknown')).toBe(false);
+    expect(isTaintingScanSummary('UNKNOWN')).toBe(false);
+    expect(isTaintingScanSummary('none')).toBe(false);
+    expect(isTaintingScanSummary('')).toBe(false);
+    expect(isTaintingScanSummary(null)).toBe(false);
+    expect(isTaintingScanSummary(undefined)).toBe(false);
+  });
+
+  it('rejects scanner-unavailable shapes', () => {
+    expect(isTaintingScanSummary('scan unavailable')).toBe(false);
+    expect(isTaintingScanSummary('conversation scan unavailable (timeout) — turn allowed UNSCANNED')).toBe(false);
+  });
+
+  it('accepts concrete injection summaries', () => {
+    expect(isTaintingScanSummary('HIGH (2 detections)')).toBe(true);
+    expect(isTaintingScanSummary('CRITICAL (1 detections)')).toBe(true);
+    expect(isTaintingScanSummary('MEDIUM (1 detections)')).toBe(true);
+  });
+
+  it('accepts multi-layer THREAT summaries (non-injection dirty)', () => {
+    expect(
+      isTaintingScanSummary('THREAT in "openclaw-realtime" response: encoding: base64 (12ms)'),
+    ).toBe(true);
+  });
+});
+
+describe('#361 severityFromScanSummary', () => {
+  it('maps risk words', () => {
+    expect(severityFromScanSummary('CRITICAL (1 detections)')).toBe('critical');
+    expect(severityFromScanSummary('HIGH (2 detections)')).toBe('high');
+    expect(severityFromScanSummary('MEDIUM (1 detections)')).toBe('medium');
+  });
+
+  it('defaults concrete threat without level to medium', () => {
+    expect(severityFromScanSummary('THREAT in "x" response: encoding: base64')).toBe('medium');
+  });
+});

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -34,6 +34,7 @@ import { createRequire } from "node:module";
 
 import { readConversationAccess, describeRegisteredHooks } from './conversation-access.js';
 import { createSessionTaintStore } from './session-taint.js';
+import { isTaintingScanSummary, severityFromScanSummary } from './scan-taint-policy.js';
 import { classifyConversationOrigin } from './conversation-trust.js';
 import type { ConversationTrustDecision } from './conversation-trust.js';
 import { createInterceptor, DEFAULT_CONFIG as DEFAULT_INTERCEPTOR_CONFIG } from './interceptor.js';
@@ -1895,12 +1896,26 @@ export async function scanRealtimeContent(text: string): Promise<ConversationSca
   if (defenceMod && typeof defenceMod.scanToolResponse === "function") {
     try {
       const scan = defenceMod.scanToolResponse("openclaw-realtime", text, "advisory");
-      // Reproduce the historical summary contract exactly: risk level + detection
-      // count only when the injection scan flagged something.
-      const risk = scan.injection.clean ? "unknown" : scan.injection.riskLevel;
-      const summary = scan.injection.clean
-        ? risk
-        : `${risk} (${scan.injection.detections.length} detections)`;
+      // #361: never summarise a dirty overall scan as bare "unknown".
+      // Historical path used injection.riskLevel only when injection fired; when
+      // another layer dirtied the scan (encoding/instructions/credentials/etc.)
+      // while injection stayed clean, risk defaulted to "unknown" and the llm_input
+      // path treated that as a positive detection → session taint → AG escalate →
+      // broker unavailable deadlock on benign threads.
+      // Prefer the scanner's own multi-layer summary when dirty; only use the
+      // compact "RISK (N detections)" form for pure injection hits.
+      let summary: string;
+      if (scan.clean) {
+        summary = 'NONE';
+      } else if (!scan.injection.clean) {
+        const risk = scan.injection.riskLevel || 'UNKNOWN';
+        summary = `${risk} (${scan.injection.detections.length} detections)`;
+      } else if (typeof scan.summary === 'string' && scan.summary.trim()) {
+        // e.g. 'THREAT in "openclaw-realtime" response: encoding: base64 (12ms)'
+        summary = scan.summary;
+      } else {
+        summary = 'THREAT (non-injection layer)';
+      }
       return { clean: scan.clean, summary, available: true };
     } catch (err) {
       // A scanner that THROWS is not a clean verdict either. Same treatment as
@@ -2412,8 +2427,15 @@ export async function scanLlmInput(event: LlmInputEvent, _ctx: AgentCtx): Promis
         // logs" is an instruction, and treating it as an attack is the false
         // alarm that gets a control switched off. Everything the agent was
         // handed — including another agent on a closed channel — is data.
-        if (trust.mayTaint) {
-          sessionTaint.mark(event.sessionId, { reason: `conversation scan: ${result.summary}` });
+        // #361: taint only on a concrete detection summary. Bare "unknown" (and
+        // scanner-unavailable shapes) must not escalate Action Guard — they are
+        // degraded/uncertain states, not positive threats. Real injection keeps
+        // the HIGH/CRITICAL (N detections) form and still taints.
+        if (trust.mayTaint && isTaintingScanSummary(result.summary)) {
+          sessionTaint.mark(event.sessionId, {
+            severity: severityFromScanSummary(result.summary),
+            reason: `conversation scan: ${result.summary}`,
+          });
         }
         // #226: NO `preview`. This row carried the first 100 characters of the
         // prompt — the exact text that tripped an injection detector, i.e.
@@ -2432,7 +2454,8 @@ export async function scanLlmInput(event: LlmInputEvent, _ctx: AgentCtx): Promis
           // Whether this detection tainted the session (threat-graph Phase D:
           // lets the threat graph attribute taint-raising events). Metadata
           // only — no content, same as the fields above.
-          tainted: trust.mayTaint,
+          // #361: mirrors the mark gate — unknown/unavailable never count as taint.
+          tainted: trust.mayTaint && isTaintingScanSummary(result.summary),
           // Writer-side attestation (attestation Phase 4): the hook identity
           // above is a hardcoded literal — no conversation content can reach
           // it. RECORD-ONLY at the reader (attribution metadata); the JSONL

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -65,6 +65,8 @@ type DefenceModule = {
     mode?: 'advisory' | 'enforce',
   ) => {
     clean: boolean;
+    /** Multi-layer human summary — required for #361 non-injection dirty path. */
+    summary?: string;
     injection: { clean: boolean; riskLevel: string; detections: unknown[] };
   };
   /** #225 sink: the notify transport shared with the Action Guard (#143).

--- a/plugins/openclaw/scan-taint-policy.ts
+++ b/plugins/openclaw/scan-taint-policy.ts
@@ -1,0 +1,30 @@
+/**
+ * #361 — which conversation-scan summaries may raise session taint.
+ *
+ * Session taint escalates Action Guard. Only concrete detections may do that.
+ * Uncertainty ("unknown"), unavailable scanners, and empty noise must not.
+ */
+
+export type TaintMarkSeverity = 'low' | 'medium' | 'high' | 'critical' | 'unknown';
+
+export function isTaintingScanSummary(summary: string | undefined | null): boolean {
+  if (!summary || typeof summary !== 'string') return false;
+  const s = summary.trim();
+  if (!s) return false;
+  const lower = s.toLowerCase();
+  if (lower === 'unknown' || lower === 'none' || lower === 'clean') return false;
+  if (lower.includes('scan unavailable') || lower.includes('unscanned')) return false;
+  if (/\b(critical|high|medium|low)\b/i.test(s)) return true;
+  if (/\bthreat\b/i.test(s)) return true;
+  if (/\bdetections?\b/i.test(s) && /\d+/.test(s)) return true;
+  return false;
+}
+
+export function severityFromScanSummary(summary: string): TaintMarkSeverity {
+  const s = summary.toLowerCase();
+  if (/\bcritical\b/.test(s)) return 'critical';
+  if (/\bhigh\b/.test(s)) return 'high';
+  if (/\bmedium\b/.test(s)) return 'medium';
+  if (/\blow\b/.test(s)) return 'low';
+  return 'medium';
+}


### PR DESCRIPTION
## Summary
Fixes Jarvis production deadlock in #361.

**Chain:** conversation scan `reason: "unknown"` → `tainted: true` → Action Guard escalate (`session-taint`) → broker `judgeAssessment: unavailable` → fail-closed deny — including on SC's own `action_lease.py`.

## Root cause
In `scanRealtimeContent`, when overall `scan.clean === false` but the **injection** layer was clean, summary risk defaulted to **`"unknown"`**. The `llm_input` path then treated any `!clean` result as a positive detection and marked session taint.

## Fix
1. Dirty non-injection scans use the scanner's multi-layer `THREAT …` summary (or an explicit non-injection label) — never bare `unknown`.
2. `sessionTaint.mark` only runs when `isTaintingScanSummary(summary)` is true (HIGH/MEDIUM/… detections or THREAT…; not `unknown` / unavailable).
3. Audit `tainted` flag matches the mark gate.

## Out of scope (still open elsewhere)
- Broker unavailable → actionable operator path (#143 / #354 / #310)
- Trusted action-lease allowlist exemption (possible follow-up)
- Why a benign thread was `clean: false` at all (separate FP investigation)

## Test plan
- [x] `unknown-taint-361.test.ts` — 6 passed
- [ ] CI green