### PR TITLE
chore(release): v4.54.5 — Memory SOTA train + scorecard honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ All notable changes to this project will be documented in this file.
 
 - **Doctor / Action Guard (#354):** `notify.openclaw` alone no longer satisfies the unattended-notify check. DNP/headless denials need `notify.webhookUrl` (denial-capable sink). OpenClaw cards remain interactive-only per #310.
 
+## [4.54.5] - 2026-08-18
+
+**Memory SOTA train + defence honesty patches for hosts.** Lands main-only Memory plane work and two production deadlock/diagnostic fixes so `shieldcortex update` picks them up.
+
+### Added
+- **Memory SOTA foundation (Tracks A–D harness):** inject pack v2 + `nativeContract` gate, capture distill (multi-provider OAuth / cheap default / OpenClaw C.2), provenance scope, LongMemEval-S fetch/convert/defence-honest ingest, embed-await + serial ONNX for honest emb-on runs (#352–#357, #355–#356).
+- **Scorecard dataset-class honesty:** `SCORECARD.md` caveats and headlines classify toy / labeled-subset / full LongMemEval-S from path+count — full-500 runs no longer claim "toy fixture" (#351 residual).
+
+### Fixed
+- **Distill category aliases** map model categories onto schema `valid_category` so admits are not dropped on CHECK (#359).
+- **Doctor:** `notify.openclaw` alone is **not** a DNP denial sink — unattended notify requires webhook (#354 / #360).
+- **Conversation scan:** bare `unknown` summaries no longer taint sessions or escalate Action Guard into broker-unavailable deadlock (#361 / #362).
+- **HEARTBEAT / cron envelope** recognition for host sessions (#353 / #358).
+
+### Notes
+- Full LongMemEval-S **500** emb-on host measurement (defence ON): RRF R@5 **92.00%** / R@10 **92.80%** / MRR **0.8593**; legacy ~0.6%. Retrieval-only; not a generation bake-off vs agentmemory 95.2%.
+- Action Guard warn-mode left as operator choice (TARS stays warn unless asked).
+- SDKs: no client API change this cut — leave 0.x unchanged intentional.
+
 ## [Unreleased]
 
 ### Added

--- a/benchmark/longmemeval/scorecard.ts
+++ b/benchmark/longmemeval/scorecard.ts
@@ -9,6 +9,10 @@
  *
  * Numbers are formatted to 4 decimal places — enough precision to
  * distinguish small deltas without implying false significance.
+ *
+ * Dataset-class honesty (#351 residual): caveats and headlines MUST match
+ * toy / labeled-subset / full LongMemEval-S. Never claim "toy only" on a
+ * full-500 run, and never claim product SOTA from retrieval alone.
  */
 
 import type { BenchmarkReport, EngineScorecard, QuestionResult } from './types.js';
@@ -16,8 +20,36 @@ import type { BenchmarkReport, EngineScorecard, QuestionResult } from './types.j
 /** agentmemory's published LongMemEval-S R@5. Used as a reference line. */
 const AGENTMEMORY_REFERENCE_R5 = 0.952;
 
+export type DatasetClass = 'toy' | 'subset' | 'full' | 'unknown';
+
+/** Exported for unit tests — path + question-count heuristics. */
+export function classifyDataset(report: BenchmarkReport): DatasetClass {
+  const ds = (report.dataset_path || '').replace(/\\/g, '/');
+  const q =
+    report.engines.find((e) => e.engine === 'rrf')?.question_count ??
+    report.engines[0]?.question_count ??
+    0;
+
+  if (/toy-dataset/i.test(ds) || q > 0 && q <= 10) return 'toy';
+  if (/subset/i.test(ds)) return 'subset';
+  // full.jsonl / longmemeval-s-full / longmemeval_s_cleaned converted harness
+  if (
+    /longmemeval-s-full/i.test(ds) ||
+    /longmemeval_s_cleaned/i.test(ds) ||
+    (/longmemeval-s\.jsonl$/i.test(ds) && !/subset/i.test(ds)) ||
+    q === 500
+  ) {
+    return 'full';
+  }
+  return 'unknown';
+}
+
 export function renderScorecard(report: BenchmarkReport): string {
   const lines: string[] = [];
+  const klass = classifyDataset(report);
+  const rrf = report.engines.find((e) => e.engine === 'rrf');
+  const legacy = report.engines.find((e) => e.engine === 'legacy');
+  const qLabel = rrf?.question_count ?? legacy?.question_count ?? '?';
 
   lines.push('# ShieldCortex retrieval scorecard');
   lines.push('');
@@ -25,24 +57,54 @@ export function renderScorecard(report: BenchmarkReport): string {
   lines.push('');
   lines.push('> ⚠️ **Caveats — read before quoting any number from this file.**');
   lines.push('>');
-  lines.push('> 1. The dataset below is a small toy fixture, not the full LongMemEval-S benchmark (500 questions). The numbers are useful to compare ShieldCortex\'s RRF engine against its own legacy engine on the same fixture, and to verify the harness runs end-to-end. They are **not** comparable to numbers published against the full LongMemEval-S corpus.');
-  lines.push('> 2. The `agentmemory` reference line below is `rohitg00/agentmemory`\'s **published** result on the full LongMemEval-S corpus. ShieldCortex has not been evaluated against that corpus yet; we cite the number only to identify the algorithm (Reciprocal Rank Fusion, Cormack et al. 2009) that both implementations use.');
-  lines.push('> 3. To reproduce: `npm run bench` from the repo root regenerates this file. Full-suite numbers against LongMemEval-S are on the roadmap; see <https://shieldcortex.ai/security> for status.');
-  lines.push('');
-  const ds = report.dataset_path || '';
-  const isToy = /toy-dataset/i.test(ds);
-  const isSubset = /subset/i.test(ds);
-  const isFullS = /longmemeval-s\.jsonl$/i.test(ds) && !isSubset;
-  if (isToy) {
-    lines.push('> 4. **THIS RUN = TOY FIXTURE ONLY** (5 questions). Do not quote as LongMemEval-S.');
-  } else if (isSubset) {
-    lines.push('> 4. **THIS RUN = LABELED SUBSET** (not full 500). Cite as subset with seed/limit from convert stats. Not comparable to full-S or agentmemory.');
-  } else if (isFullS) {
-    lines.push('> 4. **THIS RUN = full LongMemEval-S harness JSONL (500)** after local convert. Still retrieval-only; not a generation score. agentmemory line remains reference-only.');
+
+  if (klass === 'toy') {
+    lines.push(
+      '> 1. **THIS RUN = TOY FIXTURE** (harness smoke). Useful only to compare RRF vs legacy on the same tiny set and prove the harness runs. **Not** LongMemEval-S.',
+    );
+    lines.push(
+      '> 2. The `agentmemory` reference line is `rohitg00/agentmemory`\'s **published** full LongMemEval-S R@5. It identifies the algorithm (RRF); it is **not** a head-to-head on this toy set.',
+    );
+    lines.push(
+      '> 3. Reproduce smoke: `npm run bench:smoke`. Full-S / subset need the upstream dataset via `npm run bench:fetch-s` + convert — see `benchmark/longmemeval/README.md`.',
+    );
+  } else if (klass === 'subset') {
+    lines.push(
+      '> 1. **THIS RUN = LABELED SUBSET** of LongMemEval-S (not the full 500). Cite seed/limit from convert stats. Do not present as full-S.',
+    );
+    lines.push(
+      '> 2. Retrieval-only (session R@k / MRR). No generation / answer-quality judge. Defence stays ON during ingest; blocked turns are skipped.',
+    );
+    lines.push(
+      '> 3. `agentmemory` 95.2% is a **published full-S reference** from another project/stack — **not 1:1 comparable** to this subset run.',
+    );
+  } else if (klass === 'full') {
+    lines.push(
+      '> 1. **THIS RUN = full LongMemEval-S (500 questions)** via local convert of the upstream cleaned release. Retrieval-only (session R@k / MRR) — not a generation scorecard.',
+    );
+    lines.push(
+      '> 2. Defence firewall stays **ON** during ingest; blocked turns are skipped (product-honest corpus). Embeddings ON/OFF is an operator choice — read the run notes / env, not this file alone.',
+    );
+    lines.push(
+      '> 3. `agentmemory` 95.2% R@5 is a **published reference** from another project with a different stack. Cite both numbers with protocol differences; do not claim "we beat them" from this table alone.',
+    );
   } else {
-    lines.push('> 4. Dataset path did not match toy/subset/full heuristics — read the path and question count before quoting.');
+    lines.push(
+      '> 1. Dataset path/count did not match toy/subset/full heuristics — read path + question count before quoting.',
+    );
+    lines.push(
+      '> 2. Retrieval-only. Defence ON during ingest unless the operator disabled it.',
+    );
+    lines.push(
+      '> 3. `agentmemory` line is reference-only (algorithm identity), not a matched bake-off.',
+    );
   }
-  lines.push('> 5. Defence firewall stays ON during ingest; blocked turns are skipped (product-honest corpus).');
+
+  lines.push(
+    '> 4. Product SOTA is **not** proven by this file alone — it needs live capture → admit → inject on real hosts as well as retrieval.',
+  );
+  lines.push('');
+  lines.push(`- Dataset class: **${klass}**`);
   lines.push(`- Dataset: \`${report.dataset_path}\``);
   lines.push(`- Top-k: ${report.k_top}`);
   lines.push(`- Generated: ${report.generated_at}`);
@@ -51,15 +113,23 @@ export function renderScorecard(report: BenchmarkReport): string {
 
   lines.push('## Headline');
   lines.push('');
-  const rrf = report.engines.find((e) => e.engine === 'rrf');
-  const legacy = report.engines.find((e) => e.engine === 'legacy');
+  const runNoun =
+    klass === 'full' ? 'full LongMemEval-S' : klass === 'subset' ? 'labeled subset' : klass === 'toy' ? 'toy fixture' : 'run';
   if (rrf) {
-    lines.push(`- **RRF R@5 (${rrf.question_count}-question fixture):** ${formatPct(rrf.recall_at_5)}`);
+    lines.push(`- **RRF R@5 (${qLabel}-question ${runNoun}):** ${formatPct(rrf.recall_at_5)}`);
   }
   if (legacy) {
-    lines.push(`- **Legacy R@5 (${legacy.question_count}-question fixture):** ${formatPct(legacy.recall_at_5)}`);
+    lines.push(`- **Legacy R@5 (${qLabel}-question ${runNoun}):** ${formatPct(legacy.recall_at_5)}`);
   }
-  lines.push(`- \`agentmemory\` reference (full LongMemEval-S, 500 questions, R@5): ${formatPct(AGENTMEMORY_REFERENCE_R5)} — **not comparable**; published by a different project against a different corpus, cited only to identify the algorithm.`);
+  if (klass === 'full') {
+    lines.push(
+      `- \`agentmemory\` published full-S R@5: ${formatPct(AGENTMEMORY_REFERENCE_R5)} — **reference only** (different stack/protocol; not a matched bake-off).`,
+    );
+  } else {
+    lines.push(
+      `- \`agentmemory\` reference (full LongMemEval-S, 500 questions, R@5): ${formatPct(AGENTMEMORY_REFERENCE_R5)} — **not comparable** to this ${runNoun}; cited to identify RRF.`,
+    );
+  }
   lines.push('');
 
   lines.push('## Comparison');
@@ -95,10 +165,18 @@ export function renderScorecard(report: BenchmarkReport): string {
 
   lines.push('## Notes');
   lines.push('');
-  lines.push('- R@k is computed at session granularity (LongMemEval convention): a question scores a hit when at least one retrieved memory in top-k comes from a session listed in the question\'s `answer_session_ids`.');
-  lines.push('- MRR is reciprocal of the *first* gold-session hit position, averaged across questions. Questions with no hit contribute 0.');
-  lines.push('- Embeddings are loaded if available; if the model is missing, the harness still runs but vector recall is empty (FTS + graph only).');
-  lines.push('- Each question runs against a fresh in-memory SQLite DB. Cross-question contamination is impossible by construction.');
+  lines.push(
+    '- R@k is computed at session granularity (LongMemEval convention): a question scores a hit when at least one retrieved memory in top-k comes from a session listed in the question\'s `answer_session_ids`.',
+  );
+  lines.push(
+    '- MRR is reciprocal of the *first* gold-session hit position, averaged across questions. Questions with no hit contribute 0.',
+  );
+  lines.push(
+    '- Embeddings are loaded if available; if the model is missing or `SHIELDCORTEX_SKIP_EMBEDDINGS=1`, the harness still runs but vector recall is empty (FTS + graph only).',
+  );
+  lines.push(
+    '- Each question runs against a fresh in-memory SQLite DB. Cross-question contamination is impossible by construction.',
+  );
   lines.push('');
 
   return lines.join('\n');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.4",
+  "version": "4.54.5",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.54.4",
+  "version": "4.54.5",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.54.4",
+  "version": "4.54.5",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.54.4
+  version: 4.54.5
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]

--- a/src/memory/__tests__/longmemeval-scorecard-honesty.test.ts
+++ b/src/memory/__tests__/longmemeval-scorecard-honesty.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from '@jest/globals';
+import { classifyDataset, renderScorecard } from '../../../benchmark/longmemeval/scorecard.js';
+import type { BenchmarkReport } from '../../../benchmark/longmemeval/types.js';
+
+function report(over: Partial<BenchmarkReport> & { path: string; q: number }): BenchmarkReport {
+  return {
+    dataset_path: over.path,
+    k_top: 10,
+    generated_at: '2026-08-18T00:00:00.000Z',
+    engines: [
+      {
+        engine: 'rrf',
+        question_count: over.q,
+        recall_at_5: 0.92,
+        recall_at_10: 0.928,
+        mrr: 0.86,
+        duration_ms: 1000,
+        per_question: [],
+      },
+      {
+        engine: 'legacy',
+        question_count: over.q,
+        recall_at_5: 0.006,
+        recall_at_10: 0.006,
+        mrr: 0.006,
+        duration_ms: 1000,
+        per_question: [],
+      },
+    ],
+  };
+}
+
+describe('scorecard dataset honesty', () => {
+  it('classifies toy / subset / full paths', () => {
+    expect(classifyDataset(report({ path: 'benchmark/longmemeval/fixtures/toy-dataset.jsonl', q: 5 }))).toBe(
+      'toy',
+    );
+    expect(
+      classifyDataset(
+        report({ path: '/home/u/.cache/shieldcortex/benchmark/longmemeval/longmemeval-s-subset50.jsonl', q: 50 }),
+      ),
+    ).toBe('subset');
+    expect(
+      classifyDataset(
+        report({ path: '/home/u/.cache/shieldcortex/benchmark/longmemeval/longmemeval-s-full.jsonl', q: 500 }),
+      ),
+    ).toBe('full');
+    // question-count fallback when path is odd but count is 500
+    expect(classifyDataset(report({ path: '/tmp/custom-lme.jsonl', q: 500 }))).toBe('full');
+  });
+
+  it('full-S scorecard never claims toy-only or "not evaluated yet"', () => {
+    const md = renderScorecard(
+      report({ path: '/home/u/.cache/shieldcortex/benchmark/longmemeval/longmemeval-s-full.jsonl', q: 500 }),
+    );
+    expect(md).toMatch(/Dataset class: \*\*full\*\*/);
+    expect(md).toMatch(/THIS RUN = full LongMemEval-S/);
+    expect(md).toMatch(/full LongMemEval-S\):\*\* 92\.00%/);
+    expect(md).not.toMatch(/small toy fixture/);
+    expect(md).not.toMatch(/has not been evaluated against that corpus yet/);
+    expect(md).not.toMatch(/500-question fixture/);
+  });
+
+  it('toy scorecard still forbids quoting as LongMemEval-S', () => {
+    const md = renderScorecard(report({ path: 'fixtures/toy-dataset.jsonl', q: 5 }));
+    expect(md).toMatch(/TOY FIXTURE/);
+    expect(md).toMatch(/Not\*\* LongMemEval-S/);
+  });
+});


### PR DESCRIPTION
## Summary
Patch cut so hosts get Memory SOTA + defence honesty via `shieldcortex update`.

### Includes (already on main, now versioned)
- Memory SOTA A–D foundation (#352–#357, C/C.2, emb harness)
- Distill category aliases (#359)
- Doctor notify.openclaw honesty (#360 / #354)
- Unknown scan must not taint (#362 / #361)
- HEARTBEAT/cron envelope (#358 / #353)

### This PR
- Bump **4.54.4 → 4.54.5** + plugin/skill lockstep
- SCORECARD dataset-class honesty (full-500 ≠ toy)
- CHANGELOG notes full-S host measurement RRF **92% R@5** (retrieval-only)

### Out of scope
- SDK 0.x bump (no client API change)
- Closing Memory epic issues (residuals remain operational)

## Test plan
- [x] scorecard honesty unit tests
- [ ] CI green
- [ ] After merge: annotated tag `v4.54.5` → publish.yml