### PR TITLE
fix(doctor): SCAN fix extract leads with conversation-access grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- **Doctor SCAN fix extraction:** when fix prose only backticks `openclaw gateway restart`, still lead with `shieldcortex openclaw install --allow-conversation-access` (Edith live doctor shape).
+
 - **Project keys (Edith):** refuse bare generic basenames (`workspace`, `openclaw`, …) in `deriveProjectKey` unless `projectAliases` maps them; auto-heal legacy/canonical collisions at end of `shieldcortex update` so the KEY warn does not return after every upgrade.
 - **Doctor OpenClaw residue (Edith):** ClawHub `lock.json` `.skills.shieldcortex` is **not** an orphan when the skill directory is on disk (`~/.openclaw/workspace/skills/shieldcortex`). Stops a permanent warn after every healthy skill install.
 - **Doctor SCAN fix commands:** conversation-access warn now leads with `shieldcortex openclaw install --allow-conversation-access` then `openclaw gateway restart` — restart alone never clears the warn.

--- a/src/cli/__tests__/doctor-report-mobile.test.ts
+++ b/src/cli/__tests__/doctor-report-mobile.test.ts
@@ -82,6 +82,15 @@ describe('extractFixCommands', () => {
     ]);
   });
 
+  it('promotes grant ahead of backticked restart-only fix prose (Edith live shape)', () => {
+    const cmds = extractFixCommands(
+      'Add hooks.allowConversationAccess=true in openclaw.json, then run `openclaw gateway restart`. Conversation content is sensitive.',
+    );
+    expect(cmds[0]).toBe('shieldcortex openclaw install --allow-conversation-access');
+    expect(cmds).toContain('openclaw gateway restart');
+  });
+
+
   it('surfaces conversation-access grant before gateway restart', () => {
     const cmds = extractFixCommands(
       'Add "hooks": { "allowConversationAccess": true } to plugins.entries["shieldcortex-realtime"] in ~/.openclaw/openclaw.json, then restart the gateway.',

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -146,6 +146,13 @@ export function extractFixCommands(fix: string | undefined): string[] {
       cmds.push(c);
     }
   }
+  // Edith: fix prose backticks only the restart. Grant must lead or operators
+  // keep restarting and the SCAN warn never clears.
+  if (/allowConversationAccess/i.test(fix)) {
+    const grant = 'shieldcortex openclaw install --allow-conversation-access';
+    const rest = unique(cmds.filter((c) => !/allow-conversation-access/i.test(c)));
+    return unique([grant, ...rest.length ? rest : ['openclaw gateway restart']]);
+  }
   if (cmds.length > 0) return unique(cmds);
 
   // Bare shieldcortex/openclaw multi-word commands without backticks.


### PR DESCRIPTION
## Summary
Follow-up to #364. Edith live doctor still showed only restart because fix prose backticks **only** \`openclaw gateway restart\`, and \`extractFixCommands\` returned early.

## Fix
If fix text mentions \`allowConversationAccess\`, always lead with:
\`shieldcortex openclaw install --allow-conversation-access\`

## Test plan
- [x] doctor-report-mobile incl. backticked-restart-only
- [ ] CI