### PR TITLE
chore(release): 4.54.6 — Edith doctor honesty patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,19 @@
-## Unreleased
-
-- **Doctor SCAN fix extraction:** when fix prose only backticks `openclaw gateway restart`, still lead with `shieldcortex openclaw install --allow-conversation-access` (Edith live doctor shape).
-
-- **Project keys (Edith):** refuse bare generic basenames (`workspace`, `openclaw`, …) in `deriveProjectKey` unless `projectAliases` maps them; auto-heal legacy/canonical collisions at end of `shieldcortex update` so the KEY warn does not return after every upgrade.
-- **Doctor OpenClaw residue (Edith):** ClawHub `lock.json` `.skills.shieldcortex` is **not** an orphan when the skill directory is on disk (`~/.openclaw/workspace/skills/shieldcortex`). Stops a permanent warn after every healthy skill install.
-- **Doctor SCAN fix commands:** conversation-access warn now leads with `shieldcortex openclaw install --allow-conversation-access` then `openclaw gateway restart` — restart alone never clears the warn.
-
-- **Action Guard / conversation scan (#361):** bare `unknown` scan summaries no longer taint sessions or escalate Action Guard. Dirty non-injection scans keep an honest multi-layer THREAT summary instead of defaulting risk to `unknown`.
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
 
 > **Coverage note**: 49 v4 versions are documented below — typically every minor (`X.Y.0`) plus significant patches. Many small patch releases between 4.0.0 and 4.20.x are not individually documented (~50 versions, mostly behaviour-preserving fixes). For a specific diff between adjacent npm versions, see `git log vX.Y.Z..vX.Y.W` or compare tarballs. Audited and reconciled 2026-05-27 — gap is intentional, not a sign of release-note drift going forward.
 
-## Unreleased
 
+## [4.54.6] - 2026-08-19
+
+**Edith doctor honesty patch (#364/#365).** Also carries late changelog notes for #354/#361 fixes whose code already shipped in 4.54.5.
+
+- **Doctor SCAN fix extraction:** when fix prose only backticks `openclaw gateway restart`, still lead with `shieldcortex openclaw install --allow-conversation-access` (Edith live doctor shape).
+- **Project keys (Edith):** refuse bare generic basenames (`workspace`, `openclaw`, …) in `deriveProjectKey` unless `projectAliases` maps them; auto-heal legacy/canonical collisions at end of `shieldcortex update` so the KEY warn does not return after every upgrade.
+- **Doctor OpenClaw residue (Edith):** ClawHub `lock.json` `.skills.shieldcortex` is **not** an orphan when the skill directory is on disk (`~/.openclaw/workspace/skills/shieldcortex`). Stops a permanent warn after every healthy skill install.
+- **Doctor SCAN fix commands:** conversation-access warn now leads with `shieldcortex openclaw install --allow-conversation-access` then `openclaw gateway restart` — restart alone never clears the warn.
+- **Action Guard / conversation scan (#361):** bare `unknown` scan summaries no longer taint sessions or escalate Action Guard. Dirty non-injection scans keep an honest multi-layer THREAT summary instead of defaulting risk to `unknown`.
 - **Doctor / Action Guard (#354):** `notify.openclaw` alone no longer satisfies the unattended-notify check. DNP/headless denials need `notify.webhookUrl` (denial-capable sink). OpenClaw cards remain interactive-only per #310.
 
 ## [4.54.5] - 2026-08-18

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.5",
+  "version": "4.54.6",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.54.5",
+  "version": "4.54.6",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,
@@ -121,7 +121,7 @@
     },
     "interceptor.conversation.posture": {
       "label": "Conversation Firewall",
-      "description": "What the conversation firewall does with a detection on the input path. off = do not scan; observe = scan, audit and alert the operator but never stop the turn (default); enforce = block the run via before_agent_run. Requires plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess=true on this host — OpenClaw refuses conversation hooks without that operator grant, and ShieldCortex will never set it for you.",
+      "description": "What the conversation firewall does with a detection on the input path. off = do not scan; observe = scan, audit and alert the operator but never stop the turn (default); enforce = block the run via before_agent_run. Requires plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess=true on this host \u2014 OpenClaw refuses conversation hooks without that operator grant, and ShieldCortex will never set it for you.",
       "type": "string"
     },
     "interceptor.actionGuard.notify.enabled": {
@@ -132,7 +132,7 @@
     },
     "interceptor.actionGuard.notify.webhookUrl": {
       "label": "Notify Webhook URL",
-      "description": "http(s) endpoint the notification is POSTed to. Conversation-firewall alerts carry no approve/deny affordance — there is nothing to approve.",
+      "description": "http(s) endpoint the notification is POSTed to. Conversation-firewall alerts carry no approve/deny affordance \u2014 there is nothing to approve.",
       "type": "string",
       "advanced": true
     },
@@ -156,7 +156,7 @@
     "properties": {
       "enabled": {
         "type": "boolean",
-        "description": "Unused — plugin on/off is controlled by plugins.entries[id].enabled on the host, not this nested config value. See #115."
+        "description": "Unused \u2014 plugin on/off is controlled by plugins.entries[id].enabled on the host, not this nested config value. See #115."
       },
       "binaryPath": {
         "type": "string"
@@ -190,7 +190,7 @@
           "trustOwnerInput": {
             "type": "boolean",
             "default": true,
-            "description": "Default true: a message the host attributes to the gateway OWNER is an instruction, so a detection in it is audited and alerted but never taints the session or blocks the turn. Set false on a host where the owner routinely pastes untrusted content and you would rather have the caution than the quiet. Content from anyone else — including another agent on a trusted channel — is data regardless of this setting."
+            "description": "Default true: a message the host attributes to the gateway OWNER is an instruction, so a detection in it is audited and alerted but never taints the session or blocks the turn. Set false on a host where the owner routinely pastes untrusted content and you would rather have the caution than the quiet. Content from anyone else \u2014 including another agent on a trusted channel \u2014 is data regardless of this setting."
           }
         }
       },
@@ -368,7 +368,7 @@
               "notify": {
                 "type": "object",
                 "additionalProperties": false,
-                "description": "Operator-notify transport (#143), also used by the conversation firewall’s detection sink (#225). Off unless enabled is exactly true.",
+                "description": "Operator-notify transport (#143), also used by the conversation firewall\u2019s detection sink (#225). Off unless enabled is exactly true.",
                 "properties": {
                   "enabled": {
                     "type": "boolean",
@@ -491,7 +491,7 @@
           "notify": {
             "type": "object",
             "additionalProperties": false,
-            "description": "Operator-notify transport (#143), also used by the conversation firewall’s detection sink (#225). Off unless enabled is exactly true.",
+            "description": "Operator-notify transport (#143), also used by the conversation firewall\u2019s detection sink (#225). Off unless enabled is exactly true.",
             "properties": {
               "enabled": {
                 "type": "boolean",

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.54.5",
+  "version": "4.54.6",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,10 +24,10 @@
   ],
   "scripts": {
     "pack:verify": "npm pack --dry-run",
-    "prepublishOnly": "node -e \"if(!require('fs').existsSync('dist/index.js'))throw new Error('plugin dist/index.js missing — run `npm run build:ts` from the repo root before publishing')\""
+    "prepublishOnly": "node -e \"if(!require('fs').existsSync('dist/index.js'))throw new Error('plugin dist/index.js missing \u2014 run `npm run build:ts` from the repo root before publishing')\""
   },
   "peerDependencies": {
-    "shieldcortex": ">=4.18.3 <5.0.0",
+    "shieldcortex": "^4.54.6",
     "openclaw": ">=2026.3.22"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary
Patch cut so `shieldcortex update` delivers #364/#365 fleet-wide (Edith is hand-patched today).

- core + realtime plugin **4.54.5 → 4.54.6** (lockstep)
- Doctor: clawhub lock false-orphan fix, SCAN grant-first fix commands
- Project keys: generic-basename refusal + auto-heal on update
- CHANGELOG: 4.54.6 entry + late notes folded

## Test plan
- [x] build:ts
- [x] doctor-report/deep-clean/project-key suites (43/43)
- [ ] CI
- [ ] After merge: tag v4.54.6 → publish → cloud/sites → fleet update