### PR TITLE
chore(release): sync skill manifest to 4.54.6

### DIFF
--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.54.5
+  version: 4.54.6
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
publish.yml prepublish check failed: skills/shieldcortex/SKILL.md still 4.54.5. Sync to 4.54.6; will re-tag after merge.