### PR TITLE
fix(notify): honest headless-denial alerts + redaction-safe surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 > **Coverage note**: 49 v4 versions are documented below — typically every minor (`X.Y.0`) plus significant patches. Many small patch releases between 4.0.0 and 4.20.x are not individually documented (~50 versions, mostly behaviour-preserving fixes). For a specific diff between adjacent npm versions, see `git log vX.Y.Z..vX.Y.W` or compare tarballs. Audited and reconciled 2026-05-27 — gap is intentional, not a sign of release-note drift going forward.
 
 
+## Unreleased
+
+- **Denial alerts honesty (#369):** headless denials (`denied_no_prompt_surface`) render as `DENIED (headless session): nothing is waiting for approval` — never `approval needed`. Outcome alerts keep the hook's redaction-safe surface (`Tool: [redacted …] fields=file_path`) instead of flattening to a placeholder that rendered as `Command: (empty)`; the surface passes an allowlist regex so values/URLs/quoting can never smuggle through. Webhook POSTs carry `X-ShieldCortex-Outcome` so receivers can route pending-vs-dead without parsing the body.
+
 ## [4.54.7] - 2026-08-19
 
 **Edith doctor honesty patch (#364/#365).** (4.54.6 tag exists but was never published — npm skipped straight to 4.54.7.) Also carries late changelog notes for #354/#361 fixes whose code already shipped in 4.54.5.

--- a/src/defence/iron-dome/__tests__/operator-notify.test.ts
+++ b/src/defence/iron-dome/__tests__/operator-notify.test.ts
@@ -477,3 +477,41 @@ describe('Action Guard terminal outcome notification construction', () => {
 
 // keep jest from complaining about an unused import in some ts configs
 expect(typeof jest).toBe('object');
+
+describe('#369 — honest denial alerts', () => {
+  const base = {
+    event: 'action_guard_denial' as const,
+    outcome: 'denied_no_prompt_surface',
+    tool: 'Write',
+    surface: 'Write: [redacted action surface; command not persisted to notify or denials.jsonl preview] fields=file_path',
+    signals: ['stop-process-or-service'],
+    severity: 'dangerous',
+    reason: 'unused — builder derives',
+    detectedAt: '2026-08-19T05:16:28.008Z',
+  };
+
+  it('keeps the redacted surface instead of flattening it to the literal placeholder', () => {
+    const n = buildActionGuardOutcomeNotification(base);
+    expect(n.surface).toContain('fields=file_path');
+    expect(n.surface).toContain('Write:');
+  });
+
+  it('refuses a surface containing quoting (value smuggling)', () => {
+    const n = buildActionGuardOutcomeNotification({ ...base, surface: 'Bash: "curl http://evil"' });
+    expect(n.surface).toBe('redacted action surface');
+  });
+
+  it('headless denial headline says DENIED, not blocked-generic, and never approval', () => {
+    const n = buildActionGuardOutcomeNotification(base);
+    const text = formatOperatorNotification(n);
+    expect(text).toContain('DENIED (headless session)');
+    expect(text).toContain('nothing is waiting for approval');
+    expect(text).not.toContain('approval needed');
+  });
+
+  it('non-headless denial keeps the BLOCKED headline', () => {
+    const n = buildActionGuardOutcomeNotification({ ...base, outcome: 'auto_denied' });
+    const text = formatOperatorNotification(n);
+    expect(text).toContain('Action Guard BLOCKED a tool call');
+  });
+});

--- a/src/defence/iron-dome/operator-notify.ts
+++ b/src/defence/iron-dome/operator-notify.ts
@@ -482,6 +482,26 @@ function safeDetectedAt(v: unknown): string {
     : '1970-01-01T00:00:00.000Z';
 }
 
+/** #369 — a values-free action surface for outcome alerts. The caller's
+ *  surface is already redacted (`Tool: [redacted...] fields=file_path`), but
+ *  this builder used to throw even that away and pin the literal string
+ *  `redacted action surface`, which rendered as `Command: (empty)` on the
+ *  operator's phone. Keep it: strip anything that looks like a value (quotes,
+ *  slashes-with-content beyond a bounded length), keep tool + field names. */
+const SAFE_SURFACE_RE =
+  /^[A-Za-z][A-Za-z0-9_.-]{0,63}: \[redacted[^\][]{0,120}\](?: fields=[a-z_][a-z0-9_,]{0,120}| no command field)?$/;
+
+function safeActionGuardSurface(raw: unknown): string {
+  if (typeof raw !== 'string') return 'redacted action surface';
+  const trimmed = raw.trim();
+  // ALLOWLIST, not blocklist: only the hook's own redacted-surface shape
+  // (`Tool: [redacted …] fields=a,b` / `… no command field`) passes. URLs,
+  // quoting, paths, free text — anything else — flattens to the placeholder,
+  // so this can never become a smuggling path for command text or secrets.
+  if (!SAFE_SURFACE_RE.test(trimmed)) return 'redacted action surface';
+  return truncate(trimmed, 200);
+}
+
 export function buildActionGuardOutcomeNotification(
   input: ActionGuardOutcomeInput,
 ): ActionGuardOutcomeNotification {
@@ -491,7 +511,7 @@ export function buildActionGuardOutcomeNotification(
     event,
     outcome,
     tool: safeActionGuardTool(input.tool),
-    surface: 'redacted action surface',
+    surface: safeActionGuardSurface((input as { surface?: unknown }).surface),
     signals: safeActionGuardSignals(input.signals),
     severity: safeActionGuardSeverity(input.severity, event),
     reason: safeActionGuardReason(event, outcome),
@@ -584,9 +604,12 @@ export function formatActionGuardOutcomeNotification(n: ActionGuardOutcomeNotifi
     return truncate(extra.digestText, 4_000);
   }
   const denied = n.event === 'action_guard_denial';
+  const headless = n.outcome === 'denied_no_prompt_surface';
   const lines = [
     denied
-      ? '🛡️ ShieldCortex — Action Guard BLOCKED a tool call'
+      ? headless
+        ? '🛡️ ShieldCortex — DENIED (headless session): nothing is waiting for approval'
+        : '🛡️ ShieldCortex — Action Guard BLOCKED a tool call'
       : '🛡️ ShieldCortex — Action Guard warning: advisory-mode tool call ran',
     '',
     `Tool:      ${n.tool}`,

--- a/src/defence/iron-dome/webhook-notify-channel.ts
+++ b/src/defence/iron-dome/webhook-notify-channel.ts
@@ -164,6 +164,11 @@ export function createWebhookNotifyChannel(opts: WebhookNotifyChannelOptions): N
         // of having a header at all.
         'X-ShieldCortex-Event': eventOf(notification),
       };
+      // #369 — receivers routing "is anything actually pending?" need the
+      // outcome without parsing the body. Only outcome-bearing alerts have one.
+      if (isActionGuardOutcomeNotification(notification)) {
+        headers['X-ShieldCortex-Outcome'] = notification.outcome;
+      }
       if (opts.secret) {
         headers['X-ShieldCortex-Signature'] = createHmac('sha256', opts.secret).update(body).digest('hex');
       }


### PR DESCRIPTION
Closes #369.

## What Michael was receiving
```
🛡️ ShieldCortex — approval needed
Tool:     Write
Command:  (empty)
Reason:   … no prompt surface; the tool call was denied.
```
A denial dressed as a question, with zero actionable context, repeated per cron run.

## Fixes
1. **Honest headline** — `formatActionGuardOutcomeNotification` renders `denied_no_prompt_surface` as `DENIED (headless session): nothing is waiting for approval`.
2. **Surface kept** — `buildActionGuardOutcomeNotification` no longer flattens the hook's already-redacted surface to a placeholder. Allowlist regex (`Tool: [redacted …] fields=…` shape only) so URLs/quotes/values still flatten — pinned by the existing secret-redaction test.
3. **`X-ShieldCortex-Outcome` header** on webhook POSTs — receivers can route dead-vs-pending without body parsing.

Dedupe/coalescing already exists (#331 DNP digest window) — not duplicated here.

## Tests
- 4 new cases in operator-notify.test.ts
- Full iron-dome + prompt-surface-deny: **1423/1423**
- build:ts clean