### PR TITLE
fix(openclaw): surface native approval cards for require_approval (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- **OpenClaw native approval cards (#310):** interactive `require_approval` now returns OpenClaw `{ requireApproval }` (allow-once / deny, 10-minute timeout, fail-closed) instead of swallowing the `TypedApprovalRequest` bridge throw as `failure_denied`. Cron/heartbeat host sessions stay immediately fail-closed (no #112 hang). Catastrophic stays hard-block. Secret-egress card copy withholds the command body.
 - **Denial alerts honesty (#369):** headless denials (`denied_no_prompt_surface`) render as `DENIED (headless session): nothing is waiting for approval` — never `approval needed`. Outcome alerts keep the hook's redaction-safe surface (`Tool: [redacted …] fields=file_path`) instead of flattening to a placeholder that rendered as `Command: (empty)`; the surface passes an allowlist regex so values/URLs/quoting can never smuggle through. Webhook POSTs carry `X-ShieldCortex-Outcome` so receivers can route pending-vs-dead without parsing the body.
 
 ## [4.54.7] - 2026-08-19

--- a/plugins/openclaw/__tests__/action-guard.test.ts
+++ b/plugins/openclaw/__tests__/action-guard.test.ts
@@ -82,6 +82,30 @@ describe('interceptor — Action Guard wiring', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('#310: TypedApprovalRequest from requireApproval propagates (card bridge)', async () => {
+    const i = makeInterceptor({ actionGuard: { enabled: true, enforce: true } });
+    const bridge = new Error('mint card');
+    bridge.name = 'TypedApprovalRequest';
+    await expect(
+      i.handleToolCall({
+        toolName: 'Bash',
+        arguments: { command: 'rm /home/u/notes.txt' },
+        requireApproval: async () => { throw bridge; },
+      }),
+    ).rejects.toBe(bridge);
+  });
+
+  it('#310: a generic requireApproval error still fail-closes', async () => {
+    const i = makeInterceptor({ actionGuard: { enabled: true, enforce: true } });
+    await expect(
+      i.handleToolCall({
+        toolName: 'Bash',
+        arguments: { command: 'rm /home/u/notes.txt' },
+        requireApproval: async () => { throw new Error('transport down'); },
+      }),
+    ).rejects.toThrow(/approval error, failure policy: deny/);
+  });
+
   it('catastrophic ops are blocked even in enforce mode regardless of approval', async () => {
     const i = makeInterceptor({ actionGuard: { enabled: true, enforce: true } });
     await expect(

--- a/plugins/openclaw/__tests__/interceptor-config-112.test.ts
+++ b/plugins/openclaw/__tests__/interceptor-config-112.test.ts
@@ -3,6 +3,7 @@ import plugin, {
   __resetConfigStateForTest,
   __setDefenceModuleForTest,
   __setRuntimeForTest,
+  __buildTypedApprovalRequestForTest,
 } from '../index.js';
 import { evaluateToolCall } from '../../../src/defence/iron-dome/tool-action-guard.js';
 
@@ -143,18 +144,20 @@ describe('#112 — normaliseConfig() preserves nested interceptor config', () =>
 // ==================== 2. End-to-end: config → before_tool_call gate ====================
 
 describe('#112 — end-to-end: plugin config controls the before_tool_call gate', () => {
-  // "Gate armed" observable: the typed-hook bridge currently surfaces an armed
-  // gate either as { requireApproval } or as a failure-policy { block } (the
-  // interceptor catches the TypedApprovalRequest bridge throw as an approval
-  // error). Both mean the tool call was intercepted; neither may appear when
-  // the user disabled the gate.
+  // #310: an armed interactive gate must mint a native card. `block` remains
+  // valid for catastrophic / unattended; disabled-gate tests still use this
+  // helper to assert neither shape appears.
   const intercepted = (result: any): boolean => Boolean(result && (result.requireApproval || result.block));
 
-  it('CONTROL (harness validity): default config arms the gate — dangerous op is intercepted', async () => {
+  it('CONTROL (harness validity): default config arms the gate — dangerous op is a native card', async () => {
     const { api, hooks } = makeApi(rootConfigWith({}));
     plugin.register(api);
     const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } });
-    expect(intercepted(result)).toBe(true);
+    expect(result?.requireApproval).toBeTruthy();
+    expect(result?.block).toBeUndefined();
+    expect(result.requireApproval.allowedDecisions).toEqual(['allow-once', 'deny']);
+    expect(result.requireApproval.timeoutBehavior).toBe('deny');
+    expect(result.requireApproval.timeoutMs).toBe(600_000);
   });
 
   it('interceptor.enabled:false → the before_tool_call hook is not registered at all (stronger contract post-#112-follow-up)', () => {
@@ -221,5 +224,37 @@ describe('#112 — deep-merge semantics: shield config + plugin override, per-ke
     plugin.register(api);
     const result = await hooks['before_tool_call']({ toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } });
     expect(result).toBeUndefined();
+  });
+});
+
+describe('#310 — OpenClaw native approval cards', () => {
+  it('cron/heartbeat sessions fail closed immediately — no card', async () => {
+    const { api, hooks } = makeApi(rootConfigWith({}));
+    plugin.register(api);
+    const event = { toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } };
+    const cron = await hooks['before_tool_call'](event, { sessionKey: 'agent:main:cron:abc' });
+    expect(cron?.requireApproval).toBeUndefined();
+    expect(cron?.block).toBe(true);
+    const beat = await hooks['before_tool_call'](event, { sessionKey: 'agent:main:heartbeat' });
+    expect(beat?.requireApproval).toBeUndefined();
+    expect(beat?.block).toBe(true);
+  });
+
+  it('secret-egress card copy withholds the payload', () => {
+    const req = __buildTypedApprovalRequestForTest([
+      'ShieldCortex — Action Intercepted',
+      'Tool:       Bash',
+      'Action:     exec',
+      'Risk:       dangerous',
+      'Signals:    secret-egress',
+      'Reason:     posted credential-material to example.invalid',
+    ].join('\n'));
+    expect(req.description).toContain('command withheld');
+    expect(req.description).not.toContain('credential-material');
+    expect(req.description).not.toContain('example.invalid');
+    expect(req.description).toMatch(/Signals:/i);
+    expect(req.allowedDecisions).toEqual(['allow-once', 'deny']);
+    expect(req.timeoutBehavior).toBe('deny');
+    expect(req.timeoutMs).toBe(600000);
   });
 });

--- a/plugins/openclaw/__tests__/session-guard-260.test.ts
+++ b/plugins/openclaw/__tests__/session-guard-260.test.ts
@@ -72,7 +72,7 @@ describe('#260 interceptor stamps origin + sessionKey and indexes a deny', () =>
   it('an unattended dangerous deny carries origin=openclaw-interceptor and a sc- sessionKey', async () => {
     const captured: InterceptAuditEntry[] = [];
     const indexed: InterceptAuditEntry[] = [];
-    const sessionId = 'openclaw-cron-backup';
+    const sessionId = 'agent:main:cron:backup';
     const { handleToolCall } = createInterceptor(DEFAULT_CONFIG, okPipeline as never, {
       evaluateToolCall: evaluateToolCall as never,
       onAuditEntry: (e) => captured.push(e),
@@ -164,7 +164,7 @@ describe('#260 plugin session_end / agent_end summarise the OpenClaw index', () 
     const { api, hooks } = makeApi();
     plugin.register(api);
 
-    const sessionId = 'openclaw-cron-backup';
+    const sessionId = 'agent:main:cron:backup';
     const result = await hooks.before_tool_call(
       { toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } },
       { sessionId },
@@ -195,7 +195,7 @@ describe('#260 plugin session_end / agent_end summarise the OpenClaw index', () 
     const { api, hooks } = makeApi();
     plugin.register(api);
 
-    const sessionId = 'once-only-oc';
+    const sessionId = 'agent:main:cron:once-only';
     await hooks.before_tool_call(
       { toolName: 'Bash', params: { command: 'sudo systemctl stop ssh' } },
       { sessionId },

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -400,6 +400,10 @@ type AgentCtx = {
 type TypedBeforeToolCallEvent = {
   toolName: string;
   params?: Record<string, unknown>;
+  // Not supplied by today's OpenClaw (the session rides on the tool context —
+  // see #233), but resolveHookSessionId prefers the event when a host does
+  // send one, and every other hook's event carries it.
+  sessionId?: string;
 };
 type TypedBeforeToolCallResult = {
   block?: boolean;
@@ -3302,6 +3306,19 @@ function truncateApprovalText(text: string, maxLength: number): string {
   return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
 }
 
+/** A held command can itself contain the credential that tripped the guard, and
+ *  an approval card is a chat surface. Same rule, same phrasing and same
+ *  trade as the Telegram card path (isSecretEgress / buildCardFields in
+ *  src/defence/iron-dome/openclaw-approval-channel.ts): the operator keeps the
+ *  tool, the signals and the severity, and loses exactly the text that must not
+ *  be forwarded. */
+const SECRET_EGRESS_PROMPT = /secret|credential/iu;
+const WITHHELD_COMMAND_TEXT = "(command withheld — contains credential material)";
+/** Prompt lines safe to forward on a secret-egress hold — label-only metadata.
+ *  `Reason:` (action guard) and `Content:` (memory write) are the two lines
+ *  that quote the payload, so anything not on this list is dropped. */
+const SAFE_APPROVAL_LINE = /^(?:Tool|Action|Risk|Signals|Threats):/iu;
+
 function buildTypedApprovalRequest(message: string): NonNullable<TypedBeforeToolCallResult["requireApproval"]> {
   const lines = message
     .split(/\r?\n/u)
@@ -3309,7 +3326,13 @@ function buildTypedApprovalRequest(message: string): NonNullable<TypedBeforeTool
     .filter(Boolean)
     .filter((line) => !/^\[(?:Approve|Deny)\]/i.test(line));
   const rawTitle = (lines[0] || "ShieldCortex approval required").replace(/^🛡️\s*/u, "");
-  const details = lines.slice(1).join(" | ") || rawTitle;
+  const detailLines = lines.slice(1);
+  const withholdPayload = SECRET_EGRESS_PROMPT.test(message);
+  const details = (
+    withholdPayload
+      ? [WITHHELD_COMMAND_TEXT, ...detailLines.filter((line) => SAFE_APPROVAL_LINE.test(line))]
+      : detailLines
+  ).join(" | ") || rawTitle;
   const riskText = message.toLowerCase();
   const severity = /\b(?:critical|catastrophic|auto[-_\s]?deny|exfil|rm\s+-rf)\b/u.test(riskText)
     ? "critical"
@@ -3321,26 +3344,43 @@ function buildTypedApprovalRequest(message: string): NonNullable<TypedBeforeTool
     title: truncateApprovalText(rawTitle, 80),
     description: truncateApprovalText(details, 256),
     severity,
-    timeoutMs: 120_000,
+    // The host's own ceiling (MAX_PLUGIN_APPROVAL_TIMEOUT_MS), matching
+    // CARD_TIMEOUT_MS on the Telegram card path. 120s was the old bridge's
+    // number and it expired cards the operator was still walking back to.
+    timeoutMs: 600_000,
     timeoutBehavior: "deny",
     allowedDecisions: ["allow-once", "deny"],
   };
 }
 
+export const __buildTypedApprovalRequestForTest = buildTypedApprovalRequest;
+
 async function handleTypedBeforeToolCall(
   event: TypedBeforeToolCallEvent,
   interceptor: ReturnType<typeof createInterceptor>,
   logger: PluginApi["logger"],
-  sessionId?: string,
+  ctx?: AgentCtx,
 ): Promise<TypedBeforeToolCallResult | void> {
+  const sessionId = resolveHookSessionId(event, ctx);
+  // #310: a card is only worth minting when a human is there to tap it. Cron
+  // and heartbeat runs are host-keyed automation with no operator attached, so
+  // offering OpenClaw an approval request there recreates #112 exactly — the
+  // turn waits out the timeout on a decision nobody can give. Withholding
+  // `requireApproval` puts the interceptor on its unattended branch instead,
+  // which denies on the failure policy immediately and loudly.
+  const attended = !isTrustedAutomationSession(sessionId);
   try {
     await interceptor.handleToolCall({
       toolName: event.toolName,
       arguments: event.params ?? {},
       sessionId,
-      requireApproval: async (message: string) => {
-        throw new TypedApprovalRequest(message, buildTypedApprovalRequest(message));
-      },
+      ...(attended
+        ? {
+            requireApproval: async (message: string) => {
+              throw new TypedApprovalRequest(message, buildTypedApprovalRequest(message));
+            },
+          }
+        : {}),
     });
   } catch (err) {
     if (err instanceof TypedApprovalRequest) {
@@ -3648,13 +3688,16 @@ export default {
     if (!interceptorDisabledInHostConfig) {
       // Typed before_tool_call hook: this is the OpenClaw agent-loop gate that
       // can block or require approval before the selected tool executes.
-      api.on('before_tool_call', async (event: TypedBeforeToolCallEvent, ctx?: { sessionId?: string }) => {
+      api.on('before_tool_call', async (event: TypedBeforeToolCallEvent, ctx?: AgentCtx) => {
         const interceptor = await initInterceptor();
         if (!interceptor) return;
         // #233: the host supplies the session on the tool CONTEXT, not the
         // event. Without it a taint cannot be matched to the call it should
         // gate, so the escalation would silently never fire.
-        return handleTypedBeforeToolCall(event, interceptor, api.logger, ctx?.sessionId);
+        // #310: the WHOLE context, not just `sessionId` — resolveHookSessionId
+        // also reads `sessionKey`, which is where a cron/heartbeat run's key
+        // actually arrives, and that key decides whether a card is minted.
+        return handleTypedBeforeToolCall(event, interceptor, api.logger, ctx);
       }, { priority: 80, timeoutMs: 30_000 });
       _beforeToolCallRegistered = true;
       // NOTE: session_end is NOT registered here — it moved out of this guard

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -547,6 +547,23 @@ export function formatActionGuardPrompt(toolName: string, v: ToolGuardVerdictLik
   ].join('\n');
 }
 
+/**
+ * #310: the OpenClaw-native approval card is delivered by THROWING out of the
+ * injected `requireApproval` — the plugin's typed-hook bridge catches that
+ * throw and hands `{ requireApproval }` back to the host, which draws the card.
+ * So this particular rejection is control flow, not a failure, and the catch
+ * blocks below must let it pass straight through.
+ *
+ * Matched by NAME, not by class: the class lives in the plugin entrypoint
+ * (index.ts) and this file is deliberately free of a compile-time dependency on
+ * it, the same discipline as ToolGuardVerdictLike. Swallowing it as an approval
+ * error is exactly what turned every native card into a `failure_denied` the
+ * operator never saw.
+ */
+function isTypedApprovalRequest(err: unknown): boolean {
+  return err instanceof Error && err.name === 'TypedApprovalRequest';
+}
+
 // --- Audit Logging (local JSONL) ---
 
 /** Resolve per write so isolated tests can redirect every realtime audit path.
@@ -1297,6 +1314,10 @@ export function createInterceptor(
         brokered ? brokerApprovalTimeoutMs(v.severity) : 0,
       );
     } catch (err) {
+      // #310: a minted approval card, not an error. Re-thrown untouched so the
+      // typed-hook bridge can turn it into the operator's card; auditing it
+      // here would write a denial for a decision nobody has made yet.
+      if (isTypedApprovalRequest(err)) throw err;
       if (brokered && err instanceof ApprovalTimeout) {
         // The asymmetric path. Silence is only ever a yes for something the
         // broker already pre-cleared — and that returned long before here — so
@@ -1477,6 +1498,9 @@ export function createInterceptor(
     try {
       approved = await context.requireApproval(message);
     } catch (err) {
+      // #310: same bridge, same rule — the card request is not an approval
+      // failure. Everything else below stays fail-closed.
+      if (isTypedApprovalRequest(err)) throw err;
       const failAction = config.failurePolicy[severity];
       log.warn(`[shieldcortex] ⚠️ requireApproval error: ${err instanceof Error ? err.message : err} — failure policy: ${failAction}`);
       const entry: InterceptAuditEntry = {


### PR DESCRIPTION
## Problem

Edith 2026-08-19 02:53Z: OpenClaw-native require_approval (install-package-global) ended as failure_denied with no Telegram card, even though the operator was in the originating conversation.

This is not a missing protocol. The typed hook already injected requireApproval that throws TypedApprovalRequest so OpenClaw can return `{ requireApproval }`. The interceptor then caught that throw as an approval error and converted it to failure_denied. The #112 tests treated `{ requireApproval } || { block }` as the same pass, so CI stayed green while the card never shipped.

## Approach

- Rethrow TypedApprovalRequest (err.name) from both interceptor requireApproval catch sites. Other errors stay fail-closed.
- Inject the card only when the session is not host cron/heartbeat, after resolving session from the full hook context (sessionKey included). Automation stays immediately fail-closed (no #112 hang).
- Card: allow-once + deny only, timeoutBehavior deny, 10-minute timeout. No allow-always. No reviewedScripts mint/spend.
- Secret-egress / credential prompt text is withheld from the card description.
- Not implementing DESIGN-310 mint-on-intent retry-after-DNP.

#310 stays the design record until soak. Implements Michael's 19 Aug OpenClaw-native card decision.

## Tests

Focused: action-guard + interceptor-config-112 = 35 passed.
Nearby: interceptor-broker-143 + unattended-codex-112 = 36 passed.
CONTROL test now requires result.requireApproval (not merely block).

## Dual review

- Grok 4.6: APPROVE_WITH_NITS, blockers none
- SOL Pro: APPROVE_WITH_NITS, blockers none
- Folded the tractable nit: test helper is `__buildTypedApprovalRequestForTest`

## Risk

OpenClaw must honour `{ requireApproval }` on before_tool_call (typed hook contract since 2026.3.28+). Unattended automation is still instant deny. Catastrophic still hard-blocks. Needs a live Edith/Jarvis Telegram tap after merge — not claimed from unit tests.

## Exclusions

- DESIGN-310 retry-after-DNP cards
- Claude CLI PreToolUse async pause
- Doctor sink-probe from #354 (already shipped in #360)
