### PR TITLE
fix(372): audit rows for card-held approval decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Card-held approval decisions now leave an audit row (#372): operator card
+  decisions on both the action-guard and memory-write pipelines write
+  `approved_once` / `card_denied` / `card_timeout` / `card_cancelled` intercept
+  rows at decision time, with hold-time session attribution, indexed for #260
+  session summaries. Refused card outcomes count as guard degradation;
+  approvals do not.
+
 ### Added
 - **Cron discovery + denial honesty (#375):** `allowlist scan` reads OpenClaw's migrated SQLite cron store (`~/.openclaw/state/openclaw.sqlite`, `cron_jobs`) as a new `openclaw-cron-db` source, unioned with the legacy `cron/jobs.json` when it still exists; `.bak`/`.migrated` leftovers are never read and never taken as proof the store is absent. Paths come from `payload_message`, `trigger_script` and a structural walk of `job_json` string leaves. `enabled` is coerced in JS over all rows, never `WHERE enabled = 1`, so a textual flag cannot report a live store as empty. Store access is read-only throughout (`readonly` + `fileMustExist`); no SQL writes to any OpenClaw store. An OpenClaw host where NEITHER cron source is readable is reported visibly and exits 1 — "we could not look" is not "all clear"; a host with no `~/.openclaw` stays empty-ok. Unreadable or schema-mismatched stores exit 1 as before. `--yes` is refused while any `openclaw-cron-db` script is still unpinned: the first sqlite backfill is per-item review only.
 - **Cron denial correlation (#375):** new `shieldcortex doctor` CRON check joins `~/.shieldcortex/denials.jsonl` (4 MiB tail, deduped by `actionId`) to `cron_run_logs` and WARNs when a guard denial landed inside a run OpenClaw recorded as `ok`, naming the job and offering `shieldcortex allowlist add <path>` per script the job itself declares. Attribution is exact-shape only (`agent:<agent>:cron:<uuid>:run:`); anything else is an unattributed count. The run row is matched by exact `session_key` inside an SQL-bounded window with no nearest-run fallback — no matching row is reported as unconfirmed, never as silent and never as a pass. An unreadable denial log or a missing/unreadable `cron_run_logs` is WARN cannot-correlate, never INFO and never `0 silent`. Denied scripts sort first in the scan review list. No denial surface or command body reaches any new output.

--- a/plugins/openclaw/__tests__/card-decision-audit-372.test.ts
+++ b/plugins/openclaw/__tests__/card-decision-audit-372.test.ts
@@ -164,6 +164,55 @@ describe('#372 interceptor — a held card carries its own decision writer', () 
     expect(decision!.actionKey).toBe(DANGEROUS_COMMAND);
   });
 
+  it('snapshots args at hold time: in-place mutation cannot forge the binding', async () => {
+    const h = makeHarness();
+    const args: Record<string, unknown> = { command: DANGEROUS_COMMAND };
+    const thrown = await h.handleToolCall({
+      toolName: 'Bash',
+      arguments: args,
+      sessionId: 'sess-A',
+      requireApproval: async () => { throw mintCard(); },
+    }).then(() => null, (err: unknown) => err);
+    const card = thrown as CardError;
+
+    // The attacker's move: mutate the SAME object the interceptor saw, then
+    // let the operator's approval land. A reference capture would bind the
+    // decision row to the rewritten command.
+    args.command = 'ls -la';
+    card.decisionAudit!('approved_once');
+
+    const decision = h.captured[h.captured.length - 1];
+    expect(decision!.actionKey).toBe(DANGEROUS_COMMAND);
+  });
+
+  it('stamps decision time as ts and keeps the hold time as heldAtTs', async () => {
+    const h = makeHarness();
+    const card = await holdCard(h, 'sess-A');
+    const heldTs = new Date().toISOString();
+    await new Promise((r) => setTimeout(r, 10));
+
+    card.decisionAudit!('approved_once');
+
+    const decision = h.captured[h.captured.length - 1];
+    expect(typeof decision!.heldAtTs).toBe('string');
+    expect(decision!.heldAtTs! <= heldTs).toBe(true);
+    expect(decision!.ts > decision!.heldAtTs!).toBe(true);
+  });
+
+  it('the writer refuses an outcome outside the card union at runtime', async () => {
+    const h = makeHarness();
+    const card = await holdCard(h, 'sess-A');
+    const rowsBefore = h.captured.length;
+
+    (card.decisionAudit as unknown as (o: string) => void)('failure_allowed');
+    (card.decisionAudit as unknown as (o: string) => void)('constructor');
+    expect(h.captured.length).toBe(rowsBefore);
+
+    // The junk attempts must not have eaten the one-shot latch.
+    card.decisionAudit!('card_denied');
+    expect(h.captured[h.captured.length - 1]).toMatchObject({ outcome: 'card_denied' });
+  });
+
   it('indexes the decision row into the session guard (#260 can see it)', async () => {
     const h = makeHarness();
     const card = await holdCard(h, 'sess-index');
@@ -367,8 +416,10 @@ describe('#372 plugin — the host decision reaches the audit stream', () => {
 
     expect(() => request.onResolution('allow-once')).not.toThrow();
 
+    // The closure now contains the failure itself (review hardening): the row
+    // is lost, the host sees nothing, and the bridge's own failure warn is the
+    // backstop for throws ABOVE the closure, not inside it.
     expect(auditRows()).toHaveLength(0);
-    expect(warnings.some((w) => /approval decision audit failed/.test(w))).toBe(true);
   });
 
   it('the memory-write pipeline card also writes a decision row (#372 second site)', async () => {

--- a/plugins/openclaw/__tests__/card-decision-audit-372.test.ts
+++ b/plugins/openclaw/__tests__/card-decision-audit-372.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { GUARD_DEGRADED_OUTCOMES } from '../../../src/defence/iron-dome/session-guard.js';
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { evaluateToolCall } from '../../../src/defence/iron-dome/tool-action-guard.js';
+import plugin, {
+  __resetConfigStateForTest,
+  __setDefenceModuleForTest,
+  __setRuntimeForTest,
+} from '../index.js';
+import { createInterceptor, DEFAULT_CONFIG, type ApprovalDecisionAudit, type InterceptAuditEntry } from '../interceptor.js';
+
+/**
+ * #372 — the operator's answer to an OpenClaw-native approval card must reach
+ * the audit stream.
+ *
+ * #310 made the card real by THROWING out of `requireApproval`, and
+ * deliberately wrote no audit row at the throw site: no decision exists when a
+ * card is minted. But nothing wrote one when the decision arrived either — the
+ * host reports it on `requireApproval.onResolution`, which was never set. An
+ * operator tapping "Approve" on a recursive delete therefore left NO SC-side
+ * intercept entry at all, and the #260 session summaries could not see it.
+ *
+ * The contract pinned here:
+ *   1. The hold still writes nothing, and the card error is re-thrown intact.
+ *   2. The card carries a one-shot writer that snapshots the call AT HOLD TIME
+ *      — a later tool call on the same interceptor cannot skew attribution.
+ *   3. Resolving writes through the SAME pipeline as every other row
+ *      (jsonl + sessionGuard.index + onAuditEntry + origin), exactly once.
+ *   4. The plugin maps every host decision onto that writer, and the host
+ *      never sees a throw from it.
+ */
+
+const DANGEROUS_COMMAND = 'rm /home/u/notes.txt';
+
+const okPipeline = () => ({
+  allowed: true,
+  firewall: { result: 'ALLOW' as const, reason: '', threatIndicators: [] as string[], anomalyScore: 0, blockedPatterns: [] as string[] },
+  trust: { score: 0.5 },
+  sensitivity: { level: 'INTERNAL' },
+  fragmentation: null,
+  auditId: 1,
+});
+
+/** The bridge as `plugins/openclaw/index.ts` builds it: matched by NAME, and
+ *  carrying the interceptor's decision writer once the hold is taken. */
+type CardError = Error & { decisionAudit?: ApprovalDecisionAudit };
+
+function mintCard(): CardError {
+  const err: CardError = new Error('ShieldCortex approval required');
+  err.name = 'TypedApprovalRequest';
+  return err;
+}
+
+// ==================== 1. Interceptor: the closure itself ====================
+
+describe('#372 interceptor — a held card carries its own decision writer', () => {
+  type Harness = {
+    handleToolCall: (ctx: Record<string, unknown>) => Promise<void>;
+    captured: InterceptAuditEntry[];
+    indexed: InterceptAuditEntry[];
+  };
+
+  function makeHarness(overrides: {
+    keyFor?: (sessionId: string | undefined) => string | null;
+  } = {}): Harness {
+    const captured: InterceptAuditEntry[] = [];
+    const indexed: InterceptAuditEntry[] = [];
+    const { handleToolCall } = createInterceptor(
+      { ...DEFAULT_CONFIG, actionGuard: { enabled: true, enforce: true, autoApprove: [] } } as never,
+      okPipeline as never,
+      {
+        evaluateToolCall: evaluateToolCall as never,
+        onAuditEntry: (e) => { captured.push(e); },
+        sessionGuard: {
+          keyFor: overrides.keyFor ?? ((id) => (id ? `sc-${id}` : null)),
+          index: (entry) => { indexed.push(entry); },
+        },
+        // Stands in for #224 attachEnforcementBinding: proves WHICH call's args
+        // the row was bound to, which is the whole point of capturing at hold.
+        bindAudit: (entry, args) => ({ ...entry, actionKey: String(args?.command ?? 'no-args') }),
+      },
+    );
+    return { handleToolCall: handleToolCall as Harness['handleToolCall'], captured, indexed };
+  }
+
+  /** Drive a dangerous op up to the mint, and hand back the card the plugin
+   *  bridge would receive. */
+  async function holdCard(h: Harness, sessionId?: string, command = DANGEROUS_COMMAND): Promise<CardError> {
+    const thrown = await h.handleToolCall({
+      toolName: 'Bash',
+      arguments: { command },
+      sessionId,
+      requireApproval: async () => { throw mintCard(); },
+    }).then(() => null, (err: unknown) => err);
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).name).toBe('TypedApprovalRequest');
+    return thrown as CardError;
+  }
+
+  it('mints the card with NO row, re-throws it intact, and attaches the writer', async () => {
+    const h = makeHarness();
+    const card = await holdCard(h, 'sess-hold');
+    // #310 unchanged: a hold is not a decision.
+    expect(h.captured).toHaveLength(0);
+    expect(h.indexed).toHaveLength(0);
+    expect(typeof card.decisionAudit).toBe('function');
+  });
+
+  it('an approved card writes exactly one require_approval / approved_once row', async () => {
+    const h = makeHarness();
+    const card = await holdCard(h, 'sess-approve');
+
+    card.decisionAudit!('approved_once');
+
+    expect(h.captured).toHaveLength(1);
+    expect(h.captured[0]).toMatchObject({
+      type: 'intercept',
+      tool: 'Bash',
+      action: 'require_approval',
+      outcome: 'approved_once',
+      origin: 'openclaw-interceptor',
+    });
+    // The guard's own bounded preview — never the approval prompt text.
+    expect(h.captured[0]!.preview).toContain('Bash');
+    expect(h.captured[0]!.preview.length).toBeLessThanOrEqual(200);
+  });
+
+  it.each([
+    ['card_denied'],
+    ['card_timeout'],
+    ['card_cancelled'],
+  ] as const)('a %s decision writes its own require_approval row', async (outcome) => {
+    const h = makeHarness();
+    const card = await holdCard(h, `sess-${outcome}`);
+
+    card.decisionAudit!(outcome);
+
+    expect(h.captured).toHaveLength(1);
+    expect(h.captured[0]).toMatchObject({ action: 'require_approval', outcome, origin: 'openclaw-interceptor' });
+  });
+
+  it('keeps the HOLD-time session and args when the session moves on before the answer', async () => {
+    const h = makeHarness();
+    const card = await holdCard(h, 'sess-A');
+
+    // Minutes pass. The same interceptor serves another call on another
+    // session — the state `emitAudit` reads live is now someone else's.
+    await h.handleToolCall({
+      toolName: 'Bash',
+      arguments: { command: 'sudo systemctl stop ssh' },
+      sessionId: 'sess-B',
+      requireApproval: async () => true,
+    });
+    const rowsBefore = h.captured.length;
+
+    card.decisionAudit!('approved_once');
+
+    const decision = h.captured[rowsBefore];
+    expect(decision).toMatchObject({ outcome: 'approved_once' });
+    expect(decision!.sessionKey).toBe('sc-sess-A');
+    expect(decision!.actionKey).toBe(DANGEROUS_COMMAND);
+  });
+
+  it('indexes the decision row into the session guard (#260 can see it)', async () => {
+    const h = makeHarness();
+    const card = await holdCard(h, 'sess-index');
+
+    card.decisionAudit!('card_denied');
+
+    expect(h.indexed).toHaveLength(1);
+    expect(h.indexed[0]).toMatchObject({
+      outcome: 'card_denied',
+      origin: 'openclaw-interceptor',
+      sessionKey: 'sc-sess-index',
+    });
+  });
+
+  it('is one-shot: a second resolution writes nothing', async () => {
+    const h = makeHarness();
+    const card = await holdCard(h, 'sess-double');
+
+    card.decisionAudit!('approved_once');
+    card.decisionAudit!('card_denied');
+    card.decisionAudit!('approved_once');
+
+    expect(h.captured).toHaveLength(1);
+    expect(h.indexed).toHaveLength(1);
+    expect(h.captured[0]!.outcome).toBe('approved_once');
+  });
+
+  it('a throwing session-key resolver costs the row its key, never the card', async () => {
+    const h = makeHarness({ keyFor: () => { throw new Error('salt unreadable'); } });
+    const card = await holdCard(h, 'sess-nokey');
+
+    expect(typeof card.decisionAudit).toBe('function');
+    card.decisionAudit!('approved_once');
+
+    expect(h.captured).toHaveLength(1);
+    expect(h.captured[0]!.sessionKey).toBeUndefined();
+  });
+
+  it('writes the decision to the audit jsonl, same sink as every other row', async () => {
+    const previous = process.env.SHIELDCORTEX_AUDIT_DIR;
+    const dir = mkdtempSync(join(tmpdir(), 'sc-372-sink-'));
+    process.env.SHIELDCORTEX_AUDIT_DIR = dir;
+    try {
+      const h = makeHarness();
+      const card = await holdCard(h, 'sess-sink');
+      expect(readdirSync(dir).filter((f) => /^realtime-.*\.jsonl$/.test(f))).toHaveLength(0);
+
+      card.decisionAudit!('approved_once');
+
+      const rows = readdirSync(dir)
+        .filter((f) => /^realtime-.*\.jsonl$/.test(f))
+        .flatMap((f) => readFileSync(join(dir, f), 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l)));
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ type: 'intercept', action: 'require_approval', outcome: 'approved_once' });
+    } finally {
+      if (previous === undefined) delete process.env.SHIELDCORTEX_AUDIT_DIR;
+      else process.env.SHIELDCORTEX_AUDIT_DIR = previous;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ==================== 2. Plugin bridge: onResolution wiring ====================
+
+describe('#372 plugin — the host decision reaches the audit stream', () => {
+  const originalAuditDir = process.env.SHIELDCORTEX_AUDIT_DIR;
+  let auditDir = '';
+  let warnings: string[] = [];
+
+  type Hooks = Record<string, (...args: any[]) => any>;
+
+  function makeApi(config: unknown = {}): { api: any; hooks: Hooks } {
+    const hooks: Hooks = {};
+    const api = {
+      id: 'shieldcortex-realtime',
+      name: 'ShieldCortex Real-time Scanner',
+      logger: { info: () => {}, warn: (m: string) => { warnings.push(m); } },
+      on: (name: string, handler: (...args: any[]) => any) => { hooks[name] = handler; },
+      registerCommand: () => {},
+      runtime: { config: { current: () => ({ plugins: { entries: { 'shieldcortex-realtime': { enabled: true, config } } } }) } },
+    };
+    return { api, hooks };
+  }
+
+  function auditRows(): Array<Record<string, unknown>> {
+    return readdirSync(auditDir)
+      .filter((f) => /^realtime-.*\.jsonl$/.test(f))
+      .flatMap((f) => readFileSync(join(auditDir, f), 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l)));
+  }
+
+  function stubDefence(extra: Record<string, unknown> = {}) {
+    __setDefenceModuleForTest({ runDefencePipeline: okPipeline, evaluateToolCall, ...extra } as never);
+  }
+
+  beforeEach(() => {
+    auditDir = mkdtempSync(join(tmpdir(), 'sc-372-plug-'));
+    process.env.SHIELDCORTEX_AUDIT_DIR = auditDir;
+    warnings = [];
+    __resetConfigStateForTest();
+    __setRuntimeForTest({
+      callCortex: async () => null,
+      isOpenClawAutoMemoryEnabled: () => false,
+      loadShieldConfig: async () => ({}),
+    } as never);
+    stubDefence();
+  });
+
+  afterEach(() => {
+    __setDefenceModuleForTest(undefined);
+    __setRuntimeForTest(null);
+    __resetConfigStateForTest();
+    if (originalAuditDir === undefined) delete process.env.SHIELDCORTEX_AUDIT_DIR;
+    else process.env.SHIELDCORTEX_AUDIT_DIR = originalAuditDir;
+    try { rmSync(auditDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  /** Attended session → a real card comes back from the typed hook. */
+  async function holdCard(hooks: Hooks, sessionId = 'agent:main:chat:372'): Promise<any> {
+    const result = await hooks.before_tool_call(
+      { toolName: 'Bash', params: { command: DANGEROUS_COMMAND } },
+      { sessionId },
+    );
+    expect(result?.requireApproval).toBeDefined();
+    return result.requireApproval;
+  }
+
+  it.each([
+    ['allow-once', 'approved_once'],
+    ['allow-always', 'approved_once'],
+    ['deny', 'card_denied'],
+    ['timeout', 'card_timeout'],
+    ['cancelled', 'card_cancelled'],
+  ])('resolving a card with %s writes outcome %s', async (decision, outcome) => {
+    const { api, hooks } = makeApi();
+    plugin.register(api);
+    const request = await holdCard(hooks);
+
+    expect(auditRows()).toHaveLength(0);
+    expect(typeof request.onResolution).toBe('function');
+    await request.onResolution(decision);
+
+    const rows = auditRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      type: 'intercept',
+      tool: 'Bash',
+      action: 'require_approval',
+      outcome,
+      origin: 'openclaw-interceptor',
+    });
+  });
+
+  it('a card the host resolves twice still yields one row', async () => {
+    const { api, hooks } = makeApi();
+    plugin.register(api);
+    const request = await holdCard(hooks);
+
+    await request.onResolution('allow-once');
+    await request.onResolution('deny');
+
+    expect(auditRows()).toHaveLength(1);
+    expect(auditRows()[0]).toMatchObject({ outcome: 'approved_once' });
+  });
+
+  it('a decision this build does not know writes nothing and says so', async () => {
+    const { api, hooks } = makeApi();
+    plugin.register(api);
+    const request = await holdCard(hooks);
+
+    // The host awaits this callback; it resolves rather than rejecting.
+    expect(() => request.onResolution('allow-for-an-hour')).not.toThrow();
+
+    // Inventing an outcome would forge the operator's answer, so: no row.
+    expect(auditRows()).toHaveLength(0);
+    expect(warnings.some((w) => /unrecognised approval decision 'allow-for-an-hour'/.test(w))).toBe(true);
+  });
+
+  it('an unknown decision reaches the gateway log as a label, not as free text', async () => {
+    const { api, hooks } = makeApi();
+    plugin.register(api);
+    const request = await holdCard(hooks);
+
+    expect(() => request.onResolution('deny\n[shieldcortex] action-guard ALLOWED everything')).not.toThrow();
+
+    expect(auditRows()).toHaveLength(0);
+    const warned = warnings.find((w) => /unrecognised approval decision/.test(w));
+    expect(warned).toBeDefined();
+    expect(warned).not.toContain('\n');
+    expect(warned).not.toContain('ALLOWED everything');
+  });
+
+  it('a failing audit write never throws into the host', async () => {
+    // #224 binding is the one step in the write path that can throw on the
+    // host's callback. The operator already decided; that must stand.
+    stubDefence({
+      attachEnforcementBinding: () => { throw new Error('binding ledger unwritable'); },
+    });
+    const { api, hooks } = makeApi();
+    plugin.register(api);
+    const request = await holdCard(hooks);
+
+    expect(() => request.onResolution('allow-once')).not.toThrow();
+
+    expect(auditRows()).toHaveLength(0);
+    expect(warnings.some((w) => /approval decision audit failed/.test(w))).toBe(true);
+  });
+
+  it('the memory-write pipeline card also writes a decision row (#372 second site)', async () => {
+    // The memory-write pipeline mints cards too; its operator decision must
+    // leave the same audit row as the action-guard lane.
+    const quarantinePipeline = () => ({
+      allowed: false,
+      firewall: { result: 'QUARANTINE' as const, reason: 'suspicious', threatIndicators: ['injection'], anomalyScore: 0.7, blockedPatterns: [] as string[] },
+      trust: { score: 0.2 },
+      sensitivity: { level: 'INTERNAL' },
+      fragmentation: null,
+      auditId: 2,
+    });
+    stubDefence({ runDefencePipeline: quarantinePipeline });
+    const { api, hooks } = makeApi({ interceptor: { severityActions: { high: 'require_approval' } } });
+    plugin.register(api);
+
+    const result = await hooks.before_tool_call(
+      { toolName: 'remember', params: { title: 'note', content: 'remember this for later' } },
+      { sessionId: 'agent:main:chat:372' },
+    );
+
+    expect(result?.requireApproval).toBeDefined();
+    expect(result.requireApproval.onResolution).toBeDefined();
+    expect(auditRows()).toHaveLength(0);
+
+    await result.requireApproval.onResolution('allow-once');
+    const rows = auditRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].action).toBe('require_approval');
+    expect(rows[0].outcome).toBe('approved_once');
+    expect(rows[0].tool).toBe('remember');
+    expect(rows[0].origin).toBe('openclaw-interceptor');
+  });
+
+  it('refused card outcomes count as guard degradation; approved_once does not (#260 parity)', () => {
+    expect(GUARD_DEGRADED_OUTCOMES.has('card_denied')).toBe(true);
+    expect(GUARD_DEGRADED_OUTCOMES.has('card_timeout')).toBe(true);
+    expect(GUARD_DEGRADED_OUTCOMES.has('card_cancelled')).toBe(true);
+    expect(GUARD_DEGRADED_OUTCOMES.has('approved_once')).toBe(false);
+  });
+});

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -38,7 +38,7 @@ import { isTaintingScanSummary, severityFromScanSummary } from './scan-taint-pol
 import { classifyConversationOrigin } from './conversation-trust.js';
 import type { ConversationTrustDecision } from './conversation-trust.js';
 import { createInterceptor, DEFAULT_CONFIG as DEFAULT_INTERCEPTOR_CONFIG } from './interceptor.js';
-import type { InterceptorConfig, BrokerRuntime } from './interceptor.js';
+import type { ApprovalDecisionAudit, ApprovalDecisionOutcome, InterceptorConfig, BrokerRuntime } from './interceptor.js';
 import { syncInterceptEvent } from './intercept-ingest.js';
 import { cloudSync } from './cloud-sync.js';
 import { createGatewayNotifyChannel } from './gateway-notify-channel.js';
@@ -405,6 +405,10 @@ type TypedBeforeToolCallEvent = {
   // send one, and every other hook's event carries it.
   sessionId?: string;
 };
+/** Every answer the host can report for a minted card. The first three are
+ *  buttons (a subset of which the card offers via `allowedDecisions`); the last
+ *  two are the host closing the card without one. */
+type CardDecision = "allow-once" | "allow-always" | "deny" | "timeout" | "cancelled";
 type TypedBeforeToolCallResult = {
   block?: boolean;
   blockReason?: string;
@@ -414,8 +418,8 @@ type TypedBeforeToolCallResult = {
     severity?: "info" | "warning" | "critical";
     timeoutMs?: number;
     timeoutBehavior?: "allow" | "deny";
-    allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
-    onResolution?: (decision: "allow-once" | "allow-always" | "deny" | "timeout" | "cancelled") => Promise<void> | void;
+    allowedDecisions?: Array<Extract<CardDecision, "allow-once" | "allow-always" | "deny">>;
+    onResolution?: (decision: CardDecision) => Promise<void> | void;
   };
 };
 type PluginApi = {
@@ -3292,6 +3296,12 @@ function handleLlmOutput(event: LlmOutputEvent, ctx: AgentCtx): void {
 
 class TypedApprovalRequest extends Error {
   request: NonNullable<TypedBeforeToolCallResult["requireApproval"]>;
+  /** #372 — one-shot audit writer the interceptor hangs on this error at hold
+   *  time, carrying the guard's audit base and the session the hold belongs to.
+   *  Absent when the hold came from a path with no guard audit base (an older
+   *  installed interceptor, the memory-write pipeline): then no `onResolution`
+   *  is wired at all and the card behaves exactly as it did before #372. */
+  decisionAudit?: ApprovalDecisionAudit;
 
   constructor(message: string, request: NonNullable<TypedBeforeToolCallResult["requireApproval"]>) {
     super(message);
@@ -3355,6 +3365,28 @@ function buildTypedApprovalRequest(message: string): NonNullable<TypedBeforeTool
 
 export const __buildTypedApprovalRequestForTest = buildTypedApprovalRequest;
 
+/** #372 — the operator's answer, as the audit stream records it.
+ *
+ * `allow-always` is defensive: today's card only offers allow-once/deny (see
+ * `allowedDecisions`), but a host that grows the button must not be able to
+ * produce an approval nobody can find afterwards. It maps to `approved_once`
+ * rather than a sticky outcome because ShieldCortex grants nothing durable
+ * here — the next call is gated again. */
+/** The decision label as it may appear in a gateway log line. Host-supplied,
+ *  so it is reduced to an identifier shape first — a log line is not a place to
+ *  render whatever a caller passed. */
+function safeDecisionLabel(decision: unknown): string {
+  return String(decision).replace(/[^A-Za-z0-9_.:-]/gu, "?").slice(0, 32) || "unknown";
+}
+
+const CARD_DECISION_OUTCOME: Record<CardDecision, ApprovalDecisionOutcome> = {
+  "allow-once": "approved_once",
+  "allow-always": "approved_once",
+  deny: "card_denied",
+  timeout: "card_timeout",
+  cancelled: "card_cancelled",
+};
+
 async function handleTypedBeforeToolCall(
   event: TypedBeforeToolCallEvent,
   interceptor: ReturnType<typeof createInterceptor>,
@@ -3384,6 +3416,27 @@ async function handleTypedBeforeToolCall(
     });
   } catch (err) {
     if (err instanceof TypedApprovalRequest) {
+      const decisionAudit = err.decisionAudit;
+      if (decisionAudit) {
+        // #372: the hold writes no row because no decision exists yet — THIS is
+        // where the operator's answer becomes one. The host owns this callback
+        // and awaits it, so it must never see a throw: a broken audit sink is
+        // not a reason to disturb a decision the operator already made.
+        err.request.onResolution = (decision: CardDecision) => {
+          try {
+            const outcome = CARD_DECISION_OUTCOME[decision];
+            if (!outcome) {
+              // A decision this build does not know. Say so loudly rather than
+              // guess — inventing an outcome would forge the operator's answer.
+              (logger as any)?.warn?.(`[shieldcortex] unrecognised approval decision '${safeDecisionLabel(decision)}' — no audit row written`);
+              return;
+            }
+            decisionAudit(outcome);
+          } catch (auditErr) {
+            (logger as any)?.warn?.(`[shieldcortex] approval decision audit failed (${safeDecisionLabel(decision)}): ${auditErr instanceof Error ? auditErr.message : auditErr}`);
+          }
+        };
+      }
       return { requireApproval: err.request };
     }
 

--- a/plugins/openclaw/index.ts
+++ b/plugins/openclaw/index.ts
@@ -3298,8 +3298,8 @@ class TypedApprovalRequest extends Error {
   request: NonNullable<TypedBeforeToolCallResult["requireApproval"]>;
   /** #372 — one-shot audit writer the interceptor hangs on this error at hold
    *  time, carrying the guard's audit base and the session the hold belongs to.
-   *  Absent when the hold came from a path with no guard audit base (an older
-   *  installed interceptor, the memory-write pipeline): then no `onResolution`
+   *  Both mint sites attach it (action-guard and memory-write pipelines).
+   *  Absent only for an older installed interceptor: then no `onResolution`
    *  is wired at all and the card behaves exactly as it did before #372. */
   decisionAudit?: ApprovalDecisionAudit;
 
@@ -3424,7 +3424,7 @@ async function handleTypedBeforeToolCall(
         // not a reason to disturb a decision the operator already made.
         err.request.onResolution = (decision: CardDecision) => {
           try {
-            const outcome = CARD_DECISION_OUTCOME[decision];
+            const outcome = Object.hasOwn(CARD_DECISION_OUTCOME, decision) ? CARD_DECISION_OUTCOME[decision] : undefined;
             if (!outcome) {
               // A decision this build does not know. Say so loudly rather than
               // guess — inventing an outcome would forge the operator's answer.

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -198,6 +198,43 @@ export interface ToolCallContext {
   sessionId?: string;
 }
 
+/**
+ * #372 — outcomes only an OpenClaw-native approval card can produce.
+ *
+ * The card is minted by throwing (see isTypedApprovalRequest) and the
+ * operator's answer comes back through the host minutes later, long after the
+ * hook returned. These outcomes are deliberately distinct from the synchronous
+ * `approved`/`denied` pair: a row that says `approved_once` is a human tapping
+ * a button on a card, not an approver function returning true inside the turn.
+ */
+export type ApprovalDecisionOutcome =
+  | 'approved_once'
+  | 'card_denied'
+  | 'card_timeout'
+  | 'card_cancelled';
+
+/** #372 — one-shot writer for the decision a held card eventually receives.
+ *  Hung on the thrown approval request by the interceptor; invoked by the
+ *  plugin bridge from the host's `onResolution`. Never throws. */
+export type ApprovalDecisionAudit = (outcome: ApprovalDecisionOutcome) => void;
+
+/** Structural view of the plugin's TypedApprovalRequest error. Matched by
+ *  shape and never imported — the same compile-time-independence discipline as
+ *  isTypedApprovalRequest and ToolGuardVerdictLike. */
+interface DecisionAuditCarrier {
+  decisionAudit?: ApprovalDecisionAudit;
+}
+
+/** #372 — what an audit row needs from the tool call that produced it,
+ *  snapshotted at hold time. A card decision lands minutes later, by which
+ *  point the interceptor's live `lastSessionId`/`lastCallArgs` may describe a
+ *  completely different call — attributing the decision to THAT call would be
+ *  a forgery in exactly the record forensics trusts. */
+interface CapturedAuditContext {
+  sessionKey?: string;
+  args?: Record<string, unknown>;
+}
+
 export interface InterceptAuditEntry {
   type: 'intercept';
   tool: string;
@@ -210,7 +247,10 @@ export interface InterceptAuditEntry {
   fragmentationScore: number | null;  // from the pipeline result's fragmentation score, or null
   pipelineDurationMs: number;         // wall-clock ms around the runDefencePipeline call
   action: InterceptAction | 'auto_deny' | 'rate_limit' | 'allow' | 'gate_degraded';
-  outcome: 'approved' | 'denied' | 'auto_denied' | 'logged' | 'warned' | 'failure_allowed' | 'failure_denied' | 'allowed';
+  outcome: 'approved' | 'denied' | 'auto_denied' | 'logged' | 'warned' | 'failure_allowed' | 'failure_denied' | 'allowed'
+    // #372 — card-held decisions, written when the operator answers rather than
+    // when the hold is taken. `action` for these rows is 'require_approval'.
+    | ApprovalDecisionOutcome;
   preview: string;
   ts: string;
   /** The approval broker's record for this call (#143). Present on exactly the
@@ -560,7 +600,7 @@ export function formatActionGuardPrompt(toolName: string, v: ToolGuardVerdictLik
  * error is exactly what turned every native card into a `failure_denied` the
  * operator never saw.
  */
-function isTypedApprovalRequest(err: unknown): boolean {
+function isTypedApprovalRequest(err: unknown): err is Error & DecisionAuditCarrier {
   return err instanceof Error && err.name === 'TypedApprovalRequest';
 }
 
@@ -907,17 +947,61 @@ export function createInterceptor(
   /** Bare tool names seen this session, newest last. See buildSessionSummary. */
   const recentTools: string[] = [];
 
-  function emitAudit(entry: InterceptAuditEntry): void {
-    const sessionKey = options?.sessionGuard?.keyFor(lastSessionId) ?? undefined;
+  /** The one write path every intercept row takes. `captured` is normally the
+   *  in-flight call (emitAudit below); #372 hands it a hold-time snapshot so a
+   *  decision that arrives after the turn moved on still lands on ITS call. */
+  function emitAuditWith(entry: InterceptAuditEntry, captured: CapturedAuditContext): void {
     const withOrigin: InterceptAuditEntry = {
       ...entry,
       origin: 'openclaw-interceptor',
-      ...(sessionKey ? { sessionKey } : {}),
+      ...(captured.sessionKey ? { sessionKey: captured.sessionKey } : {}),
     };
-    const bound = bindAudit ? bindAudit(withOrigin, lastCallArgs) : withOrigin;
+    const bound = bindAudit ? bindAudit(withOrigin, captured.args) : withOrigin;
     writeAuditEntry(bound);
     try { options?.sessionGuard?.index(bound); } catch { /* never wedge the turn */ }
     onAuditEntry?.(bound);
+  }
+
+  function emitAudit(entry: InterceptAuditEntry): void {
+    emitAuditWith(entry, {
+      sessionKey: options?.sessionGuard?.keyFor(lastSessionId) ?? undefined,
+      args: lastCallArgs,
+    });
+  }
+
+  /**
+   * #372 — hang a one-shot decision writer on a minted approval card.
+   *
+   * The hold itself is still unaudited by design: no decision exists yet. What
+   * was missing is the other end — the host reports the operator's answer on
+   * the request's `onResolution`, and nothing on that path knew what the guard
+   * saw, so an operator-APPROVED dangerous action left no intercept row at all
+   * (invisible to the #260 session summaries).
+   *
+   * Everything the row needs is captured HERE: the guard's audit base, the
+   * session key, and the args behind the #224 actionKey. Nothing about the
+   * approval prompt is retained — the preview is the guard's own already-bounded
+   * one, so the secret-egress discipline the card copy follows holds here too.
+   */
+  function attachDecisionAudit(
+    err: Error & DecisionAuditCarrier,
+    auditBase: Omit<InterceptAuditEntry, 'action' | 'outcome'>,
+  ): void {
+    let sessionKey: string | undefined;
+    // Resolving the key is new work on the card path — nothing used to call
+    // keyFor here. A throwing resolver costs the row its key; it must never
+    // turn a mintable card into an approval error.
+    try { sessionKey = options?.sessionGuard?.keyFor(lastSessionId) ?? undefined; } catch { /* unkeyed row */ }
+    const captured: CapturedAuditContext = { sessionKey, args: lastCallArgs };
+    const held: Omit<InterceptAuditEntry, 'action' | 'outcome'> = { ...auditBase };
+    let written = false;
+    err.decisionAudit = (outcome) => {
+      // The host resolves a card once. Enforcing it here is cheaper than
+      // trusting it: a duplicate row would double-count in every summary.
+      if (written) return;
+      written = true;
+      emitAuditWith({ ...held, action: 'require_approval', outcome }, captured);
+    };
   }
 
   function guardAuditBase(toolName: string, v: ToolGuardVerdictLike, preview: string): Omit<InterceptAuditEntry, 'action' | 'outcome'> {
@@ -1317,7 +1401,12 @@ export function createInterceptor(
       // #310: a minted approval card, not an error. Re-thrown untouched so the
       // typed-hook bridge can turn it into the operator's card; auditing it
       // here would write a denial for a decision nobody has made yet.
-      if (isTypedApprovalRequest(err)) throw err;
+      if (isTypedApprovalRequest(err)) {
+        // #372: still no row for the hold — but the card leaves carrying the
+        // closure that writes one the moment the operator answers.
+        attachDecisionAudit(err, auditBase);
+        throw err;
+      }
       if (brokered && err instanceof ApprovalTimeout) {
         // The asymmetric path. Silence is only ever a yes for something the
         // broker already pre-cleared — and that returned long before here — so
@@ -1500,7 +1589,17 @@ export function createInterceptor(
     } catch (err) {
       // #310: same bridge, same rule — the card request is not an approval
       // failure. Everything else below stays fail-closed.
-      if (isTypedApprovalRequest(err)) throw err;
+      // #372: this path (memory-write pipeline) mints cards too — its
+      // operator decision must leave the same audit row as the action-guard
+      // lane, captured at hold time for the same attribution reasons.
+      if (isTypedApprovalRequest(err)) {
+        attachDecisionAudit(err, {
+          type: 'intercept', tool: context.toolName, severity, firewallResult,
+          threats, anomalyScore, trustScore, sensitivityLevel, fragmentationScore, pipelineDurationMs,
+          preview: fullContent.slice(0, 200), ts: new Date().toISOString(),
+        });
+        throw err;
+      }
       const failAction = config.failurePolicy[severity];
       log.warn(`[shieldcortex] ⚠️ requireApproval error: ${err instanceof Error ? err.message : err} — failure policy: ${failAction}`);
       const entry: InterceptAuditEntry = {

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -213,6 +213,12 @@ export type ApprovalDecisionOutcome =
   | 'card_timeout'
   | 'card_cancelled';
 
+/** #372 — the runtime mirror of ApprovalDecisionOutcome: the closure crosses a
+ *  plugin boundary, so the union is enforced with a Set, not just the compiler. */
+const CARD_AUDIT_OUTCOMES: ReadonlySet<string> = new Set([
+  'approved_once', 'card_denied', 'card_timeout', 'card_cancelled',
+]);
+
 /** #372 — one-shot writer for the decision a held card eventually receives.
  *  Hung on the thrown approval request by the interceptor; invoked by the
  *  plugin bridge from the host's `onResolution`. Never throws. */
@@ -238,6 +244,9 @@ interface CapturedAuditContext {
 export interface InterceptAuditEntry {
   type: 'intercept';
   tool: string;
+  /** #372 — card decision rows only: when the action was HELD. `ts` on those
+   *  rows is the operator's decision time; the pair bounds the wait. */
+  heldAtTs?: string;
   severity: Severity;
   firewallResult: string;
   threats: string[];
@@ -992,15 +1001,31 @@ export function createInterceptor(
     // keyFor here. A throwing resolver costs the row its key; it must never
     // turn a mintable card into an approval error.
     try { sessionKey = options?.sessionGuard?.keyFor(lastSessionId) ?? undefined; } catch { /* unkeyed row */ }
-    const captured: CapturedAuditContext = { sessionKey, args: lastCallArgs };
+    // Shallow-snapshot the args: reference capture would let in-place mutation
+    // of the params object between hold and resolution rewrite the one
+    // forensic binding this row exists to protect (review nit, both reviewers).
+    const captured: CapturedAuditContext = { sessionKey, args: lastCallArgs ? { ...lastCallArgs } : undefined };
     const held: Omit<InterceptAuditEntry, 'action' | 'outcome'> = { ...auditBase };
     let written = false;
     err.decisionAudit = (outcome) => {
+      // The closure's type says CardAuditOutcome, but it crosses a plugin
+      // boundary — make the union real at runtime rather than trusting the
+      // caller's compiler (defence-in-depth, both reviewers).
+      if (!CARD_AUDIT_OUTCOMES.has(outcome)) return;
       // The host resolves a card once. Enforcing it here is cheaper than
       // trusting it: a duplicate row would double-count in every summary.
       if (written) return;
       written = true;
-      emitAuditWith({ ...held, action: 'require_approval', outcome }, captured);
+      // Never throws, by contract — even if the audit plumbing does. The latch
+      // is consumed either way: never-double-write beats a retried row.
+      try {
+        // ts is the DECISION time; the hold time stays in heldAtTs so
+        // forensics can see both ends of the operator's think.
+        emitAuditWith(
+          { ...held, heldAtTs: held.ts, ts: new Date().toISOString(), action: 'require_approval', outcome },
+          captured,
+        );
+      } catch { /* audit is best-effort; the decision itself already happened */ }
     };
   }
 

--- a/src/defence/iron-dome/session-guard.ts
+++ b/src/defence/iron-dome/session-guard.ts
@@ -22,6 +22,13 @@ export const GUARD_DEGRADED_OUTCOMES = new Set([
   'failure_allowed',
   'warned',
   'denied',
+  // #372: operator card decisions that ended in NO. A held dangerous action
+  // the operator refused (or let time out / cancelled) is guard degradation a
+  // #260 summary must surface. `approved_once` stays out on the same logic
+  // that keeps `approved` out — a granted approval is not degradation.
+  'card_denied',
+  'card_timeout',
+  'card_cancelled',
 ]);
 
 export const GUARD_INDEX_ORIGINS = new Set(['claude-code-hook', 'openclaw-interceptor']);


### PR DESCRIPTION
Closes #372 (filed by @jarvis-drakon from PR #371 review).

The typed approval card's `onResolution` hook existed in the host contract but was never set — operator decisions on card-held actions wrote no intercept row at all (pre-#310 the same path wrote a wrong row; after, none). Now: a one-shot decision writer is attached to the TypedApprovalRequest **at hold time** (auditBase + sessionKey + bindAudit args frozen at the rethrow, so a later tool call on the session can't skew attribution when the operator taps minutes later) and wired to `onResolution` in the typed-hook bridge.

- Outcomes: `approved_once` / `card_denied` / `card_timeout` / `card_cancelled` (`allow-always` defensively maps to `approved_once`; unknown strings log sanitised, write nothing)
- Same write pipeline as every other intercept row → #260 sessionGuard index sees them
- Both mint sites covered: action-guard lane AND the memory-write pipeline (Opus's build left the second site; closed in review)
- Refused card outcomes join GUARD_DEGRADED_OUTCOMES — an operator saying NO to a held dangerous action is degradation a session summary must surface; approvals stay out
- Audit write failures never throw into the host; double resolution writes once

+21 tests; plugins/openclaw 415 green; iron-dome 1452 green.