### PR TITLE
fix(378): hook DNP fingerprints are not gated on retryCards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 > **Coverage note**: 49 v4 versions are documented below — typically every minor (`X.Y.0`) plus significant patches. Many small patch releases between 4.0.0 and 4.20.x are not individually documented (~50 versions, mostly behaviour-preserving fixes). For a specific diff between adjacent npm versions, see `git log vX.Y.Z..vX.Y.W` or compare tarballs. Audited and reconciled 2026-05-27 — gap is intentional, not a sign of release-note drift going forward.
 
 
+## [Unreleased]
+
+- **Action Guard / Claude Code hook (#378):** `denied_no_prompt_surface` on the hook lane now always writes a retry fingerprint and honours `shieldcortex approve --denial <actionId>`, even when `actionGuard.retryCards` is off (the soak-dark default). Cards, waiter, and card-budget stay gated on exact `retryCards: true`. Catastrophic still has no retry path. Bare `shieldcortex approve` still lists #118 held calls only, but now points at `--denial` when fingerprints exist. Live-hold Telegram cards remain the OpenClaw interceptor path (#371) — PreToolUse still cannot pause.
+
 ## [4.54.8] - 2026-08-19
 
 **Operator control plane.** #310 retry cards (dark), #371 live interactive cards, #369 honest denial alerts.

--- a/docs/design/2026-08-19-378-hook-dnp-fingerprint.md
+++ b/docs/design/2026-08-19-378-hook-dnp-fingerprint.md
@@ -1,0 +1,51 @@
+# #378 — Hook-lane DNP always leaves a fingerprint
+
+## Problem (proven)
+
+On clawdbot1, 272/313 denials in 14d are `origin: claude-code-hook` +
+`denied_no_prompt_surface`. `shieldcortex approve` prints "No pending Action
+Guard approvals." `approve --denial` is also empty.
+
+Cause on `origin/main` (`c73ede9`): `scripts/pre-tool-hook.mjs`
+`loadRetryControl()` returns null unless `actionGuard.retryCards === true`.
+That gates the **entire** retry plane — fingerprint write, grant consume, and
+cards — behind the soak switch. ADR-2026-08-19 said the opposite: denial
+always leaves a fingerprint; cards stay dark.
+
+#371 is not this bug. It is OpenClaw-native live-hold `{ requireApproval }`.
+Claude Code PreToolUse cannot pause for a Telegram card. OpenClaw-spawned hook
+sessions still DNP. That stays structural.
+
+## Non-goals
+
+- Live-hold / PreToolUse async pause
+- Flipping `retryCards` default (Edith soak still owns that)
+- Interceptor fingerprint/consume (ADR left interceptor out this phase)
+- Catastrophic grant path
+- Mint-on-DNP spendable pendings / #118 pending records for DNP
+
+## Design
+
+1. `loadRetryControl` loads the dist module whenever it is complete. It no
+   longer returns null just because `retryCards !== true`.
+2. Every dangerous-tier hook DNP records a fingerprint (same
+   `recordDenialFingerprint` contract as today).
+3. `consumeRetryGrant` always runs when the module loaded, so
+   `shieldcortex approve --denial <actionId>` works with cards off.
+4. `raiseRetryCard` / waiter / budget debit run only when
+   `normaliseRetryControlConfig(...).retryCards === true`.
+5. Catastrophic still never touches the retry plane.
+6. Bare `shieldcortex approve` still lists #118 held calls only, but if any
+   fingerprint rows exist it points at `approve --denial`. Looking never
+   creates the store.
+
+## Security invariants
+
+- Nothing spendable is minted on denial.
+- Cards remain strict-true `retryCards`.
+- TTY gate on grant is unchanged.
+- Grant scope `{cwd, tool}` AND-match unchanged.
+- No `reviewedScripts` mint/spend.
+- Payload / permission_mode never mute or arm this.
+- Dist incomplete → null → same terminal DNP as today (fail closed on the
+  retry plane, not on the denial).

--- a/docs/design/ADR-2026-08-19-retry-control.md
+++ b/docs/design/ADR-2026-08-19-retry-control.md
@@ -22,8 +22,14 @@ store either — a grant minted from a hook denial has no origin binding that me
 that surface. Anyone extending this to the interceptor is writing a new ADR, not a patch.
 
 ## Rollout
-Dark behind `actionGuard.retryCards=false`. Soak gate: ≥3 days on an Edith-class host,
-deny/approve/timeout matrix across ≥3 cron identities, empty-origin, grant-then-newer-DNP,
-budget-exhaustion. Default flips only after soak review against this ADR.
+Cards stay dark behind `actionGuard.retryCards=false`. Soak gate: ≥3 days on an
+Edith-class host, deny/approve/timeout matrix across ≥3 cron identities,
+empty-origin, grant-then-newer-DNP, budget-exhaustion. Default flips only after
+soak review against this ADR.
+
+#378 (2026-08-19): fingerprint write + TTY `approve --denial` consume on the
+Claude Code hook are **not** gated on `retryCards`. The soak switch arms cards
+only. A host that never flipped the switch still gets a CLI retry path; it does
+not get a card.
 
 Full mechanism: DESIGN-310.md (v3-final) in this directory.

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -1187,7 +1187,7 @@ async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict
   // Only for an event that survived the suppression check, and only once the
   // digest window whose START it shares has been read (R3 rule 7).
   let retryCard = null;
-  if (retry && retry.config.retryCards === true && retryStep?.ok && !retrySuppressed) {
+  if (retry && retry?.config?.retryCards === true && retryStep?.ok && !retrySuppressed) {
     try {
       retryCard = await raiseRetryCard(retry, notify, {
         id: retryStep.id,
@@ -2112,7 +2112,9 @@ process.stdin.on('end', async () => {
     // #310 / #378 operator retry control, loaded once for both halves: the
     // consume just below, and the fingerprint (plus optional card) on the DNP
     // path further down. Null only when the dist module is missing or
-    // incomplete. Cards still require `actionGuard.retryCards === true`.
+    // incomplete. `retryPlane` being non-null does NOT mean cards are armed —
+    // consume/fingerprint are always-on; cards still require
+    // `actionGuard.retryCards === true` at the raise site.
     const retryPlane = await loadRetryControl(cfg.retry);
     const retryOriginCwd = retryPlane ? retryPlane.mod.canonicaliseCwd(hookData.cwd) : undefined;
     const retryCtx = retryPlane ? { rawConfig: cfg.retry, cwd: retryOriginCwd } : null;

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -114,10 +114,11 @@ function loadActionGuardConfig() {
       // malformed means no exemption ever fires, which is where the guard
       // started — the allowlist can only fail closed.
       reviewedScripts: Array.isArray(raw.reviewedScripts) ? raw.reviewedScripts : null,
-      // #310 operator retry control — RAW again, validated only by
-      // normaliseRetryControlConfig in dist. `retryCards` must be exactly
-      // true to arm anything; absent or junk means this hook behaves exactly
-      // as it did before #310 (DNP terminal, no fingerprint, no card).
+      // #310 / #378 operator retry control — RAW again, validated only by
+      // normaliseRetryControlConfig in dist. Fingerprint + `approve --denial`
+      // are always-on when the dist module is complete. `retryCards` must be
+      // exactly true to raise a card; absent or junk means DNP stays terminal
+      // with a fingerprint and no card (the soak-dark default).
       retry: {
         retryCards: raw.retryCards,
         retryGrantTtlMs: raw.retryGrantTtlMs,
@@ -243,16 +244,16 @@ async function loadApprovals() {
 }
 
 /**
- * Load the #310 retry-control plane. Returns null unless
- * `actionGuard.retryCards` is exactly true AND the dist module is present and
- * complete — the same discipline as loadBroker/loadNotify, for the same
- * reason: a half-assembled trust surface must degrade to "not configured",
- * never to a crash and never to a changed decision.
+ * Load the #310 retry-control plane. Returns null unless the dist module is
+ * present and complete — the same discipline as loadBroker/loadNotify: a
+ * half-assembled trust surface must degrade to "not configured", never to a
+ * crash and never to a changed decision.
  *
- * Null is the normal answer. The feature ships dark (ADR rollout gate).
+ * #378: fingerprint write + grant consume are always-on once the module
+ * loads. Cards stay dark unless `actionGuard.retryCards` is exactly true
+ * (normaliseRetryControlConfig). Null is only "dist missing/incomplete".
  */
 async function loadRetryControl(rawRetry, digestWindowMs) {
-  if (!rawRetry || rawRetry.retryCards !== true) return null;
   const distRoot = process.env.SHIELDCORTEX_DIST_ROOT ?? resolve(here, '..', 'dist');
   try {
     const mod = await import(
@@ -265,8 +266,7 @@ async function loadRetryControl(rawRetry, digestWindowMs) {
       'formatBudgetExhaustedNotice', 'formatUnspentExpiryNotice',
     ];
     if (required.some((fn) => typeof mod[fn] !== 'function')) return null;
-    const config = mod.normaliseRetryControlConfig(rawRetry, { digestWindowMs });
-    if (!config?.retryCards) return null;
+    const config = mod.normaliseRetryControlConfig(rawRetry ?? {}, { digestWindowMs });
     return { config, mod };
   } catch {
     return null;
@@ -1009,6 +1009,8 @@ function classifyNotifyStatus(notifyMod, result) {
  * waiter's own parser and is deliberately not used from here.
  */
 async function raiseRetryCard(retry, notify, ctx) {
+  // Cards stay soak-gated. Fingerprints can exist with this switch off.
+  if (retry?.config?.retryCards !== true) return { raised: false, reason: 'retry-cards-off' };
   const openclawBin = notify?.openclawBin;
   if (!openclawBin) return { raised: false, reason: 'no-openclaw-card-channel' };
 
@@ -1185,7 +1187,7 @@ async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict
   // Only for an event that survived the suppression check, and only once the
   // digest window whose START it shares has been read (R3 rule 7).
   let retryCard = null;
-  if (retry && retryStep?.ok && !retrySuppressed) {
+  if (retry && retry.config.retryCards === true && retryStep?.ok && !retrySuppressed) {
     try {
       retryCard = await raiseRetryCard(retry, notify, {
         id: retryStep.id,
@@ -2107,11 +2109,10 @@ process.stdin.on('end', async () => {
       process.exit(0); // Advisory: warn, emit no decision.
     }
 
-    // #310 operator retry control, loaded once for both halves: the consume
-    // just below, and the fingerprint/card on the DNP path further down. Null
-    // — the normal answer — unless `actionGuard.retryCards` is exactly true
-    // and the dist module is complete, in which case this hook behaves
-    // exactly as it did before #310.
+    // #310 / #378 operator retry control, loaded once for both halves: the
+    // consume just below, and the fingerprint (plus optional card) on the DNP
+    // path further down. Null only when the dist module is missing or
+    // incomplete. Cards still require `actionGuard.retryCards === true`.
     const retryPlane = await loadRetryControl(cfg.retry);
     const retryOriginCwd = retryPlane ? retryPlane.mod.canonicaliseCwd(hookData.cwd) : undefined;
     const retryCtx = retryPlane ? { rawConfig: cfg.retry, cwd: retryOriginCwd } : null;

--- a/src/__tests__/pre-tool-hook-retry-310.test.ts
+++ b/src/__tests__/pre-tool-hook-retry-310.test.ts
@@ -10,7 +10,8 @@
  *
  * What is pinned here is the WIRING and its ordering, which is where this
  * feature can hurt:
- *   - it does not exist until `actionGuard.retryCards` is exactly true;
+ *   - cards do not exist until `actionGuard.retryCards` is exactly true;
+ *   - fingerprints + `approve --denial` consume ARE on even with cards off (#378);
  *   - a catastrophic call never reaches any of it;
  *   - suppression is checked BEFORE the digest window opens and before any
  *     budget is spent;
@@ -25,6 +26,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { grantRetry } from '../defence/iron-dome/retry-control.js';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const HOOK = join(repoRoot, 'scripts', 'pre-tool-hook.mjs');
@@ -221,28 +223,54 @@ describe('#310 — retry control through the real Claude Code hook', () => {
     return predicate();
   }
 
-  // ── Default OFF ────────────────────────────────────────────────────────
+  // ── Default OFF (cards) ────────────────────────────────────────────────
+  // #378 — the retry *plane* (fingerprint + TTY --denial) is always-on.
+  // Cards stay dark until retryCards is exactly true.
 
-  it('does not exist until switched on — same terminal denial as before #310', () => {
+  it('cards stay off by default — denial is still terminal, but a fingerprint is left', () => {
     writeConfig({ notify: { enabled: true, webhookUrl: webhookUrl() } });
     const r = runHook(IRREVERSIBLE);
 
     expect(r.decision).toBe('deny');
-    expect(store()).toBeNull();
+    const rows = store()!.rows;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].grant).toBeUndefined();
+    expect(rows[0].claim).toBeUndefined();
+    expect(store()!.budget).toBeNull();
     expect(evidence()).toHaveLength(1);
-    // No retry copy anywhere on the operator's alert — the #331 digest text is
+    // No card copy on the operator's alert — the #331 digest text is
     // exactly what it was.
     const body = JSON.stringify(evidence());
     expect(body).not.toContain('budget_exhausted');
     expect(body).not.toContain('approve --denial');
+    expect(r.stderr).not.toMatch(/retry card raised/);
   });
 
-  it('stays off for a config that merely mentions retryCards without true', () => {
+  it('stays card-dark for a config that merely mentions retryCards without true', () => {
     writeConfig({ retryCards: 'yes', notify: { enabled: true, webhookUrl: webhookUrl() } });
     const r = runHook(IRREVERSIBLE);
 
     expect(r.decision).toBe('deny');
-    expect(store()).toBeNull();
+    const rows = store()!.rows;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].claim).toBeUndefined();
+    expect(rows[0].grant).toBeUndefined();
+    expect(r.stderr).not.toMatch(/retry card raised/);
+  });
+
+  it('#378 TTY --denial grant is consumable with cards off', () => {
+    writeConfig({ notify: { enabled: true, webhookUrl: webhookUrl() } });
+    expect(runHook(IRREVERSIBLE).decision).toBe('deny');
+    const row = store()!.rows[0];
+    expect(row.claim).toBeUndefined();
+
+    const granted = grantRetry({ id: row.id }, { isInteractive: true }, { home });
+    expect(granted.ok).toBe(true);
+
+    const retried = runHook(IRREVERSIBLE);
+    expect(retried.decision).toBeUndefined();
+    expect(retried.stderr).toContain('consumed operator RETRY grant');
+    expect(runHook(IRREVERSIBLE).decision).toBe('deny');
   });
 
   // ── Fingerprint, and only a fingerprint ────────────────────────────────

--- a/src/cli/__tests__/approve-denial-310.test.ts
+++ b/src/cli/__tests__/approve-denial-310.test.ts
@@ -268,7 +268,20 @@ describe('#310 — approve --denial', () => {
     const code = runApprove([], { home, now: t0, interactive: false, log: out.write, error: out.write });
     expect(code).toBe(0);
     expect(out.text()).toContain('No pending Action Guard approvals');
+    expect(out.text()).not.toContain('headless denial');
     // No store file was created just by looking.
     expect(getRetryRow({ hash: HASH, cwd }, { home })).toBeUndefined();
+  });
+
+  it('#378 bare approve points at --denial when fingerprints exist', () => {
+    denial();
+    const out = sink();
+    const code = runApprove([], { home, now: t0, interactive: false, log: out.write, error: out.write });
+    expect(code).toBe(0);
+    expect(out.text()).toContain('No pending Action Guard approvals');
+    expect(out.text()).toMatch(/1 headless denial/);
+    expect(out.text()).toContain('shieldcortex approve --denial');
+    // Looking still does not grant.
+    expect(getRetryRow({ hash: HASH, cwd }, { home })?.grant).toBeUndefined();
   });
 });

--- a/src/cli/approve.ts
+++ b/src/cli/approve.ts
@@ -61,9 +61,15 @@ function age(ms: number): string {
   return `${Math.round(s / 3600)}h ago`;
 }
 
-function renderList(records: ApprovalRecord[], now: number): string {
+function renderList(records: ApprovalRecord[], now: number, retryRows: RetryRow[] = []): string {
   if (records.length === 0) {
-    return `${DIM}No pending Action Guard approvals.${RESET}\n`;
+    const lines = [`${DIM}No pending Action Guard approvals.${RESET}`];
+    if (retryRows.length > 0) {
+      lines.push(
+        `${DIM}${retryRows.length} headless denial(s) on file — list with: shieldcortex approve --denial${RESET}`,
+      );
+    }
+    return `${lines.join('\n')}\n`;
   }
   const lines: string[] = [`${BOLD}Action Guard — recent refusals${RESET}\n`];
   for (const r of records) {
@@ -193,7 +199,7 @@ export function runApprove(argv: string[], deps: ApproveDeps = {}): number {
   const hash = positional[0];
 
   if (!hash) {
-    log(renderList(listApprovals({ home, now }), now));
+    log(renderList(listApprovals({ home, now }), now, listRetryRows({ home, now })));
     return 0;
   }
 


### PR DESCRIPTION
## Problem

#378: the claude-code-hook lane fail-closes dangerous-tier calls with `denied_no_prompt_surface` and leaves no consent path. On clawdbot1 that is 272/313 denials in 14d. Bare `shieldcortex approve` prints "No pending Action Guard approvals" because that list is #118 held calls, and `approve --denial` was also empty.

Root cause: `loadRetryControl()` returned null unless `actionGuard.retryCards === true`, so the soak-dark default disabled fingerprint write **and** grant consume, not just cards.

#371 is not this bug. It is OpenClaw-native live-hold `{ requireApproval }`. Claude Code PreToolUse still cannot pause.

## Approach

Honour ADR-2026-08-19 as written:

- Always load the retry-control module when dist is complete.
- Always record a fingerprint on hook-lane dangerous DNP.
- Always honour `consumeRetryGrant` / `shieldcortex approve --denial`.
- Cards, waiter, and card-budget stay gated on exact `retryCards: true`.
- Catastrophic still never reaches the retry plane.
- Bare `approve` still lists #118 only, but points at `--denial` when fingerprints exist.

## Tests

- `pre-tool-hook-retry-310`: default-off now asserts fingerprint + no claim; TTY grant is consumable with cards off; existing card-on matrix unchanged.
- `approve-denial-310`: bare approve hint; looking still does not create a store or grant.
- Nearby: `prompt-surface-deny`, `retry-control-310` — all green.

## Risk

Hosts that never flipped retryCards will start writing `~/.shieldcortex/approvals/retry-control.json` on hook DNP. That file is 0600, fingerprints only (no grant/claim). Cards stay dark.

Closes #378