### PR TITLE
release: v4.54.9 — operator control plane patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 > **Coverage note**: 49 v4 versions are documented below — typically every minor (`X.Y.0`) plus significant patches. Many small patch releases between 4.0.0 and 4.20.x are not individually documented (~50 versions, mostly behaviour-preserving fixes). For a specific diff between adjacent npm versions, see `git log vX.Y.Z..vX.Y.W` or compare tarballs. Audited and reconciled 2026-05-27 — gap is intentional, not a sign of release-note drift going forward.
 
 
-## [Unreleased]
+## [4.54.9] - 2026-08-19
+
+**Operator control plane, patch.** #378 hook-lane DNP fingerprints + `--denial` approvals (cards stay soak-dark), #372 card-decision audit rows, #375 sqlite cron discovery + denial↔cron honesty.
 
 - **Action Guard / Claude Code hook (#378):** `denied_no_prompt_surface` on the hook lane now always writes a retry fingerprint and honours `shieldcortex approve --denial <actionId>`, even when `actionGuard.retryCards` is off (the soak-dark default). Cards, waiter, and card-budget stay gated on exact `retryCards: true`. Catastrophic still has no retry path. Bare `shieldcortex approve` still lists #118 held calls only, but now points at `--denial` when fingerprints exist. Live-hold Telegram cards remain the OpenClaw interceptor path (#371) — PreToolUse still cannot pause.
+- **Card-decision audit rows (#372):** operator card decisions on both the action-guard and memory-write pipelines write `approved_once` / `card_denied` / `card_timeout` / `card_cancelled` intercept rows at decision time, with hold-time session attribution, indexed for #260 session summaries. Refused card outcomes count as guard degradation; approvals do not.
+- **Cron discovery + denial honesty (#375):** `allowlist scan` reads OpenClaw's migrated SQLite cron store (`~/.openclaw/state/openclaw.sqlite`, `cron_jobs`) as a new `openclaw-cron-db` source, unioned with the legacy `cron/jobs.json` when it still exists; `.bak`/`.migrated` leftovers are never read and never taken as proof the store is absent. Paths come from `payload_message`, `trigger_script` and a structural walk of `job_json` string leaves. `enabled` is coerced in JS over all rows, never `WHERE enabled = 1`, so a textual flag cannot report a live store as empty. Store access is read-only throughout (`readonly` + `fileMustExist`); no SQL writes to any OpenClaw store. An OpenClaw host where NEITHER cron source is readable is reported visibly and exits 1 — "we could not look" is not "all clear"; a host with no `~/.openclaw` stays empty-ok. Unreadable or schema-mismatched stores exit 1 as before. `--yes` is refused while any `openclaw-cron-db` script is still unpinned: the first sqlite backfill is per-item review only.
+- **Cron denial correlation (#375):** new `shieldcortex doctor` CRON check joins `~/.shieldcortex/denials.jsonl` (4 MiB tail, deduped by `actionId`) to `cron_run_logs` and WARNs when a guard denial landed inside a run OpenClaw recorded as `ok`, naming the job and offering `shieldcortex allowlist add <path>` per script the job itself declares. Attribution is exact-shape only (`agent:<agent>:cron:<uuid>:run:`); anything else is an unattributed count. The run row is matched by exact `session_key` inside an SQL-bounded window with no nearest-run fallback — no matching row is reported as unconfirmed, never as silent and never as a pass. An unreadable denial log or a missing/unreadable `cron_run_logs` is WARN cannot-correlate, never INFO and never `0 silent`. Denied scripts sort first in the scan review list. No denial surface or command body reaches any new output.
 
 ## [4.54.8] - 2026-08-19
 
@@ -49,17 +54,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Fixed
-- Card-held approval decisions now leave an audit row (#372): operator card
-  decisions on both the action-guard and memory-write pipelines write
-  `approved_once` / `card_denied` / `card_timeout` / `card_cancelled` intercept
-  rows at decision time, with hold-time session attribution, indexed for #260
-  session summaries. Refused card outcomes count as guard degradation;
-  approvals do not.
-
 ### Added
-- **Cron discovery + denial honesty (#375):** `allowlist scan` reads OpenClaw's migrated SQLite cron store (`~/.openclaw/state/openclaw.sqlite`, `cron_jobs`) as a new `openclaw-cron-db` source, unioned with the legacy `cron/jobs.json` when it still exists; `.bak`/`.migrated` leftovers are never read and never taken as proof the store is absent. Paths come from `payload_message`, `trigger_script` and a structural walk of `job_json` string leaves. `enabled` is coerced in JS over all rows, never `WHERE enabled = 1`, so a textual flag cannot report a live store as empty. Store access is read-only throughout (`readonly` + `fileMustExist`); no SQL writes to any OpenClaw store. An OpenClaw host where NEITHER cron source is readable is reported visibly and exits 1 — "we could not look" is not "all clear"; a host with no `~/.openclaw` stays empty-ok. Unreadable or schema-mismatched stores exit 1 as before. `--yes` is refused while any `openclaw-cron-db` script is still unpinned: the first sqlite backfill is per-item review only.
-- **Cron denial correlation (#375):** new `shieldcortex doctor` CRON check joins `~/.shieldcortex/denials.jsonl` (4 MiB tail, deduped by `actionId`) to `cron_run_logs` and WARNs when a guard denial landed inside a run OpenClaw recorded as `ok`, naming the job and offering `shieldcortex allowlist add <path>` per script the job itself declares. Attribution is exact-shape only (`agent:<agent>:cron:<uuid>:run:`); anything else is an unattributed count. The run row is matched by exact `session_key` inside an SQL-bounded window with no nearest-run fallback — no matching row is reported as unconfirmed, never as silent and never as a pass. An unreadable denial log or a missing/unreadable `cron_run_logs` is WARN cannot-correlate, never INFO and never `0 silent`. Denied scripts sort first in the scan review list. No denial surface or command body reaches any new output.
 - **Memory SOTA Track C:** capture distill provider (OpenAI-compatible + Anthropic), fail-closed extract path on stop/session-end, L1 salience cap, no silent regex fallback (#350 / epic #347).
 - **Memory SOTA Track C (OAuth):** distill resolves Hermes OAuth on disk (xai-oauth → openai-codex) when no API key is set — fleet hosts reuse existing login; `SHIELDCORTEX_DISTILL_OAUTH=0` disables.
 - **Memory SOTA Track C (defaults):** distill defaults to cheap models (`grok-4.3` on xAI OAuth, not main chat `grok-4.6`); zero-config when Hermes is already logged in.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.1",
+  "version": "4.54.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.54.1",
+      "version": "4.54.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.8",
+  "version": "4.54.9",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.54.8",
+  "version": "4.54.9",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,
@@ -121,7 +121,7 @@
     },
     "interceptor.conversation.posture": {
       "label": "Conversation Firewall",
-      "description": "What the conversation firewall does with a detection on the input path. off = do not scan; observe = scan, audit and alert the operator but never stop the turn (default); enforce = block the run via before_agent_run. Requires plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess=true on this host \u2014 OpenClaw refuses conversation hooks without that operator grant, and ShieldCortex will never set it for you.",
+      "description": "What the conversation firewall does with a detection on the input path. off = do not scan; observe = scan, audit and alert the operator but never stop the turn (default); enforce = block the run via before_agent_run. Requires plugins.entries.shieldcortex-realtime.hooks.allowConversationAccess=true on this host — OpenClaw refuses conversation hooks without that operator grant, and ShieldCortex will never set it for you.",
       "type": "string"
     },
     "interceptor.actionGuard.notify.enabled": {
@@ -132,7 +132,7 @@
     },
     "interceptor.actionGuard.notify.webhookUrl": {
       "label": "Notify Webhook URL",
-      "description": "http(s) endpoint the notification is POSTed to. Conversation-firewall alerts carry no approve/deny affordance \u2014 there is nothing to approve.",
+      "description": "http(s) endpoint the notification is POSTed to. Conversation-firewall alerts carry no approve/deny affordance — there is nothing to approve.",
       "type": "string",
       "advanced": true
     },
@@ -156,7 +156,7 @@
     "properties": {
       "enabled": {
         "type": "boolean",
-        "description": "Unused \u2014 plugin on/off is controlled by plugins.entries[id].enabled on the host, not this nested config value. See #115."
+        "description": "Unused — plugin on/off is controlled by plugins.entries[id].enabled on the host, not this nested config value. See #115."
       },
       "binaryPath": {
         "type": "string"
@@ -190,7 +190,7 @@
           "trustOwnerInput": {
             "type": "boolean",
             "default": true,
-            "description": "Default true: a message the host attributes to the gateway OWNER is an instruction, so a detection in it is audited and alerted but never taints the session or blocks the turn. Set false on a host where the owner routinely pastes untrusted content and you would rather have the caution than the quiet. Content from anyone else \u2014 including another agent on a trusted channel \u2014 is data regardless of this setting."
+            "description": "Default true: a message the host attributes to the gateway OWNER is an instruction, so a detection in it is audited and alerted but never taints the session or blocks the turn. Set false on a host where the owner routinely pastes untrusted content and you would rather have the caution than the quiet. Content from anyone else — including another agent on a trusted channel — is data regardless of this setting."
           }
         }
       },
@@ -368,7 +368,7 @@
               "notify": {
                 "type": "object",
                 "additionalProperties": false,
-                "description": "Operator-notify transport (#143), also used by the conversation firewall\u2019s detection sink (#225). Off unless enabled is exactly true.",
+                "description": "Operator-notify transport (#143), also used by the conversation firewall’s detection sink (#225). Off unless enabled is exactly true.",
                 "properties": {
                   "enabled": {
                     "type": "boolean",
@@ -491,7 +491,7 @@
           "notify": {
             "type": "object",
             "additionalProperties": false,
-            "description": "Operator-notify transport (#143), also used by the conversation firewall\u2019s detection sink (#225). Off unless enabled is exactly true.",
+            "description": "Operator-notify transport (#143), also used by the conversation firewall’s detection sink (#225). Off unless enabled is exactly true.",
             "properties": {
               "enabled": {
                 "type": "boolean",

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.54.8",
+  "version": "4.54.9",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "pack:verify": "npm pack --dry-run",
-    "prepublishOnly": "node -e \"if(!require('fs').existsSync('dist/index.js'))throw new Error('plugin dist/index.js missing \u2014 run `npm run build:ts` from the repo root before publishing')\""
+    "prepublishOnly": "node -e \"if(!require('fs').existsSync('dist/index.js'))throw new Error('plugin dist/index.js missing — run `npm run build:ts` from the repo root before publishing')\""
   },
   "peerDependencies": {
     "shieldcortex": "^4.54.8",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.54.8
+  version: 4.54.9
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
Version PR for the 4.54.9 patch train (double-publish lock: Jarvis owns this cut, per Tars handoff on Ekho oc-1787157357146).

Carries everything on main since v4.54.8:
- **#378 / PR #379** — hook-lane DNP fingerprints always written + `shieldcortex approve --denial` works with `retryCards` off. Cards stay soak-dark.
- **#372 / PR #377** — card-decision audit rows.
- **#375 / PR #376** — OpenClaw sqlite cron discovery + denial↔cron honesty.

Release mechanics per 4.54.8 pattern: this PR is version bump + changelog only (lockstep sync of plugin package.json / openclaw.plugin.json / SKILL.md via sync-plugin-version.mjs). Annotated tag v4.54.9 goes on the merge commit; publish.yml runs the npm + ClawHub train off the tag. Changelog note: the two new-since-4.54.8 entries were folded out of the stray mid-file `[Unreleased]` block into the 4.54.9 section; the pre-existing stale remainder of that block is untouched (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)