### PR TITLE
fix(381): post-merge dual-review nits — doctor contract validation, stop-hook copy, sampling read-clamp

### DIFF
--- a/scripts/lib/auto-memory-config.mjs
+++ b/scripts/lib/auto-memory-config.mjs
@@ -59,7 +59,10 @@ export function getAutoMemoryConfig() {
     keepSlashCommandProse: typeof overrides.keepSlashCommandProse === 'boolean'
       ? overrides.keepSlashCommandProse
       : DEFAULTS.keepSlashCommandProse,
-    stopHookSamplingTurns: pickPositiveInt(overrides.stopHookSamplingTurns, DEFAULTS.stopHookSamplingTurns),
+    // #381 review: the CLI clamps 1-20 on write, but a pre-CLI or hand-written
+    // value bypasses that — the read side enforces the same ceiling so a
+    // sampling of 10000 cannot silently disable capture-by-sampling.
+    stopHookSamplingTurns: Math.min(pickPositiveInt(overrides.stopHookSamplingTurns, DEFAULTS.stopHookSamplingTurns), 20),
     stopHookSalienceBypass: typeof overrides.stopHookSalienceBypass === 'boolean'
       ? overrides.stopHookSalienceBypass
       : DEFAULTS.stopHookSalienceBypass,

--- a/scripts/stop-hook.mjs
+++ b/scripts/stop-hook.mjs
@@ -935,7 +935,10 @@ process.stdin.on('end', async () => {
       // per session so the failure is visible (was silent-amnesia in #41).
       logDisabledOnceForSession(
         guardSummary.sessionKey || sessionKeyFor(hookData.session_id),
-        `disabled — set autoMemory.enableStop=true in ~/.shieldcortex/config.json (or re-run \`shieldcortex setup --with-stop-hook\`)`,
+        // #381 class: never prescribe hand-editing the signed config — that
+        // invalidates _sig and forces strict mode. The setup flag is the
+        // signed write path for this gate.
+        `disabled — re-run \`shieldcortex setup --with-stop-hook\` to enable auto-memory (this sets autoMemory.enableStop via the signed config path)`,
       );
       if (guardHealthNote) {
         recordStopTelemetry(startedAt, { exitCode: hookTelemetryExitCode, notes: guardHealthNote });

--- a/src/cli/__tests__/doctor-empty-brain-sota.test.ts
+++ b/src/cli/__tests__/doctor-empty-brain-sota.test.ts
@@ -82,6 +82,23 @@ describe('checkMemoryPlaneEmptyBrain', () => {
     expect(r.message).toMatch(/nativeContract/i);
   });
 
+  it('a junk nativeContract string is treated as unset, not vouched for (#381 review)', async () => {
+    // coexist_dedup is rejected by the signed CLI and by the runtime — doctor
+    // passing it would make doctor more lenient than the code it vouches for.
+    writeConfig({
+      openclawAutoMemory: true,
+      memory: { inject: { mode: 'start', nativeContract: 'coexist_dedup' } },
+    });
+    const db = openDb();
+    db.prepare(
+      `INSERT INTO memories (title, content, status, sensitivity_level) VALUES ('a','b','active','INTERNAL')`,
+    ).run();
+    db.close();
+    const r = await runCheck();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/nativeContract/i);
+  });
+
   it('nativeContract fail fix prescribes the signed CLI flag, never a config.json hand-edit', async () => {
     writeConfig({
       openclawAutoMemory: true,

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2816,7 +2816,11 @@ export async function checkMemoryPlaneEmptyBrain(): Promise<CheckResult> {
     else if (typeof raw.memoryInjectMode === 'string') injectMode = raw.memoryInjectMode as string;
     else if (injectConfigured) injectMode = 'start';
     const nc = inject.nativeContract ?? raw.memoryNativeInjectContract ?? mem.nativeInjectContract;
-    nativeContract = typeof nc === 'string' ? nc : null;
+    // #381 review: only the two values the runtime accepts count as "set".
+    // A junk string (or the rejected coexist_dedup) previously PASSED doctor
+    // and then failed at runtime — doctor must not be more lenient than the
+    // code it vouches for.
+    nativeContract = typeof nc === 'string' && (nc === 'sc_only' || nc === 'disable_native_inject') ? nc : null;
   } catch { /* defaults */ }
 
   const bound = openclawAuto || proactive || injectMode === 'start' || injectMode === 'both';


### PR DESCRIPTION
Post-merge independent dual review of #381 (Grok 4.6 / GPT-5.6 SOL Pro): **both APPROVE_WITH_NITS, zero blockers**. All seven hunt items came back clean — sibling-preserving atomic re-sign, allowlist validation, coexist_dedup rejected both layers, no injection, no half-mutation on disk, doctor copy redirected, sampling rejected at both layers.

This PR folds the three nits worth fixing (doctor leniency on junk contract strings, one surviving hand-edit prescription in stop-hook.mjs, sampling read-side clamp) + regression test.

Documented follow-up candidates (pre-existing, not from #381): tampered-config RMW behaviour, shallow config cache on failed write, multi-flag non-transactionality.