### PR TITLE
fix(383): detect and heal corrupt embedding model cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **#383 — corrupt embedding model cache no longer fails silently.** A truncated
+  `~/.cache/shieldcortex/models/.../onnx/model.onnx` (Edith ran 3.5 months on a
+  50 MB stub vs the known-good 90 MB weight) made every preload log-and-retry the
+  same bad bytes forever while `doctor` still printed green for "model cached".
+  Doctor now verifies size (+ trusted sidecar sha); the embedding worker
+  quarantines a corrupt weight on load failure and retries download once.
+
 ### Added
 - **Memory SOTA Track C:** capture distill provider (OpenAI-compatible + Anthropic), fail-closed extract path on stop/session-end, L1 salience cap, no silent regex fallback (#350 / epic #347).
 - **Memory SOTA Track C (OAuth):** distill resolves Hermes OAuth on disk (xai-oauth → openai-codex) when no API key is set — fleet hosts reuse existing login; `SHIELDCORTEX_DISTILL_OAUTH=0` disables.

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -4174,33 +4174,21 @@ export async function checkStatePermissions(stateDir: string = getShieldCortexDi
 
 // ── Check 8: Model cache ─────────────────────────────────
 async function checkModelCache(): Promise<CheckResult> {
-  const cacheDir = path.join(os.homedir(), '.cache', 'shieldcortex', 'models', 'Xenova', 'all-MiniLM-L6-v2');
-
-  if (!fs.existsSync(cacheDir)) {
-    return {
-      label: 'Embeddings',
-      status: 'info',
-      message: 'model not cached — will download on first recall',
-    };
-  }
-
+  // #383: "directory non-empty" was a green lie for truncated model.onnx.
+  // Integrity is size (+ trusted sidecar sha, or live sha). Never pass a
+  // corrupt weight; never fail the whole doctor run on a missing optional model.
   try {
-    let totalSize = 0;
-    const entries = fs.readdirSync(cacheDir);
-    for (const entry of entries) {
-      const fullPath = path.join(cacheDir, entry);
-      try {
-        const stat = fs.statSync(fullPath);
-        if (stat.isFile()) totalSize += stat.size;
-      } catch {
-        // Skip
-      }
-    }
-
+    const {
+      inspectEmbeddingModelCache,
+      formatModelCacheDoctorMessage,
+    } = await import('../embeddings/model-cache.js');
+    const insp = await inspectEmbeddingModelCache();
+    const formatted = formatModelCacheDoctorMessage(insp);
     return {
       label: 'Embeddings',
-      status: 'pass',
-      message: `model cached (${formatBytes(totalSize)})`,
+      status: formatted.status,
+      message: formatted.message,
+      ...(formatted.fix ? { fix: formatted.fix } : {}),
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/embeddings/__tests__/model-cache-383.test.ts
+++ b/src/embeddings/__tests__/model-cache-383.test.ts
@@ -26,7 +26,10 @@ import {
   inspectEmbeddingModelCache,
   isCorruptModelLoadError,
   quarantineEmbeddingOnnx,
+  resetModelCacheHealLatchForTests,
   resolveEmbeddingModelPaths,
+  hasAttemptedModelCacheHeal,
+  markModelCacheHealAttempted,
   writeModelCacheSidecar,
 } from '../model-cache.js';
 
@@ -55,11 +58,25 @@ function writeOnnxSparse(cacheRoot: string, bytes: number, head: Buffer = Buffer
   return onnxPath;
 }
 
+function writeTrustedSidecarFor(cacheRoot: string): void {
+  const { onnxPath, sidecarPath } = resolveEmbeddingModelPaths(cacheRoot);
+  const st = statSync(onnxPath);
+  writeModelCacheSidecar(sidecarPath, {
+    sha256: EMBEDDING_ONNX_EXPECTED_SHA256,
+    bytes: EMBEDDING_ONNX_EXPECTED_BYTES,
+    modelId: EMBEDDING_MODEL_ID,
+    verifiedAt: '2026-08-20T00:00:00.000Z',
+    mtimeMs: st.mtimeMs,
+    ino: st.ino,
+  });
+}
+
 describe('model-cache #383', () => {
   let cacheRoot: string;
 
   beforeEach(() => {
     cacheRoot = makeCacheRoot();
+    resetModelCacheHealLatchForTests();
   });
 
   afterEach(() => {
@@ -74,7 +91,6 @@ describe('model-cache #383', () => {
   });
 
   it('flags truncated size without needing a sha (Edith class)', async () => {
-    // 50_187_903 was the live truncated size on Edith — any wrong size is enough.
     writeOnnxSparse(cacheRoot, 50_187_903);
     const insp = await inspectEmbeddingModelCache({ cacheRoot });
     expect(insp.status).toBe('size_mismatch');
@@ -92,41 +108,52 @@ describe('model-cache #383', () => {
     expect(insp.sha256).not.toBe(EMBEDDING_ONNX_EXPECTED_SHA256);
   });
 
-  it('accepts right-size + trusted sidecar without re-hashing content we control', async () => {
+  it('accepts right-size + identity-bound sidecar without live hashing junk bytes', async () => {
     const onnxPath = writeOnnxSparse(cacheRoot, EMBEDDING_ONNX_EXPECTED_BYTES, Buffer.alloc(16, 0));
-    const { sidecarPath } = resolveEmbeddingModelPaths(cacheRoot);
-    writeModelCacheSidecar(sidecarPath, {
-      sha256: EMBEDDING_ONNX_EXPECTED_SHA256,
-      bytes: EMBEDDING_ONNX_EXPECTED_BYTES,
-      modelId: EMBEDDING_MODEL_ID,
-      verifiedAt: '2026-08-20T00:00:00.000Z',
-    });
+    writeTrustedSidecarFor(cacheRoot);
     const insp = await inspectEmbeddingModelCache({ cacheRoot });
     expect(insp.status).toBe('ok');
-    expect(insp.bytes).toBe(EMBEDDING_ONNX_EXPECTED_BYTES);
-    // File is zeros — if we had hashed it, status would be sha_mismatch.
-    // Sidecar trust is intentional for doctor cheap-path; load path still
-    // validates by actually running ONNX.
+    expect(insp.verifiedVia).toBe('sidecar');
+    const doc = formatModelCacheDoctorMessage(insp);
+    expect(doc.message).toMatch(/sidecar attestation/i);
+    expect(doc.message).not.toMatch(/live-sha verified/i);
     expect(existsSync(onnxPath)).toBe(true);
   });
 
+  it('rejects a sidecar when file identity no longer matches (same-size replace)', async () => {
+    const onnxPath = writeOnnxSparse(cacheRoot, EMBEDDING_ONNX_EXPECTED_BYTES, Buffer.alloc(16, 0));
+    writeTrustedSidecarFor(cacheRoot);
+    // Replace weight in place with same size but different bytes/identity.
+    writeOnnxSparse(cacheRoot, EMBEDDING_ONNX_EXPECTED_BYTES, Buffer.alloc(32, 9));
+    expect(existsSync(onnxPath)).toBe(true);
+    const insp = await inspectEmbeddingModelCache({ cacheRoot });
+    // Stale sidecar (old ino/mtime) → live hash → mismatch on junk bytes.
+    expect(insp.status).toBe('sha_mismatch');
+  });
+
   it('rejects a sidecar that attests the wrong sha even when size matches', async () => {
-    writeOnnxSparse(cacheRoot, EMBEDDING_ONNX_EXPECTED_BYTES, Buffer.alloc(32, 3));
+    const onnxPath = writeOnnxSparse(cacheRoot, EMBEDDING_ONNX_EXPECTED_BYTES, Buffer.alloc(32, 3));
+    const st = statSync(onnxPath);
     const { sidecarPath } = resolveEmbeddingModelPaths(cacheRoot);
     writeModelCacheSidecar(sidecarPath, {
       sha256: '0'.repeat(64),
       bytes: EMBEDDING_ONNX_EXPECTED_BYTES,
       modelId: EMBEDDING_MODEL_ID,
       verifiedAt: '2026-08-20T00:00:00.000Z',
+      mtimeMs: st.mtimeMs,
+      ino: st.ino,
     });
     const insp = await inspectEmbeddingModelCache({ cacheRoot });
-    // Untrusted sidecar → live hash → mismatch on zeros-filled file.
     expect(insp.status).toBe('sha_mismatch');
   });
 
-  it('quarantine renames the weight aside and preserves bytes', () => {
+  it('quarantine renames the weight aside, preserves bytes, and invalidates sidecar', () => {
     const payload = Buffer.from('truncated-onnx-bytes');
     const onnxPath = writeOnnx(cacheRoot, payload);
+    writeTrustedSidecarFor(cacheRoot); // will be identity-bound to this small file's meta; fine for move test
+    // Force a sidecar to exist with any content
+    const { sidecarPath } = resolveEmbeddingModelPaths(cacheRoot);
+    writeFileSync(sidecarPath, JSON.stringify({ sha256: EMBEDDING_ONNX_EXPECTED_SHA256, bytes: EMBEDDING_ONNX_EXPECTED_BYTES, modelId: EMBEDDING_MODEL_ID, verifiedAt: 't', mtimeMs: 1, ino: 1 }) + '\n');
     const before = readFileSync(onnxPath);
     const q = quarantineEmbeddingOnnx({
       cacheRoot,
@@ -138,6 +165,20 @@ describe('model-cache #383', () => {
     expect(existsSync(q.quarantinedPath!)).toBe(true);
     expect(readFileSync(q.quarantinedPath!)).toEqual(before);
     expect(q.quarantinedPath).toContain('bak-protobuf-failed');
+    // Sidecar must not remain next to the (now empty) weight path.
+    expect(existsSync(sidecarPath)).toBe(false);
+    expect(existsSync(`${q.quarantinedPath}.shieldcortex.json`)).toBe(true);
+  });
+
+  it('after quarantine, a same-size junk redownload does not green via leftover sidecar', async () => {
+    writeOnnxSparse(cacheRoot, EMBEDDING_ONNX_EXPECTED_BYTES, Buffer.alloc(8, 1));
+    writeTrustedSidecarFor(cacheRoot);
+    const q = quarantineEmbeddingOnnx({ cacheRoot, reason: 'load-failed', stamp: 't1' });
+    expect(q.quarantinedPath).toBeTruthy();
+    // Simulate redownload of right-size wrong bytes with no new sidecar.
+    writeOnnxSparse(cacheRoot, EMBEDDING_ONNX_EXPECTED_BYTES, Buffer.alloc(8, 2));
+    const insp = await inspectEmbeddingModelCache({ cacheRoot });
+    expect(insp.status).toBe('sha_mismatch');
   });
 
   it('quarantine is a no-op when the weight is already gone', () => {
@@ -146,26 +187,35 @@ describe('model-cache #383', () => {
     expect(q.detail).toMatch(/nothing to quarantine/);
   });
 
-  it('isCorruptModelLoadError matches the Edith protobuf failure', () => {
+  it('isCorruptModelLoadError matches Edith protobuf failure and rejects generic load noise', () => {
     expect(
       isCorruptModelLoadError(
         'Load model from /home/edith/.cache/shieldcortex/models/Xenova/all-MiniLM-L6-v2/onnx/model.onnx failed:Protobuf parsing failed.',
       ),
     ).toBe(true);
+    expect(isCorruptModelLoadError('Protobuf parsing failed.')).toBe(true);
     expect(isCorruptModelLoadError('ENOTFOUND huggingface.co')).toBe(false);
     expect(isCorruptModelLoadError('401 Unauthorized')).toBe(false);
+    // Over-broad "onnx failed" alone must NOT quarantine a healthy weight.
+    expect(isCorruptModelLoadError('onnxruntime native addon failed to init')).toBe(false);
+    expect(isCorruptModelLoadError('Load model from /tmp/x failed: network timeout')).toBe(false);
+  });
+
+  it('process heal latch is one-shot', () => {
+    expect(hasAttemptedModelCacheHeal()).toBe(false);
+    markModelCacheHealAttempted();
+    expect(hasAttemptedModelCacheHeal()).toBe(true);
+    resetModelCacheHealLatchForTests();
+    expect(hasAttemptedModelCacheHeal()).toBe(false);
   });
 
   it('known-good constants match the fleet reference weight when present', () => {
-    // Guard against accidental constant drift in this repo checkout.
     const homeOnnx = join(
       process.env.HOME || '',
       '.cache/shieldcortex/models/Xenova/all-MiniLM-L6-v2/onnx/model.onnx',
     );
     if (!existsSync(homeOnnx)) return;
     expect(statSync(homeOnnx).size).toBe(EMBEDDING_ONNX_EXPECTED_BYTES);
-    // Cheap size assertion only here; full sha is expensive and covered by
-    // the constant definition + Edith post-heal verification.
     expect(EMBEDDING_ONNX_EXPECTED_SHA256).toHaveLength(64);
     expect(createHash('sha256').update('x').digest('hex')).toHaveLength(64);
   });

--- a/src/embeddings/__tests__/model-cache-383.test.ts
+++ b/src/embeddings/__tests__/model-cache-383.test.ts
@@ -1,0 +1,172 @@
+/**
+ * #383 — corrupt/truncated embedding model cache must be detected and
+ * quarantined, never reported green off "directory non-empty".
+ */
+import { createHash } from 'node:crypto';
+import {
+  closeSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  ftruncateSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  EMBEDDING_MODEL_ID,
+  EMBEDDING_ONNX_EXPECTED_BYTES,
+  EMBEDDING_ONNX_EXPECTED_SHA256,
+  formatModelCacheDoctorMessage,
+  inspectEmbeddingModelCache,
+  isCorruptModelLoadError,
+  quarantineEmbeddingOnnx,
+  resolveEmbeddingModelPaths,
+  writeModelCacheSidecar,
+} from '../model-cache.js';
+
+function makeCacheRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'sc-383-model-'));
+}
+
+function writeOnnx(cacheRoot: string, contents: Buffer | string): string {
+  const { onnxPath } = resolveEmbeddingModelPaths(cacheRoot);
+  mkdirSync(join(onnxPath, '..'), { recursive: true });
+  writeFileSync(onnxPath, contents);
+  return onnxPath;
+}
+
+/** Sparse file of exact byte length — avoids allocating 90 MB in the test process. */
+function writeOnnxSparse(cacheRoot: string, bytes: number, head: Buffer = Buffer.from([1, 2, 3, 4])): string {
+  const { onnxPath } = resolveEmbeddingModelPaths(cacheRoot);
+  mkdirSync(join(onnxPath, '..'), { recursive: true });
+  const fd = openSync(onnxPath, 'w');
+  try {
+    if (head.length > 0) writeFileSync(fd, head);
+    ftruncateSync(fd, bytes);
+  } finally {
+    closeSync(fd);
+  }
+  return onnxPath;
+}
+
+describe('model-cache #383', () => {
+  let cacheRoot: string;
+
+  beforeEach(() => {
+    cacheRoot = makeCacheRoot();
+  });
+
+  afterEach(() => {
+    rmSync(cacheRoot, { recursive: true, force: true });
+  });
+
+  it('reports missing when model.onnx is absent', async () => {
+    const insp = await inspectEmbeddingModelCache({ cacheRoot });
+    expect(insp.status).toBe('missing');
+    const doc = formatModelCacheDoctorMessage(insp);
+    expect(doc.status).toBe('info');
+  });
+
+  it('flags truncated size without needing a sha (Edith class)', async () => {
+    // 50_187_903 was the live truncated size on Edith — any wrong size is enough.
+    writeOnnxSparse(cacheRoot, 50_187_903);
+    const insp = await inspectEmbeddingModelCache({ cacheRoot });
+    expect(insp.status).toBe('size_mismatch');
+    expect(insp.bytes).toBe(50_187_903);
+    const doc = formatModelCacheDoctorMessage(insp);
+    expect(doc.status).toBe('warn');
+    expect(doc.message).toMatch(/corrupt/i);
+  });
+
+  it('flags right-size wrong-sha as sha_mismatch', async () => {
+    writeOnnxSparse(cacheRoot, EMBEDDING_ONNX_EXPECTED_BYTES, Buffer.alloc(64, 7));
+    const insp = await inspectEmbeddingModelCache({ cacheRoot, forceSha: true });
+    expect(insp.status).toBe('sha_mismatch');
+    expect(insp.sha256).toBeTruthy();
+    expect(insp.sha256).not.toBe(EMBEDDING_ONNX_EXPECTED_SHA256);
+  });
+
+  it('accepts right-size + trusted sidecar without re-hashing content we control', async () => {
+    const onnxPath = writeOnnxSparse(cacheRoot, EMBEDDING_ONNX_EXPECTED_BYTES, Buffer.alloc(16, 0));
+    const { sidecarPath } = resolveEmbeddingModelPaths(cacheRoot);
+    writeModelCacheSidecar(sidecarPath, {
+      sha256: EMBEDDING_ONNX_EXPECTED_SHA256,
+      bytes: EMBEDDING_ONNX_EXPECTED_BYTES,
+      modelId: EMBEDDING_MODEL_ID,
+      verifiedAt: '2026-08-20T00:00:00.000Z',
+    });
+    const insp = await inspectEmbeddingModelCache({ cacheRoot });
+    expect(insp.status).toBe('ok');
+    expect(insp.bytes).toBe(EMBEDDING_ONNX_EXPECTED_BYTES);
+    // File is zeros — if we had hashed it, status would be sha_mismatch.
+    // Sidecar trust is intentional for doctor cheap-path; load path still
+    // validates by actually running ONNX.
+    expect(existsSync(onnxPath)).toBe(true);
+  });
+
+  it('rejects a sidecar that attests the wrong sha even when size matches', async () => {
+    writeOnnxSparse(cacheRoot, EMBEDDING_ONNX_EXPECTED_BYTES, Buffer.alloc(32, 3));
+    const { sidecarPath } = resolveEmbeddingModelPaths(cacheRoot);
+    writeModelCacheSidecar(sidecarPath, {
+      sha256: '0'.repeat(64),
+      bytes: EMBEDDING_ONNX_EXPECTED_BYTES,
+      modelId: EMBEDDING_MODEL_ID,
+      verifiedAt: '2026-08-20T00:00:00.000Z',
+    });
+    const insp = await inspectEmbeddingModelCache({ cacheRoot });
+    // Untrusted sidecar → live hash → mismatch on zeros-filled file.
+    expect(insp.status).toBe('sha_mismatch');
+  });
+
+  it('quarantine renames the weight aside and preserves bytes', () => {
+    const payload = Buffer.from('truncated-onnx-bytes');
+    const onnxPath = writeOnnx(cacheRoot, payload);
+    const before = readFileSync(onnxPath);
+    const q = quarantineEmbeddingOnnx({
+      cacheRoot,
+      reason: 'protobuf-failed',
+      stamp: '20260820T120000Z',
+    });
+    expect(q.quarantinedPath).toBeTruthy();
+    expect(existsSync(onnxPath)).toBe(false);
+    expect(existsSync(q.quarantinedPath!)).toBe(true);
+    expect(readFileSync(q.quarantinedPath!)).toEqual(before);
+    expect(q.quarantinedPath).toContain('bak-protobuf-failed');
+  });
+
+  it('quarantine is a no-op when the weight is already gone', () => {
+    const q = quarantineEmbeddingOnnx({ cacheRoot, reason: 'missing' });
+    expect(q.quarantinedPath).toBeNull();
+    expect(q.detail).toMatch(/nothing to quarantine/);
+  });
+
+  it('isCorruptModelLoadError matches the Edith protobuf failure', () => {
+    expect(
+      isCorruptModelLoadError(
+        'Load model from /home/edith/.cache/shieldcortex/models/Xenova/all-MiniLM-L6-v2/onnx/model.onnx failed:Protobuf parsing failed.',
+      ),
+    ).toBe(true);
+    expect(isCorruptModelLoadError('ENOTFOUND huggingface.co')).toBe(false);
+    expect(isCorruptModelLoadError('401 Unauthorized')).toBe(false);
+  });
+
+  it('known-good constants match the fleet reference weight when present', () => {
+    // Guard against accidental constant drift in this repo checkout.
+    const homeOnnx = join(
+      process.env.HOME || '',
+      '.cache/shieldcortex/models/Xenova/all-MiniLM-L6-v2/onnx/model.onnx',
+    );
+    if (!existsSync(homeOnnx)) return;
+    expect(statSync(homeOnnx).size).toBe(EMBEDDING_ONNX_EXPECTED_BYTES);
+    // Cheap size assertion only here; full sha is expensive and covered by
+    // the constant definition + Edith post-heal verification.
+    expect(EMBEDDING_ONNX_EXPECTED_SHA256).toHaveLength(64);
+    expect(createHash('sha256').update('x').digest('hex')).toHaveLength(64);
+  });
+});

--- a/src/embeddings/index.ts
+++ b/src/embeddings/index.ts
@@ -10,3 +10,6 @@ export {
   defaultEmbeddingCacheRoot,
   isCorruptModelLoadError,
 } from './model-cache.js';
+export { hasAttemptedModelCacheHeal } from './model-cache.js';
+export { markModelCacheHealAttempted } from './model-cache.js';
+export { resetModelCacheHealLatchForTests } from './model-cache.js';

--- a/src/embeddings/index.ts
+++ b/src/embeddings/index.ts
@@ -9,7 +9,7 @@ export {
   resolveEmbeddingModelPaths,
   defaultEmbeddingCacheRoot,
   isCorruptModelLoadError,
+  hasAttemptedModelCacheHeal,
+  markModelCacheHealAttempted,
 } from './model-cache.js';
-export { hasAttemptedModelCacheHeal } from './model-cache.js';
-export { markModelCacheHealAttempted } from './model-cache.js';
-export { resetModelCacheHealLatchForTests } from './model-cache.js';
+// resetModelCacheHealLatchForTests stays module-private for tests (import from model-cache.js directly).

--- a/src/embeddings/index.ts
+++ b/src/embeddings/index.ts
@@ -1,1 +1,12 @@
 export { generateEmbedding, cosineSimilarity, isModelLoaded, preloadModel, disposeModel } from './generator.js';
+export {
+  inspectEmbeddingModelCache,
+  quarantineEmbeddingOnnx,
+  formatModelCacheDoctorMessage,
+  EMBEDDING_ONNX_EXPECTED_BYTES,
+  EMBEDDING_ONNX_EXPECTED_SHA256,
+  EMBEDDING_MODEL_ID,
+  resolveEmbeddingModelPaths,
+  defaultEmbeddingCacheRoot,
+  isCorruptModelLoadError,
+} from './model-cache.js';

--- a/src/embeddings/model-cache.ts
+++ b/src/embeddings/model-cache.ts
@@ -1,0 +1,344 @@
+/**
+ * #383 — embedding model cache integrity + heal helpers.
+ *
+ * Xenova/all-MiniLM-L6-v2 is cached under
+ *   ~/.cache/shieldcortex/models/Xenova/all-MiniLM-L6-v2/onnx/model.onnx
+ *
+ * A truncated download (Edith, May→Aug 2026) left a ~50 MB file that every
+ * launch retried forever. Doctor only checked "directory non-empty", so the
+ * box looked healthy while semantic search/dedup were silently dead.
+ *
+ * Contract:
+ *  - known size + sha256 of the upstream fp32 ONNX weight
+ *  - inspect never throws
+ *  - quarantine renames aside (keeps the bad bytes for forensics)
+ *  - one re-download attempt is the caller's job (worker load path)
+ */
+import { createHash } from 'node:crypto';
+import {
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { finished } from 'node:stream/promises';
+
+/** HuggingFace / transformers.js model id we pin for memory embeddings. */
+export const EMBEDDING_MODEL_ID = 'Xenova/all-MiniLM-L6-v2';
+
+/**
+ * Known-good fp32 ONNX weight for Xenova/all-MiniLM-L6-v2.
+ * Verified on multiple healthy fleet hosts (TARS + post-heal Edith).
+ * If upstream ever republishes a different weight, bump both constants
+ * together and regenerate fixtures — do not "accept any parseable file".
+ */
+export const EMBEDDING_ONNX_EXPECTED_BYTES = 90_387_606;
+export const EMBEDDING_ONNX_EXPECTED_SHA256 =
+  '759c3cd2b7fe7e93933ad23c4c9181b7396442a2ed746ec7c1d46192c469c46e';
+
+/** Relative path under the transformers.js cacheDir. */
+export const EMBEDDING_ONNX_RELATIVE = join(
+  'Xenova',
+  'all-MiniLM-L6-v2',
+  'onnx',
+  'model.onnx',
+);
+
+export type ModelCacheStatus =
+  | 'missing'
+  | 'ok'
+  | 'size_mismatch'
+  | 'sha_mismatch'
+  | 'unreadable';
+
+export interface ModelCacheInspection {
+  status: ModelCacheStatus;
+  cacheDir: string;
+  onnxPath: string;
+  bytes?: number;
+  sha256?: string;
+  expectedBytes: number;
+  expectedSha256: string;
+  detail?: string;
+}
+
+export interface ModelCachePaths {
+  cacheRoot: string;
+  modelDir: string;
+  onnxPath: string;
+  sidecarPath: string;
+}
+
+export function defaultEmbeddingCacheRoot(home = homedir()): string {
+  return join(home, '.cache', 'shieldcortex', 'models');
+}
+
+export function resolveEmbeddingModelPaths(cacheRoot = defaultEmbeddingCacheRoot()): ModelCachePaths {
+  const onnxPath = join(cacheRoot, EMBEDDING_ONNX_RELATIVE);
+  return {
+    cacheRoot,
+    modelDir: join(cacheRoot, 'Xenova', 'all-MiniLM-L6-v2'),
+    onnxPath,
+    sidecarPath: `${onnxPath}.shieldcortex.json`,
+  };
+}
+
+export interface ModelCacheSidecar {
+  sha256: string;
+  bytes: number;
+  modelId: string;
+  verifiedAt: string;
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return Boolean(err) && typeof err === 'object' && 'code' in (err as object);
+}
+
+/** Streaming sha256 — 90 MB must not be slurped into a single Buffer. */
+export async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash('sha256');
+  const stream = createReadStream(filePath);
+  stream.on('data', (chunk: string | Buffer) => {
+    hash.update(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  });
+  await finished(stream);
+  return hash.digest('hex');
+}
+
+export function readModelCacheSidecar(sidecarPath: string): ModelCacheSidecar | null {
+  try {
+    if (!existsSync(sidecarPath)) return null;
+    const raw = JSON.parse(readFileSync(sidecarPath, 'utf8')) as Partial<ModelCacheSidecar>;
+    if (
+      typeof raw.sha256 !== 'string' ||
+      typeof raw.bytes !== 'number' ||
+      typeof raw.modelId !== 'string' ||
+      typeof raw.verifiedAt !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      sha256: raw.sha256,
+      bytes: raw.bytes,
+      modelId: raw.modelId,
+      verifiedAt: raw.verifiedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeModelCacheSidecar(sidecarPath: string, sidecar: ModelCacheSidecar): void {
+  mkdirSync(dirname(sidecarPath), { recursive: true });
+  writeFileSync(sidecarPath, `${JSON.stringify(sidecar, null, 2)}\n`, { mode: 0o600 });
+}
+
+/**
+ * Fast path: size must match. Sha is checked when:
+ *  - size already mismatches (skip — status is size_mismatch), or
+ *  - no trusted sidecar, or
+ *  - sidecar disagrees with expected constants, or
+ *  - opts.forceSha is true (doctor --deep / post-download verify).
+ *
+ * A matching sidecar written by us after a verified load lets doctor stay
+ * cheap on the happy path without re-hashing 90 MB every run.
+ */
+export async function inspectEmbeddingModelCache(
+  opts: {
+    cacheRoot?: string;
+    forceSha?: boolean;
+    now?: () => Date;
+  } = {},
+): Promise<ModelCacheInspection> {
+  const paths = resolveEmbeddingModelPaths(opts.cacheRoot ?? defaultEmbeddingCacheRoot());
+  const base = {
+    cacheDir: paths.modelDir,
+    onnxPath: paths.onnxPath,
+    expectedBytes: EMBEDDING_ONNX_EXPECTED_BYTES,
+    expectedSha256: EMBEDDING_ONNX_EXPECTED_SHA256,
+  };
+
+  if (!existsSync(paths.onnxPath)) {
+    return { ...base, status: 'missing', detail: 'model.onnx not present' };
+  }
+
+  let bytes: number;
+  try {
+    bytes = statSync(paths.onnxPath).size;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ...base, status: 'unreadable', detail: msg };
+  }
+
+  if (bytes !== EMBEDDING_ONNX_EXPECTED_BYTES) {
+    return {
+      ...base,
+      status: 'size_mismatch',
+      bytes,
+      detail: `model.onnx is ${bytes} bytes; expected ${EMBEDDING_ONNX_EXPECTED_BYTES}`,
+    };
+  }
+
+  const sidecar = readModelCacheSidecar(paths.sidecarPath);
+  const sidecarTrusted =
+    sidecar != null &&
+    sidecar.bytes === EMBEDDING_ONNX_EXPECTED_BYTES &&
+    sidecar.sha256 === EMBEDDING_ONNX_EXPECTED_SHA256 &&
+    sidecar.modelId === EMBEDDING_MODEL_ID;
+
+  if (sidecarTrusted && !opts.forceSha) {
+    return {
+      ...base,
+      status: 'ok',
+      bytes,
+      sha256: sidecar.sha256,
+      detail: 'size + sidecar sha match',
+    };
+  }
+
+  try {
+    const sha256 = await sha256File(paths.onnxPath);
+    if (sha256 !== EMBEDDING_ONNX_EXPECTED_SHA256) {
+      return {
+        ...base,
+        status: 'sha_mismatch',
+        bytes,
+        sha256,
+        detail: `model.onnx sha256 ${sha256.slice(0, 12)}… does not match known-good`,
+      };
+    }
+    // Refresh sidecar so subsequent doctor runs stay cheap.
+    try {
+      writeModelCacheSidecar(paths.sidecarPath, {
+        sha256,
+        bytes,
+        modelId: EMBEDDING_MODEL_ID,
+        verifiedAt: (opts.now ?? (() => new Date()))().toISOString(),
+      });
+    } catch {
+      // Sidecar is an optimisation; integrity already passed.
+    }
+    return { ...base, status: 'ok', bytes, sha256, detail: 'size + sha match' };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ...base, status: 'unreadable', bytes, detail: msg };
+  }
+}
+
+/**
+ * Move a suspect weight aside. Keeps the bad bytes for forensics.
+ * Returns the quarantine path, or null if the file was already gone / rename failed.
+ */
+export function quarantineEmbeddingOnnx(
+  opts: {
+    cacheRoot?: string;
+    reason?: string;
+    stamp?: string;
+  } = {},
+): { quarantinedPath: string | null; onnxPath: string; detail: string } {
+  const paths = resolveEmbeddingModelPaths(opts.cacheRoot ?? defaultEmbeddingCacheRoot());
+  if (!existsSync(paths.onnxPath)) {
+    return {
+      quarantinedPath: null,
+      onnxPath: paths.onnxPath,
+      detail: 'nothing to quarantine',
+    };
+  }
+
+  const stamp =
+    opts.stamp ??
+    new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z');
+  const reason = (opts.reason ?? 'suspect').replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 48);
+  const dest = `${paths.onnxPath}.bak-${reason}-${stamp}`;
+
+  try {
+    renameSync(paths.onnxPath, dest);
+    // Sidecar is meaningless without the weight it attests.
+    if (existsSync(paths.sidecarPath)) {
+      try {
+        renameSync(paths.sidecarPath, `${dest}.shieldcortex.json`);
+      } catch {
+        /* ignore */
+      }
+    }
+    return {
+      quarantinedPath: dest,
+      onnxPath: paths.onnxPath,
+      detail: `quarantined to ${dest}`,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // EEXIST: pick a unique suffix once.
+    if (isNodeError(err) && err.code === 'EEXIST') {
+      const dest2 = `${dest}-${process.pid}`;
+      try {
+        renameSync(paths.onnxPath, dest2);
+        return {
+          quarantinedPath: dest2,
+          onnxPath: paths.onnxPath,
+          detail: `quarantined to ${dest2}`,
+        };
+      } catch (err2) {
+        const msg2 = err2 instanceof Error ? err2.message : String(err2);
+        return { quarantinedPath: null, onnxPath: paths.onnxPath, detail: msg2 };
+      }
+    }
+    return { quarantinedPath: null, onnxPath: paths.onnxPath, detail: msg };
+  }
+}
+
+/** Load failures that mean "the on-disk weight is garbage", not "network/auth". */
+export function isCorruptModelLoadError(message: string): boolean {
+  const m = message.toLowerCase();
+  if (m.includes('protobuf parsing failed') || m.includes('protobuf')) return true;
+  if (m.includes('invalid flatbuffer')) return true;
+  if (m.includes('failed to load model from') || m.includes('load model from')) return true;
+  if (m.includes('onnx') && m.includes('failed')) return true;
+  if (m.includes('file is too small') || m.includes('unexpected eof')) return true;
+  if (m.includes('truncated')) return true;
+  return false;
+}
+
+export function formatModelCacheDoctorMessage(insp: ModelCacheInspection): {
+  status: 'pass' | 'warn' | 'info' | 'fail';
+  message: string;
+  fix?: string;
+} {
+  switch (insp.status) {
+    case 'missing':
+      return {
+        status: 'info',
+        message: 'model not cached — will download on first recall',
+      };
+    case 'ok':
+      return {
+        status: 'pass',
+        message: `model cached and verified (${insp.bytes ?? EMBEDDING_ONNX_EXPECTED_BYTES} bytes, sha ok)`,
+      };
+    case 'size_mismatch':
+    case 'sha_mismatch':
+      return {
+        status: 'warn',
+        message:
+          `embedding model cache is corrupt (${insp.detail ?? insp.status}) — semantic search/dedup may be degraded until it is re-downloaded`,
+        fix:
+          'Remove the bad weight (or let the next preload quarantine it) and re-run a recall, or: ' +
+          `mv "${insp.onnxPath}" "${insp.onnxPath}.bak-manual" && shieldcortex doctor`,
+      };
+    case 'unreadable':
+      return {
+        status: 'warn',
+        message: `embedding model cache unreadable — ${insp.detail ?? 'unknown error'}`,
+        fix: `Check permissions on ${insp.cacheDir}`,
+      };
+    default: {
+      const _exhaustive: never = insp.status;
+      return { status: 'warn', message: `unexpected model cache status: ${_exhaustive}` };
+    }
+  }
+}

--- a/src/embeddings/model-cache.ts
+++ b/src/embeddings/model-cache.ts
@@ -12,7 +12,9 @@
  *  - known size + sha256 of the upstream fp32 ONNX weight
  *  - inspect never throws
  *  - quarantine renames aside (keeps the bad bytes for forensics)
- *  - one re-download attempt is the caller's job (worker load path)
+ *  - sidecar is always invalidated when the weight is quarantined
+ *  - one heal attempt per process (caller uses the latch)
+ *  - doctor wording never claims a live sha when only a sidecar attested
  */
 import { createHash } from 'node:crypto';
 import {
@@ -23,6 +25,7 @@ import {
   renameSync,
   statSync,
   writeFileSync,
+  type Stats,
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -56,6 +59,8 @@ export type ModelCacheStatus =
   | 'sha_mismatch'
   | 'unreadable';
 
+export type ModelCacheOkVia = 'sidecar' | 'live_sha';
+
 export interface ModelCacheInspection {
   status: ModelCacheStatus;
   cacheDir: string;
@@ -65,6 +70,8 @@ export interface ModelCacheInspection {
   expectedBytes: number;
   expectedSha256: string;
   detail?: string;
+  /** Present only when status === 'ok'. */
+  verifiedVia?: ModelCacheOkVia;
 }
 
 export interface ModelCachePaths {
@@ -93,6 +100,9 @@ export interface ModelCacheSidecar {
   bytes: number;
   modelId: string;
   verifiedAt: string;
+  /** File identity binding — stale sidecar must not green-lie after replace. */
+  mtimeMs: number;
+  ino: number;
 }
 
 function isNodeError(err: unknown): err is NodeJS.ErrnoException {
@@ -118,7 +128,9 @@ export function readModelCacheSidecar(sidecarPath: string): ModelCacheSidecar | 
       typeof raw.sha256 !== 'string' ||
       typeof raw.bytes !== 'number' ||
       typeof raw.modelId !== 'string' ||
-      typeof raw.verifiedAt !== 'string'
+      typeof raw.verifiedAt !== 'string' ||
+      typeof raw.mtimeMs !== 'number' ||
+      typeof raw.ino !== 'number'
     ) {
       return null;
     }
@@ -127,6 +139,8 @@ export function readModelCacheSidecar(sidecarPath: string): ModelCacheSidecar | 
       bytes: raw.bytes,
       modelId: raw.modelId,
       verifiedAt: raw.verifiedAt,
+      mtimeMs: raw.mtimeMs,
+      ino: raw.ino,
     };
   } catch {
     return null;
@@ -138,15 +152,22 @@ export function writeModelCacheSidecar(sidecarPath: string, sidecar: ModelCacheS
   writeFileSync(sidecarPath, `${JSON.stringify(sidecar, null, 2)}\n`, { mode: 0o600 });
 }
 
+function sidecarMatchesFile(sidecar: ModelCacheSidecar, st: Stats): boolean {
+  return (
+    sidecar.bytes === st.size &&
+    sidecar.bytes === EMBEDDING_ONNX_EXPECTED_BYTES &&
+    sidecar.sha256 === EMBEDDING_ONNX_EXPECTED_SHA256 &&
+    sidecar.modelId === EMBEDDING_MODEL_ID &&
+    sidecar.mtimeMs === st.mtimeMs &&
+    sidecar.ino === st.ino
+  );
+}
+
 /**
  * Fast path: size must match. Sha is checked when:
  *  - size already mismatches (skip — status is size_mismatch), or
- *  - no trusted sidecar, or
- *  - sidecar disagrees with expected constants, or
+ *  - no trusted sidecar bound to this inode/mtime, or
  *  - opts.forceSha is true (doctor --deep / post-download verify).
- *
- * A matching sidecar written by us after a verified load lets doctor stay
- * cheap on the happy path without re-hashing 90 MB every run.
  */
 export async function inspectEmbeddingModelCache(
   opts: {
@@ -167,14 +188,15 @@ export async function inspectEmbeddingModelCache(
     return { ...base, status: 'missing', detail: 'model.onnx not present' };
   }
 
-  let bytes: number;
+  let st: Stats;
   try {
-    bytes = statSync(paths.onnxPath).size;
+    st = statSync(paths.onnxPath);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { ...base, status: 'unreadable', detail: msg };
   }
 
+  const bytes = st.size;
   if (bytes !== EMBEDDING_ONNX_EXPECTED_BYTES) {
     return {
       ...base,
@@ -185,19 +207,16 @@ export async function inspectEmbeddingModelCache(
   }
 
   const sidecar = readModelCacheSidecar(paths.sidecarPath);
-  const sidecarTrusted =
-    sidecar != null &&
-    sidecar.bytes === EMBEDDING_ONNX_EXPECTED_BYTES &&
-    sidecar.sha256 === EMBEDDING_ONNX_EXPECTED_SHA256 &&
-    sidecar.modelId === EMBEDDING_MODEL_ID;
+  const sidecarTrusted = sidecar != null && sidecarMatchesFile(sidecar, st);
 
   if (sidecarTrusted && !opts.forceSha) {
     return {
       ...base,
       status: 'ok',
       bytes,
-      sha256: sidecar.sha256,
-      detail: 'size + sidecar sha match',
+      sha256: sidecar!.sha256,
+      verifiedVia: 'sidecar',
+      detail: 'size + sidecar attestation match file identity',
     };
   }
 
@@ -214,25 +233,64 @@ export async function inspectEmbeddingModelCache(
     }
     // Refresh sidecar so subsequent doctor runs stay cheap.
     try {
+      // Re-stat after hash in case something replaced the file mid-read.
+      const st2 = statSync(paths.onnxPath);
+      if (st2.size !== EMBEDDING_ONNX_EXPECTED_BYTES) {
+        return {
+          ...base,
+          status: 'size_mismatch',
+          bytes: st2.size,
+          detail: 'model.onnx size changed during verification',
+        };
+      }
       writeModelCacheSidecar(paths.sidecarPath, {
         sha256,
-        bytes,
+        bytes: st2.size,
         modelId: EMBEDDING_MODEL_ID,
         verifiedAt: (opts.now ?? (() => new Date()))().toISOString(),
+        mtimeMs: st2.mtimeMs,
+        ino: st2.ino,
       });
     } catch {
       // Sidecar is an optimisation; integrity already passed.
     }
-    return { ...base, status: 'ok', bytes, sha256, detail: 'size + sha match' };
+    return {
+      ...base,
+      status: 'ok',
+      bytes,
+      sha256,
+      verifiedVia: 'live_sha',
+      detail: 'size + live sha match',
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { ...base, status: 'unreadable', bytes, detail: msg };
   }
 }
 
+function moveSidecarAside(sidecarPath: string, destWeightPath: string): void {
+  if (!existsSync(sidecarPath)) return;
+  const dest = `${destWeightPath}.shieldcortex.json`;
+  try {
+    renameSync(sidecarPath, dest);
+  } catch {
+    // Last resort: overwrite sidecar with an invalid marker so it can never
+    // attest the next weight. Prefer rename; this is the honesty backstop.
+    try {
+      writeFileSync(
+        sidecarPath,
+        `${JSON.stringify({ invalidated: true, at: new Date().toISOString() })}\n`,
+        { mode: 0o600 },
+      );
+    } catch {
+      /* ignore — inspect will live-hash if sidecar is unreadable/untrusted */
+    }
+  }
+}
+
 /**
  * Move a suspect weight aside. Keeps the bad bytes for forensics.
- * Returns the quarantine path, or null if the file was already gone / rename failed.
+ * Always invalidates the sidecar when the weight moves (main + EEXIST paths).
  */
 export function quarantineEmbeddingOnnx(
   opts: {
@@ -253,55 +311,83 @@ export function quarantineEmbeddingOnnx(
   const stamp =
     opts.stamp ??
     new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z');
-  const reason = (opts.reason ?? 'suspect').replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 48);
+  // Suffix only — never path-join the reason. Strip dots so ".." cannot appear.
+  const reason = (opts.reason ?? 'suspect').replace(/[^a-zA-Z0-9_-]+/g, '-').slice(0, 48);
   const dest = `${paths.onnxPath}.bak-${reason}-${stamp}`;
 
+  const tryRename = (target: string): boolean => {
+    try {
+      renameSync(paths.onnxPath, target);
+      moveSidecarAside(paths.sidecarPath, target);
+      return true;
+    } catch (err) {
+      if (isNodeError(err) && err.code === 'EEXIST') return false;
+      throw err;
+    }
+  };
+
   try {
-    renameSync(paths.onnxPath, dest);
-    // Sidecar is meaningless without the weight it attests.
-    if (existsSync(paths.sidecarPath)) {
-      try {
-        renameSync(paths.sidecarPath, `${dest}.shieldcortex.json`);
-      } catch {
-        /* ignore */
-      }
+    if (tryRename(dest)) {
+      return {
+        quarantinedPath: dest,
+        onnxPath: paths.onnxPath,
+        detail: `quarantined to ${dest}`,
+      };
+    }
+    const dest2 = `${dest}-${process.pid}`;
+    if (tryRename(dest2)) {
+      return {
+        quarantinedPath: dest2,
+        onnxPath: paths.onnxPath,
+        detail: `quarantined to ${dest2}`,
+      };
     }
     return {
-      quarantinedPath: dest,
+      quarantinedPath: null,
       onnxPath: paths.onnxPath,
-      detail: `quarantined to ${dest}`,
+      detail: 'quarantine rename failed (destination exists)',
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    // EEXIST: pick a unique suffix once.
-    if (isNodeError(err) && err.code === 'EEXIST') {
-      const dest2 = `${dest}-${process.pid}`;
-      try {
-        renameSync(paths.onnxPath, dest2);
-        return {
-          quarantinedPath: dest2,
-          onnxPath: paths.onnxPath,
-          detail: `quarantined to ${dest2}`,
-        };
-      } catch (err2) {
-        const msg2 = err2 instanceof Error ? err2.message : String(err2);
-        return { quarantinedPath: null, onnxPath: paths.onnxPath, detail: msg2 };
-      }
-    }
     return { quarantinedPath: null, onnxPath: paths.onnxPath, detail: msg };
   }
 }
 
-/** Load failures that mean "the on-disk weight is garbage", not "network/auth". */
+/**
+ * Load failures that mean "the on-disk weight is garbage", not network/auth.
+ * Kept tight on purpose: over-broad matching would quarantine a healthy weight
+ * on transient native errors (review blocker).
+ */
 export function isCorruptModelLoadError(message: string): boolean {
   const m = message.toLowerCase();
-  if (m.includes('protobuf parsing failed') || m.includes('protobuf')) return true;
+  if (m.includes('protobuf parsing failed')) return true;
   if (m.includes('invalid flatbuffer')) return true;
-  if (m.includes('failed to load model from') || m.includes('load model from')) return true;
-  if (m.includes('onnx') && m.includes('failed')) return true;
-  if (m.includes('file is too small') || m.includes('unexpected eof')) return true;
+  if (m.includes('unexpected eof')) return true;
+  if (m.includes('file is too small')) return true;
   if (m.includes('truncated')) return true;
+  // transformers.js phrasing when the ONNX protobuf itself will not parse:
+  // "Load model from <path> failed:Protobuf parsing failed."
+  // Require both the load-from cue AND a parse/integrity cue.
+  if (m.includes('load model from') && (m.includes('protobuf') || m.includes('parse'))) {
+    return true;
+  }
   return false;
+}
+
+/** Process-level latch: at most one quarantine+redownload heal per worker. */
+let healAttemptedThisProcess = false;
+
+export function hasAttemptedModelCacheHeal(): boolean {
+  return healAttemptedThisProcess;
+}
+
+export function markModelCacheHealAttempted(): void {
+  healAttemptedThisProcess = true;
+}
+
+/** Test-only reset. */
+export function resetModelCacheHealLatchForTests(): void {
+  healAttemptedThisProcess = false;
 }
 
 export function formatModelCacheDoctorMessage(insp: ModelCacheInspection): {
@@ -316,9 +402,17 @@ export function formatModelCacheDoctorMessage(insp: ModelCacheInspection): {
         message: 'model not cached — will download on first recall',
       };
     case 'ok':
+      if (insp.verifiedVia === 'live_sha') {
+        return {
+          status: 'pass',
+          message: `model cached and live-sha verified (${insp.bytes ?? EMBEDDING_ONNX_EXPECTED_BYTES} bytes)`,
+        };
+      }
       return {
         status: 'pass',
-        message: `model cached and verified (${insp.bytes ?? EMBEDDING_ONNX_EXPECTED_BYTES} bytes, sha ok)`,
+        message:
+          `model cached; size + sidecar attestation ok (${insp.bytes ?? EMBEDDING_ONNX_EXPECTED_BYTES} bytes) ` +
+          `— not a live content hash this run`,
       };
     case 'size_mismatch':
     case 'sha_mismatch':
@@ -327,7 +421,7 @@ export function formatModelCacheDoctorMessage(insp: ModelCacheInspection): {
         message:
           `embedding model cache is corrupt (${insp.detail ?? insp.status}) — semantic search/dedup may be degraded until it is re-downloaded`,
         fix:
-          'Remove the bad weight (or let the next preload quarantine it) and re-run a recall, or: ' +
+          'Let the next preload quarantine the bad weight and re-download, or: ' +
           `mv "${insp.onnxPath}" "${insp.onnxPath}.bak-manual" && shieldcortex doctor`,
       };
     case 'unreadable':

--- a/src/embeddings/worker.ts
+++ b/src/embeddings/worker.ts
@@ -45,11 +45,33 @@ async function loadModel(): Promise<void> {
   // user-facing `remember`/`scan` output on a healthy install (#129). fp32 is
   // exactly what it was defaulting to on CPU, so behaviour is unchanged; the
   // defence judge worker pins its dtype the same way.
-  extractor = await pipelineFn(
-    'feature-extraction',
-    'Xenova/all-MiniLM-L6-v2',
-    { dtype: 'fp32' },
-  );
+  //
+  // #383: a truncated/corrupt on-disk weight used to fail every launch forever
+  // against the same bad bytes. Quarantine once, then let transformers.js
+  // re-download. A second failure surfaces — we never loop.
+  const { isCorruptModelLoadError, quarantineEmbeddingOnnx } = await import('./model-cache.js');
+  try {
+    extractor = await pipelineFn(
+      'feature-extraction',
+      'Xenova/all-MiniLM-L6-v2',
+      { dtype: 'fp32' },
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!isCorruptModelLoadError(message)) throw err;
+    const q = quarantineEmbeddingOnnx({ reason: 'load-failed' });
+    parentPort?.postMessage({
+      type: 'error',
+      error:
+        `Embedding model cache looked corrupt (${message}). ` +
+        `${q.detail}. Retrying download once.`,
+    });
+    extractor = await pipelineFn(
+      'feature-extraction',
+      'Xenova/all-MiniLM-L6-v2',
+      { dtype: 'fp32' },
+    );
+  }
 }
 
 async function embed(text: string): Promise<number[]> {

--- a/src/embeddings/worker.ts
+++ b/src/embeddings/worker.ts
@@ -49,7 +49,12 @@ async function loadModel(): Promise<void> {
   // #383: a truncated/corrupt on-disk weight used to fail every launch forever
   // against the same bad bytes. Quarantine once, then let transformers.js
   // re-download. A second failure surfaces — we never loop.
-  const { isCorruptModelLoadError, quarantineEmbeddingOnnx } = await import('./model-cache.js');
+  const {
+    isCorruptModelLoadError,
+    quarantineEmbeddingOnnx,
+    hasAttemptedModelCacheHeal,
+    markModelCacheHealAttempted,
+  } = await import('./model-cache.js');
   try {
     extractor = await pipelineFn(
       'feature-extraction',
@@ -59,6 +64,13 @@ async function loadModel(): Promise<void> {
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (!isCorruptModelLoadError(message)) throw err;
+    // One heal per worker process — never pile up .bak files or hammer the network.
+    if (hasAttemptedModelCacheHeal()) {
+      throw new Error(
+        `Embedding model cache still corrupt after one heal attempt: ${message}`,
+      );
+    }
+    markModelCacheHealAttempted();
     const q = quarantineEmbeddingOnnx({ reason: 'load-failed' });
     parentPort?.postMessage({
       type: 'error',

--- a/src/embeddings/worker.ts
+++ b/src/embeddings/worker.ts
@@ -76,7 +76,7 @@ async function loadModel(): Promise<void> {
       type: 'error',
       error:
         `Embedding model cache looked corrupt (${message}). ` +
-        `${q.detail}. Retrying download once.`,
+        `${q.detail}. Attempting one re-download (process heal latch armed).`,
     });
     extractor = await pipelineFn(
       'feature-extraction',

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,7 +287,7 @@ async function startMcpServer(dbPath?: string): Promise<void> {
       // #383: worker quarantines a corrupt on-disk weight and retries once.
       // If we still land here, the heal did not recover — operator should run doctor.
       console.error(
-        '[shieldcortex] Model preload failed (will retry on first use; run `shieldcortex doctor` if this repeats):',
+        '[shieldcortex] Model preload failed (worker heals a corrupt cache at most once per process; run `shieldcortex doctor` if this repeats):',
         err instanceof Error ? err.message : err,
       );
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,12 @@ async function startMcpServer(dbPath?: string): Promise<void> {
   // Fire-and-forget: failure is fine — searchMemories falls back to FTS-only.
   if (process.env.SHIELDCORTEX_SKIP_EMBEDDINGS !== '1') {
     preloadModel().catch(err => {
-      console.error('[shieldcortex] Model preload failed (will retry on first use):', err.message);
+      // #383: worker quarantines a corrupt on-disk weight and retries once.
+      // If we still land here, the heal did not recover — operator should run doctor.
+      console.error(
+        '[shieldcortex] Model preload failed (will retry on first use; run `shieldcortex doctor` if this repeats):',
+        err instanceof Error ? err.message : err,
+      );
     });
   }
 


### PR DESCRIPTION
## Summary
Closes #383.

Edith ran **3.5 months** on a truncated `model.onnx` (~50 MB vs known-good ~90 MB). Every launch logged preload failure, retried the same bad bytes, and doctor still passed on \"model cached (directory non-empty)\". Semantic search + embed-dedup were silently degraded.

## Fix
1. **Integrity module** (`src/embeddings/model-cache.ts`): known size + sha256, streaming hash, trusted sidecar for cheap doctor path, quarantine-by-rename (keeps bad bytes).
2. **Worker heal**: on corrupt-load errors (protobuf parse, etc.) quarantine once and retry download once — never loop.
3. **Doctor**: Embeddings check verifies integrity; corrupt → WARN with fix; missing stays INFO.
4. **Tests**: truncated Edith size, wrong-sha, sidecar trust/distrust, quarantine preserves bytes, error classifier.

## Test plan
- [x] `npm run build:ts`
- [x] focused jest: model-cache-383 + doctor disk/models + empty-brain
- [ ] CI green
- [ ] Dual independent code review

## Non-goals
- Does not auto-download on doctor (doctor stays offline-safe).
- Does not change embedding model id / dimensions.