### PR TITLE
feat(cli): mobile-first terminal UX for scan + update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Terminal UX pass (mobile SSH first):** shared `src/cli/term-ui.ts` width/wrap/box/chip/verdict primitives (40-col floor, no new deps). `allowlist scan` review cards are decision-first — no 40-line source wall by default; `[v]iew` pages 12 sanitised lines; `[y]/[n]/[q]` default-deny unchanged. `--yes` batch uses compact identity rows. `shieldcortex update` ends with a closing VERDICT panel (OK / NEEDS ATTENTION / FAILED) from a step ledger; narrow terminals drop spinner redraw junk; `paint()` honours `NO_COLOR` / `TERM=dumb`. Design lock: `docs/design/2026-08-21-terminal-ux.md`.
+
 ### Fixed
 - **#386 — content ≠ intent for package-install on write tools; honest human-auth copy.**
   Forensic writes that *mention* a global install (Friday: log after a real deny)

--- a/docs/design/2026-08-21-terminal-ux.md
+++ b/docs/design/2026-08-21-terminal-ux.md
@@ -1,0 +1,198 @@
+# ShieldCortex Terminal UX — design lock v2
+
+**Status:** LOCKED v3 (SOL APPROVE_WITH_NITS; Opus MF1-4 folded; implement)  
+**Supersedes:** v1 draft in same path  
+**Reference pain:** Michael phone SSH screenshots — `update` status soup + `allowlist scan` 40-line source walls
+
+## North star
+
+Crafted TUI feel on mobile SSH (40-col first), pure Node stdlib + ANSI, **no** Ink/Blessed, **no** security-gate regressions.
+
+## Locked principles
+
+1. **Decision first, evidence on demand** — pin card leads with status/basename/progress; source body off by default.
+2. **Width-aware** — single width brain; floor 40; content clamp 40–240; frame width `min(content, 72)`.
+3. **One glanceable VERDICT** per command close — never mixed into stage spam.
+4. **Shared marks** — `[ok] [!] [x] [i]` for pass/warn/fail/info; chips `NEW|CHANGED|CURRENT|MISSING|TOO_LARGE` separate.
+5. **Mobile SSH first-class** — design at 40; 80+ is luxury, not an excuse to restore dumps.
+6. **No new runtime deps.**
+7. **Security copy stays blunt** — never prettify fail-closed / unproven / incomplete into all-clear.
+8. **No invented fields** — pin card shows only real `ScanItem` (and derived basename / display path). No `risk`, no generated “hint” prose.
+
+## Module: extract + extend `doctor-report` width brain → `src/cli/term-ui.ts`
+
+Not a parallel system. **Extract** width/colour helpers so one brain exists:
+
+- `getWidth(opts?)` → `clamp(injected || COLUMNS || stdout.columns || 80, 40, 240)`  
+  Rendering width never below 40 even if `COLUMNS=1`.
+- `supportsColor()` — `NO_COLOR` / `FORCE_COLOR` / TTY / **`TERM=dumb` → false**. **Per call**, not module-load `isTTY`.
+- `supportsUnicode()` — **independent** of color. False when `TERM=dumb`, `SHIELDCORTEX_ASCII=1`/`SC_ASCII=1`, or locale not UTF-8.
+- `visibleWidth(s)` / strip ANSI for measurement
+- `wrapText(s, width, indent?)` — word-boundary; **same behaviour as doctor `wrapLine`**
+- `truncatePath(p, width)` — basename preserved; `head…tail`; home→`~` when applicable (**display only**)
+- `truncateMiddle(s, width)`
+- `hr(width)`, `box(title, lines, width)` — unicode boxes only if `supportsUnicode`; else ASCII `+--+`
+- `chip(status)`, `section(title)`, `verdict(kind, summary)`
+- injectable `style` / `width` / `unicode` / `color` for tests
+
+**Renderers are pure and return `string[]`.** Callers write line-by-line. No `process.stdout` inside renderers.
+
+`doctor-report.ts` re-exports or imports from `term-ui` (no behaviour change required in v1 beyond shared width if trivial).
+
+### Untrusted field display
+
+- `sanitiseDisplayField(s)` before measure/paint: strip CSI/OSC/C0, `\n`/`\r` → `⏎`, strip bidi/zero-width.  
+- **Not** `sanitiseForReport` on pin paths (no env-value redaction of path segments).
+- Frames enclose **only** ShieldCortex-generated chrome. Paths, sources, job names, preview: frameless + left gutter.
+
+### Path + SHA visibility (Opus security-visibility, mobile-readable)
+
+- Decision line: **basename** bold + status chip + `i/n`.
+- Next lines: **full canonical path**, word-wrapped (not mid-token garbage). Prefer wrap over destructive ellipsis when width is tight; `truncatePath` allowed on secondary summary lists only when full path already shown above or in `--json`.
+- SHA: show ≥16 hex always (full 16 on card); never wrap mid-hex without end ellipsis rule on a dedicated sha line.
+
+## Surface A — `allowlist scan`
+
+### Summary header
+
+```
+allowlist scan
+3 found · 0 current · 3 review
+sources: hermes ok · oc-db ok
+```
+
+- Compact two-line rows max at 40 cols for the list (chip + basename; dim path/notes).
+- Broken/incomplete discovery: **red, exit 1**, never pretty-empty.
+- Source short labels (display only): `hermes-cron→hermes`, `openclaw-cron→oc`, `openclaw-cron-db→oc-db`, `glob→glob`. Full ids remain in `--json`.
+
+### Review card (default)
+
+```
+── 1/3 · NEW · backup.sh
+path  /Users/…/friday/scripts/backup.sh
+      (wrapped full path)
+sha   a3f1c9e2b4d6f801…
+src   oc-db
+[! ]  network calls likely (if networkHint)
+[! ]  denied note (if deniedNote)
+
+[y] pin  [n] skip  [v]iew  [q] quit
+```
+
+**No source body by default.**
+
+### Preview = paging, not a wall
+
+- `[v]` / `view`: show next page of **12** sanitised lines (existing `sanitisePreviewLine` + byte cap 2048).
+- Pages through up to existing `PREVIEW_MAX_LINES` (40). Card states `lines 1–12 of 40`.
+- Preview exhaustion when pages cover `PREVIEW_MAX_LINES` (or `MAX_VIEW_PAGES=8` cap); then `no more source`. Further `v` counts as **skip** (default-deny), never hang.
+- `v` never pins, never advances item index, never increments counters.
+- Second path: collapse not required if paging forward-only; document forward-only paging.
+
+### Prompt parser (default-deny untouched)
+
+- Pin **only** if trimmed lower-case is `y` or `yes`.
+- `n` / other / empty / EOF → **skip** (never pin).
+- `q` / `quit` → quit.
+- `v` / `view` → page preview, re-prompt **same** item.
+- Optional note prompt after `y` unchanged.
+- Gate `isInteractive` / TTY checks stay **before** any card render that could confuse; non-interactive: zero pins, exit 3 when new/changed, refusal copy unchanged.
+
+### `--yes` batch
+
+- **No** N×40 source walls.
+- Compact identity list via dedicated `renderBatchIdentity` (not `renderReviewItem`): status, path, short sha, flags.
+- Still requires typed `approve` on TTY; non-TTY `--yes` → exit 1.
+- First sqlite backfill `--yes` refuse unchanged.
+- Full bodies: per-item review without `--yes`.
+
+### Unchanged contracts
+
+- `--json` shape keys/counts; no TUI chrome; no pin
+- exit `0 | 3 | 1` matrix
+- `pinReviewedScript` + expectedSha256 TOCTOU
+- discovery honesty / schema mismatch
+
+## Surface B — `shieldcortex update` closing panel
+
+### Placement
+
+- Build a **step ledger** during `runUpdate`.
+- Emit **one** panel as the **last write** of `runUpdate` (after protection self-check, engine remediation, project-key heal, allowlist hook/pointer, **and** 411/dashboard notices — fold those into panel `next` or print them before the panel).
+- Mid-flow Action Guard lines still print when they happen.
+- `footer()` may stay earlier; the **panel is the final closer** so phone scroll ends on the verdict.
+- `update.ts` `paint()` must use `supportsColor()` per call (fix NO_COLOR ignore).
+
+### Panel content (facts only)
+
+```
++-- update 4.54.4 -> 4.54.9 --+
+| VERDICT  NEEDS ATTENTION    |
+| package  ok                 |
+| plugin   ok                 |
+| guard    blocked            |
+| selfchk  unproven           |
+| canary   ok                 |
++-----------------------------+
+  detail  guard: Action Guard held a cleanup once
+  next    shieldcortex doctor --ai
+```
+
+**Framed cells = closed vocabulary only:** status tokens (`ok|warn|blocked|unproven|failed|skipped`), short counts, version strings matching `^[\w.+-]{1,32}$`.
+Any free-form child-process/registry reason prints **frameless** under the box (left gutter) after `sanitiseDisplayField`.
+**Runnable commands are never ellipsized** — wrap or print frameless below; never `truncateMiddle` a copy-pastable command.
+
+### VERDICT enum (display) + exit coupling
+
+| Kind | When |
+|---|---|
+| `OK` | no fail, no warn/unproven/blocked residual; **and** exitCode === 0 |
+| `NEEDS ATTENTION` | warn / blocked / unproven / remediation-needed; exit may still be 0 |
+| `INCOMPLETE` | discovery/source cannot-look class (exit 1) |
+| `FAILED` | hard fail / protection verify fail (exit 1) |
+
+**One ledger, one truth:** panel VERDICT and `process.exitCode` derive from the same step ledger.
+`exitCode !== 0` implies panel is **never** `OK`.
+`stepVerifyProtection` returns a structured outcome; **caller** sets `process.exitCode`.
+
+Unproven self-check **cannot** display as `OK`.
+
+### Stage lines at narrow width (in scope v1)
+
+When `width < 60`: no spinner, no `padEnd` to 24, one compact line per step (no `\r` redraw garbage on phone).  
+When `width >= 60`: keep current spinner behaviour if desired.
+
+## Surface C — doctor
+
+Optional adopt shared `getWidth`/`wrapText`. No check-logic change required in v1.
+
+## Non-goals v1
+
+- Full-screen alt buffer, mouse, Ink/Blessed
+- Changing pin/hash/TTY/`--yes`/JSON semantics
+- Invented risk scores on cards
+
+## Tests (must ship)
+
+**Gates:** non-interactive no write exit 3; `--yes` non-TTY exit 1; `--yes` typed approve; first-backfill refuse; TOCTOU pin refuse; `--json` stable; incomplete discovery exit 1.
+
+**Prompt:** `v,v,y` → one pin; `v`×20 → MAX_VIEW_PAGES then no pin; only `y`/`yes` pins; empty/EOF skip.
+
+**TUI:** width 40/80 snapshots ANSI-stripped; every line ≤ render width; default card no source wall; preview sanitises CSI spoof; path with ESC/newline cannot forge frame; `supportsColor` ⊥ `supportsUnicode`; no new deps.
+
+**Update:** verdict matrix unit from fake ledger; panel after allowlist hook; no credentials in panel if step text poisoned; narrow width no spinner.
+
+## Acceptance
+
+1. Phone 40-col: pin decision without scrolling a code wall  
+2. Update finish: verdict panel understandable in <5s  
+3. Desktop 80+ intentional, still no default 40-line dump  
+4. Design APPROVE from ≥2/3 of Grok, SOL, Opus on **this v2**  
+5. Dual code review on implementation PR  
+
+## Implementation order
+
+1. `term-ui.ts` + extract/wire doctor helpers + tests  
+2. `allowlist-scan` summary + cards + prompt `v` paging  
+3. `update` narrow steps + end panel from ledger  
+4. CHANGELOG + PR

--- a/src/cli/__tests__/allowlist-scan-cron-db-375.test.ts
+++ b/src/cli/__tests__/allowlist-scan-cron-db-375.test.ts
@@ -76,6 +76,28 @@ function buildStore(
   }
 }
 
+
+
+
+/** Paths may soft/hard-wrap for 40-col TUI; assert against whitespace-collapsed logs.
+ *  macOS realpath often adds a `/private` prefix — accept both forms. */
+function flatLogs(logs: string[]): string {
+  return logs.join('\n').replace(/\s+/g, '');
+}
+function normPath(path: string): string {
+  const p = path.replace(/\s+/g, '');
+  return p.startsWith('/private/') ? p.slice('/private'.length) : p;
+}
+function expectLogPath(logs: string[], path: string): void {
+  const hay = flatLogs(logs);
+  const needle = path.replace(/\s+/g, '');
+  const ok =
+    hay.includes(needle) ||
+    hay.includes(normPath(needle)) ||
+    hay.includes(`/private${normPath(needle)}`);
+  expect(ok).toBe(true);
+}
+
 describe('allowlist scan: OpenClaw SQLite cron source (#375)', () => {
   const NOW = 1_760_000_000_000;
   let dir: string;
@@ -139,7 +161,7 @@ describe('allowlist scan: OpenClaw SQLite cron source (#375)', () => {
     const code = await runAllowlistScan([], deps());
     expect(code).toBe(3);
     expect(logs.join('\n')).toContain('openclaw-cron-db');
-    expect(logs.join('\n')).toContain(realpathSync(scriptPath));
+    expectLogPath(logs, realpathSync(scriptPath));
     expect(stored).toEqual([]);
   });
 
@@ -201,7 +223,7 @@ describe('allowlist scan: OpenClaw SQLite cron source (#375)', () => {
 
     const code = await runAllowlistScan([], deps());
     expect(code).toBe(1);
-    expect(logs.join('\n')).toContain(dbPath);
+    expectLogPath([...logs, ...errs], dbPath);
     expect(`${logs.join('\n')}\n${errs.join('\n')}`).toMatch(/could not look|not readable|incomplete/i);
   });
 
@@ -231,7 +253,7 @@ describe('allowlist scan: OpenClaw SQLite cron source (#375)', () => {
     expect(code).toBe(1);
     expect(stored).toEqual([]);
     expect(logs.join('\n')).toContain('UNREADABLE');
-    expect(errs.join('\n')).toContain(dbPath);
+    expect(errs.join('\n').replace(/\s+/g, '')).toContain(String(dbPath).replace(/\s+/g, ''));
   });
 
   test('a cron_jobs table missing a column we read exits 1 as schema_mismatch', async () => {
@@ -266,7 +288,7 @@ describe('allowlist scan: OpenClaw SQLite cron source (#375)', () => {
     });
     const code = await runAllowlistScan(['--openclaw-cron-db', elsewhere], deps({ openclawDbPath: undefined }));
     expect(code).toBe(3);
-    expect(logs.join('\n')).toContain(realpathSync(scriptPath));
+    expectLogPath(logs, realpathSync(scriptPath));
   });
 
   // -- Denied-first ordering ------------------------------------
@@ -323,8 +345,8 @@ describe('allowlist scan: OpenClaw SQLite cron source (#375)', () => {
     const code = await runAllowlistScan(['--yes'], deps({ interactive: true, prompt: answers(['approve']) }));
     expect(code).toBe(1);
     expect(stored).toEqual([]);
-    expect(errs.join('\n')).toContain('openclaw-cron-db');
-    expect(errs.join('\n')).toContain('without --yes');
+    expect(errs.join('\n').replace(/\s+/g, '')).toContain(String('openclaw-cron-db').replace(/\s+/g, ''));
+    expect(errs.join('\n').replace(/\s+/g, '')).toContain(String('without --yes').replace(/\s+/g, ''));
   });
 
   test('--yes works again once the SQLite backfill has been reviewed per item', async () => {

--- a/src/cli/__tests__/allowlist-scan-cron-db-375.test.ts
+++ b/src/cli/__tests__/allowlist-scan-cron-db-375.test.ts
@@ -321,7 +321,16 @@ describe('allowlist scan: OpenClaw SQLite cron source (#375)', () => {
     expect(code).toBe(3);
     const out = logs.join('\n');
     expect(out).toContain('guard-denied in the last 7 days (job: inbox sweep)');
-    expect(out.indexOf(realpathSync(scriptPath))).toBeLessThan(out.indexOf(realpathSync(quiet)));
+    // Paths may wrap at 40 cols — compare on whitespace-collapsed text and
+    // tolerate macOS /private realpath prefix.
+    const flat = flatLogs(logs);
+    const denied = normPath(realpathSync(scriptPath));
+    const other = normPath(realpathSync(quiet));
+    const di = Math.max(flat.indexOf(denied), flat.indexOf(`/private${denied}`));
+    const oi = Math.max(flat.indexOf(other), flat.indexOf(`/private${other}`));
+    expect(di).toBeGreaterThanOrEqual(0);
+    expect(oi).toBeGreaterThanOrEqual(0);
+    expect(di).toBeLessThan(oi);
     // The denial surface never reaches the review list.
     expect(out).not.toContain('act-0000000000000001');
   });

--- a/src/cli/__tests__/allowlist-scan.test.ts
+++ b/src/cli/__tests__/allowlist-scan.test.ts
@@ -28,6 +28,28 @@ import { hashScriptSource } from '../../defence/iron-dome/reviewed-scripts.js';
 
 const SOURCE = '#!/usr/bin/env python3\nprint("sentry sweep")\n';
 
+
+
+
+/** Paths may soft/hard-wrap for 40-col TUI; assert against whitespace-collapsed logs.
+ *  macOS realpath often adds a `/private` prefix — accept both forms. */
+function flatLogs(logs: string[]): string {
+  return logs.join('\n').replace(/\s+/g, '');
+}
+function normPath(path: string): string {
+  const p = path.replace(/\s+/g, '');
+  return p.startsWith('/private/') ? p.slice('/private'.length) : p;
+}
+function expectLogPath(logs: string[], path: string): void {
+  const hay = flatLogs(logs);
+  const needle = path.replace(/\s+/g, '');
+  const ok =
+    hay.includes(needle) ||
+    hay.includes(normPath(needle)) ||
+    hay.includes(`/private${normPath(needle)}`);
+  expect(ok).toBe(true);
+}
+
 describe('shieldcortex allowlist scan (#309)', () => {
   let dir: string; // stands in for $HOME — real ~/.hermes and ~/.openclaw are never read
   let scriptPath: string;
@@ -175,7 +197,7 @@ describe('shieldcortex allowlist scan (#309)', () => {
     const code = await runAllowlistScan([], deps({ prompt: answers(['y', '']) }));
     expect(code).toBe(3);
     expect(stored).toEqual([]);
-    expect(logs.join('\n')).toContain(realpathSync(scriptPath));
+    expectLogPath(logs, realpathSync(scriptPath));
     expect(logs.join('\n')).toContain('shieldcortex allowlist scan');
   });
 
@@ -215,7 +237,7 @@ describe('shieldcortex allowlist scan (#309)', () => {
     writeFileSync(join(dir, 'scripts', 'notes.txt'), 'not a script\n');
     const code = await runAllowlistScan(['--glob', join(dir, 'scripts', '*.sh')], deps());
     expect(code).toBe(3);
-    expect(logs.join('\n')).toContain(realpathSync(globbed));
+    expectLogPath(logs, realpathSync(globbed));
     expect(logs.join('\n')).not.toContain('notes.txt');
   });
 
@@ -226,7 +248,7 @@ describe('shieldcortex allowlist scan (#309)', () => {
     writeFileSync(hermes, JSON.stringify({ jobs: [{ prompt: `sh ${scriptPath}` }] }));
     const code = await runAllowlistScan(['--hermes-cron', hermes], deps());
     expect(code).toBe(3);
-    expect(logs.join('\n')).toContain(realpathSync(scriptPath));
+    expectLogPath(logs, realpathSync(scriptPath));
   });
 
   // ── Interactive review: the only path that writes ─────────
@@ -272,7 +294,7 @@ describe('shieldcortex allowlist scan (#309)', () => {
     const result = await reviewScanItems(items, deps({ interactive: false, prompt: answers(['y', '']) }));
     expect(result.pinned).toBe(0);
     expect(stored).toEqual([]);
-    expect(errs.join('\n')).toContain('interactive terminal');
+    expect(errs.join('\n').replace(/\s+/g, '')).toContain(String('interactive terminal').replace(/\s+/g, ''));
   });
 
   test('--yes without a TTY is refused with exit 1 and no writes', async () => {
@@ -280,7 +302,7 @@ describe('shieldcortex allowlist scan (#309)', () => {
     const code = await runAllowlistScan(['--yes'], deps({ interactive: false, prompt: answers(['approve']) }));
     expect(code).toBe(1);
     expect(stored).toEqual([]);
-    expect(errs.join('\n')).toContain('interactive terminal');
+    expect(errs.join('\n').replace(/\s+/g, '')).toContain(String('interactive terminal').replace(/\s+/g, ''));
   });
 
   test('--yes on a TTY demands the typed word "approve"', async () => {

--- a/src/cli/__tests__/allowlist-scan.test.ts
+++ b/src/cli/__tests__/allowlist-scan.test.ts
@@ -250,7 +250,7 @@ describe('shieldcortex allowlist scan (#309)', () => {
     writeHermesCron({ jobs: [{ prompt: `python3 ${scriptPath}` }] });
     const code = await runAllowlistScan([], deps({ interactive: true, prompt: answers(['y', '']) }));
     expect(code).toBe(0);
-    expect(logs.join('\n')).toContain('changed');
+    expect(logs.join('\n').toLowerCase()).toContain('changed');
     expect(stored).toHaveLength(1);
     expect((stored[0] as Record<string, unknown>).sha256).toBe(hashScriptSource(SOURCE));
   });

--- a/src/cli/__tests__/term-ui.test.ts
+++ b/src/cli/__tests__/term-ui.test.ts
@@ -1,0 +1,147 @@
+/**
+ * term-ui primitives + pin card / update panel (design lock v3).
+ */
+import {
+  clampWidth,
+  getWidth,
+  stripAnsi,
+  sanitiseDisplayField,
+  wrapText,
+  truncatePath,
+  renderPinCard,
+  renderBatchIdentity,
+  renderUpdatePanel,
+  deriveUpdateVerdict,
+  supportsColor,
+  supportsUnicode,
+  NO_STYLE,
+} from '../term-ui.js';
+
+describe('term-ui width', () => {
+  it('clamps below 40 up to 40', () => {
+    expect(clampWidth(1)).toBe(40);
+    expect(clampWidth(39)).toBe(40);
+  });
+  it('clamps above 240 down to 240', () => {
+    expect(clampWidth(999)).toBe(240);
+  });
+  it('getWidth respects injected width and floors at 40', () => {
+    expect(getWidth({ width: 20 })).toBe(40);
+    expect(getWidth({ width: 80 })).toBe(80);
+  });
+});
+
+describe('term-ui wrap + path', () => {
+  it('wrapText stays within width', () => {
+    const lines = wrapText('one two three four five six seven eight', 20, 0, 0);
+    for (const l of lines) expect(stripAnsi(l).length).toBeLessThanOrEqual(20);
+  });
+  it('truncatePath keeps basename', () => {
+    const p = '/Users/michael/Library/something/long/friday/scripts/backup.sh';
+    const t = truncatePath(p, 40);
+    expect(t.endsWith('backup.sh') || t.includes('backup.sh')).toBe(true);
+    expect(t.length).toBeLessThanOrEqual(40);
+  });
+});
+
+describe('sanitiseDisplayField', () => {
+  it('strips CSI and newlines', () => {
+    const s = sanitiseDisplayField('pre\u001b[2Jpath\nnext');
+    expect(s).not.toMatch(/\u001b/);
+    expect(s).toContain('⏎');
+  });
+});
+
+describe('supportsColor / unicode independence', () => {
+  it('NO_COLOR disables color', () => {
+    expect(supportsColor({ NO_COLOR: '1' } as NodeJS.ProcessEnv, true)).toBe(false);
+  });
+  it('TERM=dumb disables color', () => {
+    expect(supportsColor({ TERM: 'dumb' } as NodeJS.ProcessEnv, true)).toBe(false);
+  });
+  it('unicode can stay on when color off', () => {
+    expect(supportsUnicode({ LANG: 'en_US.UTF-8' } as NodeJS.ProcessEnv)).toBe(true);
+    expect(supportsUnicode({ TERM: 'dumb', LANG: 'en_US.UTF-8' } as NodeJS.ProcessEnv)).toBe(false);
+  });
+});
+
+describe('renderPinCard', () => {
+  it('default card has no source wall and fits 40 cols', () => {
+    const lines = renderPinCard({
+      index: 1,
+      total: 3,
+      status: 'new',
+      path: '/Users/michael/Library/Application Support/hermes/friday/scripts/backup.sh',
+      sha256: 'a'.repeat(64),
+      sources: ['openclaw-cron-db'],
+      networkHint: true,
+    }, { width: 40, style: NO_STYLE });
+    const text = lines.join('\n');
+    expect(text).toMatch(/backup\.sh/);
+    expect(text).toMatch(/\[y\].*pin/);
+    expect(text).toMatch(/network calls likely/);
+    expect(text).not.toMatch(/first 40 lines/);
+    for (const l of lines) {
+      expect(stripAnsi(l).length).toBeLessThanOrEqual(40);
+    }
+  });
+
+  it('preview page shows bounded source lines', () => {
+    const lines = renderPinCard({
+      index: 1,
+      total: 1,
+      status: 'new',
+      path: '/tmp/x.sh',
+      sha256: 'abcd'.repeat(16),
+      sources: ['hermes-cron'],
+      previewLines: ['#!/bin/bash', 'echo hi'],
+      previewPage: 1,
+      previewTotalLines: 40,
+    }, { width: 40, style: NO_STYLE });
+    const text = lines.join('\n');
+    expect(text).toMatch(/source lines 1–2 of 40/);
+    expect(text).toMatch(/echo hi/);
+  });
+});
+
+describe('renderBatchIdentity', () => {
+  it('is compact', () => {
+    const lines = renderBatchIdentity({
+      status: 'new',
+      path: '/home/edith/scripts/jotform/club_form_payment_upgrade.py',
+      sha256: 'deadbeef'.repeat(8),
+    }, { width: 40, style: NO_STYLE });
+    expect(lines.join('\n')).toMatch(/NEW/);
+    expect(lines.join('\n')).toMatch(/club_form_payment_upgrade\.py/);
+  });
+});
+
+describe('renderUpdatePanel + verdict', () => {
+  it('exitCode !== 0 never yields OK', () => {
+    expect(deriveUpdateVerdict({ exitCode: 1, attention: false })).toBe('FAILED');
+    expect(deriveUpdateVerdict({ exitCode: 0, attention: true })).toBe('NEEDS ATTENTION');
+    expect(deriveUpdateVerdict({ exitCode: 0 })).toBe('OK');
+  });
+
+  it('panel framed cells stay closed-vocab; details frameless', () => {
+    const lines = renderUpdatePanel({
+      fromVersion: '4.54.4',
+      toVersion: '4.54.9',
+      verdict: 'NEEDS ATTENTION',
+      rows: [
+        { label: 'package', status: 'ok' },
+        { label: 'selfchk', status: 'unproven' },
+      ],
+      details: ['selfchk: roster could not be read'],
+      next: ['shieldcortex doctor --ai'],
+    }, { width: 40, style: NO_STYLE, unicode: false });
+    const text = lines.join('\n');
+    expect(text).toMatch(/VERDICT  NEEDS ATTENTION/);
+    expect(text).toMatch(/selfchk\s+unproven/);
+    expect(text).toMatch(/detail/);
+    expect(text).toMatch(/shieldcortex doctor --ai/);
+    for (const l of lines) {
+      expect(stripAnsi(l).length).toBeLessThanOrEqual(40);
+    }
+  });
+});

--- a/src/cli/__tests__/update-install-parity-171.test.ts
+++ b/src/cli/__tests__/update-install-parity-171.test.ts
@@ -63,8 +63,13 @@ describe('#171 — update ends by verifying protection, like repair', () => {
   });
 
   it('an applied-but-failed verify sets a non-zero exit code — no false all-clear', () => {
-    const body = bodyOf('stepVerifyProtection');
-    expect(body).toMatch(/result\.applied && !result\.ok.*exitCode = 1/s);
+    // v3 TUI: step returns failed; runUpdate sets process.exitCode from ledger.
+    const stepBody = bodyOf('stepVerifyProtection');
+    const runBody = bodyOf('runUpdate');
+    expect(stepBody).toMatch(/result\.applied && !result\.ok/);
+    expect(stepBody).toMatch(/status:\s*'failed'/);
+    expect(runBody).toMatch(/process\.exitCode\s*=\s*1/);
+    expect(runBody).toMatch(/protection\.status === 'failed'/);
   });
 
   it('runUpdate invokes it', () => {

--- a/src/cli/allowlist-scan.ts
+++ b/src/cli/allowlist-scan.ts
@@ -28,6 +28,19 @@
 
 import { readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
+import {
+  getWidth,
+  chip,
+  renderPinCard,
+  renderBatchIdentity,
+  shortSourceLabel,
+  sanitiseDisplayField,
+  wrapText,
+  basenameOf,
+  defaultColorStyle,
+  NO_STYLE,
+  supportsColor,
+} from './term-ui.js';
 import { isAbsolute, join, resolve as resolvePath } from 'node:path';
 import { isInteractive } from './approve.js';
 import { pinReviewedScript, MAX_REVIEWABLE_BYTES, type AllowlistDeps } from './allowlist.js';
@@ -475,84 +488,113 @@ export function markCronDenials(items: ScanItem[], report: CronDenialReport | nu
 
 // ── Rendering ───────────────────────────────────────────────
 
-function statusPaint(status: ScanStatus): string {
-  if (status === 'new') return `${YELLOW}new${RESET}`;
-  if (status === 'changed') return `${YELLOW}changed${RESET}`;
-  if (status === 'current') return `${GREEN}current${RESET}`;
-  if (status === 'missing') return `${RED}missing${RESET}`;
-  return `${RED}too_large${RESET}`;
+function statusPaint(status: ScanStatus, style = supportsColor() ? defaultColorStyle() : NO_STYLE): string {
+  return chip(status, style);
 }
 
 function renderSummary(items: ScanItem[], sources?: CronSources): string {
+  const width = getWidth();
+  const style = supportsColor() ? defaultColorStyle() : NO_STYLE;
   const lines: string[] = [];
   if (sources) {
     for (const s of [sources.hermes, sources.openclaw, sources.openclawDb]) {
       if (s.status === 'absent') continue;
       if (s.status === 'ok') {
-        lines.push(`${DIM}source ok: ${s.path}${RESET}`);
+        lines.push(...wrapText(`${style.dim}source ok: ${sanitiseDisplayField(s.path)}${style.reset}`, width));
       } else if (s.status === 'invalid_json') {
-        lines.push(`${RED}source INVALID JSON (did not scan): ${s.path}${RESET}`);
+        lines.push(...wrapText(`${style.red}source INVALID JSON (did not scan): ${sanitiseDisplayField(s.path)}${style.reset}`, width));
       } else if (s.status === 'schema_mismatch') {
-        lines.push(`${RED}source SCHEMA MISMATCH (did not scan): ${s.path}${RESET}`);
+        lines.push(...wrapText(`${style.red}source SCHEMA MISMATCH (did not scan): ${sanitiseDisplayField(s.path)}${style.reset}`, width));
       } else {
-        lines.push(`${RED}source UNREADABLE (did not scan): ${s.path}${RESET}`);
+        lines.push(...wrapText(`${style.red}source UNREADABLE (did not scan): ${sanitiseDisplayField(s.path)}${style.reset}`, width));
       }
     }
     if (sources.openclawCronUnverifiable) {
-      // Both absent while OpenClaw is installed. Absent sources are normally
-      // silent; this pair is the one case where silence would be the bug.
-      lines.push(
-        `${RED}OpenClaw is installed but NO cron source is readable — discovery incomplete, not empty:${RESET}`,
-      );
-      lines.push(`${RED}  absent: ${sources.openclaw.path}${RESET}`);
-      lines.push(`${RED}  absent: ${sources.openclawDb.path}${RESET}`);
+      lines.push(`${style.red}OpenClaw is installed but NO cron source is readable — discovery incomplete, not empty:${style.reset}`);
+      lines.push(...wrapText(`${style.red}  absent: ${sanitiseDisplayField(sources.openclaw.path)}${style.reset}`, width));
+      lines.push(...wrapText(`${style.red}  absent: ${sanitiseDisplayField(sources.openclawDb.path)}${style.reset}`, width));
     }
   }
   if (items.length === 0) {
     lines.push(
-      `${DIM}Reviewed-script scan — no scripts discovered from readable Hermes/OpenClaw cron jobs ` +
-        `(absolute or ~/ paths with script extensions only; relative names are not extracted).${RESET}`,
+      ...wrapText(
+        `${style.dim}Reviewed-script scan — no scripts discovered from readable Hermes/OpenClaw cron jobs ` +
+          `(absolute or ~/ paths with script extensions only; relative names are not extracted).${style.reset}`,
+        width,
+      ),
     );
     return lines.join('\n');
   }
   const count = (s: ScanStatus): number => items.filter((i) => i.status === s).length;
+  const reviewN = count('new') + count('changed');
+  lines.push(`${style.bold}allowlist scan${style.reset}`);
   lines.push(
-    `${BOLD}Reviewed-script scan${RESET} — ${items.length} script(s) discovered: ` +
-      `${count('current')} current · ${count('new')} new · ${count('changed')} changed · ` +
-      `${count('missing')} missing · ${count('too_large')} too large`,
+    ...wrapText(
+      `${items.length} found · ${count('current')} current · ${reviewN} review · ` +
+        `${count('missing')} missing · ${count('too_large')} too large`,
+      width,
+    ),
   );
   lines.push('');
   for (const i of items) {
-    const notes: string[] = [i.sources.join(', ')];
-    if (i.sha256) notes.push(`sha256 ${i.sha256.slice(0, 12)}…`);
-    if (i.status === 'changed' && i.pinnedSha256) notes.push(`pinned ${i.pinnedSha256.slice(0, 12)}…`);
-    if (i.status === 'missing') notes.push('path does not resolve — cannot pin');
-    if (i.status === 'too_large') notes.push('>256KB — never folded, nothing to exempt');
-    if (i.networkHint) notes.push(`${YELLOW}network?${RESET}`);
-    if (i.deniedNote) notes.push(`${YELLOW}${i.deniedNote}${RESET}`);
-    lines.push(`  ${statusPaint(i.status)}  ${BOLD}${i.path}${RESET}`);
-    lines.push(`     ${DIM}${notes.join(' · ')}${RESET}`);
+    lines.push(
+      ...renderBatchIdentity(
+        {
+          status: i.status,
+          path: i.path,
+          sha256: i.sha256,
+          networkHint: i.networkHint,
+          deniedNote: Boolean(i.deniedNote),
+        },
+        { width, style },
+      ),
+    );
+    if (i.deniedNote) {
+      lines.push(...wrapText(`${style.yellow}${sanitiseDisplayField(i.deniedNote)}${style.reset}`, width, 2, 2));
+    }
   }
   return lines.join('\n');
 }
 
-function renderReviewItem(item: ScanItem, index: number, total: number): string {
-  const lines: string[] = [
-    '',
-    `${BOLD}── ${index}/${total} · ${item.status === 'changed' ? 'CHANGED' : 'NEW'} · ${item.path}${RESET}`,
-  ];
-  const meta: string[] = [`sha256 ${(item.sha256 ?? '').slice(0, 16)}…`];
-  if (item.status === 'changed' && item.pinnedSha256) meta.push(`was ${item.pinnedSha256.slice(0, 16)}…`);
-  meta.push(`sources: ${item.sources.join(', ')}`);
-  if (item.networkHint) meta.push(`${YELLOW}network calls likely (advisory sniff)${RESET}`);
-  lines.push(`   ${DIM}${meta.join(' · ')}${RESET}`);
-  if (item.deniedNote) lines.push(`   ${YELLOW}${item.deniedNote}${RESET}`);
-  if (item.preview) {
-    lines.push(`   ${DIM}┄┄ first ${PREVIEW_MAX_LINES} lines ┄┄${RESET}`);
-    for (const l of item.preview.split('\n')) lines.push(`   ${DIM}│${RESET} ${l}`);
-    lines.push(`   ${DIM}┄┄${RESET}`);
+const VIEW_PAGE_LINES = 12;
+
+function previewPages(preview: string | undefined): string[][] {
+  if (!preview) return [];
+  const all = preview.split('\n');
+  const pages: string[][] = [];
+  for (let i = 0; i < all.length; i += VIEW_PAGE_LINES) {
+    pages.push(all.slice(i, i + VIEW_PAGE_LINES));
   }
-  return lines.join('\n');
+  return pages;
+}
+
+function renderReviewItem(
+  item: ScanItem,
+  index: number,
+  total: number,
+  previewPage = 0,
+): string {
+  const width = getWidth();
+  const style = supportsColor() ? defaultColorStyle() : NO_STYLE;
+  const pages = previewPages(item.preview);
+  const pageLines = previewPage > 0 && previewPage <= pages.length ? pages[previewPage - 1] : undefined;
+  return renderPinCard(
+    {
+      index,
+      total,
+      status: item.status === 'changed' ? 'changed' : 'new',
+      path: item.path,
+      sha256: item.sha256,
+      pinnedSha256: item.pinnedSha256,
+      sources: item.sources,
+      networkHint: item.networkHint,
+      deniedNote: item.deniedNote,
+      previewLines: pageLines,
+      previewPage: pageLines ? previewPage : undefined,
+      previewTotalLines: item.preview ? item.preview.split('\n').length : undefined,
+    },
+    { width, style },
+  ).join('\n');
 }
 
 // ── Interactive review ──────────────────────────────────────
@@ -595,31 +637,54 @@ export async function reviewScanItems(items: ScanItem[], deps: ScanDeps = {}): P
   }
 
   const ask = deps.prompt ?? ttyPrompt;
+  const style = supportsColor() ? defaultColorStyle() : NO_STYLE;
   for (let i = 0; i < reviewable.length; i++) {
     const item = reviewable[i];
-    log(renderReviewItem(item, i + 1, reviewable.length));
-    const answer = (await ask(`  [y] pin / [n] skip / [q] quit > `)).trim().toLowerCase();
-    if (answer === 'q' || answer === 'quit') {
-      result.quit = true;
-      log(`${DIM}Stopped — ${result.pinned} pinned this run stay pinned; the rest fold as usual.${RESET}`);
+    let previewPage = 0;
+    const pages = previewPages(item.preview);
+    // re-prompt loop for same item (view paging)
+    for (;;) {
+      log(renderReviewItem(item, i + 1, reviewable.length, previewPage));
+      const answer = (await ask(`> `)).trim().toLowerCase();
+      if (answer === 'q' || answer === 'quit') {
+        result.quit = true;
+        log(`${style.dim}Stopped — ${result.pinned} pinned this run stay pinned; the rest fold as usual.${style.reset}`);
+        return result;
+      }
+      if (answer === 'v' || answer === 'view') {
+        if (pages.length === 0) {
+          log(`${style.dim}no source preview available${style.reset}`);
+          continue;
+        }
+        if (previewPage >= pages.length) {
+          // exhausted — further v is skip (default-deny, no hang)
+          result.skipped += 1;
+          log(`${style.dim}no more source — skipped${style.reset}`);
+          break;
+        }
+        previewPage += 1;
+        continue;
+      }
+      if (answer === 'y' || answer === 'yes') {
+        const note = (await ask('note (optional, why trusted): ')).trim() || undefined;
+        const pin = pinReviewedScript(item.path, note, {
+          ...deps,
+          ...(item.sha256 ? { expectedSha256: item.sha256 } : {}),
+        });
+        if (pin.ok) {
+          result.pinned += 1;
+          log(`  ${style.green}✓${style.reset} pinned ${style.bold}${basenameOf(pin.entry.path)}${style.reset} · edit re-gates`);
+        } else {
+          result.failed += 1;
+          err(`  ✗ ${pin.error}`);
+        }
+        break;
+      }
+      // empty / n / other / EOF-as-empty → skip
+      result.skipped += 1;
       break;
     }
-    if (answer !== 'y' && answer !== 'yes') {
-      result.skipped += 1;
-      continue;
-    }
-    const note = (await ask('  note (optional, why is this trusted): ')).trim() || undefined;
-    const pin = pinReviewedScript(item.path, note, {
-      ...deps,
-      ...(item.sha256 ? { expectedSha256: item.sha256 } : {}),
-    });
-    if (pin.ok) {
-      result.pinned += 1;
-      log(`  ${GREEN}✓${RESET} Pinned ${BOLD}${pin.entry.path}${RESET} — any edit re-gates it.`);
-    } else {
-      result.failed += 1;
-      err(`  ✗ ${pin.error}`);
-    }
+    if (result.quit) break;
   }
   return result;
 }
@@ -790,9 +855,17 @@ export async function runAllowlistScan(argv: string[], deps: ScanDeps = {}): Pro
       return 1;
     }
 
-    // Show the same previews the per-item loop would before batch approve.
-    for (let i = 0; i < needsReview.length; i++) {
-      log(renderReviewItem(needsReview[i], i + 1, needsReview.length));
+    // Compact identity only — no N×40 source walls on --yes batch.
+    const batchStyle = supportsColor() ? defaultColorStyle() : NO_STYLE;
+    const batchWidth = getWidth();
+    for (const item of needsReview) {
+      log(renderBatchIdentity({
+        status: item.status,
+        path: item.path,
+        sha256: item.sha256,
+        networkHint: item.networkHint,
+        deniedNote: Boolean(item.deniedNote),
+      }, { width: batchWidth, style: batchStyle }).join('\n'));
     }
     const ask = deps.prompt ?? ttyPrompt;
     const answer = (

--- a/src/cli/allowlist-scan.ts
+++ b/src/cli/allowlist-scan.ts
@@ -545,6 +545,7 @@ function renderSummary(items: ScanItem[], sources?: CronSources): string {
           sha256: i.sha256,
           networkHint: i.networkHint,
           deniedNote: Boolean(i.deniedNote),
+          sources: i.sources,
         },
         { width, style },
       ),
@@ -865,6 +866,7 @@ export async function runAllowlistScan(argv: string[], deps: ScanDeps = {}): Pro
         sha256: item.sha256,
         networkHint: item.networkHint,
         deniedNote: Boolean(item.deniedNote),
+        sources: item.sources,
       }, { width: batchWidth, style: batchStyle }).join('\n'));
     }
     const ask = deps.prompt ?? ttyPrompt;

--- a/src/cli/term-ui.ts
+++ b/src/cli/term-ui.ts
@@ -361,8 +361,12 @@ export function renderBatchIdentity(item: {
   const sha = item.sha256 ? item.sha256.slice(0, 12) + '…' : '';
   const srcFull = (item.sources ?? []).map(sanitiseDisplayField).join(',');
   const line1 = `${chip(item.status, style)}  ${style.bold}${base}${style.reset}`;
-  const line2 = [truncatePath(path, Math.max(12, width - 2)), sha, srcFull, ...flags].filter(Boolean).join(' · ');
-  return [line1, ...wrapText(`${style.dim}${line2}${style.reset}`, width, 2, 2)];
+  // Full path wrapped (macOS tests + operators need the canonical path visible;
+  // never rely on truncatePath alone in the scan summary).
+  const out = [line1, ...wrapText(path, width, 2, 2)];
+  const meta = [sha, srcFull, ...flags].filter(Boolean).join(' · ');
+  if (meta) out.push(...wrapText(`${style.dim}${meta}${style.reset}`, width, 2, 2));
+  return out;
 }
 
 /** Closed-vocab status tokens allowed inside update panel frames. */

--- a/src/cli/term-ui.ts
+++ b/src/cli/term-ui.ts
@@ -1,0 +1,445 @@
+/**
+ * Shared terminal UX primitives for ShieldCortex CLI.
+ *
+ * Design lock: docs/design/2026-08-21-terminal-ux.md (v3).
+ * Pure helpers + pure renderers (string[]). No process.stdout inside renderers.
+ * Mobile SSH (40-col) is first-class. No Ink/Blessed/new runtime deps.
+ */
+
+export type TermStyle = {
+  bold: string;
+  reset: string;
+  green: string;
+  yellow: string;
+  red: string;
+  cyan: string;
+  dim: string;
+};
+
+export const NO_STYLE: TermStyle = {
+  bold: '',
+  reset: '',
+  green: '',
+  yellow: '',
+  red: '',
+  cyan: '',
+  dim: '',
+};
+
+export function defaultColorStyle(): TermStyle {
+  return {
+    bold: '\x1b[1m',
+    reset: '\x1b[0m',
+    green: '\x1b[32m',
+    yellow: '\x1b[33m',
+    red: '\x1b[31m',
+    cyan: '\x1b[36m',
+    dim: '\x1b[2m',
+  };
+}
+
+export interface WidthOpts {
+  width?: number;
+  env?: NodeJS.ProcessEnv;
+  columns?: number;
+}
+
+/** Clamp display width: floor 40, cap 240. */
+export function clampWidth(w: number): number {
+  if (!Number.isFinite(w) || w < 40) return 40;
+  if (w > 240) return 240;
+  return Math.floor(w);
+}
+
+export function getWidth(opts: WidthOpts = {}): number {
+  if (typeof opts.width === 'number') return clampWidth(opts.width);
+  const env = opts.env ?? process.env;
+  const fromEnv = Number(env.COLUMNS || '');
+  if (Number.isFinite(fromEnv) && fromEnv > 0) return clampWidth(fromEnv);
+  if (typeof opts.columns === 'number') return clampWidth(opts.columns);
+  const cols = Number(process.stdout?.columns || 80);
+  return clampWidth(cols || 80);
+}
+
+/** Frame width for boxes — never wider than 72. */
+export function frameWidth(contentWidth: number): number {
+  return Math.min(clampWidth(contentWidth), 72);
+}
+
+export function supportsColor(
+  env: NodeJS.ProcessEnv = process.env,
+  stdoutIsTTY = !!process.stdout?.isTTY,
+): boolean {
+  if (env.NO_COLOR != null && env.NO_COLOR !== '') return false;
+  if (env.FORCE_COLOR === '0') return false;
+  if (String(env.TERM || '').toLowerCase() === 'dumb') return false;
+  if (env.FORCE_COLOR) return true;
+  return stdoutIsTTY;
+}
+
+export function supportsUnicode(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (String(env.TERM || '').toLowerCase() === 'dumb') return false;
+  if (env.SHIELDCORTEX_ASCII === '1' || env.SC_ASCII === '1') return false;
+  const loc = `${env.LC_ALL || ''}${env.LC_CTYPE || ''}${env.LANG || ''}`;
+  if (loc && !/utf-?8/i.test(loc)) return false;
+  return true;
+}
+
+const ANSI_RE = /\u001b\[[0-9;?]*[ -/]*[@-~]|\u001b\][^\u0007]*(?:\u0007|\u001b\\)?|\u001b./g;
+
+export function stripAnsi(s: string): string {
+  return String(s ?? '').replace(ANSI_RE, '');
+}
+
+export function visibleWidth(s: string): number {
+  return stripAnsi(s).length;
+}
+
+/** Display safety for untrusted fields (paths, job names, sources). Not secret redaction. */
+export function sanitiseDisplayField(s: string): string {
+  return String(s ?? '')
+    .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '')
+    .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)?/g, '')
+    .replace(/\u001b./g, '')
+    .replace(/[\r\n]/g, '⏎')
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '')
+    .replace(/[\u200b-\u200f\u202a-\u202e\u2060-\u2064\ufeff]/g, '');
+}
+
+export function ellipsize(s: string, max: number): string {
+  const t = String(s ?? '');
+  if (t.length <= max) return t;
+  if (max <= 1) return '…';
+  return `${t.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+/** Soft-wrap at spaces; hanging indent on continuation. Same contract as doctor wrapLine. */
+export function wrapText(text: string, width: number, indent = 0, hang = 0): string[] {
+  // Per-line budget: first line uses indent, continuations use hang — so
+  // hang+token never exceeds width (phone SSH regression).
+  const words = String(text ?? '').split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [' '.repeat(Math.min(indent, Math.max(0, width)))];
+  const lines: string[] = [];
+  let cur = '';
+  let lineIndex = 0;
+  const pad = () => (lineIndex === 0 ? indent : hang);
+  const budget = () => Math.max(1, width - pad());
+  const push = () => {
+    if (!cur) return;
+    lines.push(`${' '.repeat(pad())}${cur}`);
+    cur = '';
+    lineIndex += 1;
+  };
+  for (const w of words) {
+    if (!cur) {
+      let rest = w;
+      while (rest.length > budget()) {
+        const b = budget();
+        lines.push(`${' '.repeat(pad())}${rest.slice(0, b)}`);
+        rest = rest.slice(b);
+        lineIndex += 1;
+      }
+      cur = rest;
+      continue;
+    }
+    if (`${cur} ${w}`.length <= budget()) {
+      cur = `${cur} ${w}`;
+    } else {
+      push();
+      let rest = w;
+      while (rest.length > budget()) {
+        const b = budget();
+        lines.push(`${' '.repeat(pad())}${rest.slice(0, b)}`);
+        rest = rest.slice(b);
+        lineIndex += 1;
+      }
+      cur = rest;
+    }
+  }
+  push();
+  return lines.length ? lines : [' '.repeat(Math.min(indent, Math.max(0, width)))];
+}
+
+export function wrapLine(text: string, width: number, indent = 0, hang = 0): string[] {
+  return wrapText(text, width, indent, hang);
+}
+
+export function basenameOf(p: string): string {
+  const s = String(p ?? '').replace(/\\/g, '/');
+  const i = s.lastIndexOf('/');
+  return i >= 0 ? s.slice(i + 1) || s : s;
+}
+
+export function homeToTilde(p: string, home?: string): string {
+  const h = home ?? (typeof process.env.HOME === 'string' ? process.env.HOME : '');
+  if (h && (p === h || p.startsWith(h + '/') || p.startsWith(h + '\\'))) {
+    return `~${p.slice(h.length).replace(/\\/g, '/')}`;
+  }
+  return p.replace(/\\/g, '/');
+}
+
+/** Secondary-list path truncate: keep basename, head…tail. */
+export function truncatePath(p: string, width: number, home?: string): string {
+  const raw = homeToTilde(sanitiseDisplayField(p), home);
+  if (raw.length <= width) return raw;
+  const base = basenameOf(raw);
+  if (width <= 4) return ellipsize(base, width);
+  if (base.length + 2 >= width) return ellipsize(base, width);
+  const room = width - base.length - 1; // for …
+  const headLen = Math.max(1, Math.ceil(room * 0.45));
+  const tailFromBase = base.length;
+  // path without basename
+  const prefix = raw.slice(0, Math.max(0, raw.length - base.length));
+  const head = prefix.slice(0, headLen);
+  return `${head}…/${base}`.length <= width
+    ? `${head}…/${base}`
+    : ellipsize(`${head}…${base}`, width);
+}
+
+export function truncateMiddle(s: string, width: number): string {
+  const t = String(s ?? '');
+  if (t.length <= width) return t;
+  if (width <= 1) return '…';
+  if (width === 2) return `${t[0]}…`;
+  const keep = width - 1;
+  const head = Math.ceil(keep / 2);
+  const tail = Math.floor(keep / 2);
+  return `${t.slice(0, head)}…${t.slice(t.length - tail)}`;
+}
+
+export function hr(width: number, ch = '─', unicode = true): string {
+  const c = unicode ? ch : '-';
+  return c.repeat(Math.max(8, Math.min(width, 72)));
+}
+
+export function box(title: string, bodyLines: string[], width: number, unicode = true): string[] {
+  const w = frameWidth(width);
+  const inner = Math.max(8, w - 2);
+  const t = ellipsize(sanitiseDisplayField(title), Math.max(4, inner - 4));
+  const top = unicode ? `┌─ ${t} ${'─'.repeat(Math.max(0, inner - 3 - t.length))}┐` : `+- ${t} ${'-'.repeat(Math.max(0, inner - 3 - t.length))}+`;
+  const bot = unicode ? `└${'─'.repeat(inner)}┘` : `+${'-'.repeat(inner)}+`;
+  const sideL = unicode ? '│' : '|';
+  const sideR = unicode ? '│' : '|';
+  const lines = [top];
+  for (const raw of bodyLines) {
+    const plain = stripAnsi(raw);
+    const pad = Math.max(0, inner - plain.length);
+    // if overflow, hard clip plain measurement — callers should wrap first
+    const cell = plain.length > inner ? `${plain.slice(0, inner - 1)}…` : raw + ' '.repeat(pad);
+    if (plain.length > inner) {
+      lines.push(`${sideL}${ellipsize(plain, inner)}${sideR}`);
+    } else {
+      lines.push(`${sideL}${raw}${' '.repeat(pad)}${sideR}`);
+    }
+  }
+  lines.push(bot);
+  return lines;
+}
+
+export type ChipStatus = 'new' | 'changed' | 'current' | 'missing' | 'too_large';
+
+export function chip(status: ChipStatus, style: TermStyle = NO_STYLE): string {
+  const label =
+    status === 'new' ? 'NEW' :
+    status === 'changed' ? 'CHANGED' :
+    status === 'current' ? 'CURRENT' :
+    status === 'missing' ? 'MISSING' :
+    'TOO_LARGE';
+  const color =
+    status === 'current' ? style.green :
+    status === 'new' || status === 'changed' ? style.yellow :
+    style.red;
+  return `${color}${label}${style.reset}`;
+}
+
+export type VerdictKind = 'OK' | 'NEEDS ATTENTION' | 'INCOMPLETE' | 'FAILED';
+
+export function verdictLine(kind: VerdictKind, style: TermStyle = NO_STYLE): string {
+  if (kind === 'OK') return `${style.green}${style.bold}VERDICT  OK${style.reset}`;
+  if (kind === 'NEEDS ATTENTION') return `${style.yellow}${style.bold}VERDICT  NEEDS ATTENTION${style.reset}`;
+  if (kind === 'INCOMPLETE') return `${style.red}${style.bold}VERDICT  INCOMPLETE${style.reset}`;
+  return `${style.red}${style.bold}VERDICT  FAILED${style.reset}`;
+}
+
+export function shortSourceLabel(source: string): string {
+  const s = String(source || '');
+  if (s === 'hermes-cron') return 'hermes';
+  if (s === 'openclaw-cron') return 'oc';
+  if (s === 'openclaw-cron-db') return 'oc-db';
+  if (s === 'glob') return 'glob';
+  return s;
+}
+
+export interface PinCardInput {
+  index: number;
+  total: number;
+  status: 'new' | 'changed';
+  path: string;
+  sha256?: string;
+  pinnedSha256?: string;
+  sources: string[];
+  networkHint?: boolean;
+  deniedNote?: string;
+  /** When set, show this preview page (already sanitised lines). */
+  previewLines?: string[];
+  previewPage?: number;
+  previewTotalLines?: number;
+}
+
+export function renderPinCard(item: PinCardInput, opts: {
+  width?: number;
+  style?: TermStyle;
+  unicode?: boolean;
+} = {}): string[] {
+  const width = getWidth({ width: opts.width });
+  const style = opts.style ?? NO_STYLE;
+  const path = sanitiseDisplayField(item.path);
+  const base = basenameOf(path);
+  const lines: string[] = [];
+  const head = `── ${item.index}/${item.total} · ${item.status === 'changed' ? 'CHANGED' : 'NEW'} · ${base}`;
+  for (const l of wrapText(head, width, 0, 2)) {
+    lines.push(`${style.bold}${l}${style.reset}`);
+  }
+  // Full path, wrapped
+  for (const l of wrapText(path, width, 0, 2)) lines.push(l);
+  const sha = (item.sha256 ?? '').slice(0, 16);
+  if (sha) {
+    const shaLine = item.status === 'changed' && item.pinnedSha256
+      ? `sha   ${sha}…  was ${(item.pinnedSha256).slice(0, 16)}…`
+      : `sha   ${sha}…`;
+    lines.push(...wrapText(shaLine, width, 0, 6));
+  }
+  if (item.sources?.length) {
+    const src = `src   ${item.sources.map(shortSourceLabel).map(sanitiseDisplayField).join(' · ')}`;
+    lines.push(...wrapText(src, width, 0, 6));
+  }
+  if (item.networkHint) {
+    lines.push(...wrapText(`${style.yellow}[!]${style.reset} network calls likely (advisory)`, width, 0, 4));
+  }
+  if (item.deniedNote) {
+    lines.push(...wrapText(`${style.yellow}[!]${style.reset} ${sanitiseDisplayField(item.deniedNote)}`, width, 0, 4));
+  }
+  if (item.previewLines && item.previewLines.length > 0) {
+    const total = item.previewTotalLines ?? item.previewLines.length;
+    const page = item.previewPage ?? 1;
+    const start = (page - 1) * item.previewLines.length + 1;
+    const end = Math.min(total, start + item.previewLines.length - 1);
+    lines.push(`${style.dim}source lines ${start}–${end} of ${total}${style.reset}`);
+    for (const pl of item.previewLines) {
+      const safe = sanitiseDisplayField(pl);
+      for (const wl of wrapText(`${style.dim}│${style.reset} ${safe}`, width, 0, 2)) lines.push(wl);
+    }
+  }
+  lines.push('');
+  for (const l of wrapText('[y] pin  [n] skip  [v]iew  [q]uit', width, 0, 0)) {
+    lines.push(l.replace('[y]', `${style.bold}[y]${style.reset}`)
+      .replace('[n]', `${style.bold}[n]${style.reset}`)
+      .replace('[v]', `${style.bold}[v]${style.reset}`)
+      .replace('[q]', `${style.bold}[q]${style.reset}`));
+  }
+  return lines;
+}
+
+export function renderBatchIdentity(item: {
+  status: ChipStatus;
+  path: string;
+  sha256?: string;
+  networkHint?: boolean;
+  deniedNote?: boolean;
+}, opts: { width?: number; style?: TermStyle } = {}): string[] {
+  const width = getWidth({ width: opts.width });
+  const style = opts.style ?? NO_STYLE;
+  const path = sanitiseDisplayField(item.path);
+  const base = basenameOf(path);
+  const flags: string[] = [];
+  if (item.networkHint) flags.push('net');
+  if (item.deniedNote) flags.push('denied');
+  const sha = item.sha256 ? item.sha256.slice(0, 12) + '…' : '';
+  const line1 = `${chip(item.status, style)}  ${style.bold}${base}${style.reset}`;
+  const line2 = [truncatePath(path, Math.max(12, width - 2)), sha, ...flags].filter(Boolean).join(' · ');
+  return [line1, ...wrapText(`${style.dim}${line2}${style.reset}`, width, 2, 2)];
+}
+
+/** Closed-vocab status tokens allowed inside update panel frames. */
+const PANEL_STATUS = new Set(['ok', 'warn', 'blocked', 'unproven', 'failed', 'skipped', 'attention']);
+
+export interface UpdatePanelRow {
+  /** Short label, SC-generated */
+  label: string;
+  /** Closed vocabulary status */
+  status: string;
+}
+
+export interface UpdatePanelInput {
+  fromVersion?: string;
+  toVersion?: string;
+  verdict: VerdictKind;
+  rows: UpdatePanelRow[];
+  /** Frameless detail lines (already should be sanitised by caller). */
+  details?: string[];
+  /** Frameless next-step commands — never truncated mid-command. */
+  next?: string[];
+}
+
+function safeVersion(v: string | undefined): string {
+  const s = String(v ?? '').trim();
+  if (/^[\w.+-]{1,32}$/.test(s)) return s;
+  return '';
+}
+
+export function renderUpdatePanel(input: UpdatePanelInput, opts: {
+  width?: number;
+  style?: TermStyle;
+  unicode?: boolean;
+} = {}): string[] {
+  const width = getWidth({ width: opts.width });
+  const style = opts.style ?? NO_STYLE;
+  const unicode = opts.unicode !== false;
+  const from = safeVersion(input.fromVersion);
+  const to = safeVersion(input.toVersion);
+  const title = from && to ? `update ${from} -> ${to}` : from ? `update ${from}` : 'update';
+  const body: string[] = [];
+  // verdict row without relying on ANSI inside box measurement much
+  body.push(stripAnsi(verdictLine(input.verdict, NO_STYLE)));
+  for (const r of input.rows) {
+    const lab = sanitiseDisplayField(r.label).slice(0, 12).padEnd(10);
+    const st = PANEL_STATUS.has(r.status) ? r.status : 'attention';
+    body.push(`${lab}${st}`);
+  }
+  const fw = frameWidth(width);
+  const out = box(title, body.map((l) => ellipsize(l, fw - 2)), width, unicode);
+  // colorize verdict line inside box roughly by rebuilding first body — keep simple: paint after
+  const painted: string[] = [];
+  for (const line of out) {
+    if (line.includes('VERDICT')) {
+      painted.push(line.replace('VERDICT  OK', `${style.green}VERDICT  OK${style.reset}`)
+        .replace('VERDICT  NEEDS ATTENTION', `${style.yellow}VERDICT  NEEDS ATTENTION${style.reset}`)
+        .replace('VERDICT  INCOMPLETE', `${style.red}VERDICT  INCOMPLETE${style.reset}`)
+        .replace('VERDICT  FAILED', `${style.red}VERDICT  FAILED${style.reset}`));
+    } else {
+      painted.push(line);
+    }
+  }
+  for (const d of input.details ?? []) {
+    for (const wl of wrapText(`detail  ${sanitiseDisplayField(d)}`, width, 0, 8)) painted.push(`${style.dim}${wl}${style.reset}`);
+  }
+  for (const n of input.next ?? []) {
+    // never ellipsize commands — wrap only
+    for (const wl of wrapText(`next    ${sanitiseDisplayField(n)}`, width, 0, 8)) painted.push(wl);
+  }
+  return painted;
+}
+
+export function deriveUpdateVerdict(args: {
+  exitCode: number;
+  failed?: boolean;
+  incomplete?: boolean;
+  attention?: boolean;
+}): VerdictKind {
+  if (args.exitCode !== 0 && args.incomplete) return 'INCOMPLETE';
+  if (args.exitCode !== 0 || args.failed) return 'FAILED';
+  if (args.attention) return 'NEEDS ATTENTION';
+  return 'OK';
+}

--- a/src/cli/term-ui.ts
+++ b/src/cli/term-ui.ts
@@ -348,6 +348,8 @@ export function renderBatchIdentity(item: {
   sha256?: string;
   networkHint?: boolean;
   deniedNote?: boolean;
+  /** Full source ids (kept for --json parity / tests); short labels also shown. */
+  sources?: string[];
 }, opts: { width?: number; style?: TermStyle } = {}): string[] {
   const width = getWidth({ width: opts.width });
   const style = opts.style ?? NO_STYLE;
@@ -357,8 +359,9 @@ export function renderBatchIdentity(item: {
   if (item.networkHint) flags.push('net');
   if (item.deniedNote) flags.push('denied');
   const sha = item.sha256 ? item.sha256.slice(0, 12) + '…' : '';
+  const srcFull = (item.sources ?? []).map(sanitiseDisplayField).join(',');
   const line1 = `${chip(item.status, style)}  ${style.bold}${base}${style.reset}`;
-  const line2 = [truncatePath(path, Math.max(12, width - 2)), sha, ...flags].filter(Boolean).join(' · ');
+  const line2 = [truncatePath(path, Math.max(12, width - 2)), sha, srcFull, ...flags].filter(Boolean).join(' · ');
   return [line1, ...wrapText(`${style.dim}${line2}${style.reset}`, width, 2, 2)];
 }
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -19,6 +19,18 @@ import { fileURLToPath } from 'url';
 import { resolveRealtimePluginInstallPath, readInstalledRealtimePluginVersion } from '../integrations/openclaw-plugin-state.js';
 import { describeRunFailure, sanitiseForReport } from '../integrations/child-output.js';
 import type { CapturedError } from '../integrations/child-output.js';
+import {
+  getWidth,
+  supportsColor,
+  supportsUnicode,
+  renderUpdatePanel,
+  deriveUpdateVerdict,
+  defaultColorStyle,
+  NO_STYLE,
+  type VerdictKind,
+  type UpdatePanelRow,
+  sanitiseDisplayField,
+} from './term-ui.js';
 
 // ── ANSI ────────────────────────────────────────────────────
 
@@ -37,7 +49,8 @@ const ANSI = {
 const isTTY = Boolean(process.stdout.isTTY);
 
 function paint(color: keyof typeof ANSI, s: string): string {
-  return isTTY ? `${ANSI[color]}${s}${ANSI.reset}` : s;
+  // Color follows NO_COLOR / TERM=dumb / FORCE_COLOR — not bare isTTY alone.
+  return supportsColor() ? `${ANSI[color]}${s}${ANSI.reset}` : s;
 }
 
 // ── Progress runner ─────────────────────────────────────────
@@ -46,7 +59,7 @@ const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', 
 const LABEL_WIDTH = 24;
 
 interface StepResult {
-  status: 'ok' | 'warn' | 'skip';
+  status: 'ok' | 'warn' | 'skip' | 'failed' | 'blocked' | 'unproven';
   summary?: string;
   /**
    * What the failing child process actually said (#221). `summary` is padded
@@ -68,15 +81,17 @@ export async function step(
   let frame = 0;
   let timer: NodeJS.Timeout | null = null;
 
-  if (isTTY) {
+  const width = getWidth();
+  const narrow = width < 60;
+  if (isTTY && !narrow) {
     process.stdout.write(`  ${paint('cyan', SPINNER_FRAMES[0])}  ${padded}`);
     timer = setInterval(() => {
       frame = (frame + 1) % SPINNER_FRAMES.length;
       process.stdout.write(`\r  ${paint('cyan', SPINNER_FRAMES[frame])}  ${padded}`);
     }, 80);
     timer.unref();
-  } else {
-    process.stdout.write(`  ◦  ${label}…\n`);
+  } else if (!isTTY) {
+    process.stdout.write(`  ·  ${label}…\n`);
   }
 
   try {
@@ -94,11 +109,12 @@ export async function step(
     const summary = result.summary
       ? paint('gray', result.summary).padEnd(LABEL_WIDTH + 9)
       : ''.padEnd(LABEL_WIDTH);
-    if (isTTY) {
+    if (isTTY && !narrow) {
       process.stdout.write(`\r  ${icon}  ${padded}  ${summary}  ${paint('gray', elapsed)}\n`);
     } else {
+      const mark = result.status === 'ok' ? '✓' : result.status === 'warn' ? '!' : '·';
       process.stdout.write(
-        `  ${result.status === 'ok' ? '✓' : result.status === 'warn' ? '⚠' : '·'}  ${label}: ${result.summary ?? 'done'} (${elapsed})\n`,
+        `  ${mark}  ${label}: ${result.summary ?? 'done'} (${elapsed})\n`,
       );
     }
     // #221: print what the child actually said, indented under its step. This
@@ -687,36 +703,36 @@ async function stepStatePermissions(): Promise<StepResult> {
  * disk, so importing here loads the FRESHLY INSTALLED reconcile/self-check —
  * the new version verifies itself with its own logic, not last release's.
  */
-export async function stepVerifyProtection(home: string): Promise<void> {
-  // #248: `isRealtimePluginRegistered` collapses "genuinely not installed"
-  // and "installs.json exists but could not be confirmed" into the same
-  // `false`, which made an unreadable registry return here silently — the
-  // protection self-check never ran, and the run still ended green with no
-  // hint it had been skipped. Read the split result so "unreadable" gets
-  // its own branch instead of falling through the same gate as "absent".
+export async function stepVerifyProtection(home: string): Promise<StepResult> {
+  // #248: split unreadable vs absent. Caller owns process.exitCode from ledger.
   const registration = readRealtimePluginRegistration(home);
   if (registration.unreadable) {
     process.stdout.write('\n');
+    const detail = registration.detail ?? 'could not confirm install state';
     process.stdout.write(
-      `  ${paint('yellow', '!')}  ${paint('gray', `protection check skipped — plugin registry unreadable: ${registration.detail ?? 'could not confirm install state'}`)}\n`,
+      `  ${paint('yellow', '!')}  ${paint('gray', `protection check skipped — plugin registry unreadable: ${detail}`)}\n`,
     );
-    return;
+    return { status: 'unproven', summary: 'registry unreadable', detail: [detail] };
   }
-  if (!registration.registered) return;
+  if (!registration.registered) return { status: 'skip', summary: 'plugin not registered' };
   process.stdout.write('\n');
   try {
     const { reconcileOpenClawPluginState, formatReconcileReport } = await import('../setup/openclaw-reconcile.js');
-    // Expected version read fresh from disk — after the npm step this is the
-    // NEW build, and pinning expectations to the in-process (old) version
-    // would certify the very staleness this step exists to end.
     const result = await reconcileOpenClawPluginState({ home, expectedVersion: readPackageVersion() });
     for (const line of formatReconcileReport(result)) {
       process.stdout.write(`  ${line}\n`);
     }
-    if (result.applied && !result.ok) process.exitCode = 1;
+    if (result.applied && !result.ok) {
+      return { status: 'failed', summary: 'reconcile not ok' };
+    }
+    if (!result.ok) {
+      return { status: 'unproven', summary: 'protection unproven' };
+    }
+    return { status: 'ok', summary: 'protected' };
   } catch (err) {
     const msg = sanitiseForReport(err instanceof Error ? err.message : String(err), { home });
     process.stdout.write(`  ${paint('gray', `protection check skipped — ${msg}`)}\n`);
+    return { status: 'unproven', summary: 'protection check skipped', detail: [msg] };
   }
 }
 
@@ -755,9 +771,7 @@ export async function runUpdate(): Promise<void> {
 
   footer(Date.now() - flowStart, mainUpdated, latest);
 
-  // The verdict comes AFTER the footer so the last thing on screen is the one
-  // line that answers "am I protected?" — not a spinner summary.
-  await stepVerifyProtection(home);
+  const protection = await stepVerifyProtection(home);
 
   // If the binding couldn't be auto-healed, print the exact copy-paste fix.
   if (engineResult.remediation) {
@@ -768,9 +782,7 @@ export async function runUpdate(): Promise<void> {
     process.stdout.write('\n');
   }
 
-  // Edith / OpenClaw hosts: bare cwd basename "workspace" collides with
-  // canonical owner-repo keys. Heal after every update so doctor KEY warn
-  // does not reappear the moment new rows land under the legacy key.
+  let keyAttention = false;
   try {
     const { fixProjectKeyCollisions } = await import('./doctor.js');
     const heal = await fixProjectKeyCollisions();
@@ -779,6 +791,7 @@ export async function runUpdate(): Promise<void> {
         `  ${paint('green', '✓')}  ${paint('gray', `project keys: remapped ${heal.applied} legacy row(s)`)}\n`,
       );
     } else if (heal.skippedAmbiguous > 0) {
+      keyAttention = true;
       process.stdout.write(
         `  ${paint('yellow', '⚠')}  ${paint('gray', `project keys: ${heal.skippedAmbiguous} ambiguous collision(s) — run shieldcortex doctor --fix-project-keys`)}\n`,
       );
@@ -787,9 +800,7 @@ export async function runUpdate(): Promise<void> {
     /* update must not fail on project-key heal */
   }
 
-  // #309 — after the package is current, surface new/changed cron-referenced
-  // scripts for TTY batch review. Headless updates only print a pointer line;
-  // never auto-pin and never fail the update if discovery is weird.
+  // #309 — allowlist review / pointer before the closing panel.
   try {
     const { maybeReviewAllowlistAfterUpdate } = await import('./allowlist-scan.js');
     await maybeReviewAllowlistAfterUpdate({
@@ -801,4 +812,59 @@ export async function runUpdate(): Promise<void> {
 
   maybePrint411Notice(currentVersion, mainUpdated);
   await maybePrintDashboardHint();
+
+  // Closing panel — last write (design lock v3).
+  const rows: UpdatePanelRow[] = [
+    { label: 'package', status: mainUpdated ? 'ok' : 'ok' },
+    { label: 'engine', status: engineResult.remediation ? 'warn' : 'ok' },
+    {
+      label: 'selfchk',
+      status:
+        protection.status === 'failed' ? 'failed' :
+        protection.status === 'unproven' ? 'unproven' :
+        protection.status === 'skip' ? 'skipped' :
+        protection.status === 'warn' ? 'warn' : 'ok',
+    },
+  ];
+  const details: string[] = [];
+  if (protection.detail?.length) {
+    for (const d of protection.detail) details.push(`selfchk: ${d}`);
+  }
+  if (engineResult.remediation) details.push('engine: database binding needs manual rebuild');
+  if (keyAttention) details.push('keys: ambiguous project-key collisions remain');
+
+  const failed = protection.status === 'failed';
+  const attention =
+    keyAttention ||
+    Boolean(engineResult.remediation) ||
+    protection.status === 'unproven' ||
+    protection.status === 'warn' ||
+    protection.status === 'blocked';
+
+  if (failed) process.exitCode = 1;
+  const exitCode = typeof process.exitCode === 'number' ? process.exitCode : 0;
+  const verdict: VerdictKind = deriveUpdateVerdict({
+    exitCode,
+    failed,
+    attention,
+  });
+
+  const next: string[] = [];
+  if (attention || failed) next.push('shieldcortex doctor --ai');
+  if (keyAttention) next.push('shieldcortex doctor --fix-project-keys');
+
+  const style = supportsColor() ? defaultColorStyle() : NO_STYLE;
+  const panel = renderUpdatePanel(
+    {
+      fromVersion: currentVersion,
+      toVersion: latest.version || currentVersion,
+      verdict,
+      rows,
+      details,
+      next,
+    },
+    { width: getWidth(), style, unicode: supportsUnicode() },
+  );
+  process.stdout.write('\n');
+  for (const line of panel) process.stdout.write(`${line}\n`);
 }

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -753,11 +753,14 @@ export async function runUpdate(): Promise<void> {
   }
 
   let mainUpdated = false;
+  let npmStatus: StepResult['status'] = 'ok';
   try {
     const npmStep = await stepNpmPackage(currentVersion, latest, force);
     mainUpdated = npmStep.updated;
+    npmStatus = npmStep.result?.status ?? 'ok';
   } catch {
     // npm failure already surfaced by step(); continue with reconcile.
+    npmStatus = 'failed';
   }
 
   // Verify (and self-heal) the native DB binding after the install completes.
@@ -815,7 +818,7 @@ export async function runUpdate(): Promise<void> {
 
   // Closing panel — last write (design lock v3).
   const rows: UpdatePanelRow[] = [
-    { label: 'package', status: mainUpdated ? 'ok' : 'ok' },
+    { label: 'package', status: npmStatus === 'failed' ? 'failed' : npmStatus === 'warn' ? 'warn' : 'ok' },
     { label: 'engine', status: engineResult.remediation ? 'warn' : 'ok' },
     {
       label: 'selfchk',
@@ -833,7 +836,7 @@ export async function runUpdate(): Promise<void> {
   if (engineResult.remediation) details.push('engine: database binding needs manual rebuild');
   if (keyAttention) details.push('keys: ambiguous project-key collisions remain');
 
-  const failed = protection.status === 'failed';
+  const failed = protection.status === 'failed' || npmStatus === 'failed';
   const attention =
     keyAttention ||
     Boolean(engineResult.remediation) ||


### PR DESCRIPTION
## Summary
Michael’s phone SSH screenshots showed `shieldcortex update` + `allowlist scan` as unreadable walls (40-line source dumps, mid-token path wrap, status soup).

This PR ships a **crafted terminal UX** without Ink/Blessed:

- `src/cli/term-ui.ts` — shared width/wrap/box/chip/verdict (floor 40, cap 240)
- **allowlist scan** — decision-first cards; source off by default; `[v]` pages 12 lines; gates unchanged
- **update** — closing VERDICT panel (last write); narrow width drops spinner junk; `NO_COLOR`/`TERM=dumb` respected
- Design locked via Grok 4.6 + GPT 5.6 SOL + Opus loop → `docs/design/2026-08-21-terminal-ux.md`

## Security unchanged
- Pin only on `y`/`yes` (default-deny)
- Non-interactive never writes (exit 3)
- `--yes` still needs typed `approve` on TTY
- TOCTOU `expectedSha256`, first sqlite backfill refuse, `--json` shape

## Tests
- `term-ui.test.ts` + full `allowlist-scan` + doctor-report-mobile: **59 passed**
- `npm run build:ts` clean

## Test plan
- [x] unit/gates
- [ ] CI
- [ ] Dual code review
- [ ] Phone SSH smoke after merge (optional)