### PR TITLE
fix(cli): update footer — calm VERDICT, no double FAILED essay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **`shieldcortex update` protection footer (mobile-first):** compact reconcile report by default — English headline + short proof chips (`guard live · v4.54.10 · roster unread`), no double `FAILED` essay, no full self-check reason dump. Full forensic report with `--verbose` / `SHIELDCORTEX_VERBOSE=1`. Closing VERDICT panel labels the row `guard` (not `selfchk`). Canary-live + roster-unread is **NEEDS ATTENTION** (exit 0), not FAILED (exit 1). True unprotected (roster absent / version downgrade) still fails closed.
+
+### Fixed
+- **False FAILED after successful canary:** when the live enforcement probe denies+audits and the build matches, but the gateway boot roster cannot be read, repair/update no longer scream `FAILED: could not confirm loaded AND enforcing` with a duplicated SQLite/roster essay. Outcome is `protected-unproven` with next step `openclaw gateway restart`.
+- **Canary log noise on update:** synthetic canary no longer prints raw Action Guard block lines for the expected probe deny during `update` (still audited).
+
 ### Added
 - **Memory SOTA Track C:** capture distill provider (OpenAI-compatible + Anthropic), fail-closed extract path on stop/session-end, L1 salience cap, no silent regex fallback (#350 / epic #347).
 - **Memory SOTA Track C (OAuth):** distill resolves Hermes OAuth on disk (xai-oauth → openai-codex) when no API key is set — fleet hosts reuse existing login; `SHIELDCORTEX_DISTILL_OAUTH=0` disables.

--- a/docs/design/2026-08-21-terminal-ux.md
+++ b/docs/design/2026-08-21-terminal-ux.md
@@ -196,3 +196,10 @@ Optional adopt shared `getWidth`/`wrapText`. No check-logic change required in v
 2. `allowlist-scan` summary + cards + prompt `v` paging  
 3. `update` narrow steps + end panel from ledger  
 4. CHANGELOG + PR
+
+## Follow-on (landed): update protection footer
+
+- Compact `formatReconcileReport({ compact: true })` on `shieldcortex update`.
+- Canary-live + roster-unread → `protected-unproven` / NEEDS ATTENTION, never double FAILED.
+- Quiet canary logger (no raw Action Guard block scare line on stderr for the probe).
+- `--verbose` restores full forensic dump for repair-class diagnosis.

--- a/src/cli/__tests__/term-ui.test.ts
+++ b/src/cli/__tests__/term-ui.test.ts
@@ -130,14 +130,14 @@ describe('renderUpdatePanel + verdict', () => {
       verdict: 'NEEDS ATTENTION',
       rows: [
         { label: 'package', status: 'ok' },
-        { label: 'selfchk', status: 'unproven' },
+        { label: 'guard', status: 'unproven' },
       ],
-      details: ['selfchk: roster could not be read'],
+      details: ['Enforcement is live; roster unread'],
       next: ['shieldcortex doctor --ai'],
     }, { width: 40, style: NO_STYLE, unicode: false });
     const text = lines.join('\n');
     expect(text).toMatch(/VERDICT  NEEDS ATTENTION/);
-    expect(text).toMatch(/selfchk\s+unproven/);
+    expect(text).toMatch(/guard\s+unproven/);
     expect(text).toMatch(/detail/);
     expect(text).toMatch(/shieldcortex doctor --ai/);
     for (const l of lines) {

--- a/src/cli/__tests__/update-install-parity-171.test.ts
+++ b/src/cli/__tests__/update-install-parity-171.test.ts
@@ -63,11 +63,12 @@ describe('#171 — update ends by verifying protection, like repair', () => {
   });
 
   it('an applied-but-failed verify sets a non-zero exit code — no false all-clear', () => {
-    // v3 TUI: step returns failed; runUpdate sets process.exitCode from ledger.
+    // Ledger maps true unprotected → failed; unproven (canary live / roster unread)
+    // stays attention. runUpdate exits 1 only on protection.status === 'failed'.
     const stepBody = bodyOf('stepVerifyProtection');
     const runBody = bodyOf('runUpdate');
-    expect(stepBody).toMatch(/result\.applied && !result\.ok/);
-    expect(stepBody).toMatch(/status:\s*'failed'/);
+    expect(stepBody).toMatch(/protectionLedgerFromReconcile/);
+    expect(stepBody).toMatch(/ledger\.status/);
     expect(runBody).toMatch(/process\.exitCode\s*=\s*1/);
     expect(runBody).toMatch(/protection\.status === 'failed'/);
   });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -868,7 +868,10 @@ export async function runUpdate(): Promise<void> {
     .filter((d) => d.startsWith('next:'))
     .map((d) => d.replace(/^next:\s*/, ''));
   for (const n of nextFromGuard) if (!next.includes(n)) next.push(n);
-  if ((attention || failed) && !next.some((n) => n.includes('doctor'))) {
+  // Prefer the single best next. If guard already named a restart, don't stack doctor on 40-col.
+  if ((attention || failed) && next.length === 0) {
+    next.push('shieldcortex doctor --ai');
+  } else if (failed && !next.some((n) => n.includes('doctor'))) {
     next.push('shieldcortex doctor --ai');
   }
   if (keyAttention) next.push('shieldcortex doctor --fix-project-keys');

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -717,18 +717,23 @@ export async function stepVerifyProtection(home: string): Promise<StepResult> {
   if (!registration.registered) return { status: 'skip', summary: 'plugin not registered' };
   process.stdout.write('\n');
   try {
-    const { reconcileOpenClawPluginState, formatReconcileReport } = await import('../setup/openclaw-reconcile.js');
+    const {
+      reconcileOpenClawPluginState,
+      formatReconcileReport,
+      protectionLedgerFromReconcile,
+    } = await import('../setup/openclaw-reconcile.js');
     const result = await reconcileOpenClawPluginState({ home, expectedVersion: readPackageVersion() });
-    for (const line of formatReconcileReport(result)) {
+    // Compact by default on update (mobile-first). Full forensic dump only with --verbose.
+    const compact = !process.argv.includes('--verbose') && process.env.SHIELDCORTEX_VERBOSE !== '1';
+    for (const line of formatReconcileReport(result, { compact })) {
       process.stdout.write(`  ${line}\n`);
     }
-    if (result.applied && !result.ok) {
-      return { status: 'failed', summary: 'reconcile not ok' };
-    }
-    if (!result.ok) {
-      return { status: 'unproven', summary: 'protection unproven' };
-    }
-    return { status: 'ok', summary: 'protected' };
+    const ledger = protectionLedgerFromReconcile(result);
+    return {
+      status: ledger.status === 'warn' ? 'warn' : ledger.status,
+      summary: ledger.summary,
+      detail: ledger.detail,
+    };
   } catch (err) {
     const msg = sanitiseForReport(err instanceof Error ? err.message : String(err), { home });
     process.stdout.write(`  ${paint('gray', `protection check skipped — ${msg}`)}\n`);
@@ -821,7 +826,7 @@ export async function runUpdate(): Promise<void> {
     { label: 'package', status: npmStatus === 'failed' ? 'failed' : npmStatus === 'warn' ? 'warn' : 'ok' },
     { label: 'engine', status: engineResult.remediation ? 'warn' : 'ok' },
     {
-      label: 'selfchk',
+      label: 'guard',
       status:
         protection.status === 'failed' ? 'failed' :
         protection.status === 'unproven' ? 'unproven' :
@@ -830,12 +835,17 @@ export async function runUpdate(): Promise<void> {
     },
   ];
   const details: string[] = [];
+  // Prefer the plain-English ledger headline once — not "selfchk:" jargon.
   if (protection.detail?.length) {
-    for (const d of protection.detail) details.push(`selfchk: ${d}`);
+    for (const d of protection.detail) {
+      if (d.startsWith('next:')) continue;
+      details.push(d);
+    }
   }
   if (engineResult.remediation) details.push('engine: database binding needs manual rebuild');
   if (keyAttention) details.push('keys: ambiguous project-key collisions remain');
 
+  // Unproven is attention, not failure. Only true unprotected / npm fail exit 1.
   const failed = protection.status === 'failed' || npmStatus === 'failed';
   const attention =
     keyAttention ||
@@ -853,7 +863,14 @@ export async function runUpdate(): Promise<void> {
   });
 
   const next: string[] = [];
-  if (attention || failed) next.push('shieldcortex doctor --ai');
+  // Prefer next from protection detail (openclaw gateway restart) over generic doctor when present.
+  const nextFromGuard = (protection.detail ?? [])
+    .filter((d) => d.startsWith('next:'))
+    .map((d) => d.replace(/^next:\s*/, ''));
+  for (const n of nextFromGuard) if (!next.includes(n)) next.push(n);
+  if ((attention || failed) && !next.some((n) => n.includes('doctor'))) {
+    next.push('shieldcortex doctor --ai');
+  }
   if (keyAttention) next.push('shieldcortex doctor --fix-project-keys');
 
   const style = supportsColor() ? defaultColorStyle() : NO_STYLE;

--- a/src/setup/__tests__/reconcile-report-compact-update.test.ts
+++ b/src/setup/__tests__/reconcile-report-compact-update.test.ts
@@ -103,3 +103,41 @@ describe('protectionLedgerFromReconcile', () => {
     expect(ledger.summary).toMatch(/guard live|roster unread/i);
   });
 });
+
+describe('protectionLedgerFromReconcile fail-closed', () => {
+  it('roster absent → failed unprotected', () => {
+    const r = fridayClassResult();
+    r.selfCheck = {
+      ok: false,
+      rosterProof: false,
+      rosterState: 'absent',
+      canaryProof: false,
+      versionProof: true,
+      reasons: ['ABSENT from running gateway'],
+      canary: { ran: true, denied: false, auditEntryFound: false },
+    };
+    r.ok = false;
+    const ledger = protectionLedgerFromReconcile(r);
+    expect(ledger.status).toBe('failed');
+    expect(ledger.outcome).toBe('unprotected');
+    const compact = formatReconcileReport(r, { compact: true }).join('\n');
+    expect(compact).toMatch(/roster absent|Not protected/i);
+    expect(compact).toMatch(/unprotected/i);
+  });
+
+  it('version downgrade → failed unprotected', () => {
+    const r = fridayClassResult();
+    r.selfCheck = {
+      ok: false,
+      rosterProof: true,
+      rosterState: 'loaded',
+      canaryProof: true,
+      versionProof: false,
+      reasons: ['on-disk older than expected'],
+      canary: { ran: true, denied: true, auditEntryFound: true },
+    };
+    const ledger = protectionLedgerFromReconcile(r);
+    expect(ledger.status).toBe('failed');
+    expect(ledger.outcome).toBe('unprotected');
+  });
+});

--- a/src/setup/__tests__/reconcile-report-compact-update.test.ts
+++ b/src/setup/__tests__/reconcile-report-compact-update.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  formatReconcileReport,
+  protectionLedgerFromReconcile,
+  type ReconcileExecResult,
+} from '../openclaw-reconcile.js';
+
+/**
+ * Friday Mac phone-SSH screenshot class: canary denied+audited, version OK,
+ * roster unread after reload. Update must not dump a double FAILED essay.
+ */
+function fridayClassResult(): ReconcileExecResult {
+  return {
+    verdict: {
+      state: 'duplicate-install',
+      severity: 'warn',
+      recommendedAction: 'prune',
+      enabledInConfig: true,
+      loadedInIndex: true,
+      openClawTracked: true,
+      indexWarnsConflict: false,
+      metadataConflict: false,
+      indexVersion: '4.54.10',
+      installsJsonVersion: '4.54.10',
+      onDiskVersion: '4.54.10',
+      expectedVersion: '4.54.10',
+      reasons: ['3 plugin project dirs on disk'],
+    },
+    postVerdict: {
+      state: 'healthy',
+      severity: 'ok',
+      recommendedAction: 'none',
+      enabledInConfig: true,
+      loadedInIndex: true,
+      openClawTracked: true,
+      indexWarnsConflict: false,
+      metadataConflict: false,
+      indexVersion: '4.54.10',
+      installsJsonVersion: '4.54.10',
+      onDiskVersion: '4.54.10',
+      expectedVersion: '4.54.10',
+      reasons: [
+        'enabled and installed, versions agree at the expected build — but the running gateway boot roster could NOT be read, so the plugin is not proven loaded',
+      ],
+    },
+    plan: [],
+    applied: true,
+    stepResults: [
+      { kind: 'prune-duplicate-dirs', ok: true, detail: 'pruned 2 dir(s)' },
+      { kind: 'openclaw-update', ok: true, detail: 'shieldcortex-realtime is up to date (4.54.10).' },
+      { kind: 'gateway-reload', ok: true, detail: 'reloaded and ready in 3.0s' },
+      {
+        kind: 'self-check',
+        ok: false,
+        detail:
+          'roster proof FAILED: could not read the running gateway boot roster; canary proof: live probe was denied by the interceptor and audited; version proof: on-disk build 4.54.10 satisfies expected 4.54.10',
+      },
+    ],
+    selfCheck: {
+      ok: false,
+      rosterProof: false,
+      rosterState: 'unproven',
+      canaryProof: true,
+      versionProof: true,
+      reasons: [
+        'roster proof FAILED: could not read the running gateway boot roster (log rotated, wiped, or written elsewhere) — cannot confirm the interceptor is loaded; the SQLite install index lists it as enabled, but that is install state, not load state; canary proof: live probe was denied by the interceptor and audited; version proof: on-disk build 4.54.10 satisfies expected 4.54.10',
+      ],
+      canary: { ran: true, denied: true, auditEntryFound: true },
+    },
+    ok: false,
+    messages: [
+      'self-check FAILED after remediation — plugin not confirmed loaded + enforcing: roster proof FAILED…',
+    ],
+  };
+}
+
+describe('formatReconcileReport compact (update footer)', () => {
+  it('does not print FAILED / self-check essay for canary-live roster-unread', () => {
+    const text = formatReconcileReport(fridayClassResult(), { compact: true }).join('\n');
+    expect(text).toMatch(/Enforcement is live|probe denied/i);
+    expect(text).toMatch(/guard live/);
+    expect(text).toMatch(/roster unread/);
+    expect(text).not.toMatch(/✗\s*FAILED/);
+    expect(text).not.toMatch(/self-check FAILED after remediation/);
+    expect(text).not.toMatch(/SQLite install index/);
+    expect(text).not.toMatch(/Applied remediation/);
+    // no mid-essay dump of full reasons twice
+    expect(text.split('roster').length).toBeLessThan(6);
+  });
+
+  it('full mode no longer red-banners protected-unproven as FAILED', () => {
+    const text = formatReconcileReport(fridayClassResult()).join('\n');
+    expect(text).not.toMatch(/✗\s*FAILED: could not confirm the plugin is loaded AND enforcing/);
+    expect(text).toMatch(/Enforcement is live|⚠/);
+  });
+});
+
+describe('protectionLedgerFromReconcile', () => {
+  it('maps friday-class to unproven attention, not failed', () => {
+    const ledger = protectionLedgerFromReconcile(fridayClassResult());
+    expect(ledger.status).toBe('unproven');
+    expect(ledger.outcome).toBe('protected-unproven');
+    expect(ledger.summary).toMatch(/guard live|roster unread/i);
+  });
+});

--- a/src/setup/__tests__/repair-verdict-156.test.ts
+++ b/src/setup/__tests__/repair-verdict-156.test.ts
@@ -115,6 +115,19 @@ describe('#156 — no internal vocabulary reaches the headline', () => {
     }
   });
 
+  
+  it('canary live + roster unread is protected-unproven, never unprotected/FAILED', () => {
+    const v = summariseRepair({
+      applied: true,
+      canaryConsented: true,
+      selfCheck: { ok: false, rosterState: 'unproven', canaryProof: true, versionProof: true },
+    });
+    expect(v.outcome).toBe('protected-unproven');
+    expect(v.headline).toMatch(/Enforcement is live|probe denied/i);
+    expect(v.headline).not.toMatch(/FAILED|Not protected/i);
+    expect(v.nextCommand).toMatch(/gateway restart/);
+  });
+
   it('never claims protection without BOTH proofs — the words changed, the standard did not', () => {
     for (const c of cases) {
       const v = summariseRepair(c);

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -422,15 +422,47 @@ export async function reconcileOpenClawPluginState(options: ReconcileOptions): P
  * and the self-check passed, and points a dry-run operator at the consent env
  * needed to actually remediate.
  */
-export function formatReconcileReport(result: ReconcileExecResult): string[] {
+export interface FormatReconcileReportOptions {
+  /**
+   * Operator-facing short form (mobile / update footer). Headline + short
+   * proof chips + one next step. Full forensic dump only when false/omitted
+   * or SHIELDCORTEX_UPDATE=1 / --verbose is set by the caller.
+   */
+  compact?: boolean;
+}
+
+function shortProofChips(result: ReconcileExecResult): string {
+  const sc = result.selfCheck;
+  const bits: string[] = [];
+  if (sc) {
+    if (sc.canaryProof) bits.push('guard live');
+    else if (sc.canary?.ran) bits.push('guard unproven');
+    const verStep = result.stepResults.find((s) => s.kind === 'openclaw-update' && s.ok);
+    if (verStep) {
+      const m = verStep.detail.match(/(\d+\.\d+\.\d+)/);
+      if (m) bits.push(`v${m[1]}`);
+    } else if (result.postVerdict?.onDiskVersion) {
+      bits.push(`v${result.postVerdict.onDiskVersion}`);
+    }
+    if (sc.rosterState === 'loaded') bits.push('roster ok');
+    else if (sc.rosterState === 'absent') bits.push('roster absent');
+    else bits.push('roster unread');
+  }
+  const pruned = result.stepResults.find((s) => s.kind === 'prune-duplicate-dirs' && s.ok);
+  if (pruned) bits.push('pruned dups');
+  const reload = result.stepResults.find((s) => s.kind === 'gateway-reload' && s.ok);
+  if (reload) bits.push('gateway reloaded');
+  return bits.filter(Boolean).join(' · ');
+}
+
+export function formatReconcileReport(
+  result: ReconcileExecResult,
+  opts?: FormatReconcileReportOptions,
+): string[] {
   const lines: string[] = [];
   const { verdict } = result;
 
-  // #156: the operator's question first, in English. The evidence still follows
-  // in full — this codebase has spent a week learning not to hide evidence —
-  // but it stops being the headline. An operator wants to know whether they are
-  // protected and what the single next thing is; they should not have to parse
-  // "roster proof"/"plugins_json"/"the 4.25.4 class" to find out.
+  // Always compute the English headline first (#156).
   const summary = summariseRepair({
     applied: result.applied,
     canaryConsented: process.env.SHIELDCORTEX_ALLOW_GATEWAY_CANARY === '1' || Boolean(process.stdin.isTTY),
@@ -448,6 +480,24 @@ export function formatReconcileReport(result: ReconcileExecResult): string[] {
     ...(result.postVerdict ? { postState: result.postVerdict.state } : {}),
   });
   lines.push(...renderRepairHeadline(summary));
+
+  // Compact operator path (update footer / mobile): no double FAIL essay.
+  if (opts?.compact) {
+    const chips = shortProofChips(result);
+    if (chips) lines.push(`   ${chips}`);
+    // One short post-state line when useful — never dump full reasons twice.
+    if (result.postVerdict && result.postVerdict.state !== 'healthy') {
+      lines.push(`   state  ${result.postVerdict.state}`);
+    } else if (result.applied && result.postVerdict?.state === 'healthy' && summary.outcome === 'protected-unproven') {
+      lines.push('   state  installed · enabled · load line unread');
+    }
+    // Do NOT print ✗ FAILED when outcome is merely unproven.
+    if (summary.outcome === 'unprotected') {
+      lines.push('   status unprotected');
+    }
+    return lines;
+  }
+
   lines.push('');
 
   lines.push(`Plugin load state: ${verdict.state} [${verdict.severity}]`);
@@ -484,19 +534,64 @@ export function formatReconcileReport(result: ReconcileExecResult): string[] {
     for (const r of result.postVerdict.reasons) lines.push(`  • ${r}`);
     lines.push('');
   }
-  if (result.ok) {
-    lines.push('✓ reconciled: plugin confirmed loaded (roster) and enforcing (canary).');
-  } else {
-    lines.push('✗ FAILED: could not confirm the plugin is loaded AND enforcing.');
+  if (result.ok || summary.outcome === 'protected' || summary.outcome === 'protected-unproven') {
+    if (result.ok) {
+      lines.push('✓ reconciled: plugin confirmed loaded (roster) and enforcing (canary).');
+    } else {
+      // Unproven is not FAILED — keep evidence without a red banner.
+      lines.push(`⚠ ${summary.headline}`);
+    }
+  } else if (summary.outcome === 'unprotected') {
+    lines.push('✗ FAILED: plugin is not protecting this gateway.');
     for (const m of result.messages) {
-      // Never echo the PRE-remediation state under the failure banner — that
-      // is the exact false red #145 documents. Post-state and self-check
-      // messages carry the current truth.
+      if (m.startsWith('state before remediation')) continue;
+      if (/fail|not confirmed|not run|did not|absent|OLDER/i.test(m)) lines.push(`  ${m}`);
+    }
+  } else {
+    lines.push(`⚠ ${summary.headline}`);
+    for (const m of result.messages) {
       if (m.startsWith('state before remediation')) continue;
       if (/fail|not confirmed|not run|did not/i.test(m)) lines.push(`  ${m}`);
     }
   }
   return lines;
+}
+
+/** Map reconcile+self-check to the update step ledger without false FAILED. */
+export function protectionLedgerFromReconcile(result: ReconcileExecResult): {
+  status: 'ok' | 'unproven' | 'failed' | 'warn';
+  summary: string;
+  detail: string[];
+  outcome: ReturnType<typeof summariseRepair>['outcome'];
+} {
+  const summary = summariseRepair({
+    applied: result.applied,
+    canaryConsented: process.env.SHIELDCORTEX_ALLOW_GATEWAY_CANARY === '1' || Boolean(process.stdin.isTTY),
+    readinessUnproven: result.stepResults.some(s => s.kind === 'gateway-reload' && /readiness (timed out|could not be observed)/.test(s.detail)),
+    ...(result.selfCheck
+      ? {
+        selfCheck: {
+          ok: result.selfCheck.ok,
+          rosterState: result.selfCheck.rosterState,
+          canaryProof: result.selfCheck.canaryProof,
+          versionProof: result.selfCheck.versionProof,
+        },
+      }
+      : {}),
+    ...(result.postVerdict ? { postState: result.postVerdict.state } : {}),
+  });
+  const detail: string[] = [summary.headline];
+  if (summary.nextCommand) detail.push(`next: ${summary.nextCommand}`);
+  if (summary.outcome === 'protected') {
+    return { status: 'ok', summary: 'protected', detail, outcome: summary.outcome };
+  }
+  if (summary.outcome === 'unprotected') {
+    return { status: 'failed', summary: 'unprotected', detail, outcome: summary.outcome };
+  }
+  if (summary.outcome === 'protected-unproven') {
+    return { status: 'unproven', summary: 'guard live · roster unread', detail, outcome: summary.outcome };
+  }
+  return { status: 'unproven', summary: 'protection unproven', detail, outcome: summary.outcome };
 }
 
 /**

--- a/src/setup/openclaw-reconcile.ts
+++ b/src/setup/openclaw-reconcile.ts
@@ -426,7 +426,7 @@ export interface FormatReconcileReportOptions {
   /**
    * Operator-facing short form (mobile / update footer). Headline + short
    * proof chips + one next step. Full forensic dump only when false/omitted
-   * or SHIELDCORTEX_UPDATE=1 / --verbose is set by the caller.
+   * Update passes compact unless --verbose or SHIELDCORTEX_VERBOSE=1.
    */
   compact?: boolean;
 }
@@ -589,7 +589,15 @@ export function protectionLedgerFromReconcile(result: ReconcileExecResult): {
     return { status: 'failed', summary: 'unprotected', detail, outcome: summary.outcome };
   }
   if (summary.outcome === 'protected-unproven') {
-    return { status: 'unproven', summary: 'guard live · roster unread', detail, outcome: summary.outcome };
+    // Do not hardcode Friday-class chips — other unproven classes exist
+    // (roster loaded, canary not consented). Prefer the English headline.
+    const chip = shortProofChips(result);
+    return {
+      status: 'unproven',
+      summary: chip || 'protection unproven',
+      detail,
+      outcome: summary.outcome,
+    };
   }
   return { status: 'unproven', summary: 'protection unproven', detail, outcome: summary.outcome };
 }

--- a/src/setup/openclaw-selfcheck.ts
+++ b/src/setup/openclaw-selfcheck.ts
@@ -581,7 +581,11 @@ export async function dispatchCanaryThroughInstalledInterceptor(
 
   let interceptor: ReturnType<InterceptorLikeModule['createInterceptor']>;
   try {
-    interceptor = mod.createInterceptor(resolveBoxInterceptorConfig(home, mod.DEFAULT_CONFIG), benignPipeline, { evaluateToolCall: deps.evaluator });
+    // Quiet logger: canary deny is expected. Dumping action-guard BLOCKED on
+    // stderr during `update` scares customers into thinking the upgrade failed.
+    const baseCfg: any = resolveBoxInterceptorConfig(home, mod.DEFAULT_CONFIG);
+    const quietCfg = { ...baseCfg, logger: { info: () => {}, warn: () => {} } };
+    interceptor = mod.createInterceptor(quietCfg, benignPipeline, { evaluateToolCall: deps.evaluator });
   } catch (err) {
     return { dispatched: false, detail: `failed to construct the installed interceptor: ${errMsg(err)}` };
   }

--- a/src/setup/repair-verdict.ts
+++ b/src/setup/repair-verdict.ts
@@ -121,6 +121,18 @@ export function summariseRepair(input: RepairVerdictInput): RepairVerdict {
       };
   }
 
+  // Canary proved enforcement live, version OK, but boot roster unread.
+  // Not unprotected — never scream FAILED for "install healthy, load line missing".
+  // versionProof===false already returned unprotected above; remaining is true|undefined.
+  if (sc?.canaryProof === true && sc.rosterState === 'unproven') {
+    return {
+      outcome: 'protected-unproven',
+      headline:
+        'Enforcement is live (probe denied and audited). Boot roster unread — install looks healthy; load line not proven.',
+      nextCommand: 'openclaw gateway restart',
+    };
+  }
+
   if (input.readinessUnproven) {
     return {
       outcome: 'unknown',


### PR DESCRIPTION
## Summary
Customer-facing fix for Friday’s post-update phone SSH screen.

### Before
- Raw Action Guard block line for the **expected** canary deny
- Full plugin load state / applied remediation / self-check essay
- `✗ FAILED` printed **twice** even when canary denied+audited and build matched
- Mid-word wraps; VERDICT panel lost under the dump

### After
- Compact update report: English headline + proof chips (`guard live · v4.54.10 · roster unread`)
- Canary-live + roster-unread → **NEEDS ATTENTION** (exit 0), not FAILED
- True unprotected (roster absent / downgrade) still **FAILED** / exit 1
- Closing panel row labelled `guard`
- `--verbose` / `SHIELDCORTEX_VERBOSE=1` restores full forensic dump
- Canary uses quiet logger (still audits)

## Test plan
- [x] Focused unit tests (43) incl. friday-class compact report
- [ ] CI green
- [ ] Dual review