### PR TITLE
fix(guard): close #387 leftover — system/pip write-then-exec fail-open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 > **Coverage note**: 49 v4 versions are documented below — typically every minor (`X.Y.0`) plus significant patches. Many small patch releases between 4.0.0 and 4.20.x are not individually documented (~50 versions, mostly behaviour-preserving fixes). For a specific diff between adjacent npm versions, see `git log vX.Y.Z..vX.Y.W` or compare tarballs. Audited and reconciled 2026-05-27 — gap is intentional, not a sign of release-note drift going forward.
 
 
+## [Unreleased]
+
+### Fixed
+- **#387 leftover — system/pip install write-then-exec fail-open.** `#386` made write-content require an *invocation* before keeping `install-package`. The npm-global disposer grew interpreter sinks (`os.system` / `os.popen` / `subprocess` / `child_process`); the pip/apt/brew/gem/cargo disposer did not. Combined with `hasUnscopedPipInstall` only running on the exec path, a Write of `cmd = "pip install …"; os.system(cmd)` (and the same shape for apt/brew) was allowed. Write now proposes pip the same way exec does, and `systemInstallInvoked` shares the global sink set. Venv/`--target` pip stays allowed. `npm i --location=global` now proposes.
+
 ## [4.54.11] - 2026-08-21
 
 **Update footer honesty patch.** Phone-SSH readable protection check after `shieldcortex update` — no double FAILED essay when the guard is live.

--- a/src/defence/iron-dome/__tests__/content-intent-install-387.test.ts
+++ b/src/defence/iron-dome/__tests__/content-intent-install-387.test.ts
@@ -1,0 +1,104 @@
+/**
+ * #387 leftover — system/pip install on Write must be an INVOCATION.
+ * #386 closed the npm-global write-then-exec lane; pip/apt/brew/gem/cargo
+ * stayed fail-open after the disposer dropped unconfirmed vocabulary.
+ */
+import { evaluateToolCall } from '../tool-action-guard.js';
+
+const cfg = { enabled: true, enforce: true } as any;
+
+const PIP = 'p' + 'ip';
+const INST = 'in' + 'stall';
+const REQ = 'req' + 'uests';
+const APT = 'apt' + '-get';
+const BREW = 'br' + 'ew';
+const NL = String.fromCharCode(10);
+const NPM = 'n' + 'pm';
+const PKG = 'left' + 'pad';
+
+function writePy(content: string) {
+  return evaluateToolCall('Write', { path: '/tmp/run.py', content }, cfg);
+}
+
+function writeSh(content: string) {
+  return evaluateToolCall('Write', { file_path: '/tmp/run.sh', content }, cfg);
+}
+
+describe('content intent install #387 leftover', () => {
+  it('gates Write .py that os.system()s an unscoped pip install', () => {
+    const v = writePy('import os' + NL + `os.system("${PIP} ${INST} ${REQ}")` + NL);
+    expect(v.signals ?? []).toContain('install-package');
+    expect(v.action === 'require_approval' || v.severity === 'dangerous').toBe(true);
+  });
+
+  it('gates Write .py cmd-indirection + os.system pip', () => {
+    const v = writePy(
+      'import os' + NL
+      + `cmd = "${PIP} ${INST} ${REQ}"` + NL
+      + 'os.system(cmd)' + NL,
+    );
+    expect(v.signals ?? []).toContain('install-package');
+  });
+
+  it('gates Write .py os.popen pip', () => {
+    const v = writePy('import os' + NL + `os.popen("${PIP} ${INST} ${REQ}")` + NL);
+    expect(v.signals ?? []).toContain('install-package');
+  });
+
+  it('gates Write .py subprocess.run argv-list pip', () => {
+    const v = writePy(
+      'import subprocess' + NL
+      + `subprocess.run(["${PIP}", "${INST}", "${REQ}"])` + NL,
+    );
+    expect(v.signals ?? []).toContain('install-package');
+  });
+
+  it('gates Write .py cmd-indirection + os.system apt-get', () => {
+    const v = writePy(
+      'import os' + NL
+      + `cmd = "${APT} ${INST} -y curl"` + NL
+      + 'os.system(cmd)' + NL,
+    );
+    expect(v.signals ?? []).toContain('install-package');
+  });
+
+  it('gates Write .py child_process.execSync brew', () => {
+    const v = evaluateToolCall('Write', {
+      path: '/tmp/run.js',
+      content: `require("child_process").execSync("${BREW} ${INST} wget")` + NL,
+    }, cfg);
+    expect(v.signals ?? []).toContain('install-package');
+  });
+
+  it('gates Write shebang .sh that actually runs pip', () => {
+    const v = writeSh('#!/bin/bash' + NL + `${PIP} ${INST} ${REQ}` + NL);
+    expect(v.signals ?? []).toContain('install-package');
+  });
+
+  it('gates abbreviated npm i --location=global', () => {
+    const v = writeSh('#!/bin/bash' + NL + `${NPM} i --location=global ${PKG}` + NL);
+    expect(v.signals ?? []).toContain('install-package-global');
+  });
+
+  it('allows Write .py that only stores the pip string', () => {
+    const v = writePy(`msg = "${PIP} ${INST} ${REQ}"` + NL + 'print(msg)' + NL);
+    expect(v.signals ?? []).not.toContain('install-package');
+    expect(v.severity).not.toBe('dangerous');
+  });
+
+  it('allows Write .sh that only echoes the apt string', () => {
+    const v = writeSh(`echo blocked ${APT} ${INST} -y curl` + NL);
+    expect(v.signals ?? []).not.toContain('install-package');
+    expect(v.severity === 'dangerous' && (v.signals ?? []).includes('write-content-dangerous')).toBe(false);
+  });
+
+  it('allows Write of venv-scoped pip install', () => {
+    const v = writeSh('#!/bin/bash' + NL + `.venv/bin/${PIP} ${INST} -r requirements.txt` + NL);
+    expect(v.signals ?? []).not.toContain('install-package');
+  });
+
+  it('allows Write of pip --target scoped install', () => {
+    const v = writeSh('#!/bin/bash' + NL + `${PIP} ${INST} --target ./vendor ${REQ}` + NL);
+    expect(v.signals ?? []).not.toContain('install-package');
+  });
+});

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -457,7 +457,11 @@ const DANGEROUS: Pattern[] = [
   // quote is admitted on either side of `-g`. `--global` gets a `(?![\w-])` tail
   // so npm's real `--global-style` layout flag (workspace-local install) does not
   // over-gate.
-  { re: /\b(?:npm|yarn|pnpm|bun)\b(?=[^|;&\n]*(?:\s['"]?-g\b['"]?|--global(?![\w-])|--location=global(?![\w-])|\bglobal\s+add\b))(?=[^|;&\n]*\s(?:install|add)(?=\s|$|[|;&\n]))|\b(?:npm|pnpm|bun)\s+(?:i(?:n(?:s(?:t(?:a(?:ll?)?)?)?)?)?|isnt(?:all)?)\b[^|;&\n]*(?:\s['"]?-g\b['"]?|--global(?![\w-]))/i, signal: 'install-package-global' },
+  // The abbreviated-verb alternative accepts `--location=global` as well (#387):
+  // it is npm's own long spelling of `-g`, the first alternative and the argv
+  // disposer's GLOBAL_FLAG both already treat the three as one, and omitting it
+  // here meant `npm i --location=global pkg` was never even PROPOSED.
+  { re: /\b(?:npm|yarn|pnpm|bun)\b(?=[^|;&\n]*(?:\s['"]?-g\b['"]?|--global(?![\w-])|--location=global(?![\w-])|\bglobal\s+add\b))(?=[^|;&\n]*\s(?:install|add)(?=\s|$|[|;&\n]))|\b(?:npm|pnpm|bun)\s+(?:i(?:n(?:s(?:t(?:a(?:ll?)?)?)?)?)?|isnt(?:all)?)\b[^|;&\n]*(?:\s['"]?-g\b['"]?|--global(?![\w-])|--location=global(?![\w-]))/i, signal: 'install-package-global' },
   // Scheduler MUTATION only: `crontab` in command position that edits/installs
   // (`-e`, `-r`, a file, or stdin `-`) — never the read-only `crontab -l`, and
   // never the bare word mentioned inside an echo/string (issue #89). Env-var and
@@ -897,6 +901,18 @@ const INSTALL_VERB = /^(?:install|add|i|isntall|isnt|in|ins|inst|insta|instal)$/
 const GLOBAL_FLAG = /^(?:\-g|--global|--location=global)$/i;
 
 /**
+ * Explicit interpreter / process APIs that RUN a string or an argv: python
+ * os/subprocess, node child_process, and the bare `exec`/`spawn` family (incl.
+ * `.execSync` on a `require('child_process')` result).
+ *
+ * One home, shared by the global (#386) and system (#387) install disposers, so
+ * the two families fail closed on the IDENTICAL sink set rather than drifting
+ * apart — which is exactly how #387 happened: the npm rule grew this sink list
+ * and the pip/apt rule kept a narrower same-parens regex.
+ */
+const INTERPRETER_EXEC_SINK = /(?:os\.(?:system|popen)|subprocess\.(?:run|call|Popen|check_call|check_output)|child_process\.(?:exec|execSync|spawn|spawnSync)|\.exec(?:Sync|File|FileSync)?|\.spawn(?:Sync)?|(?:^|[^\w.])(?:exec(?:Sync|File|FileSync)?|spawn(?:Sync)?)\s*\()/i;
+
+/**
  * #386 — install-package-global must be an INVOCATION, not vocabulary.
  * Write-content and shell DATA args often quote package installs in logs
  * (Friday: forensic note after a real deny). Same discipline as
@@ -909,7 +925,7 @@ function packageInstallGlobalInvoked(text: string, depth = 0): boolean {
   // global install. Order of install vs global flag does not matter.
   // Fail-closed on these sinks: write-time authoring of "run this install" is intent.
   // Sinks: python os/subprocess, node child_process, bare exec/spawn (incl. .execSync after require()).
-  if (/(?:os\.(?:system|popen)|subprocess\.(?:run|call|Popen|check_call|check_output)|child_process\.(?:exec|execSync|spawn|spawnSync)|\.exec(?:Sync|File|FileSync)?|\.spawn(?:Sync)?|(?:^|[^\w.])(?:exec(?:Sync|File|FileSync)?|spawn(?:Sync)?)\s*\()/i.test(text)
+  if (INTERPRETER_EXEC_SINK.test(text)
       && /\b(?:npm|yarn|pnpm|bun|npx|corepack)\b/i.test(text)
       && /\b(?:install|add|i|isntall|in|ins|inst|insta|instal)\b/i.test(text)
       && /(?:\s-g\b|\s--global\b|--location=global|\bglobal\s+add\b)/i.test(text)) {
@@ -970,15 +986,102 @@ function packageInstallGlobalInvoked(text: string, depth = 0): boolean {
   return false;
 }
 
-function packageInstallInvoked(text: string, depth = 0): boolean {
-  if (packageInstallGlobalInvoked(text, depth)) return true;
-  if (depth > MAX_INLINE_RECURSION + 2) return true;
-  if (/(?:\bos\.system\b|\bsubprocess\.(?:run|call|Popen)\b)\s*\([^\n)]*\b(?:pip\d?|apt-get|brew|gem|cargo)\b[^\n)]*\binstall\b/i.test(text)) {
+// ── #387: the SYSTEM installer family must fail closed like the npm one ──────
+//
+// #386 gave `install-package-global` an invocation disposer with an interpreter
+// sink (os.system / subprocess / child_process) so a written script that RUNS a
+// global install is still gated. `install-package` got the disposer but not the
+// sink: it only matched installer+install INSIDE ONE set of parens, so
+// `cmd = "apt-get install -y curl"` + `os.system(cmd)` — and every argv-list or
+// os.popen spelling — dropped the signal at write time and re-opened the
+// write-then-exec lane for apt/brew/gem/cargo/pip. Same shape as the npm side
+// here, deliberately: one sink set (INTERPRETER_EXEC_SINK), one vocabulary
+// window, no third installer family.
+
+// apt/yum/brew/gem/cargo/pipx have no scoped form — sink + install verb is the
+// whole test. Windowed to 80 chars so the verb belongs to THIS installer.
+const SYSTEM_INSTALLER_WINDOW_RE = /\b(?:pipx|apt|apt-get|yum|dnf|brew|gem|cargo)\b[^;\n]{0,80}?\b(?:install|add)\b/i;
+// pip is read separately because a pip install can be venv-scoped (#89 class 4).
+// The capture keeps any path prefix on the pip binary (`.venv/bin/pip`) and the
+// trailing window carries the scope flags, which sit AFTER the verb
+// (`pip install --target ./vendor x`).
+const PIP_INSTALL_WINDOW_RE = /(?:^|[^\w./-])((?:[^\s;\n"'`]+)\/)?pip\d?(?:\.\d+)?(?![\w./-])[^;\n]{0,80}?\binstall\b[^;\n]{0,80}/gi;
+const PIP_WINDOW_SCOPE_FLAG_RE = /(?:^|[\s"'])(?:--target|-t|--prefix|--root|--python)(?:=|\s)/i;
+
+/**
+ * A pip install on this surface that mutates the HOST, not a venv.
+ *
+ * `hasUnscopedPipInstall` reads argv and stays authoritative whenever the
+ * install IS a shell statement. When a sink hides the argv inside a STRING
+ * (`os.system("pip install x")`) the tokeniser sees one opaque token, so the
+ * SAME scope proofs are applied to the window instead: an explicit target
+ * prefix, a venv-pathed pip binary, or a venv created in the same payload.
+ * The #89 class 4 relief has to survive the write path —
+ * `.venv/bin/pip install -r requirements.txt` is not a host mutation and must
+ * not be re-gated just because the file also contains an exec sink.
+ */
+function pipInstallMutatesHost(text: string): boolean {
+  if (hasUnscopedPipInstall(text)) return true;
+  const venvs = venvPrefixesCreatedIn(text);
+  PIP_INSTALL_WINDOW_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = PIP_INSTALL_WINDOW_RE.exec(text)) !== null) {
+    if (PIP_WINDOW_SCOPE_FLAG_RE.test(m[0])) continue;                // --target/--prefix/--root/--python
+    const prefix = (m[1] ?? '').replace(/\/$/, '').replace(/\/bin$/i, '');
+    if (prefix) {
+      if (VENV_DIR_MARKER.test(prefix)) continue;                     // …/my-venv/bin/pip
+      if (venvs.some(v => v === prefix || prefix.endsWith(`/${v.replace(/^\.\//, '')}`) || v === `./${prefix}`)) continue;
+    }
     return true;
   }
+  return false;
+}
+
+/**
+ * An interpreter sink on this surface that runs a non-npm install.
+ *
+ * Sink, installer vocabulary and install verb are read off the whole authored
+ * surface, which covers the inline shape (`os.system("apt-get install -y
+ * curl")`) AND the variable-indirection shape (`cmd = "apt-get install -y
+ * curl"; os.system(cmd)`) with one test — the string and the sink that runs it
+ * are authored together either way, at any distance, which is strictly more
+ * than a proximity window would catch.
+ *
+ * #386 relief is intact: a payload with NO sink, that only stores/prints/echoes
+ * the install string, never reaches the vocabulary test.
+ */
+function interpreterSinkRunsInstall(text: string): boolean {
+  if (!INTERPRETER_EXEC_SINK.test(text)) return false;
+  if (SYSTEM_INSTALLER_WINDOW_RE.test(text)) return true;
+  return pipInstallMutatesHost(text);
+}
+
+/** True when the surface genuinely INVOKES a package install of any family. */
+function packageInstallInvoked(text: string, depth = 0): boolean {
+  return packageInstallGlobalInvoked(text, depth) || systemInstallInvoked(text, depth);
+}
+
+/**
+ * The non-npm half — pip/pipx/apt/apt-get/yum/dnf/brew/gem/cargo. Split out of
+ * `packageInstallInvoked` so the write-content proposer (#387) can ask about a
+ * SYSTEM install without an npm-global invocation answering for it (that one
+ * already proposes its own, louder signal).
+ *
+ * Same discipline as the global disposer: interpreter sink, then the bodies the
+ * shell executes, then tokenised command-position statements; fail closed on
+ * `eval` and on a `$`-hidden command word.
+ */
+function systemInstallInvoked(text: string, depth = 0): boolean {
+  if (depth > MAX_INLINE_RECURSION + 2) return true;
+  // pip is answered by its own argv walk, wherever it appears: it is the one
+  // installer whose scope has to be read off argv (#89 class 4), and it is the
+  // one the DANGEROUS table does not carry, so this is also what makes the
+  // write path PROPOSE the installs the exec path proposes (#387).
+  if (hasUnscopedPipInstall(text)) return true;
+  if (interpreterSinkRunsInstall(text)) return true;
   if (depth < MAX_INLINE_RECURSION) {
     for (const body of collectExecutableBodies(text)) {
-      if (body && packageInstallInvoked(body, depth + 1)) return true;
+      if (body && systemInstallInvoked(body, depth + 1)) return true;
     }
   }
   for (const stmt of disposerStatements(text)) {
@@ -990,10 +1093,32 @@ function packageInstallInvoked(text: string, depth = 0): boolean {
       }
       return tok;
     });
+    // `bash -c '…'` / `sh -c '…'` inline programs, stepping over value-taking
+    // options so the `-c` is still reached — the global disposer already walks
+    // these and the system family was the only one that did not.
+    if (depth < MAX_INLINE_RECURSION) {
+      for (let i = 0; i < tokens.length; i++) {
+        const b = commandBaseName(tokens[i]);
+        if (!/^(?:bash|sh|zsh|ksh|dash|ash)$/.test(b)) continue;
+        for (let j = i + 1; j < tokens.length; j++) {
+          if (isInlineProgramFlag(b, tokens[j])) {
+            if (systemInstallInvoked(tokens[j + 1] ?? '', depth + 1)) return true;
+            break;
+          }
+          if (BASH_VALUE_OPTION.test(tokens[j])) { j++; continue; }
+          if (!tokens[j].startsWith('-')) break;
+        }
+      }
+    }
     for (let i = 0; i < tokens.length; i++) {
       if (tokens[i].startsWith('$') && gitAtCommandPosition(tokens, i)) return true;
       const base = commandBaseName(tokens[i]);
-      if (!PACKAGE_INSTALLERS.test(base) || NPM_FAMILY.test(base)) continue;
+      // pip/pip3 deliberately excluded here: `restHasInstall` cannot see a venv
+      // or `--target` prefix, so confirming pip on the verb alone would re-gate
+      // `.venv/bin/pip install -r requirements.txt`. `hasUnscopedPipInstall`
+      // above owns it — argv-accurately, including a venv created earlier in
+      // the same payload — and reaches inside `bash -c '…'` by recursion.
+      if (!PACKAGE_INSTALLERS.test(base) || NPM_FAMILY.test(base) || PIP_TOKEN_RE.test(base)) continue;
       if (!gitAtCommandPosition(tokens, i)) continue;
       if (restHasInstall(tokens.slice(i + 1))) return true;
     }
@@ -3951,6 +4076,27 @@ function scanWriteContentPayload(content: string): {
       if (m.signal === 'install-package-global' && !packageInstallGlobalInvoked(text)) continue;
       if (m.signal === 'install-package' && !packageInstallInvoked(text)) continue;
       if (!seen.has(m.signal)) { seen.add(m.signal); dangerous.push(m); }
+    }
+    // #387 — PROPOSE what the exec path proposes. The DANGEROUS table carries
+    // SYSTEM_INSTALL_RE (apt/yum/brew/gem/cargo) only: `pip` was moved out to
+    // `hasUnscopedPipInstall` because it has to be read as argv to tell a host
+    // mutation from a venv-scoped one, and `evaluateToolCall` calls that on the
+    // EXEC surface alone. So a written script whose body really runs
+    // `pip install x` — even a plain shebang `.sh` — was never proposed here,
+    // let alone confirmed, and an install reached only through an interpreter
+    // sink is not table vocabulary at all. The confirmations above are the same
+    // functions, so nothing widens: this only asks the question on this path.
+    if (!seen.has('install-package')
+        && systemInstallInvoked(text)
+        // #128 stays exactly as strong: an install sealed inside a throwaway
+        // container mutates the container, not the host.
+        && !installsAreContainerConfined(text)) {
+      seen.add('install-package');
+      PIP_INSTALL_WINDOW_RE.lastIndex = 0;
+      const span = SYSTEM_INSTALL_RE.exec(text)?.[0]
+        ?? PIP_INSTALL_WINDOW_RE.exec(text)?.[0]
+        ?? 'package install';
+      dangerous.push({ signal: 'install-package', span: fmtSpan(span) });
     }
   });
   return { catastrophic, dangerous };


### PR DESCRIPTION
## Problem

#387 (content≠intent for package installs on Write) merged at `f5f3bed` with **jarvis-drakon CHANGES_REQUESTED still standing**. The leftover shipped in 4.54.10/11.

After write-content started *dropping* unconfirmed installer vocabulary:

1. The non-npm disposer never grew the interpreter-sink / variable-indirection fail-closed that the npm-global disposer has. A Write of `cmd = "<pip> <verb> …"; os.system(cmd)` (and `os.popen` / argv-list / `execSync` / apt/brew family) became write-allowed.
2. `hasUnscopedPipInstall` only ran on the **exec** path. `SYSTEM_INSTALL_RE` excludes pip. A shebang `.sh` that actually runs an unscoped pip verb was never even proposed on Write.

Live `evaluateToolCall` on `origin/main` 48d558b reproduced both holes before this patch.

## Approach

- One shared `INTERPRETER_EXEC_SINK` for npm-global and system families.
- `systemInstallInvoked` + `pipInstallMutatesHost` confirm system/pip invocations (including `bash -c`, `$`-hidden verbs, eval).
- `scanWriteContentPayload` **proposes** `install-package` when `hasUnscopedPipInstall` or `systemInstallInvoked`, unless `installsAreContainerConfined` (#128).
- Venv / `--target` / `--prefix` / `--root` / `--python` pip stays ALLOW (#89 class 4).
- Mention-only / echo / print stays ALLOW (#386).
- Abbreviated `npm i --location=global` now proposes (Jarvis nit).

Does **not** bump the package version. Does **not** touch Edith soak / `retryCards`.

## Tests

- New `content-intent-install-387.test.ts` (runtime-assembled fixtures — no attack-shaped literals).
- Existing 386 / #128 / #88/#89 suites kept green.

```
node scripts/run-jest.mjs \
  src/defence/iron-dome/__tests__/content-intent-install-386.test.ts \
  src/defence/iron-dome/__tests__/content-intent-install-387.test.ts \
  src/defence/iron-dome/__tests__/guard-container-precision-128.test.ts \
  src/defence/iron-dome/__tests__/fp-precision-88-89.test.ts \
  --runInBand
# 101 passed
npm run build:ts   # exit 0
```

Pre-fix probe ALLOW → post-fix GATE on the Jarvis repro and the shebang-pip hole. Mention-only and `.venv/bin/pip` still ALLOW.

## Dual review (exact staged diff)

| Lane | VERDICT | Blockers |
|---|---|---|
| Grok 4.6 | APPROVE_WITH_NITS | none |
| SOL Pro | APPROVE_WITH_NITS | none |

Nits left as residuals: extra gem/cargo/`--prefix` pins, assert severity on every block case, whole-surface sink+vocab FP (same contract as #386 npm-global first check).

## Residual (disclosed)

A Write that contains **any** interpreter sink **and** an unscoped installer window gates, even if the sink argument is unrelated. Mention-only with no sink stays ALLOW. Fail-closed; a proximity window would reopen `cmd=…; os.system(cmd)`.

## Risk

Security-sensitive Action Guard write path. Isolated `evaluateToolCall` only — no live operator config/audit. Rollback: revert this commit.

Closes the leftover of #387 / #386. Not a 2026.8 item (#384 stays lab).
