### PR TITLE
feat(memory): Track A harden B1–B3 + T1 host-contract doctor (#348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Track A harden + T1 (#348 / #393 / #394):** signed `shieldcortex config --memory-plane`; doctor `checkMemoryPlaneDrift` + `checkMemoryHostContract` (paper-contract / dual-plane drift).
+
+### Fixed
+- **Inject trust floor (Opus B1):** `source_attested` alone no longer bypasses inject eligibility; unverified defence never injects; pack salience clamped to 0.7.
+- **Scope gate (Opus B3):** session-start `requireScope` is config default-true, not data-derived from unscoped DB rows.
+
 ### Changed
 - **Memory SOTA Track A residual fold (#348):** triple frontier review (Grok 4.6 + GPT 5.6 SOL + Opus) folded into design — A-min ≠ done; A3-leaning locks; Opus blockers B1–B4; tickets T1–T3. See `docs/design/2026-08-22-memory-sota-track-a-residual.md`.
 

--- a/docs/design/2026-08-22-memory-sota-track-a-residual.md
+++ b/docs/design/2026-08-22-memory-sota-track-a-residual.md
@@ -192,7 +192,7 @@ Until then: **keep #348 open. No false close.**
 | B1 attestation≠trust + salience + unverified | **Landed** (this PR) |
 | B2 signed `--memory-plane` + planeSetAt | **Landed** (this PR) |
 | B3 drift doctor + scope not data-derived | **Landed** (this PR) — drift signals heuristic; deepen with host telemetry as available |
-| B4 side-car API position | Doc-only deprecate+doctor-fail under sc_canonical/import_only (host contract / drift); full rewire deferred |
+| B4 side-car API position | **Deferred** — no dedicated doctor check yet; do not claim doctor-fail for GuardedMemoryBridge |
 | T1 #393 host contract enforcement | **Initial** doctor proof (`checkMemoryHostContract`) — deepen per-host disable of Memory Search |
 | T2 #394 | Partially overlapped by B2/B3; keep open until fail/warn matrix + FP fixtures complete |
 | T3 #395 | **Not started** (blocked) |

--- a/docs/design/2026-08-22-memory-sota-track-a-residual.md
+++ b/docs/design/2026-08-22-memory-sota-track-a-residual.md
@@ -184,3 +184,15 @@ All must be true:
 6. Independent review on the implementation PR(s) clears CRITICAL/HIGH  
 
 Until then: **keep #348 open. No false close.**
+
+## Implementation status (2026-08-22)
+
+| Item | Status |
+|---|---|
+| B1 attestation≠trust + salience + unverified | **Landed** (this PR) |
+| B2 signed `--memory-plane` + planeSetAt | **Landed** (this PR) |
+| B3 drift doctor + scope not data-derived | **Landed** (this PR) — drift signals heuristic; deepen with host telemetry as available |
+| B4 side-car API position | Doc-only deprecate+doctor-fail under sc_canonical/import_only (host contract / drift); full rewire deferred |
+| T1 #393 host contract enforcement | **Initial** doctor proof (`checkMemoryHostContract`) — deepen per-host disable of Memory Search |
+| T2 #394 | Partially overlapped by B2/B3; keep open until fail/warn matrix + FP fixtures complete |
+| T3 #395 | **Not started** (blocked) |

--- a/hooks/openclaw/cortex-memory/handler.ts
+++ b/hooks/openclaw/cortex-memory/handler.ts
@@ -687,7 +687,8 @@ async function maybeInjectBootstrapPack(context, wsDir, event) {
     scope: {
       hostId: injectCfg.hostId,
       agentId: injectCfg.agentId,
-      requireScope: rows.some((r) => r.host_id != null || r.agent_id != null),
+      // #348 B3: config default-true — never data-derive from unscoped rows
+      requireScope: injectCfg.requireScope !== false,
     },
     budgets: injectCfg.budgets,
     sessionState,

--- a/scripts/lib/inject-pack.mjs
+++ b/scripts/lib/inject-pack.mjs
@@ -146,23 +146,44 @@ export function isInjectEligible(row, scope = {}) {
   const sens = String(row.sensitivity_level || row.sensitivity || 'INTERNAL').toUpperCase();
   if (sens === 'RESTRICTED') return false;
 
-  // Trust: numeric trust_score >= 0.5 (medium) OR source_attested OR trust label >= medium
+  // Trust floor (Opus B1 / #348): attestation is channel identity, NOT trust.
+  // source_attested alone must not bypass the floor for non-pin rows.
+  // Escape: source_attested AND pinned AND trust_score >= 0.5 (or missing trust with allow verdict).
   const attested = row.source_attested === true || row.sourceAttested === true;
-  let trustOk = attested;
-  if (!trustOk && typeof row.trust_score === 'number') {
+  const pinned = row.pinned === true || row.pinned === 1;
+  let trustOk = false;
+  if (typeof row.trust_score === 'number') {
     trustOk = row.trust_score >= 0.5;
-  }
-  if (!trustOk && typeof row.trust === 'string') {
+  } else if (typeof row.trust === 'string') {
     const t = TRUST_ORDER[row.trust.toLowerCase()];
     trustOk = typeof t === 'number' && t >= TRUST_ORDER.medium;
-  }
-  if (!trustOk && row.trust_score == null && row.trust == null) {
-    // Legacy rows without trust: admit only if defence_verdict is allow-like
+  } else {
+    // Legacy rows without trust: only explicit allow-like defence — never "unverified"
     const v = String(row.defence_verdict || '').toLowerCase();
-    trustOk = v === 'allow' || v === 'allowed' || v === 'pass' || v === 'unverified';
+    trustOk = v === 'allow' || v === 'allowed' || v === 'pass';
+  }
+  // Attested pin escape still requires meeting the trust floor when trust is known.
+  if (!trustOk && attested && pinned) {
+    if (typeof row.trust_score === 'number') {
+      trustOk = row.trust_score >= 0.5;
+    } else if (typeof row.trust === 'string') {
+      const t = TRUST_ORDER[row.trust.toLowerCase()];
+      trustOk = typeof t === 'number' && t >= TRUST_ORDER.medium;
+    } else {
+      const v = String(row.defence_verdict || '').toLowerCase();
+      trustOk = v === 'allow' || v === 'allowed' || v === 'pass';
+    }
   }
   if (!trustOk) return false;
 
+  // Never inject never-scanned / unverified legacy (Opus B1)
+  {
+    const v = String(row.defence_verdict || '').toLowerCase();
+    if (v === 'unverified' || v === 'unknown' || v === 'unscanned') return false;
+  }
+
+  // requireScope: default TRUE. Explicit false only via config/caller — never
+  // data-derived from "DB has no scoped rows" (Opus B3 / #348).
   const requireScope = scope.requireScope !== false;
   if (requireScope) {
     const host = row.host_id ?? row.hostId;
@@ -198,7 +219,22 @@ export function clipToTokens(text, maxTokens) {
  * @param {object} row
  * @param {{ perRowTokens: number, now?: Date }} opts
  */
+/** Import / inject salience ceiling (Opus B1). Never let native import claim 1.0. */
+export const INJECT_SALIENCE_CEILING = 0.7;
+
+/**
+ * @param {unknown} raw
+ * @returns {number}
+ */
+export function clampInjectSalience(raw) {
+  const n = typeof raw === 'number' && Number.isFinite(raw) ? raw : 0;
+  if (n < 0) return 0;
+  if (n > INJECT_SALIENCE_CEILING) return INJECT_SALIENCE_CEILING;
+  return n;
+}
+
 export function toPackItem(row, opts) {
+
   const factRaw = row.fact != null ? String(row.fact) : String(row.content || '');
   const titleRaw = String(row.title || 'memory');
   // Title cannot consume the whole row budget
@@ -218,6 +254,7 @@ export function toPackItem(row, opts) {
     id: row.id,
     title,
     fact,
+    salience: clampInjectSalience(row.salience),
     source_ids: sourceIds,
     trust,
     age,
@@ -398,11 +435,16 @@ export function readInjectConfig(config = {}) {
   );
   const hostId = inject.hostId ?? mem.hostId ?? config.hostId ?? null;
   const agentId = inject.agentId ?? mem.agentId ?? config.agentId ?? null;
+  // requireScope: default true. Only explicit false disables (signed/config).
+  const requireScope = inject.requireScope === false || mem.requireScope === false
+    ? false
+    : true;
   return {
     mode,
     nativeContract,
     hostId: hostId == null ? null : String(hostId),
     agentId: agentId == null ? null : String(agentId),
+    requireScope,
     budgets: {
       tokens: inject.tokens,
       rows: inject.rows,

--- a/scripts/session-start-hook.mjs
+++ b/scripts/session-start-hook.mjs
@@ -323,8 +323,9 @@ process.stdin.on('end', async () => {
             hostId: injectCfg.hostId,
             agentId: injectCfg.agentId,
             project,
-            // Until host_id columns are widespread, allow unscoped if columns absent
-            requireScope: injectCandidates.some((r) => r.host_id != null || r.agent_id != null),
+            // Opus B3 / #348: deny-by-default is config, never data-derived.
+            // Explicit inject.requireScope === false is the only off switch.
+            requireScope: injectCfg.requireScope !== false,
           },
           budgets: injectCfg.budgets,
           sessionState,

--- a/src/__tests__/config-memory-inject-contract-cli.test.ts
+++ b/src/__tests__/config-memory-inject-contract-cli.test.ts
@@ -19,6 +19,7 @@ import {
   readRawConfig,
   isConfigTampered,
   setMemoryInjectContract,
+  setMemoryPlane,
   setAutoMemorySamplingTurns,
 } from '../cloud/config.js';
 
@@ -184,5 +185,45 @@ describe('config --auto-memory-sampling (signed sampling fix path)', () => {
     expect(() => setAutoMemorySamplingTurns(2.5)).toThrow(/between 1 and 20/);
     expect(() => setAutoMemorySamplingTurns(Number.NaN)).toThrow(/between 1 and 20/);
     expect(fs.existsSync(configFile())).toBe(false);
+  });
+});
+
+describe('config --memory-plane (signed Track A / #348)', () => {
+  it('import_only writes memory.plane + planeSetAt with _sig', () => {
+    handleCloudConfig(['--memory-plane', 'import_only']);
+    const onDisk = readOnDisk();
+    expect(onDisk.memory.plane).toBe('import_only');
+    expect(onDisk.memory.planeSetAt).toMatch(/^\d{4}-/);
+    expect(onDisk._sig).toMatch(/^[0-9a-f]{64}$/);
+    clearCloudConfigCache();
+    expect(isConfigTampered()).toBe(false);
+  });
+
+  it('rejects illegal plane and leaves config untouched', () => {
+    handleCloudConfig(['--mode', 'balanced']);
+    const before = fs.readFileSync(configFile(), 'utf-8');
+    const exitSpy = mockExit();
+    expect(() => handleCloudConfig(['--memory-plane', 'bidir'])).toThrow('exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(fs.readFileSync(configFile(), 'utf-8')).toBe(before);
+  });
+
+  it('setMemoryPlane API rejects illegal values', () => {
+    expect(() => setMemoryPlane('multi_master')).toThrow(/Invalid memory\.plane/);
+    expect(fs.existsSync(configFile())).toBe(false);
+  });
+
+  it('preserves inject sibling keys when setting plane', () => {
+    fs.writeFileSync(configFile(), JSON.stringify({
+      memory: {
+        inject: { mode: 'start', nativeContract: 'sc_only', hostId: 'tars' },
+      },
+    }, null, 2) + '\n');
+    clearCloudConfigCache();
+    handleCloudConfig(['--memory-plane', 'sc_canonical']);
+    const onDisk = readOnDisk();
+    expect(onDisk.memory.plane).toBe('sc_canonical');
+    expect(onDisk.memory.inject.nativeContract).toBe('sc_only');
+    expect(onDisk.memory.inject.hostId).toBe('tars');
   });
 });

--- a/src/cli/__tests__/doctor-memory-plane-348.test.ts
+++ b/src/cli/__tests__/doctor-memory-plane-348.test.ts
@@ -127,5 +127,60 @@ describe('checkMemoryPlaneDrift + checkMemoryHostContract', () => {
     const r = await runHost();
     expect(r.status).toBe('info');
   });
+
+  it('host contract fails when memorySearch key absent (OC default-on)', async () => {
+    writeConfig({
+      openclawAutoMemory: true,
+      memory: {
+        plane: 'dual_legacy',
+        inject: { mode: 'start', nativeContract: 'sc_only', hostId: 'tars', agentId: 'h' },
+      },
+    });
+    const ocDir = path.join(tmpHome, '.openclaw');
+    fs.mkdirSync(ocDir, { recursive: true });
+    fs.writeFileSync(path.join(ocDir, 'openclaw.json'), JSON.stringify({ agents: { defaults: {} } }, null, 2));
+    const r = await runHost();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/default-on|not proven off|Memory Search/i);
+  });
+
+  it('host contract passes only when memorySearch.enabled === false', async () => {
+    writeConfig({
+      memory: {
+        plane: 'dual_legacy',
+        inject: { mode: 'start', nativeContract: 'sc_only', hostId: 'tars', agentId: 'h' },
+      },
+    });
+    const ocDir = path.join(tmpHome, '.openclaw');
+    fs.mkdirSync(ocDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(ocDir, 'openclaw.json'),
+      JSON.stringify({ agents: { defaults: { memorySearch: { enabled: false } } } }, null, 2),
+    );
+    const r = await runHost();
+    expect(r.status).toBe('pass');
+  });
+
+  it('import_only fails on native touch even when SC has 7d admits', async () => {
+    writeConfig({
+      memory: {
+        plane: 'import_only',
+        inject: { mode: 'start', nativeContract: 'sc_only', hostId: 't', agentId: 'a' },
+      },
+    });
+    const db = openDb();
+    db.prepare(
+      `INSERT INTO memories (title, content, status, sensitivity_level, created_at)
+       VALUES ('fresh', 'fact', 'active', 'INTERNAL', datetime('now'))`,
+    ).run();
+    db.prepare(`INSERT INTO session_events (created_at) VALUES (datetime('now'))`).run();
+    db.close();
+    const ws = path.join(tmpHome, '.openclaw', 'workspace');
+    fs.mkdirSync(ws, { recursive: true });
+    fs.writeFileSync(path.join(ws, 'MEMORY.md'), '# still the brain\n'.repeat(10));
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/native memory artifact touched|drift/i);
+  });
 });
 

--- a/src/cli/__tests__/doctor-memory-plane-348.test.ts
+++ b/src/cli/__tests__/doctor-memory-plane-348.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Track A harden + T1 doctor checks (#348 / #393 / #394).
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+describe('checkMemoryPlaneDrift + checkMemoryHostContract', () => {
+  let tmpHome: string;
+  let scDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-348-home-'));
+    scDir = path.join(tmpHome, '.shieldcortex');
+    fs.mkdirSync(scDir, { recursive: true, mode: 0o700 });
+    originalEnv = { ...process.env };
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  function writeConfig(cfg: Record<string, unknown>): void {
+    fs.writeFileSync(path.join(scDir, 'config.json'), `${JSON.stringify(cfg, null, 2)}\n`);
+  }
+
+  function openDb(): Database.Database {
+    const dbPath = path.join(scDir, 'memories.db');
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE memories (
+        id INTEGER PRIMARY KEY,
+        title TEXT, content TEXT, status TEXT, sensitivity_level TEXT,
+        created_at TEXT
+      );
+      CREATE TABLE session_events (
+        id INTEGER PRIMARY KEY,
+        created_at TEXT
+      );
+    `);
+    return db;
+  }
+
+  async function runDrift() {
+    jest.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+    const mod = await import('../doctor.js');
+    return mod.checkMemoryPlaneDrift();
+  }
+
+  async function runHost() {
+    jest.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+    const mod = await import('../doctor.js');
+    return mod.checkMemoryHostContract();
+  }
+
+  it('fails illegal plane value', async () => {
+    writeConfig({ memory: { plane: 'multi_master' } });
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/illegal memory\.plane/i);
+    expect(r.fix).toMatch(/--memory-plane/);
+  });
+
+  it('warns dual_legacy when activity and zero durable admits', async () => {
+    writeConfig({
+      openclawAutoMemory: true,
+      memory: { plane: 'dual_legacy', inject: { mode: 'start', nativeContract: 'sc_only' } },
+    });
+    const db = openDb();
+    db.prepare(`INSERT INTO session_events (created_at) VALUES (datetime('now'))`).run();
+    // old admitted row outside window doesn't count as 7d durable admit
+    db.prepare(
+      `INSERT INTO memories (title, content, status, sensitivity_level, created_at)
+       VALUES ('old', 'x', 'active', 'INTERNAL', datetime('now', '-30 days'))`,
+    ).run();
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/dual_legacy/i);
+  });
+
+  it('fails import_only when native touched and zero durable admits', async () => {
+    writeConfig({
+      memory: {
+        plane: 'import_only',
+        inject: { mode: 'start', nativeContract: 'sc_only', hostId: 't', agentId: 'a' },
+      },
+    });
+    const db = openDb();
+    db.prepare(`INSERT INTO session_events (created_at) VALUES (datetime('now'))`).run();
+    db.close();
+    const ws = path.join(tmpHome, '.openclaw', 'workspace');
+    fs.mkdirSync(ws, { recursive: true });
+    fs.writeFileSync(path.join(ws, 'MEMORY.md'), '# brain\n'.repeat(20));
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/drift|import_only/i);
+  });
+
+  it('host contract fails when OC memorySearch still enabled under sc_only', async () => {
+    writeConfig({
+      memory: {
+        plane: 'dual_legacy',
+        inject: { mode: 'start', nativeContract: 'sc_only', hostId: 'tars', agentId: 'h' },
+      },
+    });
+    const ocDir = path.join(tmpHome, '.openclaw');
+    fs.mkdirSync(ocDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(ocDir, 'openclaw.json'),
+      JSON.stringify({ agents: { defaults: { memorySearch: true } } }, null, 2),
+    );
+    const r = await runHost();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/memorySearch|contract/i);
+  });
+
+  it('host contract passes when inject off', async () => {
+    writeConfig({ memory: { plane: 'dual_legacy' } });
+    const r = await runHost();
+    expect(r.status).toBe('info');
+  });
+});
+

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3078,28 +3078,79 @@ export async function checkMemoryPlaneDrift(): Promise<CheckResult> {
       } catch { /* absent */ }
     }
 
+    // Unscoped / injectable counts (best-effort; columns may be absent)
+    let unscoped = 0;
+    let injectableApprox = 0;
+    try {
+      const cols = (db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name: string }>).map((c) => c.name);
+      if (cols.includes('host_id') && cols.includes('agent_id')) {
+        unscoped = countOf(
+          `SELECT COUNT(*) AS c FROM memories
+           WHERE COALESCE(status, 'active') NOT IN ('archived', 'suppressed', 'deleted', 'forgotten')
+             AND (host_id IS NULL OR host_id = '' OR agent_id IS NULL OR agent_id = '')`,
+        );
+        // Approx inject-eligible: scoped + not restricted + trust floor when column exists
+        if (cols.includes('trust_score')) {
+          injectableApprox = countOf(
+            `SELECT COUNT(*) AS c FROM memories
+             WHERE COALESCE(status, 'active') NOT IN ('archived', 'suppressed', 'deleted', 'forgotten')
+               AND COALESCE(sensitivity_level, 'INTERNAL') != 'RESTRICTED'
+               AND host_id IS NOT NULL AND host_id != ''
+               AND agent_id IS NOT NULL AND agent_id != ''
+               AND COALESCE(trust_score, 0) >= 0.5`,
+          );
+        } else {
+          injectableApprox = countOf(
+            `SELECT COUNT(*) AS c FROM memories
+             WHERE COALESCE(status, 'active') NOT IN ('archived', 'suppressed', 'deleted', 'forgotten')
+               AND COALESCE(sensitivity_level, 'INTERNAL') != 'RESTRICTED'
+               AND host_id IS NOT NULL AND host_id != ''
+               AND agent_id IS NOT NULL AND agent_id != ''`,
+          );
+        }
+      } else {
+        telemetryOk = false;
+      }
+    } catch {
+      telemetryOk = false;
+    }
+
+    const detail =
+      `native_touched_7d=${nativeTouched7d} native_bytes≈${nativeBytes} ` +
+      `sc_durable_admits_7d=${durableAdmits7d} activity_7d=${activity} ` +
+      `injectable≈${injectableApprox} unscoped=${unscoped}`;
+
+    // Quiet host with no native signal and weak telemetry → cannot determine (never PASS)
     if (!telemetryOk && activity === 0 && !nativeTouched7d) {
       return {
         label,
         status: 'warn',
-        message: `plane=${cfg.plane}: cannot determine drift — insufficient telemetry`,
+        message: `plane=${cfg.plane}: cannot determine drift — insufficient telemetry (${detail})`,
       };
     }
 
-    // Drift: activity or native growth with ~0 SC durable admits in window
-    const drifting = (activity > 0 || nativeTouched7d) && durableAdmits7d === 0;
+    // Canonical planes: native SoT growth/touch is FAIL even if SC also has admits
+    // (that is dual-brain, not "healthy because SC has rows").
+    if ((cfg.plane === 'import_only' || cfg.plane === 'sc_canonical') && nativeTouched7d) {
+      return {
+        label,
+        status: 'fail',
+        message: `dual-plane drift under plane=${cfg.plane}: native memory artifact touched while plane forbids native SoT (${detail})`,
+        fix: 'Stop native MEMORY.md / memory-dir growth as agent brain; import via defended path or archive — docs/design/2026-08-22-memory-sota-track-a-residual.md',
+      };
+    }
 
-    if (drifting) {
-      const detail = `native_touched_7d=${nativeTouched7d} native_bytes≈${nativeBytes} sc_durable_admits_7d=${durableAdmits7d} activity_7d=${activity}`;
+    // Empty-SC-under-activity (all planes)
+    const emptyScUnderActivity = (activity > 0 || nativeTouched7d) && durableAdmits7d === 0;
+    if (emptyScUnderActivity) {
       if (cfg.plane === 'import_only' || cfg.plane === 'sc_canonical') {
         return {
           label,
           status: 'fail',
           message: `dual-plane drift under plane=${cfg.plane}: ${detail}`,
-          fix: 'Import native via defended path or stop native SoT growth; see docs/design/2026-08-22-memory-sota-track-a-residual.md',
+          fix: 'Capture/import into SC or stop claiming canonicity; see residual plan',
         };
       }
-      // dual_legacy = time-boxed defect
       let aged = false;
       if (cfg.planeSetAt) {
         const setMs = Date.parse(cfg.planeSetAt);
@@ -3113,10 +3164,20 @@ export async function checkMemoryPlaneDrift(): Promise<CheckResult> {
       };
     }
 
+    // dual_legacy + native touch + SC admits still WARN (defect mode, not PASS green-wash)
+    if (cfg.plane === 'dual_legacy' && nativeTouched7d && activity > 0) {
+      return {
+        label,
+        status: 'warn',
+        message: `dual_legacy: native still active alongside SC (${detail})`,
+        fix: 'Time-box dual_legacy; move to import_only after host contract + import',
+      };
+    }
+
     return {
       label,
       status: 'pass',
-      message: `plane=${cfg.plane}: no dual-plane drift signal (sc_durable_admits_7d=${durableAdmits7d}, activity_7d=${activity})`,
+      message: `plane=${cfg.plane}: no dual-plane drift signal (${detail})`,
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -3158,7 +3219,16 @@ export async function checkMemoryHostContract(): Promise<CheckResult> {
   // OpenClaw: memory search / bootstrap markers that still own the bus
   const ocPath = process.env.OPENCLAW_CONFIG_PATH?.trim()
     || path.join(home, '.openclaw', 'openclaw.json');
-  if (fs.existsSync(ocPath)) {
+  // OpenClaw Memory Search defaults ON when the key is absent (host default-on).
+  // Under sc_only / disable_native_inject we only PASS when native is proven OFF.
+  let ocPresent = fs.existsSync(ocPath);
+  if (!ocPresent && (cfg.nativeContract === 'sc_only' || cfg.nativeContract === 'disable_native_inject')) {
+    // Bound inject hosts without openclaw.json: cannot prove — not PASS
+    if (cfg.openclawAuto || cfg.plane === 'sc_canonical' || cfg.plane === 'import_only') {
+      findings.push('openclaw.json absent — cannot prove native Memory Search is off');
+    }
+  }
+  if (ocPresent) {
     try {
       const oc = JSON.parse(fs.readFileSync(ocPath, 'utf-8')) as Record<string, unknown>;
       const agents = (oc.agents && typeof oc.agents === 'object') ? oc.agents as Record<string, unknown> : {};
@@ -3167,13 +3237,35 @@ export async function checkMemoryHostContract(): Promise<CheckResult> {
         : {};
       if (cfg.nativeContract === 'sc_only' || cfg.nativeContract === 'disable_native_inject') {
         const ms = defaults.memorySearch;
-        if (ms === true) {
-          findings.push('openclaw agents.defaults.memorySearch enabled while SC contract claims native off-bus');
-        } else if (ms && typeof ms === 'object' && !Array.isArray(ms)) {
+        // Resolve like OC: undefined → default ON
+        let enabled: boolean | 'unknown' = true;
+        if (ms === false) enabled = false;
+        else if (ms === true) enabled = true;
+        else if (ms && typeof ms === 'object' && !Array.isArray(ms)) {
           const mse = (ms as Record<string, unknown>).enabled;
-          if (mse === true) {
-            findings.push('openclaw agents.defaults.memorySearch.enabled while SC contract claims native off-bus');
+          if (mse === false) enabled = false;
+          else if (mse === true) enabled = true;
+          else enabled = true; // absent .enabled → default on
+        } else if (ms === undefined || ms === null) {
+          enabled = true; // key absent → default on
+        }
+        // Per-agent overrides that re-enable
+        const list = Array.isArray(agents.list) ? agents.list as unknown[] : [];
+        for (const entry of list) {
+          if (!entry || typeof entry !== 'object') continue;
+          const e = entry as Record<string, unknown>;
+          const ems = e.memorySearch;
+          if (ems === true) {
+            findings.push('per-agent memorySearch enabled while SC contract claims native off-bus');
+          } else if (ems && typeof ems === 'object' && !Array.isArray(ems)
+            && (ems as Record<string, unknown>).enabled === true) {
+            findings.push('per-agent memorySearch.enabled while SC contract claims native off-bus');
           }
+        }
+        if (enabled === true) {
+          findings.push(
+            'openclaw Memory Search not proven off (default-on unless agents.defaults.memorySearch.enabled===false) while SC contract claims native off-bus',
+          );
         }
       }
     } catch {
@@ -3187,8 +3279,8 @@ export async function checkMemoryHostContract(): Promise<CheckResult> {
   try {
     if (fs.existsSync(agentsMd)) {
       const text = fs.readFileSync(agentsMd, 'utf-8');
-      if (/read\s+memory\.md/i.test(text) && /every\s+session|always|soT|source of truth/i.test(text)) {
-        findings.push('workspace AGENTS.md still orders MEMORY.md as session brain under SC nativeContract');
+      if (/memory\.md/i.test(text) && /read\s+|every\s+session|always|soul\.md|user\.md/i.test(text)) {
+        findings.push('workspace AGENTS.md still references MEMORY.md as session brain under SC nativeContract');
       }
     }
   } catch { /* ignore */ }
@@ -3206,13 +3298,12 @@ export async function checkMemoryHostContract(): Promise<CheckResult> {
   }
 
   if (findings.length > 0) {
-    const severe = cfg.plane === 'sc_canonical' || cfg.plane === 'import_only'
-      || findings.some((f) => /memorySearch enabled/i.test(f));
+    // Paper contract is always FAIL when inject contract is set — never warn-wash.
     return {
       label,
-      status: severe ? 'fail' : 'warn',
+      status: 'fail',
       message: `host contract ${cfg.nativeContract} not fully enforced: ${findings.join('; ')}`,
-      fix: 'Disable native Memory Search / stop MEMORY.md as SoT; prove SC start-pack is the only automatic bus — see #393',
+      fix: 'Set agents.defaults.memorySearch.enabled=false (OC default is ON when absent), stop MEMORY.md as SoT; prove SC start-pack is the only automatic bus — see #393',
     };
   }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2902,6 +2902,327 @@ export async function checkMemoryPlaneEmptyBrain(): Promise<CheckResult> {
   }
 }
 
+
+// ── Memory plane: dual-plane drift + host contract (Track A / #348) ──
+
+const MEMORY_PLANE_LEGAL = new Set(['dual_legacy', 'import_only', 'sc_canonical']);
+
+function readMemoryPlaneFromConfig(raw: Record<string, unknown>): {
+  plane: string;
+  planeSetAt: string | null;
+  illegal: boolean;
+  injectMode: string;
+  nativeContract: string | null;
+  openclawAuto: boolean;
+  injectConfigured: boolean;
+} {
+  const mem = (raw.memory && typeof raw.memory === 'object' && !Array.isArray(raw.memory))
+    ? raw.memory as Record<string, unknown>
+    : {};
+  const inject = (mem.inject && typeof mem.inject === 'object' && !Array.isArray(mem.inject))
+    ? mem.inject as Record<string, unknown>
+    : {};
+  const pRaw = mem.plane ?? raw.memoryPlane;
+  let plane = 'dual_legacy';
+  let illegal = false;
+  if (pRaw == null || pRaw === '') {
+    plane = 'dual_legacy';
+  } else if (typeof pRaw === 'string' && MEMORY_PLANE_LEGAL.has(pRaw)) {
+    plane = pRaw;
+  } else {
+    illegal = true;
+    plane = String(pRaw);
+  }
+  const planeSetAt = typeof mem.planeSetAt === 'string' ? mem.planeSetAt : null;
+  let injectMode = 'off';
+  const injectConfigured = Object.keys(inject).length > 0
+    || raw.memoryInjectMode != null
+    || raw.memoryNativeInjectContract != null;
+  if (typeof inject.mode === 'string') injectMode = inject.mode;
+  else if (typeof raw.memoryInjectMode === 'string') injectMode = raw.memoryInjectMode as string;
+  else if (injectConfigured) injectMode = 'start';
+  const nc = inject.nativeContract ?? raw.memoryNativeInjectContract ?? mem.nativeInjectContract;
+  const nativeContract = typeof nc === 'string'
+    && (nc === 'sc_only' || nc === 'disable_native_inject')
+    ? nc
+    : null;
+  return {
+    plane,
+    planeSetAt,
+    illegal,
+    injectMode,
+    nativeContract,
+    openclawAuto: raw.openclawAutoMemory === true,
+    injectConfigured,
+  };
+}
+
+/**
+ * Dual-plane drift (#348 T2 / Opus B3).
+ * Distinct from empty-brain: catches "SC has rows but native is still the brain"
+ * and illegal plane values. Telemetry missing → warn cannot determine, never PASS.
+ */
+export async function checkMemoryPlaneDrift(): Promise<CheckResult> {
+  const label = 'Memory plane (dual-plane drift)';
+  let raw: Record<string, unknown> = {};
+  try {
+    raw = JSON.parse(fs.readFileSync(path.join(getShieldCortexDir(), 'config.json'), 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return { label, status: 'info', message: 'no config yet' };
+  }
+  const cfg = readMemoryPlaneFromConfig(raw);
+
+  if (cfg.illegal) {
+    return {
+      label,
+      status: 'fail',
+      message: `illegal memory.plane value "${cfg.plane}" (need dual_legacy|import_only|sc_canonical)`,
+      fix: 'Run `shieldcortex config --memory-plane dual_legacy` (or import_only|sc_canonical) — signed write; do not hand-edit config.json',
+    };
+  }
+
+  // Illegal combo: inject on without legal contract (also empty-brain; keep here for plane law)
+  if (cfg.injectConfigured && cfg.injectMode !== 'off' && !cfg.nativeContract) {
+    return {
+      label,
+      status: 'fail',
+      message: `plane=${cfg.plane}: inject mode=${cfg.injectMode} without legal nativeContract`,
+      fix: 'Run `shieldcortex config --memory-inject-contract sc_only` (or disable_native_inject)',
+    };
+  }
+
+  // sc_canonical + inject off on bound auto-memory host claiming product use
+  if (cfg.plane === 'sc_canonical' && cfg.openclawAuto && (cfg.injectMode === 'off' || !cfg.injectConfigured)) {
+    return {
+      label,
+      status: 'fail',
+      message: 'plane=sc_canonical with openclawAutoMemory on but inject off — fake canonicity (no SC bus)',
+      fix: 'Enable inject with a legal nativeContract, or set plane to dual_legacy / honest sidecar posture',
+    };
+  }
+
+  const dbPath = getDbPath();
+  if (!fs.existsSync(dbPath)) {
+    return {
+      label,
+      status: 'warn',
+      message: `plane=${cfg.plane}: cannot determine drift — no database yet`,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Database = (await import('better-sqlite3')).default;
+  let db: InstanceType<typeof Database> | null = null;
+  try {
+    db = new Database(dbPath, { readonly: true, timeout: 3000, fileMustExist: true });
+    const countOf = (sql: string, params: unknown[] = []): number => {
+      const row = db!.prepare(sql).get(...params) as { c?: number } | undefined;
+      return Number(row?.c ?? 0);
+    };
+
+    let durableAdmits7d = 0;
+    let telemetryOk = true;
+    try {
+      // Prefer source_kind / created_at when present
+      const cols = (db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name: string }>).map((c) => c.name);
+      if (cols.includes('created_at')) {
+        durableAdmits7d = countOf(
+          `SELECT COUNT(*) AS c FROM memories
+           WHERE COALESCE(status, 'active') NOT IN ('archived', 'suppressed', 'deleted', 'forgotten')
+             AND COALESCE(sensitivity_level, 'INTERNAL') != 'RESTRICTED'
+             AND created_at >= datetime('now', '-7 days')`,
+        );
+      } else {
+        telemetryOk = false;
+      }
+    } catch {
+      telemetryOk = false;
+    }
+
+    let activity = 0;
+    try {
+      activity += countOf(`SELECT COUNT(*) AS c FROM session_events WHERE created_at >= datetime('now', '-7 days')`);
+    } catch { /* optional */ }
+    try {
+      activity += countOf(`SELECT COUNT(*) AS c FROM hook_invocations WHERE invoked_at >= datetime('now', '-7 days')`);
+    } catch { /* optional */ }
+
+    // Native artifact growth (OpenClaw MEMORY.md / memory dir)
+    const home = os.homedir();
+    const nativeCandidates = [
+      path.join(home, '.openclaw', 'workspace', 'MEMORY.md'),
+      path.join(home, '.openclaw', 'workspace', 'memory'),
+      path.join(home, 'MEMORY.md'),
+    ];
+    let nativeTouched7d = false;
+    let nativeBytes = 0;
+    const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    for (const pth of nativeCandidates) {
+      try {
+        const st = fs.statSync(pth);
+        if (st.isFile()) {
+          nativeBytes += st.size;
+          if (st.mtimeMs >= weekAgo) nativeTouched7d = true;
+        } else if (st.isDirectory()) {
+          // shallow: any file mtime in dir
+          for (const name of fs.readdirSync(pth).slice(0, 50)) {
+            try {
+              const cst = fs.statSync(path.join(pth, name));
+              if (cst.isFile()) {
+                nativeBytes += cst.size;
+                if (cst.mtimeMs >= weekAgo) nativeTouched7d = true;
+              }
+            } catch { /* skip */ }
+          }
+        }
+      } catch { /* absent */ }
+    }
+
+    if (!telemetryOk && activity === 0 && !nativeTouched7d) {
+      return {
+        label,
+        status: 'warn',
+        message: `plane=${cfg.plane}: cannot determine drift — insufficient telemetry`,
+      };
+    }
+
+    // Drift: activity or native growth with ~0 SC durable admits in window
+    const drifting = (activity > 0 || nativeTouched7d) && durableAdmits7d === 0;
+
+    if (drifting) {
+      const detail = `native_touched_7d=${nativeTouched7d} native_bytes≈${nativeBytes} sc_durable_admits_7d=${durableAdmits7d} activity_7d=${activity}`;
+      if (cfg.plane === 'import_only' || cfg.plane === 'sc_canonical') {
+        return {
+          label,
+          status: 'fail',
+          message: `dual-plane drift under plane=${cfg.plane}: ${detail}`,
+          fix: 'Import native via defended path or stop native SoT growth; see docs/design/2026-08-22-memory-sota-track-a-residual.md',
+        };
+      }
+      // dual_legacy = time-boxed defect
+      let aged = false;
+      if (cfg.planeSetAt) {
+        const setMs = Date.parse(cfg.planeSetAt);
+        if (!Number.isNaN(setMs) && Date.now() - setMs > 14 * 24 * 60 * 60 * 1000) aged = true;
+      }
+      return {
+        label,
+        status: 'warn',
+        message: `dual_legacy defect: activity bypasses SC (${detail})${aged ? ' — planeSetAt older than 14d' : ''}`,
+        fix: 'Run T1–T3 then `shieldcortex config --memory-plane import_only` — dual_legacy is not steady state',
+      };
+    }
+
+    return {
+      label,
+      status: 'pass',
+      message: `plane=${cfg.plane}: no dual-plane drift signal (sc_durable_admits_7d=${durableAdmits7d}, activity_7d=${activity})`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { label, status: 'warn', message: `cannot determine drift — ${msg}` };
+  } finally {
+    try { db?.close(); } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Host contract enforcement proof (#348 T1 / #393).
+ * Paper contract: config claims sc_only|disable_native_inject but native
+ * automatic memory still looks enabled on disk.
+ */
+export async function checkMemoryHostContract(): Promise<CheckResult> {
+  const label = 'Memory plane (host contract)';
+  let raw: Record<string, unknown> = {};
+  try {
+    raw = JSON.parse(fs.readFileSync(path.join(getShieldCortexDir(), 'config.json'), 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return { label, status: 'info', message: 'no config yet' };
+  }
+  const cfg = readMemoryPlaneFromConfig(raw);
+  if (!cfg.injectConfigured || cfg.injectMode === 'off') {
+    return { label, status: 'info', message: 'inject off — host contract not required' };
+  }
+  if (!cfg.nativeContract) {
+    return {
+      label,
+      status: 'fail',
+      message: 'inject on without legal nativeContract (paper contract impossible)',
+      fix: 'Run `shieldcortex config --memory-inject-contract sc_only` (or disable_native_inject)',
+    };
+  }
+
+  const home = os.homedir();
+  const findings: string[] = [];
+
+  // OpenClaw: memory search / bootstrap markers that still own the bus
+  const ocPath = process.env.OPENCLAW_CONFIG_PATH?.trim()
+    || path.join(home, '.openclaw', 'openclaw.json');
+  if (fs.existsSync(ocPath)) {
+    try {
+      const oc = JSON.parse(fs.readFileSync(ocPath, 'utf-8')) as Record<string, unknown>;
+      const agents = (oc.agents && typeof oc.agents === 'object') ? oc.agents as Record<string, unknown> : {};
+      const defaults = (agents.defaults && typeof agents.defaults === 'object')
+        ? agents.defaults as Record<string, unknown>
+        : {};
+      if (cfg.nativeContract === 'sc_only' || cfg.nativeContract === 'disable_native_inject') {
+        const ms = defaults.memorySearch;
+        if (ms === true) {
+          findings.push('openclaw agents.defaults.memorySearch enabled while SC contract claims native off-bus');
+        } else if (ms && typeof ms === 'object' && !Array.isArray(ms)) {
+          const mse = (ms as Record<string, unknown>).enabled;
+          if (mse === true) {
+            findings.push('openclaw agents.defaults.memorySearch.enabled while SC contract claims native off-bus');
+          }
+        }
+      }
+    } catch {
+      findings.push('openclaw.json unreadable — cannot prove host contract');
+    }
+  }
+
+  // AGENTS.md / workspace instructions still ordering Read MEMORY.md as brain
+  const agentsMd = path.join(home, '.openclaw', 'workspace', 'AGENTS.md');
+  const memoryMd = path.join(home, '.openclaw', 'workspace', 'MEMORY.md');
+  try {
+    if (fs.existsSync(agentsMd)) {
+      const text = fs.readFileSync(agentsMd, 'utf-8');
+      if (/read\s+memory\.md/i.test(text) && /every\s+session|always|soT|source of truth/i.test(text)) {
+        findings.push('workspace AGENTS.md still orders MEMORY.md as session brain under SC nativeContract');
+      }
+    }
+  } catch { /* ignore */ }
+
+  // sc_canonical / import_only: native MEMORY.md recent write is FAIL (bus law)
+  if (cfg.plane === 'sc_canonical' || cfg.plane === 'import_only') {
+    try {
+      if (fs.existsSync(memoryMd)) {
+        const st = fs.statSync(memoryMd);
+        if (st.mtimeMs >= Date.now() - 7 * 24 * 60 * 60 * 1000 && st.size > 64) {
+          findings.push(`MEMORY.md touched in 7d (${st.size}B) under plane=${cfg.plane} + contract=${cfg.nativeContract}`);
+        }
+      }
+    } catch { /* ignore */ }
+  }
+
+  if (findings.length > 0) {
+    const severe = cfg.plane === 'sc_canonical' || cfg.plane === 'import_only'
+      || findings.some((f) => /memorySearch enabled/i.test(f));
+    return {
+      label,
+      status: severe ? 'fail' : 'warn',
+      message: `host contract ${cfg.nativeContract} not fully enforced: ${findings.join('; ')}`,
+      fix: 'Disable native Memory Search / stop MEMORY.md as SoT; prove SC start-pack is the only automatic bus — see #393',
+    };
+  }
+
+  return {
+    label,
+    status: 'pass',
+    message: `nativeContract=${cfg.nativeContract} plane=${cfg.plane}: no paper-contract signals on disk`,
+  };
+}
+
 async function checkMemoryCaptureDist(): Promise<CheckResult[]> {
   const distResult = await runMemoryCaptureDistCheck(resolveSelfInstallDir());
   const dropsResult = runMemoryCaptureDropsCheck(getDbPath());
@@ -4385,6 +4706,8 @@ export async function runDoctor(
     checkAutoMemoryHooks,
     checkAutoMemorySampling,
     checkMemoryPlaneEmptyBrain,
+    checkMemoryPlaneDrift,
+    checkMemoryHostContract,
     checkMemoryCaptureDist,
     checkBrainWorker,
     checkProjectKeyConsistency,

--- a/src/cloud/cli.ts
+++ b/src/cloud/cli.ts
@@ -25,8 +25,10 @@ import {
   getActionGuardCoreConfig,
   setActionGuardCoreConfig,
   setMemoryInjectContract,
+  setMemoryPlane,
   setAutoMemorySamplingTurns,
   NATIVE_INJECT_CONTRACTS,
+  MEMORY_PLANE_VALUES,
   type DefenceMode,
 } from './config.js';
 import type { RankerEngine } from '../memory/types.js';
@@ -388,6 +390,23 @@ export function handleCloudConfig(args: string[]): void {
     changed = true;
   }
 
+  const memPlaneIdx = args.indexOf('--memory-plane');
+  if (memPlaneIdx !== -1) {
+    const plane = args[memPlaneIdx + 1];
+    if (!plane || plane.startsWith('--')) {
+      console.error(`Missing value for --memory-plane. Legal values: ${MEMORY_PLANE_VALUES.join(', ')}.`);
+      process.exit(1);
+    }
+    try {
+      setMemoryPlane(plane);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+    console.log(`Memory plane set to ${plane} (signed write — config re-signed; planeSetAt stamped).`);
+    changed = true;
+  }
+
   const autoMemSamplingIdx = args.indexOf('--auto-memory-sampling');
   if (autoMemSamplingIdx !== -1) {
     const rawTurns = args[autoMemSamplingIdx + 1];
@@ -463,6 +482,7 @@ export function handleCloudConfig(args: string[]): void {
     console.log('  --action-guard-notify-webhook <https-url>  Notify Action Guard denials to an https webhook');
     console.log('  --action-guard-notify-disable   Disable Action Guard denial notifications');
     console.log('  --memory-inject-contract <sc_only|disable_native_inject>  Set the memory-inject native contract (signed write)');
+    console.log('  --memory-plane <dual_legacy|import_only|sc_canonical>  Set memory.plane (signed write; stamps planeSetAt)');
     console.log('  --auto-memory-sampling <n>  Stop-hook sampling cadence in turns (1-20, ≤ 5 recommended; signed write)');
     console.log('  --restore-4.10-defaults  Restore pre-v4.11.0 defaults (recall on, strict interceptor, minimal preamble)');
     console.log('');

--- a/src/cloud/config.ts
+++ b/src/cloud/config.ts
@@ -1346,6 +1346,54 @@ export function setMemoryInjectContract(value: string): void {
   });
 }
 
+/** Legal memory.plane values (Track A / #348). dual_legacy is deprecated defect mode. */
+export const MEMORY_PLANE_VALUES = ['dual_legacy', 'import_only', 'sc_canonical'] as const;
+export type MemoryPlaneValue = (typeof MEMORY_PLANE_VALUES)[number];
+
+/**
+ * SIGNED write path for `memory.plane` — `shieldcortex config --memory-plane`.
+ * Same #275 discipline as setMemoryInjectContract. Also stamps planeSetAt so
+ * drift doctor can time-box dual_legacy. Does not mint legacy memoryPlane alias.
+ */
+export function setMemoryPlane(value: string): void {
+  if (!(MEMORY_PLANE_VALUES as readonly string[]).includes(value)) {
+    throw new Error(
+      `Invalid memory.plane "${value}". Legal values: ${MEMORY_PLANE_VALUES.join(', ')}.`,
+    );
+  }
+  mutateRawConfig((raw) => {
+    const memory = raw.memory && typeof raw.memory === 'object' && !Array.isArray(raw.memory)
+      ? raw.memory as Record<string, unknown>
+      : {};
+    memory.plane = value;
+    memory.planeSetAt = new Date().toISOString();
+    raw.memory = memory;
+  });
+}
+
+/** Read normalized plane from a raw config object (doctor / tooling). */
+export function readMemoryPlane(raw: Record<string, unknown> | null | undefined): {
+  plane: MemoryPlaneValue | null;
+  planeSetAt: string | null;
+  illegal: boolean;
+} {
+  const mem = (raw?.memory && typeof raw.memory === 'object' && !Array.isArray(raw.memory))
+    ? raw.memory as Record<string, unknown>
+    : {};
+  const p = mem.plane ?? raw?.memoryPlane;
+  if (p == null || p === '') {
+    return { plane: 'dual_legacy', planeSetAt: typeof mem.planeSetAt === 'string' ? mem.planeSetAt : null, illegal: false };
+  }
+  if (typeof p === 'string' && (MEMORY_PLANE_VALUES as readonly string[]).includes(p)) {
+    return {
+      plane: p as MemoryPlaneValue,
+      planeSetAt: typeof mem.planeSetAt === 'string' ? mem.planeSetAt : null,
+      illegal: false,
+    };
+  }
+  return { plane: null, planeSetAt: null, illegal: true };
+}
+
 const AUTO_MEMORY_SAMPLING_MIN = 1;
 const AUTO_MEMORY_SAMPLING_MAX = 20;
 

--- a/src/memory/__tests__/inject-pack-v2.test.ts
+++ b/src/memory/__tests__/inject-pack-v2.test.ts
@@ -74,6 +74,48 @@ describe('inject-pack v2', () => {
     expect(isInjectEligible(row(), scope)).toBe(true);
   });
 
+  it('attestation alone does not bypass trust floor (Opus B1 / #348)', () => {
+    expect(isInjectEligible(row({
+      trust_score: 0.2,
+      source_attested: true,
+      pinned: false,
+    }), scope)).toBe(false);
+  });
+
+  it('attested+pinned still requires trust floor', () => {
+    expect(isInjectEligible(row({
+      trust_score: 0.2,
+      source_attested: true,
+      pinned: true,
+    }), scope)).toBe(false);
+    expect(isInjectEligible(row({
+      trust_score: 0.6,
+      source_attested: true,
+      pinned: true,
+    }), scope)).toBe(true);
+  });
+
+  it('unverified defence_verdict never injects', () => {
+    const r = row({ defence_verdict: 'unverified', source_attested: false });
+    delete r.trust_score;
+    expect(isInjectEligible(r, scope)).toBe(false);
+    // even with high trust_score, unverified is hard reject
+    expect(isInjectEligible(row({
+      trust_score: 0.95,
+      defence_verdict: 'unverified',
+    }), scope)).toBe(false);
+  });
+
+  it('requireScope defaults true; unscoped rejected even if other rows scoped', () => {
+    expect(isInjectEligible(row({ host_id: null, agent_id: null }), { requireScope: true })).toBe(false);
+    expect(isInjectEligible(row({ host_id: null, agent_id: null }), {})).toBe(false);
+  });
+
+  it('clamps pack item salience to 0.7', () => {
+    const item = toPackItem(row({ salience: 1.0 }), { perRowTokens: 80 });
+    expect(item.salience).toBeLessThanOrEqual(0.7);
+  });
+
   it('builds empty pack when store empty or contract missing', () => {
     const a = buildStartPack([], baseOpts);
     expect(a.items).toEqual([]);
@@ -191,7 +233,7 @@ describe('inject-pack v2', () => {
   it('toPackItem never includes why', () => {
     const item = toPackItem(row({ title: 'x', content: 'y' }), { perRowTokens: 50 });
     expect(Object.keys(item).sort()).toEqual(
-      ['age', 'content_hash', 'fact', 'id', 'source_ids', 'title', 'tokens', 'trust'].sort(),
+      ['age', 'content_hash', 'fact', 'id', 'salience', 'source_ids', 'title', 'tokens', 'trust'].sort(),
     );
   });
 });


### PR DESCRIPTION
## Summary
Implements the **harden-then-T1** plan from the #348 triple-review fold.

### B1 — attestation ≠ trust
- `isInjectEligible`: `source_attested` alone no longer bypasses trust floor
- Attested+pinned still requires trust ≥ 0.5
- `defence_verdict=unverified` never injects
- Pack item salience clamped to **0.7**

### B2 — plane teeth
- `setMemoryPlane` + `shieldcortex config --memory-plane <dual_legacy|import_only|sc_canonical>`
- Stamps `planeSetAt`; signed write (no hand-edit happy path)

### B3 — drift + scope
- `checkMemoryPlaneDrift` (≠ empty-brain): illegal plane, dual_legacy warn, import_only/sc_canonical fail on native growth + zero durable admits
- Session-start `requireScope` from config (**default true**), not “DB has any scoped row”

### T1 #393 — host contract (initial)
- `checkMemoryHostContract`: fail when `sc_only`/`disable_native_inject` but OpenClaw `agents.defaults.memorySearch` still enabled; MEMORY.md recent touch under sc_canonical/import_only

### Not in this PR
- T3 import-once (#395) — still blocked
- Full per-host disable of native Memory Search (doctor proof first)
- B4 full rewire of GuardedMemoryBridge

## Test plan
- [x] inject-pack-v2 + doctor-memory-plane-348 + empty-brain + config-memory-plane CLI
- [ ] CI green
- [ ] Dual review (Grok + SOL)