### PR TITLE
fix(test): score #310 waiter-race lock timeout as fail-closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - **Track A harden + T1 (#348 / #393 / #394):** signed `shieldcortex config --memory-plane`; doctor `checkMemoryPlaneDrift` + `checkMemoryHostContract` (paper-contract / dual-plane drift).
 
 ### Fixed
+- **#310 waiter-race CI flake:** a lock-spin timeout (`claimCardLaunch` → `locked`) is fail-closed and must not be scored as a missing `already-claimed`. Lock sleep now wall-clock waits if `Atomics.wait` is unavailable instead of burning 60 no-op retries.
 - **Inject trust floor (Opus B1):** `source_attested` alone no longer bypasses inject eligibility; unverified defence never injects; pack salience clamped to 0.7.
 - **Scope gate (Opus B3):** session-start `requireScope` is config default-true, not data-derived from unscoped DB rows.
 

--- a/src/defence/iron-dome/__tests__/retry-control-races-310.test.ts
+++ b/src/defence/iron-dome/__tests__/retry-control-races-310.test.ts
@@ -68,7 +68,7 @@ describe('#310 — concurrency on the one lock plane', () => {
    * purpose. `spawnSync` in a loop would serialise the very thing under test
    * and every assertion below would pass for the wrong reason.
    */
-  function child(body: string): Promise<{ stdout: string; status: number | null }> {
+  function child(body: string): Promise<{ stdout: string; stderr: string; status: number | null }> {
     const script = [
       `const store = await import(${JSON.stringify(pathToFileURL(DIST_STORE).href)});`,
       `const home = ${JSON.stringify(home)};`,
@@ -82,14 +82,15 @@ describe('#310 — concurrency on the one lock plane', () => {
         stdio: ['ignore', 'pipe', 'pipe'],
       });
       let stdout = '';
+      let stderr = '';
       proc.stdout.on('data', (c) => { stdout += String(c); });
-      proc.stderr.on('data', () => { /* diagnostics only */ });
-      proc.on('close', (status) => resolvePromise({ stdout, status }));
+      proc.stderr.on('data', (c) => { stderr += String(c); });
+      proc.on('close', (status) => resolvePromise({ stdout, stderr, status }));
     });
   }
 
   /** Fan out N snippets and let them collide. */
-  function race(bodies: string[]): Promise<Array<{ stdout: string; status: number | null }>> {
+  function race(bodies: string[]): Promise<Array<{ stdout: string; stderr: string; status: number | null }>> {
     return Promise.all(bodies.map((b) => child(b)));
   }
 
@@ -146,8 +147,20 @@ describe('#310 — concurrency on the one lock plane', () => {
       + `${windowStartMs}, windowMs: 900000 });\n`
       + 'process.stdout.write(c.ok ? "CLAIMED" : "refused:" + c.reason);'));
 
-    expect(results.filter((r) => r.stdout.includes('CLAIMED'))).toHaveLength(1);
-    expect(results.filter((r) => r.stdout.includes('refused:already-claimed'))).toHaveLength(5);
+    // Security invariant: exactly one mint. Losers must be fail-closed.
+    // Under CI contention a loser can time out the lock spin (`locked`)
+    // instead of observing the committed claim (`already-claimed`). Both
+    // mint nothing. A crash / empty stdout / not-found is still a fail.
+    const dump = results.map((r) => ({ status: r.status, stdout: r.stdout, stderr: r.stderr.slice(0, 200) }));
+    expect(results.every((r) => r.status === 0)).toBe(true);
+    const claimed = results.filter((r) => r.stdout.includes('CLAIMED'));
+    const failClosed = results.filter((r) =>
+      r.stdout.includes('refused:already-claimed') || r.stdout.includes('refused:locked'));
+    expect({ claimed: claimed.length, failClosed: failClosed.length, dump }).toEqual({
+      claimed: 1,
+      failClosed: 5,
+      dump,
+    });
     expect(storeFile().rows[0].claim).toBeDefined();
   });
 

--- a/src/defence/iron-dome/retry-control.ts
+++ b/src/defence/iron-dome/retry-control.ts
@@ -350,8 +350,13 @@ const LOCK_STALE_MS = 10_000;
 function sleepSync(ms: number): void {
   try {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+    return;
   } catch {
-    /* SharedArrayBuffer unavailable — spin rather than fail */
+    /* SharedArrayBuffer / Atomics.wait unavailable — wall-clock wait */
+  }
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    /* bounded spin so lock retries actually back off */
   }
 }
 


### PR DESCRIPTION
## Why

`origin/main` @ `1199f05` (#397 merge) is **CI red**. Run [32567461828](https://github.com/Drakon-Systems-Ltd/ShieldCortex/actions/runs/32567461828): `build-and-test (20)` failed; `macos-test` green; node 22 cancelled.

Exact fail: `retry-control-races-310` — “two racing waiters cannot both hold a launch claim”

- CLAIMED = 1 (correct)
- `refused:already-claimed` = 4, expected 5

That sixth child is the known lock-spin timeout (`reason: locked`). Product contract: **locked mints nothing**. The test treated it as a missing loser. #397 CI was green on this file; not a memory-plane regression.

This flake has bitten merge-blocking runs before (20–21 Aug). Rerunning main would paper over it. Scoring it honestly.

## Change

- Waiter race: exactly one `CLAIMED`; the other five must be `already-claimed` **or** `locked`; all children exit 0; store still has one claim. Crash / empty / `not-found` still fails.
- `sleepSync`: if `Atomics.wait` throws, wall-clock wait instead of 60 instant no-op retries.
- CHANGELOG Unreleased.

## Verification

- `npm run build:ts` exit 0
- `test:dist` OK
- race file ×8 `--runInBand` PASS
- `retry-control-310` 46/46 PASS
- full suite: **490 passed / 6252 passed / 7 skipped** (exit 0)
- secret-scan of diff: clean

## Dual review (working-tree pack = this commit)

| Lane | Verdict | Blockers |
|---|---|---|
| Grok 4.6 | APPROVE_WITH_NITS | none |
| GPT 5.6 SOL Pro | APPROVE_WITH_NITS | none |

Nits parked: busy-wait quality of SAB-unavailable fallback; stdout `includes` brittleness; branch name looks like #397.

## Not this PR

- No merge to main from patrol
- No 4.54.12 cut (4.54.10/11 still carry the #387 fail-open until bump)
- #348 / #393 / #394 / #395 residuals unchanged; T3 still blocked
- #384 still lab

Do not merge until CI is CLEAN on this head.
