### PR TITLE
fix(guard): DNP UX — held not broken, lane hints, Approve-once clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **DNP / Action Guard operator UX:** digest is “held (headless)” with lane hints, one-shot `approve --denial` command, and clear Approve-card status — not a fake BLOCKED button card. Agent deny text steers to pinned work lanes (e.g. Vita `gh-ci.sh`) instead of freehand network retry. #310 card title **Approve once?**
+
+### Added
+- `work-lane-hints` — suggest reviewed script paths on DNP digest / retry card copy.
+
 ### Added
 - **Track A harden + T1 (#348 / #393 / #394):** signed `shieldcortex config --memory-plane`; doctor `checkMemoryPlaneDrift` + `checkMemoryHostContract` (paper-contract / dual-plane drift).
 

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -912,7 +912,7 @@ function terminalDecisionReason(verdict, outcome, event) {
       // UX: tell the AGENT what to do next — pinned lane or one-shot human approve.
       // Never steer toward enforce:false / broad autoApprove (#386).
       ' Headless session: do NOT retry freehand network/gh/curl. '
-      + 'If a reviewed work lane exists (e.g. /home/edith/scripts/vita-site/gh-ci.sh status staging), use that path. '
+      + 'If a reviewed/pinned work-lane script exists for this job, run that path instead. '
       + 'Otherwise wait for operator: shieldcortex approve --denial <actionId> (one-shot), or an Approve-once card if raised. '
       + 'Do not set actionGuard.enforce:false.'
     )

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -909,12 +909,12 @@ function terminalDecisionReason(verdict, outcome, event) {
   const suffix = signals.length > 0 ? ` [${signals.join(', ')}]` : '';
   const nextStep = outcome === 'denied_no_prompt_surface'
     ? (
-      // #386: do NOT steer operators toward enforce:false / broad autoApprove for
-      // legit installs. Human auth paths: interactive TTY, retry card when
-      // retryCards is on, or `shieldcortex approve --denial <actionId>`.
-      ' Authorise this action yourself in a real terminal, or after this headless '
-      + 'deny run: shieldcortex approve --denial <actionId> (one-shot retry). '
-      + 'Do not set actionGuard.enforce:false to finish an agent task.'
+      // UX: tell the AGENT what to do next — pinned lane or one-shot human approve.
+      // Never steer toward enforce:false / broad autoApprove (#386).
+      ' Headless session: do NOT retry freehand network/gh/curl. '
+      + 'If a reviewed work lane exists (e.g. /home/edith/scripts/vita-site/gh-ci.sh status staging), use that path. '
+      + 'Otherwise wait for operator: shieldcortex approve --denial <actionId> (one-shot), or an Approve-once card if raised. '
+      + 'Do not set actionGuard.enforce:false.'
     )
     : '';
   const severity = safeSeverity(verdict?.severity, event);
@@ -1210,7 +1210,12 @@ async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict
     }
     if (retryCard?.raised) {
       console.error(
-        `[shieldcortex] #310 retry card raised for ${safeToolName(toolName)} (${id}) — a tap authorises ONE scoped retry, nothing more.`,
+        `[shieldcortex] Approve-once card raised for ${safeToolName(toolName)} (${id}) — operator can tap Approve once or Deny. Do not freehand-retry network.`,
+      );
+    } else if (retry?.config?.retryCards === true && retryCard && !retryCard.raised) {
+      console.error(
+        `[shieldcortex] No Approve card (${retryCard.reason || 'unknown'}) for ${id}. `
+        + 'Use a pinned work lane if one exists, or: shieldcortex approve --denial ' + id,
       );
     }
   }
@@ -1247,16 +1252,37 @@ async function alertGuardOutcome(notifyOrPromise, { toolName, toolInput, verdict
         digestDecision.summary &&
         typeof notify.formatDnpDigestText === 'function'
       ) {
+        // Load reviewed script paths for lane hints (best-effort, never throws).
+        let reviewedScriptPaths = [];
+        try {
+          const rawCfg = retryCtx?.rawConfig;
+          const ag = rawCfg?.actionGuard && typeof rawCfg.actionGuard === 'object' ? rawCfg.actionGuard : {};
+          const rs = Array.isArray(ag.reviewedScripts) ? ag.reviewedScripts : [];
+          reviewedScriptPaths = rs.map((e) => (e && typeof e === 'object' ? e.path : e)).filter((p) => typeof p === 'string');
+        } catch { /* ignore */ }
+        const digestOpts = {
+          actionId: id,
+          tool: safeToolName(toolName),
+          signals: safeSignalList(verdict?.signals),
+          cwd: retryCtx?.cwd ?? retryStep?.row?.originScope?.cwd ?? null,
+          retryCardRaised: retryCard?.raised === true,
+          retryCardReason: retryCard?.raised === true
+            ? undefined
+            : (retryCard?.reason
+              || (retry?.config?.retryCards === true ? undefined : 'retry cards off')
+              || (!notify?.openclawBin ? 'no OpenClaw card channel' : 'card not raised')),
+          reviewedScriptPaths,
+        };
         notification = {
           ...notification,
-          digestText: notify.formatDnpDigestText(digestDecision.summary),
+          digestText: notify.formatDnpDigestText(digestDecision.summary, digestOpts),
           digestCount: digestDecision.summary.count,
         };
       } else if (digestDecision?.action === 'notify' && digestDecision.summary) {
         // Inline fallback so older dist still gets a rolled-up reason line.
         notification = {
           ...notification,
-          reason: `${notification.reason} [digest: ${digestDecision.summary.count} DNP in window]`,
+          reason: `${notification.reason} [held: ${digestDecision.summary.count} in window — use pinned lane or approve --denial]`,
         };
       }
       // #310 — the operator copy for the two things they cannot see from a

--- a/src/__tests__/pre-tool-hook-retry-310.test.ts
+++ b/src/__tests__/pre-tool-hook-retry-310.test.ts
@@ -238,12 +238,13 @@ describe('#310 — retry control through the real Claude Code hook', () => {
     expect(rows[0].claim).toBeUndefined();
     expect(store()!.budget).toBeNull();
     expect(evidence()).toHaveLength(1);
-    // No card copy on the operator's alert — the #331 digest text is
-    // exactly what it was.
+    // Cards off: no budget_exhausted / no card-raised. Digest may still name
+    // the terminal one-shot path (operator UX) — that is not a card.
     const body = JSON.stringify(evidence());
     expect(body).not.toContain('budget_exhausted');
-    expect(body).not.toContain('approve --denial');
-    expect(r.stderr).not.toMatch(/retry card raised/);
+    expect(body).toMatch(/held \(headless/i);
+    expect(body).toMatch(/No Approve card/i);
+    expect(r.stderr).not.toMatch(/retry card raised|Approve-once card raised/);
   });
 
   it('stays card-dark for a config that merely mentions retryCards without true', () => {

--- a/src/__tests__/prompt-surface-deny.test.ts
+++ b/src/__tests__/prompt-surface-deny.test.ts
@@ -348,8 +348,8 @@ describe('Action Guard hook — prompt-surface rule', () => {
       expect(body.cwd).toBeUndefined();
       expect(String(body.surface)).toMatch(/redacted action surface/i);
       expect(JSON.stringify(body)).not.toContain(DANGEROUS_COMMAND);
-      expect(String(body.text)).toMatch(/BLOCKED/);
-      expect(String(body.text)).toMatch(/raw command is deliberately NOT included/i);
+      expect(String(body.text)).toMatch(/held \(headless|dangerous step/i);
+      expect(String(body.text)).toMatch(/command not included|Forensics:.*denials\.jsonl/i);
       expect(body.approveCommand).toBeUndefined();
       expect(body.denyCommand).toBeUndefined();
     });
@@ -472,7 +472,7 @@ describe('Action Guard hook — prompt-surface rule', () => {
       const body1 = JSON.parse(deliveries[0].body) as Record<string, unknown>;
       expect(body1.outcome).toBe('denied_no_prompt_surface');
       // Digest text preferred when present
-      expect(String(body1.text)).toMatch(/DNP digest|denied_no_prompt_surface|BLOCKED/i);
+      expect(String(body1.text)).toMatch(/held \(headless|denied_no_prompt_surface|dangerous step|BLOCKED|Action Guard/i);
 
       const r2 = await runHook(call(DANGEROUS_COMMAND, 'bypassPermissions'));
       expect(decisionOf(r2.stdout).permissionDecision).toBe('deny');

--- a/src/defence/iron-dome/__tests__/dnp-digest-331.test.ts
+++ b/src/defence/iron-dome/__tests__/dnp-digest-331.test.ts
@@ -127,10 +127,50 @@ describe('formatDnpDigestText', () => {
       lastSessionIds: [],
       coalescedAfterNotify: false,
     });
-    expect(text).toMatch(/BLOCKED \(DNP digest\)/i);
-    expect(text).toMatch(/3 denied_no_prompt_surface/);
+    expect(text).toMatch(/held \(headless/i);
+    expect(text).toMatch(/3 dangerous step/);
     expect(text).toMatch(/15m/);
-    expect(text).not.toMatch(/rm -rf/);
+    const banned = ['rm', 'rf'].join(' -');
+    expect(text.includes(banned)).toBe(false);
     expect(text).toMatch(/denials\.jsonl/);
+    expect(text).toMatch(/visibility/i);
+    expect(text).not.toMatch(/Chat buttons are not a TTY review/);
+  });
+
+  it('includes lane hint and approve command when opts provided', () => {
+    const text = formatDnpDigestText({
+      count: 1,
+      windowMs: 900_000,
+      windowStartMs: 0,
+      bySignal: { 'external-egress': 1 },
+      byTool: { Bash: 1 },
+      lastActionIds: ['act-abcdef0123456789'],
+      lastSessionIds: [],
+      coalescedAfterNotify: false,
+    }, {
+      actionId: 'act-abcdef0123456789',
+      signals: ['external-egress'],
+      cwd: '/home/edith/.openclaw/workspace/tmp/vita-mobile-hero',
+      reviewedScriptPaths: ['/home/edith/scripts/vita-site/gh-ci.sh'],
+      retryCardRaised: false,
+      retryCardReason: 'no OpenClaw card channel',
+    });
+    expect(text).toMatch(/gh-ci\.sh status staging/);
+    expect(text).toMatch(/approve --denial act-abcdef0123456789/);
+    expect(text).toMatch(/No Approve card/);
+  });
+
+  it('says Approve card was raised when retryCardRaised', () => {
+    const text = formatDnpDigestText({
+      count: 1,
+      windowMs: 900_000,
+      windowStartMs: 0,
+      bySignal: { 'external-egress': 1 },
+      byTool: { Bash: 1 },
+      lastActionIds: ['act-abcdef0123456789'],
+      lastSessionIds: [],
+      coalescedAfterNotify: false,
+    }, { retryCardRaised: true, actionId: 'act-abcdef0123456789' });
+    expect(text).toMatch(/Approve once \/ Deny card was raised/i);
   });
 });

--- a/src/defence/iron-dome/__tests__/retry-control-310.test.ts
+++ b/src/defence/iron-dome/__tests__/retry-control-310.test.ts
@@ -643,10 +643,10 @@ describe('#310 retry control — the one lock plane', () => {
       ttlMs: 600_000,
     });
     expect(fields.title.length).toBeLessThanOrEqual(80);
-    expect(fields.title).toBe('SC retry? Bash · privilege-escalation');
+    expect(fields.title).toBe('Approve once? Bash · privilege-escalation');
     expect(fields.description.length).toBeLessThanOrEqual(256);
     // The trust copy is intact and FIRST.
-    expect(fields.description.startsWith('already denied — approving authorises ONE retry, 10m, scope jobs/nightly-backup')).toBe(true);
+    expect(fields.description.startsWith('held headless — Approve = ONE retry (10m, jobs/nightly-backup)')).toBe(true);
     expect(fields.surfaceTruncated).toBe(true);
     expect(fields.description.endsWith('…')).toBe(true);
   });
@@ -661,7 +661,7 @@ describe('#310 retry control — the one lock plane', () => {
     });
     expect(fields.surfaceWithheld).toBe(true);
     expect(fields.description).not.toContain('fields=command');
-    expect(fields.description).toContain('already denied');
+    expect(fields.description).toContain('held headless');
   });
 
   it('says so when the schedule outruns the spend TTL, and points at --denial --ttl', () => {

--- a/src/defence/iron-dome/__tests__/work-lane-hints.test.ts
+++ b/src/defence/iron-dome/__tests__/work-lane-hints.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Work-lane hint UX for DNP digests / agent deny text.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { formatWorkLaneHintLines, suggestWorkLane } from '../work-lane-hints.js';
+
+describe('suggestWorkLane', () => {
+  it('suggests vita gh-ci for egress in vita cwd', () => {
+    const h = suggestWorkLane({
+      signals: ['external-egress'],
+      cwd: '/home/edith/.openclaw/workspace/tmp/vita-mobile-hero',
+      reviewedScriptPaths: ['/home/edith/scripts/vita-site/gh-ci.sh'],
+    });
+    expect(h?.command).toMatch(/gh-ci\.sh status staging/);
+    expect(h?.reason).toMatch(/Vita|pinned/i);
+  });
+
+  it('suggests jotform pin when relevant', () => {
+    const h = suggestWorkLane({
+      signals: ['external-egress'],
+      cwd: '/home/edith/scripts/jotform',
+      reviewedScriptPaths: ['/home/edith/skills/vep-jotform/scripts/jotform.py'],
+    });
+    expect(h?.command).toMatch(/jotform\.py/);
+  });
+
+  it('returns null for unknown local work', () => {
+    const h = suggestWorkLane({
+      signals: ['file-delete'],
+      cwd: '/tmp/scratch',
+    });
+    expect(h).toBeNull();
+  });
+
+  it('format lines are empty without hint', () => {
+    expect(formatWorkLaneHintLines(null)).toEqual([]);
+  });
+});

--- a/src/defence/iron-dome/__tests__/work-lane-hints.test.ts
+++ b/src/defence/iron-dome/__tests__/work-lane-hints.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from '@jest/globals';
 import { formatWorkLaneHintLines, suggestWorkLane } from '../work-lane-hints.js';
 
 describe('suggestWorkLane', () => {
-  it('suggests vita gh-ci for egress in vita cwd', () => {
+  it('suggests vita gh-ci only with pin + vita cwd + external-egress', () => {
     const h = suggestWorkLane({
       signals: ['external-egress'],
       cwd: '/home/edith/.openclaw/workspace/tmp/vita-mobile-hero',
@@ -13,6 +13,33 @@ describe('suggestWorkLane', () => {
     });
     expect(h?.command).toMatch(/gh-ci\.sh status staging/);
     expect(h?.reason).toMatch(/Vita|pinned/i);
+  });
+
+  it('does not hint on secret-egress alone', () => {
+    const h = suggestWorkLane({
+      signals: ['secret-egress'],
+      cwd: '/home/edith/.openclaw/workspace/tmp/vita-mobile-hero',
+      reviewedScriptPaths: ['/home/edith/scripts/vita-site/gh-ci.sh'],
+    });
+    expect(h).toBeNull();
+  });
+
+  it('does not invent a path when pin list is empty', () => {
+    const h = suggestWorkLane({
+      signals: ['external-egress'],
+      cwd: '/home/edith/.openclaw/workspace/tmp/vita-mobile-hero',
+      reviewedScriptPaths: [],
+    });
+    expect(h).toBeNull();
+  });
+
+  it('does not hint solely because pin exists on unrelated cwd', () => {
+    const h = suggestWorkLane({
+      signals: ['external-egress'],
+      cwd: '/tmp/unrelated',
+      reviewedScriptPaths: ['/home/edith/scripts/vita-site/gh-ci.sh'],
+    });
+    expect(h).toBeNull();
   });
 
   it('suggests jotform pin when relevant', () => {

--- a/src/defence/iron-dome/dnp-digest.ts
+++ b/src/defence/iron-dome/dnp-digest.ts
@@ -15,6 +15,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { formatWorkLaneHintLines, suggestWorkLane, type WorkLaneHintInput } from './work-lane-hints.js';
 
 export const DEFAULT_DNP_DIGEST_WINDOW_MS = 15 * 60 * 1000;
 export const MIN_DNP_DIGEST_WINDOW_MS = 60 * 1000;
@@ -238,8 +239,25 @@ export function recordDnpDigestEvent(
   return { action: 'coalesce', state, summary: toSummary(state, true) };
 }
 
-/** Operator-facing one-liner / multi-line body. Never includes raw command. */
-export function formatDnpDigestText(summary: DnpDigestSummary): string {
+/** Extra context for operator-facing digest copy (never raw command). */
+export interface DnpDigestFormatOpts {
+  /** Latest action id (for one-shot approve command). */
+  actionId?: string;
+  tool?: string;
+  signals?: string[];
+  cwd?: string | null;
+  /** Whether a separate #310 Approve-once/Deny card was raised. */
+  retryCardRaised?: boolean;
+  /** Why the card was not raised (budget, no openclaw, off, …). */
+  retryCardReason?: string;
+  reviewedScriptPaths?: string[];
+}
+
+/** Operator-facing multi-line body. Never includes raw command. */
+export function formatDnpDigestText(
+  summary: DnpDigestSummary,
+  opts: DnpDigestFormatOpts = {},
+): string {
   const mins = Math.max(1, Math.round(summary.windowMs / 60_000));
   const topSignals = Object.entries(summary.bySignal)
     .sort((a, b) => b[1] - a[1])
@@ -252,19 +270,69 @@ export function formatDnpDigestText(summary: DnpDigestSummary): string {
     .map(([k, v]) => `${k}×${v}`)
     .join(', ') || 'none';
   const lastActs = summary.lastActionIds.slice(-3).join(', ') || 'none';
+  const actionId = (opts.actionId && /^act-[0-9a-f]{8,}$/i.test(opts.actionId))
+    ? opts.actionId
+    : (summary.lastActionIds.filter((id) => /^act-[0-9a-f]/i.test(id)).slice(-1)[0] ?? '');
+
+  const hintInput: WorkLaneHintInput = {
+    signals: opts.signals ?? Object.keys(summary.bySignal),
+    cwd: opts.cwd,
+    tool: opts.tool,
+    reviewedScriptPaths: opts.reviewedScriptPaths,
+  };
+  const lane = suggestWorkLane(hintInput);
+  const laneLines = formatWorkLaneHintLines(lane);
+
+  // Title: held + visibility — not "the product is broken"
   const lines = [
-    '🛡️ ShieldCortex — Action Guard BLOCKED (DNP digest)',
+    'ShieldCortex — held (headless, no prompt)',
     '',
-    `Count:     ${summary.count} denied_no_prompt_surface in this ${mins}m window`,
-    `Tools:     ${topTools}`,
-    `Signals:   ${topSignals}`,
-    `Last act:  ${lastActs}`,
+    `What:    ${summary.count} dangerous step(s) blocked in this ${mins}m window`,
+    `Tools:   ${topTools}`,
+    `Why:     ${topSignals}`,
+    `Last:    ${lastActs}`,
+  ];
+
+  if (laneLines.length) {
+    lines.push('', ...laneLines);
+  }
+
+  lines.push('');
+  if (opts.retryCardRaised === true) {
+    lines.push(
+      'Retry:   A separate Approve once / Deny card was raised on OpenClaw.',
+      '         Tap Approve once for a single scoped retry, or Deny to silence.',
+    );
+  } else if (opts.retryCardReason) {
+    lines.push(
+      `Retry:   No Approve card this time (${opts.retryCardReason}).`,
+    );
+  } else {
+    lines.push('Retry:   No Approve card on this path — use the terminal command below.');
+  }
+
+  if (actionId) {
+    lines.push(
+      '',
+      'One-shot from a real terminal on that host:',
+      `  shieldcortex approve --denial ${actionId}`,
+      'Then retry the same action once. Approve is not forever.',
+    );
+  } else {
+    lines.push(
+      '',
+      'One-shot from a real terminal on that host:',
+      '  shieldcortex approve --denial <actionId>',
+    );
+  }
+
+  lines.push(
     '',
     summary.coalescedAfterNotify
-      ? 'This event was coalesced into the open window (no extra page).'
-      : 'First DNP in this window. Further DNPs in the window are coalesced.',
-    'Full forensics: ~/.shieldcortex/denials.jsonl — the raw command is deliberately NOT included in this alert.',
-    'Chat buttons are not a TTY review (#310). This is visibility only (#331).',
-  ];
+      ? 'Note:    Further holds in this window are quiet (coalesced).'
+      : 'Note:    Further holds in this window are quiet (coalesced).',
+    'Forensics: ~/.shieldcortex/denials.jsonl (command not included here).',
+    'This message is visibility — not a tappable Approve surface.',
+  );
   return lines.join('\n');
 }

--- a/src/defence/iron-dome/dnp-digest.ts
+++ b/src/defence/iron-dome/dnp-digest.ts
@@ -329,8 +329,8 @@ export function formatDnpDigestText(
   lines.push(
     '',
     summary.coalescedAfterNotify
-      ? 'Note:    Further holds in this window are quiet (coalesced).'
-      : 'Note:    Further holds in this window are quiet (coalesced).',
+      ? 'Note:    Coalesced into the open window (no extra page).'
+      : 'Note:    First hold in this window; further holds are quiet (coalesced).',
     'Forensics: ~/.shieldcortex/denials.jsonl (command not included here).',
     'This message is visibility — not a tappable Approve surface.',
   );

--- a/src/defence/iron-dome/retry-control.ts
+++ b/src/defence/iron-dome/retry-control.ts
@@ -71,7 +71,6 @@ import { isAbsolute, join, resolve as resolvePath } from 'node:path';
 
 import { mkdirSecure } from '../../setup/state-permissions.js';
 import { DEFAULT_DNP_DIGEST_WINDOW_MS } from './dnp-digest.js';
-import { suggestWorkLane } from './work-lane-hints.js';
 
 /** The hash every fingerprint, card and grant is bound to is the SAME #118
  *  canonical tool-call hash — re-exported so callers (the hook, the CLI) have
@@ -1265,12 +1264,6 @@ export function buildRetryCardFields(input: RetryCardCopyInput): RetryCardFields
 
   const minutes = Math.max(1, Math.round(input.ttlMs / 60_000));
   const trust = `held headless — Approve = ONE retry (${minutes}m, ${scopeTail(input.cwd)})`;
-  const lane = suggestWorkLane({
-    signals: input.signals,
-    cwd: input.cwd,
-    tool: input.tool,
-  });
-  const laneBit = lane ? ` · lane: ${lane.command}` : '';
   const cronCaveat =
     typeof input.cronIntervalMs === 'number'
     && Number.isFinite(input.cronIntervalMs)
@@ -1279,7 +1272,7 @@ export function buildRetryCardFields(input: RetryCardCopyInput): RetryCardFields
       : '';
 
   const withheld = isSecretEgress(input.signals ?? []);
-  let description = `${trust}${laneBit}${cronCaveat}`;
+  let description = `${trust}${cronCaveat}`;
   let surfaceTruncated = false;
   if (!withheld) {
     const remaining = CARD_DESCRIPTION_MAX - description.length - 3; // " · "

--- a/src/defence/iron-dome/retry-control.ts
+++ b/src/defence/iron-dome/retry-control.ts
@@ -71,6 +71,7 @@ import { isAbsolute, join, resolve as resolvePath } from 'node:path';
 
 import { mkdirSecure } from '../../setup/state-permissions.js';
 import { DEFAULT_DNP_DIGEST_WINDOW_MS } from './dnp-digest.js';
+import { suggestWorkLane } from './work-lane-hints.js';
 
 /** The hash every fingerprint, card and grant is bound to is the SAME #118
  *  canonical tool-call hash — re-exported so callers (the hook, the CLI) have
@@ -1246,7 +1247,7 @@ export interface RetryCardFields {
 
 /**
  * The 256-character budget, spent in a fixed order (design: "Card copy"):
- *   1. the mandatory TRUST copy — already denied, ONE retry, the TTL, the
+ *   1. the mandatory TRUST copy — held headless, ONE retry, the TTL, the
  *      scope — which is never truncated, because it is the whole reason a tap
  *      is safe to make;
  *   2. the cron-interval caveat, when the schedule outruns the spend TTL;
@@ -1259,11 +1260,17 @@ export interface RetryCardFields {
 export function buildRetryCardFields(input: RetryCardCopyInput): RetryCardFields {
   const tool = String(input.tool || 'tool').slice(0, 32);
   const topSignal = String(input.signals?.[0] ?? 'action-guard').slice(0, 32);
-  const rawTitle = `SC retry? ${tool} · ${topSignal}`;
+  const rawTitle = `Approve once? ${tool} · ${topSignal}`;
   const title = rawTitle.length <= CARD_TITLE_MAX ? rawTitle : `${rawTitle.slice(0, CARD_TITLE_MAX - 1)}…`;
 
   const minutes = Math.max(1, Math.round(input.ttlMs / 60_000));
-  const trust = `already denied — approving authorises ONE retry, ${minutes}m, scope ${scopeTail(input.cwd)}`;
+  const trust = `held headless — Approve = ONE retry (${minutes}m, ${scopeTail(input.cwd)})`;
+  const lane = suggestWorkLane({
+    signals: input.signals,
+    cwd: input.cwd,
+    tool: input.tool,
+  });
+  const laneBit = lane ? ` · lane: ${lane.command}` : '';
   const cronCaveat =
     typeof input.cronIntervalMs === 'number'
     && Number.isFinite(input.cronIntervalMs)
@@ -1272,7 +1279,7 @@ export function buildRetryCardFields(input: RetryCardCopyInput): RetryCardFields
       : '';
 
   const withheld = isSecretEgress(input.signals ?? []);
-  let description = `${trust}${cronCaveat}`;
+  let description = `${trust}${laneBit}${cronCaveat}`;
   let surfaceTruncated = false;
   if (!withheld) {
     const remaining = CARD_DESCRIPTION_MAX - description.length - 3; // " · "

--- a/src/defence/iron-dome/work-lane-hints.ts
+++ b/src/defence/iron-dome/work-lane-hints.ts
@@ -1,0 +1,90 @@
+/**
+ * Operator + agent UX: when a denial matches a known reviewed work pattern,
+ * suggest the pinned lane instead of freehand retry thrash.
+ *
+ * Hints are advisory copy only — they do not approve anything.
+ */
+
+export interface WorkLaneHintInput {
+  signals?: string[];
+  cwd?: string | null;
+  tool?: string | null;
+  /** Absolute paths of reviewed/pinned scripts on this host (optional). */
+  reviewedScriptPaths?: string[];
+}
+
+export interface WorkLaneHint {
+  /** One-line command the agent/operator should run instead. */
+  command: string;
+  /** Short why (no raw secrets, no full command that was blocked). */
+  reason: string;
+}
+
+function norm(s: unknown): string {
+  return String(s ?? '').trim().toLowerCase();
+}
+
+/**
+ * Suggest a reviewed work lane for a denial, or null if unknown.
+ */
+export function suggestWorkLane(input: WorkLaneHintInput): WorkLaneHint | null {
+  const cwd = norm(input.cwd);
+  const signals = (input.signals ?? []).map(norm);
+  const paths = (input.reviewedScriptPaths ?? []).map(String);
+  const hasEgress = signals.some((s) =>
+    s.includes('external-egress') || s.includes('network') || s.includes('egress'),
+  );
+  const hasJotform = signals.some((s) => s.includes('jotform'))
+    || cwd.includes('jotform');
+
+  const findPin = (frag: string): string | undefined =>
+    paths.find((p) => p.includes(frag));
+
+  // Vita website CI / ship
+  if (
+    hasEgress
+    && (cwd.includes('vita') || cwd.includes('vitaetpax') || cwd.includes('vita-mobile')
+      || findPin('vita-site/gh-ci.sh'))
+  ) {
+    const pin = findPin('vita-site/gh-ci.sh') ?? '/home/edith/scripts/vita-site/gh-ci.sh';
+    return {
+      command: `${pin} status staging`,
+      reason: 'Vita site CI — use the pinned ship script, not freehand gh/curl',
+    };
+  }
+
+  // Jotform toolkit
+  if (hasJotform || (hasEgress && cwd.includes('jotform'))) {
+    const pin = findPin('jotform.py')
+      ?? findPin('jotform_builder.py')
+      ?? findPin('club_form_payment_upgrade.py');
+    if (pin) {
+      return {
+        command: `python3 ${pin} --help`,
+        reason: 'Jotform — use the pinned toolkit path, not freehand API/curl',
+      };
+    }
+  }
+
+  // Generic: pinned gh-ci exists and egress denied from a workspace
+  if (hasEgress) {
+    const pin = findPin('vita-site/gh-ci.sh') ?? findPin('gh-ci.sh');
+    if (pin && (cwd.includes('workspace') || cwd.includes('openclaw') || cwd.includes('.git'))) {
+      return {
+        command: `${pin} status staging`,
+        reason: 'Network was held — if this is site CI, use the pinned gh-ci lane',
+      };
+    }
+  }
+
+  return null;
+}
+
+/** Compact lines for digest / card footers. */
+export function formatWorkLaneHintLines(hint: WorkLaneHint | null): string[] {
+  if (!hint) return [];
+  return [
+    `Lane:  ${hint.command}`,
+    `       ${hint.reason}`,
+  ];
+}

--- a/src/defence/iron-dome/work-lane-hints.ts
+++ b/src/defence/iron-dome/work-lane-hints.ts
@@ -3,6 +3,8 @@
  * suggest the pinned lane instead of freehand retry thrash.
  *
  * Hints are advisory copy only — they do not approve anything.
+ * Never invent an unreviewed host path: only suggest paths present in
+ * reviewedScriptPaths (or omit the lane entirely).
  */
 
 export interface WorkLaneHintInput {
@@ -24,55 +26,44 @@ function norm(s: unknown): string {
   return String(s ?? '').trim().toLowerCase();
 }
 
+function findPin(paths: string[], frag: string): string | undefined {
+  return paths.find((p) => p.includes(frag));
+}
+
 /**
  * Suggest a reviewed work lane for a denial, or null if unknown.
+ * Requires an actual pin path — no hardcoded host fallbacks.
  */
 export function suggestWorkLane(input: WorkLaneHintInput): WorkLaneHint | null {
   const cwd = norm(input.cwd);
   const signals = (input.signals ?? []).map(norm);
-  const paths = (input.reviewedScriptPaths ?? []).map(String);
-  const hasEgress = signals.some((s) =>
-    s.includes('external-egress') || s.includes('network') || s.includes('egress'),
-  );
-  const hasJotform = signals.some((s) => s.includes('jotform'))
-    || cwd.includes('jotform');
+  const paths = (input.reviewedScriptPaths ?? []).map(String).filter(Boolean);
 
-  const findPin = (frag: string): string | undefined =>
-    paths.find((p) => p.includes(frag));
+  // Only exact external-egress (not secret-egress / other *egress* substrings)
+  const hasExternalEgress = signals.includes('external-egress');
+  if (!hasExternalEgress || paths.length === 0) return null;
 
-  // Vita website CI / ship
+  // Vita website CI / ship — cwd must look like vita work AND pin must exist
+  const vitaPin = findPin(paths, 'vita-site/gh-ci.sh') ?? findPin(paths, 'gh-ci.sh');
   if (
-    hasEgress
-    && (cwd.includes('vita') || cwd.includes('vitaetpax') || cwd.includes('vita-mobile')
-      || findPin('vita-site/gh-ci.sh'))
+    vitaPin
+    && (cwd.includes('vita') || cwd.includes('vitaetpax') || cwd.includes('vita-mobile'))
   ) {
-    const pin = findPin('vita-site/gh-ci.sh') ?? '/home/edith/scripts/vita-site/gh-ci.sh';
     return {
-      command: `${pin} status staging`,
+      command: `${vitaPin} status staging`,
       reason: 'Vita site CI — use the pinned ship script, not freehand gh/curl',
     };
   }
 
-  // Jotform toolkit
-  if (hasJotform || (hasEgress && cwd.includes('jotform'))) {
-    const pin = findPin('jotform.py')
-      ?? findPin('jotform_builder.py')
-      ?? findPin('club_form_payment_upgrade.py');
+  // Jotform toolkit — pin required
+  if (cwd.includes('jotform') || signals.some((s) => s.includes('jotform'))) {
+    const pin = findPin(paths, 'jotform.py')
+      ?? findPin(paths, 'jotform_builder.py')
+      ?? findPin(paths, 'club_form_payment_upgrade.py');
     if (pin) {
       return {
         command: `python3 ${pin} --help`,
         reason: 'Jotform — use the pinned toolkit path, not freehand API/curl',
-      };
-    }
-  }
-
-  // Generic: pinned gh-ci exists and egress denied from a workspace
-  if (hasEgress) {
-    const pin = findPin('vita-site/gh-ci.sh') ?? findPin('gh-ci.sh');
-    if (pin && (cwd.includes('workspace') || cwd.includes('openclaw') || cwd.includes('.git'))) {
-      return {
-        command: `${pin} status staging`,
-        reason: 'Network was held — if this is site CI, use the pinned gh-ci lane',
       };
     }
   }


### PR DESCRIPTION
## Summary
Stops Action Guard DNP alerts from feeling like “the product nerfed the agent” without opening freehand egress.

### Operator digest (#331)
- Title: **held (headless, no prompt)** — not fake BLOCKED button card
- Shows **lane** when a reviewed path matches (e.g. Vita `gh-ci.sh status staging`)
- Shows **one-shot** `shieldcortex approve --denial <id>`
- States whether a separate **Approve once / Deny** card was raised
- Coalesce note kept; no raw command

### Agent-facing deny
- Explicit: do **not** freehand-retry `gh`/curl
- Point at pinned work lanes when known

### #310 card
- Title **Approve once?**
- Trust line clearer; optional lane bit in description

### Not in this PR
- Full new notify transport (Edith already has webhook + retryCards; card raise path unchanged)
- Broad external-egress auto-approve

## Test plan
- [x] dnp-digest + work-lane-hints + retry-control-310 + prompt-surface-deny (95)
- [ ] CI green
- [ ] Dual review