### PR TITLE
fix(guard): #310 HMAC-key first-use race is fail-closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - **Track A harden + T1 (#348 / #393 / #394):** signed `shieldcortex config --memory-plane`; doctor `checkMemoryPlaneDrift` + `checkMemoryHostContract` (paper-contract / dual-plane drift).
 
 ### Fixed
+- **#310 waiter-race CI flake (macos-test after #399):** leftover after #398 — a child can return `no-key` / `unwritable` (HMAC key first-use `wx` race before the store lock) instead of `already-claimed`/`locked`. Both mint nothing. Key reread now retries briefly; the race test pre-warms the key and scores those fail-closed losers.
 - **#310 waiter-race CI flake:** a lock-spin timeout (`claimCardLaunch` → `locked`) is fail-closed and must not be scored as a missing `already-claimed`. Lock sleep now wall-clock waits if `Atomics.wait` is unavailable instead of burning 60 no-op retries.
 - **Inject trust floor (Opus B1):** `source_attested` alone no longer bypasses inject eligibility; unverified defence never injects; pack salience clamped to 0.7.
 - **Scope gate (Opus B3):** session-start `requireScope` is config default-true, not data-derived from unscoped DB rows.

--- a/src/defence/iron-dome/__tests__/retry-control-races-310.test.ts
+++ b/src/defence/iron-dome/__tests__/retry-control-races-310.test.ts
@@ -11,10 +11,14 @@
  *   - concurrent denial writes never lose an update;
  *   - two waiters cannot both hold a launch claim for one identity;
  *   - a deny racing a tap leaves the store readable, with the deny winning.
+ *
+ * HMAC-key first-use (`wx` + reread) is covered in retryHmacKey itself
+ * (retry then null). This suite pre-warms the key so children race the lock.
  */
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
+import { randomBytes } from 'node:crypto';
 import { spawn, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -26,6 +30,7 @@ import {
   grantRetry,
   hashToolCall,
   recordDenialFingerprint,
+  retryControlDir,
 } from '../retry-control.js';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
@@ -54,6 +59,14 @@ describe('#310 — concurrency on the one lock plane', () => {
   beforeEach(() => {
     home = mkdtempSync(join(tmpdir(), 'sc-retry-race-'));
     mkdirSync(join(home, '.shieldcortex'), { recursive: true });
+    // Pre-warm the HMAC key so the six claim children race the lock plane,
+    // not first-use key creation (`no-key` is fail-closed but is not the
+    // property this suite is proving).
+    const approvals = retryControlDir(home);
+    mkdirSync(approvals, { recursive: true, mode: 0o700 });
+    writeFileSync(join(approvals, 'retry-control.key'), `${randomBytes(32).toString('hex')}\n`, {
+      mode: 0o600,
+    });
     cwd = mkdtempSync(join(tmpdir(), 'sc-retry-race-cwd-'));
   });
 
@@ -148,17 +161,24 @@ describe('#310 — concurrency on the one lock plane', () => {
       + 'process.stdout.write(c.ok ? "CLAIMED" : "refused:" + c.reason);'));
 
     // Security invariant: exactly one mint. Losers must be fail-closed.
-    // Under CI contention a loser can time out the lock spin (`locked`)
-    // instead of observing the committed claim (`already-claimed`). Both
-    // mint nothing. A crash / empty stdout / not-found is still a fail.
+    // Under CI contention a loser can time out the lock spin (`locked`),
+    // lose the HMAC-key first-use race (`no-key`), or fail the locked
+    // write (`unwritable`) instead of observing `already-claimed`. All
+    // three mint nothing. not-found / budget-exhausted / empty stdout
+    // / crash still fail — those are not this race's valid losers.
     const dump = results.map((r) => ({ status: r.status, stdout: r.stdout, stderr: r.stderr.slice(0, 200) }));
     expect(results.every((r) => r.status === 0)).toBe(true);
     const claimed = results.filter((r) => r.stdout.includes('CLAIMED'));
+    const failClosedReasons = ['already-claimed', 'locked', 'unwritable', 'no-key'];
     const failClosed = results.filter((r) =>
-      r.stdout.includes('refused:already-claimed') || r.stdout.includes('refused:locked'));
-    expect({ claimed: claimed.length, failClosed: failClosed.length, dump }).toEqual({
+      failClosedReasons.some((reason) => r.stdout.includes(`refused:${reason}`)));
+    const unexpected = results.filter((r) =>
+      !r.stdout.includes('CLAIMED')
+      && !failClosedReasons.some((reason) => r.stdout.includes(`refused:${reason}`)));
+    expect({ claimed: claimed.length, failClosed: failClosed.length, unexpected, dump }).toEqual({
       claimed: 1,
       failClosed: 5,
+      unexpected: [],
       dump,
     });
     expect(storeFile().rows[0].claim).toBeDefined();

--- a/src/defence/iron-dome/retry-control.ts
+++ b/src/defence/iron-dome/retry-control.ts
@@ -318,8 +318,19 @@ function retryHmacKey(home?: string): string | null {
       writeFileSync(p, `${key}\n`, { mode: 0o600, flag: 'wx' });
       return key;
     } catch {
-      const raced = readFileSync(p, 'utf8').trim();
-      return /^[0-9a-f]{64}$/i.test(raced) ? raced.toLowerCase() : null;
+      // Another process won wx. A same-tick read can still see an empty
+      // or partial file on some hosts (macOS CI after #399); retry briefly
+      // then fail closed — no key means no card claim.
+      for (let attempt = 0; attempt < HMAC_KEY_REREAD_ATTEMPTS; attempt += 1) {
+        try {
+          const raced = readFileSync(p, 'utf8').trim();
+          if (/^[0-9a-f]{64}$/i.test(raced)) return raced.toLowerCase();
+        } catch {
+          /* still missing */
+        }
+        sleepSync(HMAC_KEY_REREAD_SLEEP_MS);
+      }
+      return null;
     }
   } catch {
     return null;
@@ -343,6 +354,9 @@ function constantTimeEquals(a: string, b: string): boolean {
 
 const LOCK_ATTEMPTS = 60;
 const LOCK_SLEEP_MS = 20;
+/** After losing exclusive key create, how long we wait to observe the winner's 64-hex write (~40ms). */
+const HMAC_KEY_REREAD_ATTEMPTS = 8;
+const HMAC_KEY_REREAD_SLEEP_MS = 5;
 /** A lock older than this is presumed abandoned (the holder is a one-shot
  *  hook process; every operation here is milliseconds of file IO). */
 const LOCK_STALE_MS = 10_000;


### PR DESCRIPTION
## Why

`main` macos-test is red after #399 (`920dad0`, run 32657274835). Linux Node 20/22 passed.

`retry-control-races-310` — two racing waiters cannot both hold a launch claim:
- claimed: 1 (correct)
- failClosed: 4, expected 5

#398 already scored `refused:locked` as fail-closed. The leftover child exited 0 with a **third** no-mint reason.

## Cause

`claimCardLaunch` calls `hmacNonce` / `retryHmacKey` **before** the store lock. Six children racing first-use can lose the exclusive `wx` create and see an empty/partial key (`no-key`) or fail the locked write (`unwritable`). Both mint nothing — same class as `locked`.

## Change

- After a lost `wx`, reread the key briefly (`HMAC_KEY_REREAD_ATTEMPTS` × `HMAC_KEY_REREAD_SLEEP_MS` ≈ 40ms), then still return null.
- Race test pre-warms `retry-control.key` so children race the lock plane, not key init.
- Score fail-closed losers: `already-claimed` | `locked` | `unwritable` | `no-key`.
- `not-found` / `budget-exhausted` / empty stdout / crash still fail.

No retryCards default change. No version bump. No 4.54.12 cut (Edith soak still held).

## Verification

- `npm run build:ts`
- `node scripts/run-jest.mjs src/defence/iron-dome/__tests__/retry-control-races-310.test.ts src/defence/iron-dome/__tests__/retry-control-310.test.ts --runInBand --forceExit` → 50/50
- Race suite 15/15 sequential repeats on Linux
- Secret scan of this diff: clean
- Dual review of the pre-nit pack: Grok 4.6 **APPROVE_WITH_NITS**, SOL Pro **APPROVE_WITH_NITS**. Named retry knobs + suite header folded.

Do not merge until GitHub CI (especially macos-test) is green on this head.