### PR TITLE
docs(arch): intent-first doctrine + target architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Design:** Intent-first doctrine + target architecture (Dashboard/X-Ray/Graph retained) — `docs/design/2026-08-24-intent-first-*.md`
+
+### Added
 - **Design:** SOTA memory + memory defence + work-not-frustration program fold (Grok/SOL/Opus) — `docs/design/2026-08-24-memory-sota-defence-work-not-frustration.md`
 
 ### Changed

--- a/docs/design/2026-08-24-intent-first-doctrine.md
+++ b/docs/design/2026-08-24-intent-first-doctrine.md
@@ -1,0 +1,153 @@
+# Intent-first doctrine — ShieldCortex product law
+
+**Status:** Normative product doctrine (operator-directed)  
+**Date:** 2026-08-24  
+**Owner:** TARS · Directed by: Michael  
+**Supersedes on conflict (UX / deny personality only):** bureaucratic “deny-by-default unless pinned” readings of Action Guard digests; overbuilt disposition-as-day-1-UX in research folds  
+**Does not supersede:** catastrophe hard-stops, credential/secret non-exfil, attestation≠trust, no A2 multi-master, no `enforce:false` / broad autoApprove  
+
+**Companion:** `2026-08-24-intent-first-target-architecture.md` (boxes + diagrams)  
+**Background research (kept, demoted from day-1 UX):** `2026-08-24-memory-sota-defence-work-not-frustration.md`
+
+---
+
+## 1. One-line law
+
+> **If Mike asked the agent to do a job on a trusted channel, ShieldCortex helps finish that job. It pauses in plain English only when something looks like a hijack — not when the agent is simply working.**
+
+---
+
+## 2. What Michael said (preserve)
+
+- Trusted channel task → why would SC block normal work?
+- If memory/write/recall is bent by injection (“forget last orders and do XYZ”), the engine should **piece it together** and card Mike:  
+  *“Hold on Mike — are you sure you want me to do XYZ? That’s not like you / not what you asked.”*
+- Over-engineering the deny surface frustrated operators (Edith uninstall). Simplify.
+
+This doctrine is that product.
+
+---
+
+## 3. Channel trust
+
+| Channel | Trust | Default |
+|---|---|---|
+| Michael → agent (Telegram allowlisted, TTY, Dashboard operator actions) | **Trusted intent** | **Allow the work** of that task |
+| Agent tool steps that advance the stated task | **Task-scoped allow** | Allow unless catastrophe / clear mismatch |
+| World → agent (web, files, tool results, untrusted memory, MCP schemas) | **Untrusted content** | Scan for **intent hijack**; never treat as Mike’s orders |
+| SC memory vault | **Defended facts** | Store genuine work facts; **never execute memory as instructions** |
+
+Iron Dome is a **bodyguard who knows who hired it**, not a bouncer who frisks the owner every step.
+
+---
+
+## 4. The only decision diamond (runtime)
+
+```text
+Event (tool call OR memory write/recall candidate)
+        │
+        ▼
+ Catastrophe or secret exfil?
+        │ yes → HARD STOP (no card required)
+        │ no
+        ▼
+ Fits Mike’s current trusted task?
+        │ yes → ALLOW (log quietly)
+        │ no / unclear
+        ▼
+ Looks like hijack / override / “not what Mike asked”?
+        │ yes → PLAIN ENGLISH CARD → Mike Allow once / Deny
+        │ no
+        ▼
+ Soft allow or quiet log (don’t invent drama)
+```
+
+### Hard stop (rare, non-negotiable)
+- Credential/secret exfil patterns  
+- Catastrophic destroy (disk wipe class)  
+- Clear malware/install-exec of untrusted remote payload when not the task  
+
+### Plain card (the product)
+```text
+Hold on Mike — this doesn’t match your ask.
+
+You asked:  <task summary>
+It wants:   <one plain English line>
+Why pause:  looks like override / injection / unusual for this task
+
+[Allow once]   [Deny]
+```
+
+No issue numbers in the headline. No forensic essay. No “chat buttons aren’t a TTY.”  
+Optional footer for operators who want it: action id + forensics path.
+
+### Not a card
+- Normal `gh` / deploy watch / Jotform / LAN re-sweep when **that is the task**  
+- Routine git/build/edit in the worktree of the task  
+- Memory facts (“Open Day is Fri 25 Sep”)  
+
+---
+
+## 5. Memory under intent-first
+
+| Do | Don’t |
+|---|---|
+| Remember genuine work facts freely | Treat work facts like poison because they mention ports/IPs/dates |
+| Keep instructions **out of inject packs** | Let “ignore Mike and …” from memory steer the agent |
+| On override-shaped memory → **same plain card** | Binary-quarantine every imperative-looking note without asking |
+| Facts in, orders from vault never auto-run | Empty the brain to feel “safe” |
+
+Smart memory defence = **“is this still Mike’s job, or a hijack?”**  
+Not a 40-row taxonomy as the operator-facing product.
+
+---
+
+## 6. What we keep (full stack — not deleted)
+
+| Surface | Role under intent-first |
+|---|---|
+| **memories.db + defence pipeline** | Immune system for durable facts |
+| **Inject pack** | Brief facts at session start — data, not orders |
+| **Iron Dome / Action Guard** | Runtime diamond above |
+| **#310 / notify / webhook** | Delivery rails for the **plain card** |
+| **Work lanes / pins** | Optional standing toolkits + less card noise — **secondary**, not the only air supply |
+| **Doctor** | Health of install/plane/guard |
+| **Dashboard** | Cockpit: memory, holds, cards, replay |
+| **X-Ray** | Workspace/file/deps sensor (environment) |
+| **Graph / constellation** | Understanding layer over memories — not the deny engine |
+| **Dream / Cortex / distill** | Capture quality for genuine work |
+| **Cloud / fleet** | Same model, multi-host |
+
+Research folds (dual-plane residual, multi-way disposition matrices) remain **engineering background**. They must not redefine day-1 personality against this doctrine.
+
+---
+
+## 7. Explicit refusals (still)
+
+- `enforce:false` / broad autoApprove as the “fix”  
+- Fake Allow buttons that don’t grant  
+- Executing instructions **from** memory/tools as if Mike said them  
+- A2 multi-master memory  
+- Training operators to uninstall  
+
+---
+
+## 8. Success (human)
+
+1. Mike can assign a real job; the agent finishes without siren theatre.  
+2. A planted “forget your orders” pause gets **one English card**, not a silent wrong action and not a death spiral of DNPs.  
+3. Dashboard/X-Ray/Graph still explain the world when Mike opens them.  
+4. Uninstall is no longer the rational move to get work done.  
+
+---
+
+## 9. Build order (docs → spike → ship)
+
+1. This doctrine + target architecture diagrams (**this PR**).  
+2. **Task-intent context** — runtime knows current trusted task summary.  
+3. **Plain card v1** — copy + Allow once / Deny on existing notify rails.  
+4. **Diamond wiring** — Action Guard + memory override share the diamond.  
+5. **Cockpit** — Dashboard shows task, holds, cards (Graph/X-Ray keep their jobs).  
+6. Only then: reinstall candidates (e.g. Edith) on intent-first personality.
+
+No fleet cut required to accept the doctrine. Implementation is gated on Michael “go” for code spikes.

--- a/docs/design/2026-08-24-intent-first-target-architecture.md
+++ b/docs/design/2026-08-24-intent-first-target-architecture.md
@@ -1,0 +1,313 @@
+# Intent-first target architecture
+
+**Status:** Normative target architecture (operator-directed)  
+**Date:** 2026-08-24  
+**Doctrine:** `2026-08-24-intent-first-doctrine.md`  
+**Code:** not in this doc — diagrams + ownership only  
+
+This document answers: **what we already built, what still belongs, and how intent-first sits on top without deleting Dashboard / X-Ray / Graph / Memory / Iron Dome.**
+
+---
+
+## 1. Answer in one breath
+
+Intent-first is a **decision personality**, not a greenfield rewrite.
+
+- **Keep** the boxes (memory plane, Iron Dome, dashboard, x-ray, graph, doctor, cloud).  
+- **Change** the diamond inside Iron Dome + memory: *trusted task → allow work; hijack → plain card; catastrophe → hard stop.*  
+- **Demote** siren-first DNP theatre and “pins or death” as the only air supply.
+
+---
+
+## 2. As-is architecture (what exists today)
+
+```text
+                         YOU (Telegram / TTY / Dashboard)
+                                    │
+                                    │ tasks + approvals
+                                    ▼
+┌──────────────────────────────────────────────────────────────┐
+│                     AGENT HOST                                 │
+│  Claude Code / OpenClaw / Hermes                               │
+│       │                                                        │
+│       │ hooks (PreToolUse, SessionStart, Stop, …)              │
+│       ▼                                                        │
+│  ┌──────────────────────┐    ┌─────────────────────────────┐  │
+│  │ Iron Dome            │    │ Memory path                   │  │
+│  │ Action Guard         │    │ remember / distill / inject │  │
+│  │ tool intercept       │    │ defence pipeline            │  │
+│  │ signals → hold/deny  │    │ → memories.db / quarantine  │  │
+│  │ cards / digests      │    │ → session inject pack       │  │
+│  └──────────┬───────────┘    └──────────────┬──────────────┘  │
+│             │                               │                 │
+│             ▼                               ▼                 │
+│        ~/.shieldcortex/  (config, denials, audit, approvals,  │
+│                          memories.db, retry-control, …)       │
+└─────────────┬───────────────────────────────┬─────────────────┘
+              │ local API                     │ optional
+              ▼                               ▼
+     ┌─────────────────┐              ┌──────────────┐
+     │ Dashboard       │              │ SC Cloud      │
+     │ Command centre  │              │ sync/replica  │
+     │ Memory / Replay │              └──────────────┘
+     │ Protection      │
+     │ Graph ◄─────────┼── entities/links from memories
+     │ X-Ray tab ◄─────┼── findings store
+     └────────┬────────┘
+              │
+              ▼
+     ┌─────────────────┐
+     │ X-Ray CLI/watch │  workspace files, deps, beacons, SARIF/CI
+     └─────────────────┘
+```
+
+### As-is Mermaid
+
+```mermaid
+flowchart TB
+  subgraph Trust["Operator channels"]
+    M[Mike: Telegram / TTY / Dashboard]
+  end
+
+  subgraph Host["Agent host"]
+    A[Agent runtime]
+    H[SC hooks]
+    ID[Iron Dome / Action Guard]
+    MP[Memory write + recall pipeline]
+    DB[(memories.db · audit · denials · approvals)]
+    A --> H
+    H --> ID
+    H --> MP
+    ID --> DB
+    MP --> DB
+  end
+
+  subgraph Cockpit["Operator cockpit"]
+    D[Dashboard]
+    G[Graph / Constellation]
+    XTab[X-Ray tab]
+    D --> G
+    D --> XTab
+  end
+
+  subgraph Sensors["Environment sensors"]
+    XR[X-Ray scan / watch / CI]
+  end
+
+  M -->|task + approvals| A
+  ID -->|holds / digests / cards| M
+  DB --> D
+  XR --> XTab
+  XR --> D
+```
+
+### Pain in the as-is personality (Edith lesson)
+
+```text
+signal matched  →  deny headless  →  loud digest  →  hope operator pins a lane
+```
+
+Correct on pure hostility. Wrong when **Mike already ordered the job**.
+
+---
+
+## 3. Target architecture (intent-first on the same boxes)
+
+```text
+                    TRUSTED INTENT
+            (Mike’s task summary + channel)
+                         │
+                         ▼
+              ┌─────────────────────┐
+              │ Intent context      │  NEW thin layer
+              │ current task, scope │
+              │ allowlisted source  │
+              └──────────┬──────────┘
+                         │
+        ┌────────────────┼────────────────┐
+        ▼                ▼                ▼
+   Iron Dome         Memory path      (future: other
+   Action Guard      write/recall      sensors)
+        │                │
+        └────────┬───────┘
+                 ▼
+        INTENT DIAMOND (shared)
+        catastrophe → STOP
+        fits task   → ALLOW
+        hijack?     → PLAIN CARD → Mike
+                 │
+                 ▼
+        existing stores + notify rails
+        (denials, approvals, memories, webhook/OpenClaw cards)
+                 │
+                 ▼
+        Dashboard / Graph / X-Ray / Doctor
+        (cockpit + sensors — unchanged jobs)
+```
+
+### Target Mermaid
+
+```mermaid
+flowchart TB
+  M[Mike trusted channel] -->|task text| IC[Intent context store]
+  M -->|Allow once / Deny| CARD[Plain English card]
+
+  A[Agent] --> H[Hooks]
+  H --> ID[Iron Dome]
+  H --> MP[Memory pipeline]
+  IC --> ID
+  IC --> MP
+
+  ID --> DMD{Intent diamond}
+  MP --> DMD
+
+  DMD -->|catastrophe| STOP[Hard stop + audit]
+  DMD -->|fits task| ALLOW[Allow + quiet log]
+  DMD -->|hijack / mismatch| CARD
+  CARD -->|Allow once| ALLOW
+  CARD -->|Deny| DENY[Deny + audit]
+
+  ALLOW --> DB[(memories / audit / approvals)]
+  STOP --> DB
+  DENY --> DB
+
+  DB --> DASH[Dashboard cockpit]
+  XR[X-Ray scanner] --> DASH
+  DB --> G[Graph]
+  DASH --> M
+```
+
+### Intent diamond (detail)
+
+```mermaid
+flowchart TD
+  E[Event: tool call or memory candidate] --> C{Catastrophe or secret exfil?}
+  C -->|yes| HS[HARD STOP]
+  C -->|no| T{Fits current trusted task?}
+  T -->|yes| AL[ALLOW]
+  T -->|no / unclear| H{Hijack or override shaped?}
+  H -->|yes| PC[Plain English card to Mike]
+  H -->|no| SA[Soft allow or quiet log]
+  PC -->|Allow once| AL
+  PC -->|Deny| DN[DENY]
+```
+
+---
+
+## 4. Where each major surface sits
+
+| Surface | Layer | Target job | Intent-first change |
+|---|---|---|---|
+| **Intent context** | Control | Know current Mike task | **New** thin store/API |
+| **Iron Dome** | Runtime | Tool allow/deny/card | Diamond uses task fit, not signal-only |
+| **Memory pipeline** | Brain | Defended durable facts | Facts free; orders-from-vault never auto-run; override → card |
+| **Inject pack** | Brain → model | Brief facts | Fact-frame only; no instructions |
+| **Plain card** | UX | One human door | Primary UX; digest becomes backup |
+| **Work lanes** | UX/ops | Standing scripts | Optional accelerator — not sole oxygen |
+| **Doctor** | Health | Install/plane/guard truth | Keep; add “held without door” when useful |
+| **Dashboard** | Cockpit | See all | Show task + cards + memory + protection |
+| **Graph** | Cockpit | Relate facts | Unchanged purpose; fed by memory |
+| **X-Ray** | Sensor | Workspace threats | Unchanged purpose; not the task diamond |
+| **Cloud** | Fleet | Sync/replica | Same model later |
+| **Dual-plane / Track A research** | Correctness | One brain long-term | Background; not day-1 deny personality |
+
+---
+
+## 5. Data / trust flows
+
+### 5.1 Trusted task in
+```text
+Mike chat/TTY/Dashboard
+  → intent context { summary, channel, time, agent, cwd/project? }
+  → agent works
+  → tool events compared to intent
+```
+
+### 5.2 Memory
+```text
+capture/distill/remember
+  → defence pipeline (keep)
+  → store facts
+  → inject only fact-frame rows
+  → if content is override-of-orders shaped → plain card (don’t silent-steer)
+```
+
+### 5.3 Environment (X-Ray)
+```text
+files/deps/CI
+  → findings store
+  → Dashboard X-Ray tab
+  → does NOT replace runtime intent diamond
+```
+
+### 5.4 Graph
+```text
+memories (+ optional session entities)
+  → graph edges
+  → Dashboard constellation
+  → helps Mike/agent understand — not a deny oracle
+```
+
+---
+
+## 6. Build slices (implementation map)
+
+| Slice | Deliverable | Touches | Done when |
+|---|---|---|---|
+| **A Docs** | Doctrine + this architecture | `docs/design/*` | Merged |
+| **B Intent context** | Record current trusted task per agent/session | hooks + small store under `~/.shieldcortex/` or session meta | Task visible on deny/card |
+| **C Plain card v1** | English copy + Allow once/Deny on existing #310/notify rails | `dnp-retry-waiter`, notify formatters, OpenClaw/webhook | Mike gets the card sample |
+| **D Diamond wiring** | Action Guard + memory override share diamond | `pre-tool-hook`, tool-action-guard, inject/recall filters | Edith-class jobs allow; hijack cards |
+| **E Cockpit** | Dashboard: current task, open cards, recent holds | dashboard routes/UI | Mike can see state without Telegram archaeology |
+| **F Demote noise** | Digest = backup; pins optional | copy + defaults | No siren-as-primary |
+| **G Reinstall candidate** | Optional host (Edith) on new personality | ops | Only after D feels right |
+
+**Non-goals for B–D:** deleting Graph/X-Ray; broad autoApprove; enforce:false; full Track A import rewrite as a blocker.
+
+---
+
+## 7. Mapping “what we built” → keep / demote
+
+| Built thing | Verdict |
+|---|---|
+| 6-layer memory defence, quarantine, audit | **Keep** — immune system |
+| Iron Dome intercept + approvals | **Keep** — wire diamond |
+| #310 retry / #399 digest work | **Keep rails**, replace personality with plain card |
+| Dashboard command centre | **Keep** — cockpit |
+| X-Ray scanner + SARIF | **Keep** — environment sensor |
+| Knowledge graph UI | **Keep** — understanding |
+| Dream/Cortex/distill | **Keep** — fill brain with real work |
+| Work-lane pins | **Keep as optional** |
+| Paper dual-plane doctor / residual Track A | **Keep as engineering track**, not UX dictator |
+| Loud DNP-as-primary, pins-or-death | **Demote** |
+
+---
+
+## 8. Relationship to prior design folds
+
+| Doc | Role now |
+|---|---|
+| `2026-08-24-intent-first-doctrine.md` | **Product law** |
+| This file | **Architecture + diagrams** |
+| `2026-08-24-memory-sota-defence-work-not-frustration.md` | Research depth; Phase tickets demoted behind intent-first slices A–D |
+| `2026-08-22-memory-sota-track-a-residual.md` | Still valid for single-plane correctness; does not override intent-first UX |
+| Epic #347 / #401 / #402 | Re-read through doctrine: doors = plain card first; lanes secondary |
+
+---
+
+## 9. Risks (short)
+
+- **Bad task summary** → over-allow. Mitigate: task scoped by channel+time+project; catastrophe still hard-stops.  
+- **Missing task context** → fall back to card, not silent allow-all.  
+- **Card fatigue** → improve task fit, don’t return to silent deny spirals.  
+- **Equating intent-first with disarm** → refuse; hard stops stay.  
+
+---
+
+## 10. Operator checklist
+
+- [x] Doctrine written  
+- [x] Target + as-is diagrams written  
+- [ ] Michael “go” on Slice B/C code spike  
+- [ ] Pick living host for card proof (not mid-crisis Edith unless asked)  
+- [ ] Cut/release only after personality feels right — soak/cut holds unchanged unless Michael lifts them  

--- a/docs/design/2026-08-24-memory-sota-defence-work-not-frustration.md
+++ b/docs/design/2026-08-24-memory-sota-defence-work-not-frustration.md
@@ -25,6 +25,7 @@
 Opus’s two REWORK items are **accepted as Phase-0/1 structural locks**, not optional polish.
 
 ---
+> **2026-08-24 operator redirect:** Day-1 product personality is now **intent-first** — see `2026-08-24-intent-first-doctrine.md` and `2026-08-24-intent-first-target-architecture.md`. This fold remains engineering background; it must not override the plain-card / trusted-task law.
 
 ## 1. North star (hold this)
 


### PR DESCRIPTION
## Summary
Michael-directed product architecture:

1. `docs/design/2026-08-24-intent-first-doctrine.md` — product law  
2. `docs/design/2026-08-24-intent-first-target-architecture.md` — as-is + target diagrams, surface map, build slices  

### Law
Trusted channel task → agent works. Hijack / override → plain English card. Catastrophe → hard stop.

### Kept
Memory plane, Iron Dome, Dashboard, X-Ray, Graph, Doctor, cloud rails.

### Demoted
Siren-first DNP as primary UX; pins-or-death as only oxygen.

## Test plan
- [x] Docs only  
- [ ] CI green  