### PR TITLE
fix(memory): #406 stop compounding decay into base salience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **#406 P0:** consolidation no longer writes temporal decay into base `salience` — only `decayed_score` (repeated consolidate/updateDecayScores stay invariant on the base).
+
+### Fixed
 - **#405 P0 security:** cloud memory delete sends content-free tombstones and honours `shouldSyncRecord` / original privacy fields; graph full-sync SELECT includes `cloud_excluded`; graph delete prune gated the same way.
 
 ### Added

--- a/src/memory/__tests__/consolidation-decay-406.test.ts
+++ b/src/memory/__tests__/consolidation-decay-406.test.ts
@@ -1,0 +1,190 @@
+/**
+ * #406 — consolidation must not compound temporal decay into base salience.
+ *
+ * Athena repro (v4.54.11): processDecay output was written back to
+ * memories.salience, then updateDecayScores recomputed from the already-
+ * reduced base → 0.9 → ~0.71 → ~0.56 with no real elapsed-time event.
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+describe('#406 consolidation decay invariant', () => {
+  beforeEach(async () => {
+    const { closeDatabase, initDatabase } = await import('../../database/init.js');
+    closeDatabase();
+    initDatabase(':memory:');
+  });
+
+  afterEach(async () => {
+    const { closeDatabase } = await import('../../database/init.js');
+    closeDatabase();
+  });
+
+  it('calculateDecayedScore never mutates base salience and is pure for fixed inputs', async () => {
+    const { calculateDecayedScore } = await import('../decay.js');
+    const base = 0.9;
+    const lastAccessed = new Date(Date.now() - 48 * 60 * 60 * 1000); // 48h ago
+    const memory = {
+      id: 1,
+      uuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      type: 'short_term' as const,
+      category: 'general' as const,
+      title: 't',
+      content: 'c',
+      tags: [] as string[],
+      salience: base,
+      accessCount: 0,
+      lastAccessed,
+      createdAt: lastAccessed,
+      updatedAt: lastAccessed,
+      decayedScore: base,
+      metadata: {},
+      scope: 'project' as const,
+      transferable: false,
+      status: 'active' as const,
+      pinned: false,
+      reviewedAt: null,
+      reviewedBy: null,
+      sourceKind: 'user' as const,
+      captureMethod: 'manual' as const,
+      trustScore: 0.8,
+      sensitivityLevel: 'INTERNAL',
+      source: null,
+      cloudExcluded: false,
+      memoryPurpose: 'durable_fact' as const,
+      memoryScope: 'project' as const,
+      hostId: null,
+      agentId: null,
+      captureLayer: null,
+    };
+
+    const a = calculateDecayedScore(memory as any);
+    const b = calculateDecayedScore(memory as any);
+    expect(memory.salience).toBe(base);
+    expect(a).toBeCloseTo(b, 10);
+    expect(a).toBeLessThan(base); // real time decay applied as a view
+  });
+
+  it('updateDecayScores writes decayed_score only — base salience stable across repeats', async () => {
+    const { getDatabase } = await import('../../database/init.js');
+    const { addMemory, getMemoryById } = await import('../store.js');
+    const { updateDecayScores } = await import('../lifecycle.js');
+
+    const m = addMemory({
+      title: 'decay base preserve',
+      content: 'base salience must not be eaten by temporal view',
+      type: 'short_term',
+      salience: 0.9,
+      project: '406',
+    });
+    const db = getDatabase();
+    // Age the row so decay is material, without changing base salience.
+    db.prepare(
+      `UPDATE memories SET last_accessed = datetime('now', '-48 hours'), created_at = datetime('now', '-48 hours'), salience = 0.9 WHERE id = ?`,
+    ).run(m.id);
+
+    const before = getMemoryById(m.id)!;
+    expect(before.salience).toBeCloseTo(0.9, 5);
+
+    const n1 = updateDecayScores();
+    const mid = getMemoryById(m.id)!;
+    expect(mid.salience).toBeCloseTo(0.9, 5);
+    expect(mid.decayedScore).toBeLessThan(0.9);
+
+    const n2 = updateDecayScores();
+    const after = getMemoryById(m.id)!;
+    expect(after.salience).toBeCloseTo(0.9, 5);
+    // Second pass may no-op writes (threshold) but must not drop base or
+    // compound the view beyond wall-clock noise.
+    expect(Math.abs(after.decayedScore - mid.decayedScore)).toBeLessThan(0.02);
+    expect(n1).toBeGreaterThanOrEqual(0);
+    expect(n2).toBeGreaterThanOrEqual(0);
+  });
+
+  it('repeated consolidate() does not compound base salience (Athena class)', async () => {
+    const { getDatabase } = await import('../../database/init.js');
+    const { addMemory, getMemoryById } = await import('../store.js');
+    const { consolidate } = await import('../consolidate.js');
+
+    const m = addMemory({
+      title: 'consolidation compound guard',
+      content: 'short-term row used only for decay path; keep below promote thresholds',
+      type: 'short_term',
+      salience: 0.9,
+      project: '406',
+    });
+    const db = getDatabase();
+    db.prepare(
+      `UPDATE memories SET
+         last_accessed = datetime('now', '-24 hours'),
+         created_at = datetime('now', '-24 hours'),
+         access_count = 0,
+         salience = 0.9
+       WHERE id = ?`,
+    ).run(m.id);
+
+    const s0 = getMemoryById(m.id)!.salience;
+    expect(s0).toBeCloseTo(0.9, 5);
+
+    consolidate();
+    const after1 = getMemoryById(m.id);
+    if (!after1) {
+      // Deleted by aggressive decay/expiry — nothing left to compound.
+      return;
+    }
+    expect(after1.salience).toBeCloseTo(0.9, 5);
+    const d1 = after1.decayedScore;
+
+    consolidate();
+    const after2 = getMemoryById(m.id);
+    if (!after2) return;
+    expect(after2.salience).toBeCloseTo(0.9, 5);
+    // Decayed view may tick with wall clock, but must NOT half again from a
+    // reduced base the way the pre-#406 bug did (~0.9→0.71→0.56).
+    expect(after2.decayedScore).toBeGreaterThan(d1 * 0.85);
+    expect(Math.abs(after2.decayedScore - d1)).toBeLessThan(0.15);
+  });
+
+  it('processDecay updated map is a decayed_score view, not a new base', async () => {
+    const { processDecay, calculateDecayedScore } = await import('../decay.js');
+    const lastAccessed = new Date(Date.now() - 12 * 60 * 60 * 1000);
+    const memory = {
+      id: 7,
+      uuid: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      type: 'short_term' as const,
+      category: 'general' as const,
+      title: 't',
+      content: 'c',
+      tags: [] as string[],
+      salience: 0.9,
+      accessCount: 0,
+      lastAccessed,
+      createdAt: lastAccessed,
+      updatedAt: lastAccessed,
+      decayedScore: 0.9,
+      metadata: {},
+      scope: 'project' as const,
+      transferable: false,
+      status: 'active' as const,
+      pinned: false,
+      reviewedAt: null,
+      reviewedBy: null,
+      sourceKind: 'user' as const,
+      captureMethod: 'manual' as const,
+      trustScore: 0.8,
+      sensitivityLevel: 'INTERNAL',
+      source: null,
+      cloudExcluded: false,
+      memoryPurpose: 'durable_fact' as const,
+      memoryScope: 'project' as const,
+      hostId: null,
+      agentId: null,
+      captureLayer: null,
+    } as any;
+
+    const { updated } = processDecay([memory]);
+    const view = updated.get(7)!;
+    expect(view).toBeCloseTo(calculateDecayedScore(memory), 10);
+    expect(memory.salience).toBe(0.9);
+    expect(view).toBeLessThan(0.9);
+  });
+});

--- a/src/memory/consolidate.ts
+++ b/src/memory/consolidate.ts
@@ -92,8 +92,11 @@ export function consolidate(
       }
     }
 
-    // Update decayed scores in database
-    const updateStmt = db.prepare('UPDATE memories SET salience = ? WHERE id = ?');
+    // #406 — Persist TEMPORAL decay only into decayed_score.
+    // Base salience is event-derived (access/reinforce/structure) and must never
+    // be overwritten by processDecay output, or the next calculateDecayedScore
+    // call compounds decay with unchanged last_accessed.
+    const updateStmt = db.prepare('UPDATE memories SET decayed_score = ? WHERE id = ?');
     for (const [id, score] of updated) {
       if (!toDelete.includes(id)) {
         updateStmt.run(score, id);

--- a/src/memory/decay.ts
+++ b/src/memory/decay.ts
@@ -10,7 +10,11 @@ import { applyExpiryRules } from './expiry.js';
 
 /**
  * Calculate the current decayed score for a memory
- * Uses exponential decay: score = base_score * (decay_rate ^ effective_hours)
+ * Uses exponential decay: score = base_salience * (decay_rate ^ effective_hours)
+ *
+ * #406 invariant: `memory.salience` is the BASE (event-derived). This function
+ * returns a VIEW into time-decayed importance. Callers must persist the result
+ * only to `decayed_score`, never back into `salience`.
  *
  * Memory types have different decay rates:
  * - Short-term: hourly decay (fastest)
@@ -178,7 +182,7 @@ export function processDecay(
 ): {
   toDelete: number[];
   toPromote: number[];
-  updated: Map<number, number>; // id -> new decayed score
+  updated: Map<number, number>; // id -> decayed_score (NOT base salience)
 } {
   const toDelete: number[] = [];
   const toPromote: number[] = [];

--- a/src/memory/lifecycle.ts
+++ b/src/memory/lifecycle.ts
@@ -331,6 +331,9 @@ export function getEnrichmentCooldownStatus(memoryId: number): {
  * Update persisted decay scores for all memories
  * Called during consolidation and periodically by the API server
  * Returns the number of memories updated
+ *
+ * #406: Writes ONLY `decayed_score`. Base `salience` is left untouched so
+ * repeated runs with unchanged last_accessed are stable (modulo wall clock).
  */
 export function updateDecayScores(): number {
   const db = getDatabase();


### PR DESCRIPTION
## Summary
Closes **#406** (Athena P0 on v4.54.11).

`consolidate()` wrote `processDecay()` output into `memories.salience`. Later `updateDecayScores()` recomputed from that already-reduced base while `last_accessed` was unchanged → repeated consolidation compounded decay (Athena: 0.9 → ~0.71 → ~0.56).

### Fix
- Persist temporal decay **only** to `decayed_score`
- Base `salience` stays event-derived (access / reinforce / structure)
- Docs on `calculateDecayedScore` / `updateDecayScores` lock the invariant
- Focused tests: pure view, updateDecayScores stability, repeated consolidate, processDecay map semantics

### Test plan
- [x] `consolidation-decay-406` 4/4
- [ ] CI green
- [ ] Dual review

Closes #406