### PR TITLE
fix(memory): #407 BM25-before-LIMIT + #410 ACL before top-k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **#407 / #410:** FTS candidate window orders by BM25 (`fts.rank`) before LIMIT; ACL filters scored candidates before top-k slice with bounded over-fetch so unauthorized rows cannot starve authorized matches.
+
+### Fixed
 - **#406 P0:** consolidation no longer writes temporal decay into base `salience` — only `decayed_score` (repeated consolidate/updateDecayScores stay invariant on the base).
 
 ### Fixed

--- a/src/__tests__/recall-batching.test.ts
+++ b/src/__tests__/recall-batching.test.ts
@@ -226,20 +226,20 @@ describe('recall-path N+1 batching (Phase 9b)', () => {
     expect(results.map((r) => r.memory.id)).toContain(winner.id);
   });
 
-  it('decayed_score prefilter falls back to raw salience for rows with NULL decayed_score (fresh writes not buried)', async () => {
-    // addMemory leaves decayed_score NULL. Under a naive `decayed_score DESC`,
-    // NULL sorts LAST and a fresh high-salience memory would be buried out of a
-    // LIMIT-1 prefilter. COALESCE(decayed_score, salience) must keep it on top.
+  it('non-query browse still COALESCE(decayed_score, salience) so fresh NULL decay is not buried (#407 keeps this on browse path)', async () => {
+    // #407 moved FTS query ordering to bm25. The COALESCE salience prefilter
+    // remains for non-query browse (empty query). Fresh writes leave
+    // decayed_score NULL — without COALESCE they sort last under DESC.
     const freshHigh = addMemory({
-      title: 'Fresh high salience zeta',
-      content: 'zeta eta theta iota kappa — fresh write, no persisted decay yet.',
+      title: 'Fresh high salience browse',
+      content: 'browse-path fresh write, no persisted decay yet.',
       category: 'note',
       project: PROJECT,
       type: 'long_term',
     });
     const oldLow = addMemory({
-      title: 'Old low salience zeta',
-      content: 'zeta eta theta iota kappa — older, persisted low decay.',
+      title: 'Old low salience browse',
+      content: 'browse-path older, persisted low decay.',
       category: 'note',
       project: PROJECT,
       type: 'long_term',
@@ -250,11 +250,10 @@ describe('recall-path N+1 batching (Phase 9b)', () => {
     db.prepare('UPDATE memories SET salience = ?, decayed_score = ? WHERE id = ?').run(0.3, 0.2, oldLow.id);
 
     const results = await searchMemoriesExplained(
-      { query: 'zeta eta theta', project: PROJECT, limit: 1 },
+      { project: PROJECT, limit: 1 }, // no query → browse path
       DEFAULT_CONFIG,
     );
 
-    // NULL decayed_score → COALESCE to salience 0.9, which beats oldLow's 0.2.
     expect(results[0]?.memory.id).toBe(freshHigh.id);
   });
 });

--- a/src/memory/__tests__/fts-bm25-acl-407-410.test.ts
+++ b/src/memory/__tests__/fts-bm25-acl-407-410.test.ts
@@ -1,0 +1,166 @@
+/**
+ * #407 — FTS BM25 ordering before LIMIT
+ * #410 — ACL filter before top-k slice (with candidate over-fetch)
+ */
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import type { MemoryConfig } from '../types.js';
+import { DEFAULT_CONFIG } from '../types.js';
+
+const PROJECT = 'fts-407-410';
+
+function cfg(over: Partial<MemoryConfig> = {}): MemoryConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    // Pin legacy scorer so FTS rank dominates the sort input set.
+    ranker: { engine: 'legacy' } as MemoryConfig['ranker'],
+    ...over,
+  };
+}
+
+describe('#407 FTS BM25 before LIMIT', () => {
+  beforeEach(async () => {
+    process.env.SHIELDCORTEX_SKIP_EMBEDDINGS = '1';
+    const { closeDatabase, initDatabase } = await import('../../database/init.js');
+    closeDatabase();
+    initDatabase(':memory:');
+  });
+
+  afterEach(async () => {
+    const { closeDatabase } = await import('../../database/init.js');
+    closeDatabase();
+    delete process.env.SHIELDCORTEX_SKIP_EMBEDDINGS;
+  });
+
+  it('returns the highest-BM25 match even when it has low salience and sits outside a salience pre-limit', async () => {
+    const { addMemory, getMemoryById } = await import('../store.js');
+    const { getDatabase } = await import('../../database/init.js');
+    const { searchMemories } = await import('../search-recall.js');
+    const db = getDatabase();
+
+    // Noise: high salience, weak lexical match (token present once).
+    for (let i = 0; i < 25; i++) {
+      const m = addMemory({
+        title: `ops note ${i}`,
+        content: `Routine checklist item ${i}. Mentions deploy once among unrelated filler text about weather and lunch.`,
+        type: 'long_term',
+        salience: 0.95,
+        project: PROJECT,
+      });
+      db.prepare('UPDATE memories SET salience = 0.95, decayed_score = 0.95 WHERE id = ?').run(m.id);
+    }
+
+    // Perfect lexical hit, intentionally low salience (would lose a salience ORDER BY LIMIT 5).
+    const perfect = addMemory({
+      title: 'deploy staging pipeline runbook',
+      content:
+        'deploy staging pipeline deploy staging pipeline deploy staging pipeline — the canonical runbook for staging deploys.',
+      type: 'long_term',
+      salience: 0.45,
+      project: PROJECT,
+    });
+    db.prepare('UPDATE memories SET salience = 0.45, decayed_score = 0.45 WHERE id = ?').run(perfect.id);
+
+    const results = await searchMemories(
+      { query: 'deploy staging pipeline', project: PROJECT, limit: 5 },
+      cfg(),
+    );
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.memory.id).toBe(perfect.id);
+    // Still present after re-fetch (not a phantom id)
+    expect(getMemoryById(perfect.id)?.title).toContain('deploy staging pipeline');
+  });
+
+  it('is stable under insertion-order changes for the same corpus', async () => {
+    const { addMemory } = await import('../store.js');
+    const { searchMemories } = await import('../search-recall.js');
+
+    const a = addMemory({
+      title: 'alpha bravo unique407',
+      content: 'alpha bravo unique407 document',
+      type: 'long_term',
+      salience: 0.5,
+      project: PROJECT,
+    });
+    const b = addMemory({
+      title: 'unrelated noise',
+      content: 'something else entirely',
+      type: 'long_term',
+      salience: 0.9,
+      project: PROJECT,
+    });
+    void b;
+
+    const first = await searchMemories({ query: 'unique407', project: PROJECT, limit: 3 }, cfg());
+    const second = await searchMemories({ query: 'unique407', project: PROJECT, limit: 3 }, cfg());
+    expect(first.map((r) => r.memory.id)).toEqual(second.map((r) => r.memory.id));
+    expect(first[0]?.memory.id).toBe(a.id);
+  });
+});
+
+describe('#410 ACL before LIMIT with over-fetch', () => {
+  beforeEach(async () => {
+    process.env.SHIELDCORTEX_SKIP_EMBEDDINGS = '1';
+    const { closeDatabase, initDatabase } = await import('../../database/init.js');
+    closeDatabase();
+    initDatabase(':memory:');
+  });
+
+  afterEach(async () => {
+    const { closeDatabase } = await import('../../database/init.js');
+    closeDatabase();
+    delete process.env.SHIELDCORTEX_SKIP_EMBEDDINGS;
+  });
+
+  it('unauthorized high-rank RESTRICTED rows do not prevent authorized fill of top-k', async () => {
+    const { addMemory } = await import('../store.js');
+    const { getDatabase } = await import('../../database/init.js');
+    const { searchMemories } = await import('../search-recall.js');
+    const db = getDatabase();
+
+    // High-rank unauthorized (RESTRICTED owned by another agent)
+    for (let i = 0; i < 15; i++) {
+      const m = addMemory({
+        title: `secret credential vault ${i}`,
+        content: `credential vault secret material ${i} credential vault`,
+        type: 'long_term',
+        salience: 0.99,
+        project: PROJECT,
+        sensitivityLevel: 'RESTRICTED',
+      });
+      db.prepare(
+        `UPDATE memories SET salience = 0.99, decayed_score = 0.99, sensitivity_level = 'RESTRICTED', source = 'cli:other-agent' WHERE id = ?`,
+      ).run(m.id);
+    }
+
+    // Authorized owner row (medium-trust agent can read own only if low; use own source match)
+    const ownerSource = 'agent:user-spawned>task-410';
+    const allowed = addMemory({
+      title: 'credential vault runbook public notes',
+      content: 'credential vault operational notes for the owner agent',
+      type: 'long_term',
+      salience: 0.4,
+      project: PROJECT,
+      sensitivityLevel: 'INTERNAL',
+    });
+    db.prepare(
+      `UPDATE memories SET salience = 0.4, decayed_score = 0.4, sensitivity_level = 'INTERNAL', source = ? WHERE id = ?`,
+    ).run(ownerSource, allowed.id);
+
+    // Caller is the owner medium-trust agent — can read own; cannot read others' RESTRICTED.
+    const source = { type: 'agent' as const, identifier: 'user-spawned>task-410' };
+
+    const results = await searchMemories(
+      { query: 'credential vault', project: PROJECT, limit: 3 },
+      cfg(),
+      source,
+    );
+
+    expect(results.some((r) => r.memory.id === allowed.id)).toBe(true);
+    // No unauthorized restricted content leaked
+    for (const r of results) {
+      expect(r.memory.sensitivityLevel).not.toBe('RESTRICTED');
+    }
+    expect(results[0]?.memory.id).toBe(allowed.id);
+  });
+});

--- a/src/memory/__tests__/fts-bm25-acl-407-410.test.ts
+++ b/src/memory/__tests__/fts-bm25-acl-407-410.test.ts
@@ -4,7 +4,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import type { MemoryConfig } from '../types.js';
-import { DEFAULT_CONFIG } from '../types.js';
+import { DEFAULT_CONFIG, DEFAULT_RANKER_CONFIG } from '../types.js';
 
 const PROJECT = 'fts-407-410';
 
@@ -49,7 +49,8 @@ describe('#407 FTS BM25 before LIMIT', () => {
       db.prepare('UPDATE memories SET salience = 0.95, decayed_score = 0.95 WHERE id = ?').run(m.id);
     }
 
-    // Perfect lexical hit, intentionally low salience (would lose a salience ORDER BY LIMIT 5).
+    // Perfect lexical hit, intentionally lower salience (would lose a salience ORDER BY LIMIT 5).
+    // Stay above default salienceThreshold (0.2) so scoring does not drop the row.
     const perfect = addMemory({
       title: 'deploy staging pipeline runbook',
       content:
@@ -67,7 +68,6 @@ describe('#407 FTS BM25 before LIMIT', () => {
 
     expect(results.length).toBeGreaterThan(0);
     expect(results[0]?.memory.id).toBe(perfect.id);
-    // Still present after re-fetch (not a phantom id)
     expect(getMemoryById(perfect.id)?.title).toContain('deploy staging pipeline');
   });
 
@@ -118,7 +118,6 @@ describe('#410 ACL before LIMIT with over-fetch', () => {
     const { searchMemories } = await import('../search-recall.js');
     const db = getDatabase();
 
-    // High-rank unauthorized (RESTRICTED owned by another agent)
     for (let i = 0; i < 15; i++) {
       const m = addMemory({
         title: `secret credential vault ${i}`,
@@ -133,7 +132,6 @@ describe('#410 ACL before LIMIT with over-fetch', () => {
       ).run(m.id);
     }
 
-    // Authorized owner row (medium-trust agent can read own only if low; use own source match)
     const ownerSource = 'agent:user-spawned>task-410';
     const allowed = addMemory({
       title: 'credential vault runbook public notes',
@@ -147,7 +145,6 @@ describe('#410 ACL before LIMIT with over-fetch', () => {
       `UPDATE memories SET salience = 0.4, decayed_score = 0.4, sensitivity_level = 'INTERNAL', source = ? WHERE id = ?`,
     ).run(ownerSource, allowed.id);
 
-    // Caller is the owner medium-trust agent — can read own; cannot read others' RESTRICTED.
     const source = { type: 'agent' as const, identifier: 'user-spawned>task-410' };
 
     const results = await searchMemories(
@@ -157,10 +154,55 @@ describe('#410 ACL before LIMIT with over-fetch', () => {
     );
 
     expect(results.some((r) => r.memory.id === allowed.id)).toBe(true);
-    // No unauthorized restricted content leaked
     for (const r of results) {
       expect(r.memory.sensitivityLevel).not.toBe('RESTRICTED');
     }
     expect(results[0]?.memory.id).toBe(allowed.id);
+  });
+
+  it('RRF default path also ACL-filters before user top-k (Grok #410 hole)', async () => {
+    const { addMemory } = await import('../store.js');
+    const { getDatabase } = await import('../../database/init.js');
+    const { searchMemories } = await import('../search-recall.js');
+    const db = getDatabase();
+
+    for (let i = 0; i < 12; i++) {
+      const m = addMemory({
+        title: `secret credential vault rrf ${i}`,
+        content: `credential vault secret material rrf ${i} credential vault`,
+        type: 'long_term',
+        salience: 0.99,
+        project: PROJECT,
+        sensitivityLevel: 'RESTRICTED',
+      });
+      db.prepare(
+        `UPDATE memories SET salience = 0.99, decayed_score = 0.99, sensitivity_level = 'RESTRICTED', source = 'cli:other-agent' WHERE id = ?`,
+      ).run(m.id);
+    }
+
+    const ownerSource = 'agent:user-spawned>task-410-rrf';
+    const allowed = addMemory({
+      title: 'credential vault runbook public notes rrf',
+      content: 'credential vault operational notes for the owner agent rrf',
+      type: 'long_term',
+      salience: 0.4,
+      project: PROJECT,
+      sensitivityLevel: 'INTERNAL',
+    });
+    db.prepare(
+      `UPDATE memories SET salience = 0.4, decayed_score = 0.4, sensitivity_level = 'INTERNAL', source = ? WHERE id = ?`,
+    ).run(ownerSource, allowed.id);
+
+    const source = { type: 'agent' as const, identifier: 'user-spawned>task-410-rrf' };
+    const results = await searchMemories(
+      { query: 'credential vault', project: PROJECT, limit: 3 },
+      cfg({ ranker: { ...DEFAULT_RANKER_CONFIG, engine: 'rrf' } }),
+      source,
+    );
+
+    expect(results.some((r) => r.memory.id === allowed.id)).toBe(true);
+    for (const r of results) {
+      expect(r.memory.sensitivityLevel).not.toBe('RESTRICTED');
+    }
   });
 });

--- a/src/memory/search-recall.ts
+++ b/src/memory/search-recall.ts
@@ -150,14 +150,30 @@ async function searchMemoriesInternal(
     params.push(...options.tags);
   }
 
-  // Prefilter on the persisted decayed-score index (CLAUDE.md: "Persisted decay
-  // scores for efficient sorting", idx_memories_decayed_score). decayed_score is
-  // NULL until updateDecayScores() persists it (addMemory leaves it unset), so
-  // COALESCE back to raw salience for un-scored rows — identical to rowToMemory's
-  // `decayed_score ?? salience`. Without the COALESCE, NULL sorts last under DESC
-  // and would bury freshly-written high-salience memories out of the prefilter.
-  sql += ' ORDER BY COALESCE(m.decayed_score, m.salience) DESC, m.last_accessed DESC LIMIT ?';
-  params.push(limit);
+  // #407 — When FTS is active, order by FTS5 rank (bm25) BEFORE LIMIT so the
+  // candidate window is true top-k lexical relevance, not salience insertion
+  // order. Tie-break on m.id for stability under insertion-order changes.
+  // Non-query browse still uses persisted decayed_score/salience.
+  //
+  // #410 — When a DefenceSource ACL will filter after scoring, over-fetch the
+  // candidate window so unauthorized high-rank rows cannot starve authorized
+  // matches. Final slice still enforces `limit` after ACL.
+  const hasFtsQuery = Boolean(options.query && options.query.trim());
+  const aclOverfetch = Boolean(source);
+  // Bound over-fetch: enough to fill top-k after heavy ACL drop, not whole table.
+  const candidateLimit = aclOverfetch
+    ? Math.min(Math.max(limit * 10, limit + 40), Math.max(limit * 25, 250))
+    : limit;
+
+  if (hasFtsQuery) {
+    // fts.rank is FTS5 bm25 (lower = better). ASC + stable id tie-break.
+    sql += ' ORDER BY fts.rank ASC, m.id ASC LIMIT ?';
+  } else {
+    // Prefilter on the persisted decayed-score index. decayed_score is NULL
+    // until updateDecayScores() persists it, so COALESCE back to raw salience.
+    sql += ' ORDER BY COALESCE(m.decayed_score, m.salience) DESC, m.last_accessed DESC, m.id ASC LIMIT ?';
+  }
+  params.push(candidateLimit);
 
   const rows = db.prepare(sql).all(...params) as Record<string, unknown>[];
   const scoringContext: SearchScoringContext = {
@@ -242,12 +258,39 @@ async function searchMemoriesInternal(
     }
   }
 
-  const finalResults = sortedResults.slice(0, limit);
+  // #410 — ACL-filter the scored candidate set BEFORE slicing to `limit`, so
+  // unauthorized high-rank rows cannot starve authorized matches. Then enrich
+  // only the authorized top-k (keeps contradiction fan-out bounded).
+  let authorizedResults = sortedResults;
+  if (source) {
+    const db2 = getDatabase();
+    const aclIds = authorizedResults.map((result) => result.memory.id);
+    const aclRows = new Map<number, Record<string, unknown>>();
+    if (aclIds.length > 0) {
+      const placeholders = aclIds.map(() => '?').join(',');
+      const fetched = db2.prepare(
+        `SELECT id, source, sensitivity_level FROM memories WHERE id IN (${placeholders})`,
+      ).all(...aclIds) as Record<string, unknown>[];
+      for (const row of fetched) aclRows.set(row.id as number, row);
+    }
+    authorizedResults = authorizedResults.filter(result => {
+      const row = aclRows.get(result.memory.id);
+      const policy = checkAccess(
+        { id: result.memory.id, source: row?.source as string | null, sensitivity_level: row?.sensitivity_level as string | null },
+        source,
+        'read',
+      );
+      if (!policy.canRead) {
+        logAccessDenial(result.memory.id, source, policy.reason, 'read', execution.attested);
+        return false;
+      }
+      return true;
+    });
+  }
 
-  // Per-result contradiction links, then their counterpart titles. The title
-  // lookup was an N+1-within-N+1 (one SELECT title per contradiction per
-  // result); collect every counterpart id first and resolve all titles with a
-  // single `WHERE id IN (...)`, then read from the id→title map below.
+  const finalResults = authorizedResults.slice(0, limit);
+
+  // Per-result contradiction links on the authorized top-k only.
   const contradictionsByResult = new Map<number, Array<{ strength: number; other_id: number }>>();
   const counterpartIds = new Set<number>();
   for (const result of finalResults) {
@@ -286,36 +329,6 @@ async function searchMemoriesInternal(
         result.explanation.reasons.push(`${contradictions.length} contradiction link${contradictions.length === 1 ? '' : 's'} attached`);
       }
     }
-  }
-
-  if (source) {
-    const db2 = getDatabase();
-    // ACL lookup was an N+1 (one `SELECT source, sensitivity_level WHERE id = ?`
-    // per result); fetch all result rows in one `WHERE id IN (...)` and read the
-    // per-result source/sensitivity from the map. checkAccess/logAccessDenial
-    // logic and filter order are unchanged.
-    const aclIds = finalResults.map((result) => result.memory.id);
-    const aclRows = new Map<number, Record<string, unknown>>();
-    if (aclIds.length > 0) {
-      const placeholders = aclIds.map(() => '?').join(',');
-      const fetched = db2.prepare(
-        `SELECT id, source, sensitivity_level FROM memories WHERE id IN (${placeholders})`,
-      ).all(...aclIds) as Record<string, unknown>[];
-      for (const row of fetched) aclRows.set(row.id as number, row);
-    }
-    return finalResults.filter(result => {
-      const row = aclRows.get(result.memory.id);
-      const policy = checkAccess(
-        { id: result.memory.id, source: row?.source as string | null, sensitivity_level: row?.sensitivity_level as string | null },
-        source,
-        'read',
-      );
-      if (!policy.canRead) {
-        logAccessDenial(result.memory.id, source, policy.reason, 'read', execution.attested);
-        return false;
-      }
-      return true;
-    });
   }
 
   return finalResults;

--- a/src/memory/search-recall.ts
+++ b/src/memory/search-recall.ts
@@ -200,6 +200,9 @@ async function searchMemoriesInternal(
 
   let sortedResults: SearchResult[];
   if (rankerConfig.engine === 'rrf') {
+    // #410 — Do not let RRF slice to the user `limit` before ACL. Fuse at least
+    // the full FTS candidate window (and vector/graph extras), then ACL+slice.
+    const rrfLimit = Math.max(candidateLimit, rows.length, limit);
     sortedResults = scoreWithRrf({
       rows,
       ftsScores,
@@ -209,7 +212,7 @@ async function searchMemoriesInternal(
       db,
       config,
       rankerConfig,
-      limit,
+      limit: rrfLimit,
       includeExplanation: execution.includeExplanation,
     });
   } else {
@@ -224,38 +227,6 @@ async function searchMemoriesInternal(
       includeExplanation: execution.includeExplanation,
       scoringContext,
     });
-  }
-
-  if (execution.enableSideEffects) {
-    const topResults = sortedResults.slice(0, 5);
-    for (const result of topResults) {
-      reinforceFromSearch(result.memory.id);
-    }
-
-    // NOTE (Phase 17 B2): the automatic all-pairs "co-access" linking that used
-    // to run here was removed. It linked every pair of the top-K results as
-    // `related` (strength 0.2), creating C(K,2) ≈ K² spurious graph edges and
-    // running one `SELECT existing` + INSERT/UPDATE per pair on every recall.
-    // Co-appearing in a single search is not a genuine relationship — these
-    // edges polluted the knowledge graph and drove an N² per-pair query storm.
-    // Genuine links are still created elsewhere (addMemory similarity links,
-    // explicit contradiction/relationship links); recall now only reinforces
-    // individual results above.
-
-    if (sortedResults.length > 0 && options.query && options.query.length > 30) {
-      const topResult = sortedResults[0];
-      const queryWords = new Set(options.query.toLowerCase().split(/\s+/).filter(w => w.length > 3));
-      const contentWords = new Set(topResult.memory.content.toLowerCase().split(/\s+/));
-      const newWords = [...queryWords].filter(w => !contentWords.has(w));
-
-      if (newWords.length > queryWords.size * 0.3 && options.query.length > 50) {
-        try {
-          enrichMemory(topResult.memory.id, options.query, 'search');
-        } catch {
-          // enrichment is best-effort
-        }
-      }
-    }
   }
 
   // #410 — ACL-filter the scored candidate set BEFORE slicing to `limit`, so
@@ -327,6 +298,30 @@ async function searchMemoriesInternal(
       }));
       if (result.explanation) {
         result.explanation.reasons.push(`${contradictions.length} contradiction link${contradictions.length === 1 ? '' : 's'} attached`);
+      }
+    }
+  }
+
+  // Side effects only on authorized top-k (post-ACL), never on denied candidates.
+  if (execution.enableSideEffects) {
+    const topResults = finalResults.slice(0, 5);
+    for (const result of topResults) {
+      reinforceFromSearch(result.memory.id);
+    }
+
+    // NOTE (Phase 17 B2): automatic all-pairs co-access linking removed.
+    if (finalResults.length > 0 && options.query && options.query.length > 30) {
+      const topResult = finalResults[0];
+      const queryWords = new Set(options.query.toLowerCase().split(/\s+/).filter(w => w.length > 3));
+      const contentWords = new Set(topResult.memory.content.toLowerCase().split(/\s+/));
+      const newWords = [...queryWords].filter(w => !contentWords.has(w));
+
+      if (newWords.length > queryWords.size * 0.3 && options.query.length > 50) {
+        try {
+          enrichMemory(topResult.memory.id, options.query, 'search');
+        } catch {
+          // enrichment is best-effort
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
Closes **#407** and **#410** (Athena HIGH findings on v4.54.11).

### #407
FTS candidate SQL ordered by salience before LIMIT, so true BM25 top-k could never enter the window.
Now: `ORDER BY fts.rank ASC, m.id ASC LIMIT ?` on query path.

### #410
ACL ran after `slice(0, limit)`, so unauthorized high-rank rows ate the window.
Now: bounded over-fetch when a DefenceSource is present → score → ACL filter (fail-closed) → slice → contradiction enrich.

### Tests
- highest-BM25 low-salience row wins top-k
- stable under repeat
- RESTRICTED foreign rows cannot block owner authorized fill

### Test plan
- [x] focused 407/410 tests
- [x] recall-batching + recall-relevance
- [ ] CI green
- [ ] dual review

Closes #407
Closes #410