### PR TITLE
release: v4.54.12 — Athena P0/HIGH security + integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.54.12] - 2026-08-25
+
+**Athena P0/HIGH security + integrity patch.** Ships cloud delete privacy tombstones, consolidation decay fix, FTS/ACL recall correctness, non-loopback API bind auth, closed Action Guard tool-input schemas, DNP/operator UX from main, and intent-first architecture docs.
+
 ### Security
 - **#412:** closed tool-input schema on Action Guard exec/git paths (unknown keys fail closed, including empty unknown fields); MCP remember/recall execute-path safeParse; env/headers are primitive-valued maps (open keys, closed value types — nested objects rejected); command/path/url values must be strings (objects/arrays/numbers/booleans fail closed). Non-exec families annotate (strip unknowns) but **retain extractor keys** so `Workflow.script` / non-exec `code` surfaces are not blinded. GitHub-API tool names (`github_*`) are not treated as git/exec for schema enforce. Write-family tools such as `create_issue` stay annotate — enforcing a closed write key set would false-block GitHub-shaped payloads.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.11",
+  "version": "4.54.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.54.11",
+      "version": "4.54.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.11",
+  "version": "4.54.12",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.54.11",
+  "version": "4.54.12",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.54.11",
+  "version": "4.54.12",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.54.11
+  version: 4.54.12
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Summary
Patch cut **4.54.12** so npm/hosts get the Athena P0/HIGH stack already on main.

### Ships
| Issue | Fix |
|---|---|
| **#405** P0 | cloud delete = content-free tombstones + privacy gate |
| **#406** P0 | consolidation does not compound temporal decay into base salience |
| **#407 / #410** | FTS BM25 before LIMIT; ACL before top-k |
| **#411** | non-loopback API bind requires opt-in + strong token |
| **#412** | closed Action Guard tool-input schemas |
| **#399** + docs | DNP/operator UX; intent-first architecture |

### Release mechanics
- root `package.json` → `4.54.12`
- `node scripts/sync-plugin-version.mjs` (plugin package + manifest + skill FM)
- CHANGELOG Unreleased → `[4.54.12]`

### After merge
1. Tag `v4.54.12` on the merge commit (triggers publish.yml)
2. Verify npm + GH release
3. Cloud/site train
4. Fleet cloud memory sync remains **OFF** until hosts on 4.54.12+ and operator OK

## Test plan
- [x] `sync-plugin-version.mjs --check`
- [ ] CI green
- [ ] tag → publish → `npm view shieldcortex version` = 4.54.12