### PR TITLE
fix(cloud): #408 atomic claim + lease for sync retry queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **#408:** cloud sync retry queue uses atomic claim + lease (owner/token/expiry); completion/failure updates are claim-conditional; expired leases are reclaimable.
+
 ## [4.54.12] - 2026-08-25
 
 **Athena P0/HIGH security + integrity patch.** Ships cloud delete privacy tombstones, consolidation decay fix, FTS/ACL recall correctness, non-loopback API bind auth, closed Action Guard tool-input schemas, DNP/operator UX from main, and intent-first architecture docs.

--- a/src/cloud/__tests__/sync-queue-lease-408.test.ts
+++ b/src/cloud/__tests__/sync-queue-lease-408.test.ts
@@ -1,0 +1,195 @@
+/**
+ * #408 — atomic claim / lease for the cloud sync retry queue.
+ */
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { closeDatabase, getDatabase, initDatabase } from '../../database/init.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  claimRetryBatch,
+  enqueueFailedSync,
+  processRetryQueue,
+  SYNC_QUEUE_LEASE_MS,
+  type SyncEntry,
+} from '../sync-queue.js';
+
+function makeAuditEntry(overrides: Partial<SyncEntry> = {}): SyncEntry {
+  return {
+    source_type: 'agent',
+    source_identifier: 'lease-test',
+    trust_score: 0.8,
+    sensitivity_level: 'INTERNAL',
+    firewall_result: 'BLOCK',
+    anomaly_score: 0.4,
+    threat_indicators: ['prompt_injection'],
+    reason: 'unit test',
+    pipeline_duration_ms: 12,
+    device_id: 'device-test',
+    device_name: 'unit-test-host',
+    platform: 'linux/arm64',
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('#408 sync_queue claim/lease', () => {
+  let configDir: string;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(async () => {
+    configDir = mkdtempSync(join(tmpdir(), 'shieldcortex-lease-408-'));
+    process.env.SHIELDCORTEX_CONFIG_DIR = configDir;
+    initDatabase(join(configDir, 'memories.db'));
+    originalFetch = globalThis.fetch;
+    const { setCloudConfig } = await import('../config.js');
+    setCloudConfig({
+      cloudEnabled: true,
+      cloudApiKey: 'sc_test_key_not_real',
+      cloudBaseUrl: 'https://example.invalid',
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.SHIELDCORTEX_CONFIG_DIR;
+    closeDatabase();
+    rmSync(configDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  function makeDue(): void {
+    getDatabase()
+      .prepare(`UPDATE sync_queue SET next_retry_at = ? WHERE status = 'pending'`)
+      .run(new Date(Date.now() - 1000).toISOString());
+  }
+
+  function rowLease(id = 1): {
+    lease_owner: string | null;
+    lease_token: string | null;
+    lease_expires_at: string | null;
+    status: string;
+    attempts: number;
+  } {
+    return getDatabase()
+      .prepare(
+        'SELECT lease_owner, lease_token, lease_expires_at, status, attempts FROM sync_queue WHERE id = ?',
+      )
+      .get(id) as {
+      lease_owner: string | null;
+      lease_token: string | null;
+      lease_expires_at: string | null;
+      status: string;
+      attempts: number;
+    };
+  }
+
+  it('two concurrent claim passes cannot both own the same row', () => {
+    enqueueFailedSync(makeAuditEntry());
+    makeDue();
+
+    const a = claimRetryBatch(10);
+    const b = claimRetryBatch(10);
+
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(0);
+    expect(a[0].leaseToken).toBeTruthy();
+    const r = rowLease(a[0].id);
+    expect(r.lease_token).toBe(a[0].leaseToken);
+    expect(r.lease_owner).toBe(a[0].leaseOwner);
+  });
+
+  it('expired lease is reclaimable by another worker', () => {
+    enqueueFailedSync(makeAuditEntry());
+    makeDue();
+    const first = claimRetryBatch(1);
+    expect(first).toHaveLength(1);
+
+    // Expire the lease in the past
+    getDatabase()
+      .prepare(`UPDATE sync_queue SET lease_expires_at = ? WHERE id = ?`)
+      .run(new Date(Date.now() - 1000).toISOString(), first[0].id);
+
+    const second = claimRetryBatch(1);
+    expect(second).toHaveLength(1);
+    expect(second[0].id).toBe(first[0].id);
+    expect(second[0].leaseToken).not.toBe(first[0].leaseToken);
+  });
+
+  it('stale claim cannot complete after re-lease', async () => {
+    enqueueFailedSync(makeAuditEntry());
+    makeDue();
+    const stale = claimRetryBatch(1)[0];
+
+    // Expire + reclaim
+    getDatabase()
+      .prepare(`UPDATE sync_queue SET lease_expires_at = ? WHERE id = ?`)
+      .run(new Date(Date.now() - 1000).toISOString(), stale.id);
+    const fresh = claimRetryBatch(1)[0];
+    expect(fresh.leaseToken).not.toBe(stale.leaseToken);
+
+    // Simulate stale worker finishing "successfully" via raw SQL matching old path —
+    // processRetryQueue uses claimed token; forge a stale completion attempt:
+    const db = getDatabase();
+    const staleComplete = db
+      .prepare(
+        `UPDATE sync_queue SET status = 'synced', attempts = 1, synced_at = ?, last_error = NULL,
+            lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL
+         WHERE id = ? AND lease_token = ? AND status = 'pending'`,
+      )
+      .run(new Date().toISOString(), stale.id, stale.leaseToken);
+    expect(staleComplete.changes).toBe(0);
+
+    // Fresh claim can still complete via processRetryQueue
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    }) as unknown as typeof globalThis.fetch;
+
+    // Row is held by fresh lease and due — processRetryQueue will try to claim;
+    // lease still held by fresh and not expired, so claimRetryBatch skips it.
+    // Complete as the fresh owner would:
+    const ok = db
+      .prepare(
+        `UPDATE sync_queue SET status = 'synced', attempts = 1, synced_at = ?, last_error = NULL,
+            lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL
+         WHERE id = ? AND lease_token = ? AND status = 'pending'`,
+      )
+      .run(new Date().toISOString(), fresh.id, fresh.leaseToken);
+    expect(ok.changes).toBe(1);
+    expect(rowLease(fresh.id).status).toBe('synced');
+  });
+
+  it('processRetryQueue claim prevents double HTTP send under concurrent workers', async () => {
+    enqueueFailedSync(makeAuditEntry());
+    makeDue();
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let sends = 0;
+    globalThis.fetch = jest.fn().mockImplementation(async () => {
+      sends++;
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 30));
+      inFlight--;
+      return { ok: true, status: 200 };
+    }) as unknown as typeof globalThis.fetch;
+
+    const [r1, r2] = await Promise.all([processRetryQueue(), processRetryQueue()]);
+    expect(sends).toBe(1);
+    expect(r1.succeeded + r2.succeeded).toBe(1);
+    expect(r1.processed + r2.processed).toBe(1);
+    expect(rowLease(1).status).toBe('synced');
+  });
+
+  it('lease duration is bounded (SYNC_QUEUE_LEASE_MS)', () => {
+    enqueueFailedSync(makeAuditEntry());
+    makeDue();
+    const [c] = claimRetryBatch(1);
+    const exp = Date.parse(c.leaseExpiresAt);
+    const delta = exp - Date.now();
+    expect(delta).toBeGreaterThan(SYNC_QUEUE_LEASE_MS - 5_000);
+    expect(delta).toBeLessThanOrEqual(SYNC_QUEUE_LEASE_MS + 5_000);
+  });
+});

--- a/src/cloud/sync-queue.ts
+++ b/src/cloud/sync-queue.ts
@@ -6,6 +6,8 @@
  * Uses SQLite sync_queue table with exponential backoff.
  */
 
+import { randomBytes } from 'node:crypto';
+import { hostname } from 'node:os';
 import { getDatabase } from '../database/init.js';
 import { getCloudConfig, getDeviceId, getDeviceName, updateLastSyncAt } from './config.js';
 import type { SyncedMemoryRecord } from './memory-sync.js';
@@ -84,6 +86,105 @@ export interface SyncQueueResult {
 export interface ReconcileQueueResult {
   removed: number;
 }
+
+/** #408 — how long a worker may hold a claimed row before another may reclaim it. */
+export const SYNC_QUEUE_LEASE_MS = 60_000;
+
+export interface SyncQueueClaim {
+  id: number;
+  payload: string;
+  attempts: number;
+  leaseToken: string;
+  leaseOwner: string;
+  leaseExpiresAt: string;
+}
+
+function workerIdentity(): string {
+  return `sc-retry/${hostname()}/${process.pid}`;
+}
+
+function mintLeaseToken(): string {
+  return randomBytes(16).toString('hex');
+}
+
+/**
+ * #408 — Atomically claim up to `limit` due pending rows.
+ * Eligible: status=pending, next_retry_at <= now, and (no lease OR lease expired).
+ * Each claim sets owner/token/expiry in the same UPDATE that selects the row.
+ */
+export function claimRetryBatch(limit: number, nowIso = new Date().toISOString()): SyncQueueClaim[] {
+  const db = getDatabase();
+  const owner = workerIdentity();
+  const claimed: SyncQueueClaim[] = [];
+  const leaseMs = SYNC_QUEUE_LEASE_MS;
+
+  const pick = db.prepare(`
+    SELECT id, payload, attempts
+    FROM sync_queue
+    WHERE status = 'pending'
+      AND next_retry_at <= ?
+      AND (
+        lease_expires_at IS NULL
+        OR lease_expires_at = ''
+        OR lease_expires_at <= ?
+      )
+    ORDER BY next_retry_at ASC
+    LIMIT 1
+  `);
+
+  const take = db.prepare(`
+    UPDATE sync_queue
+    SET lease_owner = ?,
+        lease_token = ?,
+        lease_expires_at = ?
+    WHERE id = ?
+      AND status = 'pending'
+      AND next_retry_at <= ?
+      AND (
+        lease_expires_at IS NULL
+        OR lease_expires_at = ''
+        OR lease_expires_at <= ?
+      )
+  `);
+
+  // better-sqlite3 serialises writers; loop claim-one under implicit lock.
+  while (claimed.length < limit) {
+    const row = pick.get(nowIso, nowIso) as { id: number; payload: string; attempts: number } | undefined;
+    if (!row) break;
+    const token = mintLeaseToken();
+    const exp = new Date(Date.now() + leaseMs).toISOString();
+    const info = take.run(owner, token, exp, row.id, nowIso, nowIso);
+    if (info.changes !== 1) {
+      // Lost the race — try another row
+      continue;
+    }
+    claimed.push({
+      id: row.id,
+      payload: row.payload,
+      attempts: row.attempts,
+      leaseToken: token,
+      leaseOwner: owner,
+      leaseExpiresAt: exp,
+    });
+  }
+  return claimed;
+}
+
+/** Completion/failure updates must still hold the active claim token. */
+function updateIfClaimed(
+  id: number,
+  leaseToken: string,
+  sql: string,
+  ...params: unknown[]
+): boolean {
+  const db = getDatabase();
+  // sql should end with WHERE id = ? — we append claim predicates
+  const full = `${sql} AND lease_token = ? AND status = 'pending'`;
+  const info = db.prepare(full).run(...params, id, leaseToken);
+  return info.changes === 1;
+}
+
+
 
 /**
  * Enqueue a failed sync entry for later retry.
@@ -412,7 +513,49 @@ export interface ProcessRetryOptions {
  *   - HTTP 4xx (≠429) → permanent: mark failed, no further retries.
  *   - network/timeout/5xx/429 → transient: keep pending with capped (≤1h)
  *     backoff, retrying until the 7-day TTL purge — survives long outages.
+ *
+ * #408 — claims rows with a lease before processing; completion is conditional
+ * on still holding the claim token.
  */
+
+/** #408 — permanent fail only if claim still held; clears lease. */
+function markPermanentlyFailedClaimed(
+  id: number,
+  leaseToken: string,
+  attempts: number,
+  error: string,
+): boolean {
+  const db = getDatabase();
+  const info = db.prepare(`
+    UPDATE sync_queue
+    SET status = 'failed', attempts = ?, last_error = ?,
+        lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL
+    WHERE id = ? AND lease_token = ? AND status = 'pending'
+  `).run(attempts, error, id, leaseToken);
+  return info.changes === 1;
+}
+
+/** #408 — schedule retry only if claim still held; clears lease so row is free after backoff. */
+function scheduleRetryClaimed(
+  id: number,
+  leaseToken: string,
+  priorAttempts: number,
+  attempts: number,
+  error: string,
+): boolean {
+  const db = getDatabase();
+  // Same capped exponential backoff as scheduleRetry (min(2^prior*30s, 1h)).
+  const backoffMs = Math.min(Math.pow(2, priorAttempts) * BASE_BACKOFF_MS, MAX_BACKOFF_MS);
+  const next = new Date(Date.now() + backoffMs).toISOString();
+  const info = db.prepare(`
+    UPDATE sync_queue
+    SET status = 'pending', attempts = ?, next_retry_at = ?, last_error = ?,
+        lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL
+    WHERE id = ? AND lease_token = ? AND status = 'pending'
+  `).run(attempts, next, error, id, leaseToken);
+  return info.changes === 1;
+}
+
 export async function processRetryQueue(options: ProcessRetryOptions = {}): Promise<SyncQueueResult> {
   const db = getDatabase();
   const config = getCloudConfig();
@@ -440,18 +583,9 @@ export async function processRetryQueue(options: ProcessRetryOptions = {}): Prom
 
   const now = new Date().toISOString();
 
-  // Fetch pending items ready for retry, bounded by the budget.
-  const rows = db.prepare(`
-    SELECT id, payload, attempts
-    FROM sync_queue
-    WHERE status = 'pending' AND next_retry_at <= ?
-    ORDER BY next_retry_at ASC
-    LIMIT ?
-  `).all(now, limit) as Array<{
-    id: number;
-    payload: string;
-    attempts: number;
-  }>;
+  // #408 — Atomically claim due rows (lease). Concurrent workers cannot both
+  // own the same id; completion is conditional on the claim token.
+  const rows = claimRetryBatch(limit, now);
 
   if (rows.length === 0) {
     return result;
@@ -479,26 +613,36 @@ export async function processRetryQueue(options: ProcessRetryOptions = {}): Prom
       clearTimeout(timeoutId);
 
       if (res.ok) {
-        // Success — mark as synced
-        db.prepare(`
-          UPDATE sync_queue SET status = 'synced', attempts = ?, synced_at = ?, last_error = NULL
-          WHERE id = ?
-        `).run(newAttempts, new Date().toISOString(), row.id);
-        result.succeeded++;
-        try { updateLastSyncAt(); } catch { /* non-critical */ }
+        // Success — mark as synced only if we still hold the claim
+        const ok = updateIfClaimed(
+          row.id,
+          row.leaseToken,
+          `UPDATE sync_queue SET status = 'synced', attempts = ?, synced_at = ?, last_error = NULL,
+              lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL
+           WHERE id = ?`,
+          newAttempts,
+          new Date().toISOString(),
+        );
+        if (ok) {
+          result.succeeded++;
+          try { updateLastSyncAt(); } catch { /* non-critical */ }
+        }
       } else if (classifyHttpStatus(res.status) === 'permanent') {
-        markPermanentlyFailed(row.id, newAttempts, `HTTP ${res.status}`);
-        result.permanentlyFailed++;
+        if (markPermanentlyFailedClaimed(row.id, row.leaseToken, newAttempts, `HTTP ${res.status}`)) {
+          result.permanentlyFailed++;
+        }
       } else {
         // 5xx / 429 — transient, keep retrying with capped backoff.
-        scheduleRetry(row.id, row.attempts, newAttempts, `HTTP ${res.status}`);
-        result.failed++;
+        if (scheduleRetryClaimed(row.id, row.leaseToken, row.attempts, newAttempts, `HTTP ${res.status}`)) {
+          result.failed++;
+        }
       }
     } catch (err) {
       // Network errors, timeouts (AbortError) — all transient.
       const errorMsg = formatQueueError(err);
-      scheduleRetry(row.id, row.attempts, newAttempts, errorMsg);
-      result.failed++;
+      if (scheduleRetryClaimed(row.id, row.leaseToken, row.attempts, newAttempts, errorMsg)) {
+        result.failed++;
+      }
     }
   }
 

--- a/src/cloud/sync-queue.ts
+++ b/src/cloud/sync-queue.ts
@@ -583,15 +583,13 @@ export async function processRetryQueue(options: ProcessRetryOptions = {}): Prom
 
   const now = new Date().toISOString();
 
-  // #408 — Atomically claim due rows (lease). Concurrent workers cannot both
-  // own the same id; completion is conditional on the claim token.
-  const rows = claimRetryBatch(limit, now);
-
-  if (rows.length === 0) {
-    return result;
-  }
-
-  for (const row of rows) {
+  // #408 — Claim-one-then-send (not claim-N-then-walk). Holding a batch of
+  // leases for sequential HTTP would let a second worker reclaim later rows
+  // after lease expiry while the first is still mid-batch (Grok nit).
+  for (let i = 0; i < limit; i++) {
+    const claimed = claimRetryBatch(1, new Date().toISOString());
+    if (claimed.length === 0) break;
+    const row = claimed[0];
     result.processed++;
     const newAttempts = row.attempts + 1;
 
@@ -613,7 +611,6 @@ export async function processRetryQueue(options: ProcessRetryOptions = {}): Prom
       clearTimeout(timeoutId);
 
       if (res.ok) {
-        // Success — mark as synced only if we still hold the claim
         const ok = updateIfClaimed(
           row.id,
           row.leaseToken,
@@ -632,13 +629,11 @@ export async function processRetryQueue(options: ProcessRetryOptions = {}): Prom
           result.permanentlyFailed++;
         }
       } else {
-        // 5xx / 429 — transient, keep retrying with capped backoff.
         if (scheduleRetryClaimed(row.id, row.leaseToken, row.attempts, newAttempts, `HTTP ${res.status}`)) {
           result.failed++;
         }
       }
     } catch (err) {
-      // Network errors, timeouts (AbortError) — all transient.
       const errorMsg = formatQueueError(err);
       if (scheduleRetryClaimed(row.id, row.leaseToken, row.attempts, newAttempts, errorMsg)) {
         result.failed++;

--- a/src/database/inline-schema.ts
+++ b/src/database/inline-schema.ts
@@ -355,10 +355,14 @@ export function getInlineSchema(): string {
       status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','failed','synced')),
       last_error TEXT,
       created_at TEXT DEFAULT (datetime('now')),
-      synced_at TEXT
+      synced_at TEXT,
+      lease_owner TEXT,
+      lease_token TEXT,
+      lease_expires_at TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_sync_queue_status_retry ON sync_queue(status, next_retry_at);
+    CREATE INDEX IF NOT EXISTS idx_sync_queue_lease_exp ON sync_queue(lease_expires_at);
 
     CREATE TABLE IF NOT EXISTS custom_patterns (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -347,9 +347,13 @@ export function runMigrations(database: Database.Database): void {
         status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','failed','synced')),
         last_error TEXT,
         created_at TEXT DEFAULT (datetime('now')),
-        synced_at TEXT
+        synced_at TEXT,
+        lease_owner TEXT,
+        lease_token TEXT,
+        lease_expires_at TEXT
       );
       CREATE INDEX IF NOT EXISTS idx_sync_queue_status_retry ON sync_queue(status, next_retry_at);
+      CREATE INDEX IF NOT EXISTS idx_sync_queue_lease_exp ON sync_queue(lease_expires_at);
     `);
   } catch (err) {
     logIfUnexpectedDdlError(err, 'sync_queue table + index');
@@ -961,5 +965,26 @@ export function runMigrations(database: Database.Database): void {
     database.exec('CREATE INDEX IF NOT EXISTS idx_memories_host_agent ON memories(host_id, agent_id)');
   } catch (err) {
     logIfUnexpectedDdlError(err, 'memories host_id/agent_id/capture_layer');
+  }
+
+  // Migration: #408 — sync_queue atomic claim / lease columns.
+  // Existing installs created sync_queue without lease_*; CREATE IF NOT EXISTS
+  // does not add them. Guarded ADD COLUMN so upgrades pick up the claim path.
+  try {
+    const sq = database
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_queue'")
+      .get();
+    if (sq) {
+      const cols = database.prepare('PRAGMA table_info(sync_queue)').all() as { name: string }[];
+      const have = new Set(cols.map((c) => c.name));
+      for (const col of ['lease_owner', 'lease_token', 'lease_expires_at'] as const) {
+        if (!have.has(col)) {
+          database.exec(`ALTER TABLE sync_queue ADD COLUMN ${col} TEXT`);
+        }
+      }
+      database.exec('CREATE INDEX IF NOT EXISTS idx_sync_queue_lease_exp ON sync_queue(lease_expires_at)');
+    }
+  } catch (err) {
+    logIfUnexpectedDdlError(err, 'sync_queue lease columns (#408)');
   }
 }

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -425,10 +425,15 @@ CREATE TABLE IF NOT EXISTS sync_queue (
   status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','failed','synced')),
   last_error TEXT,
   created_at TEXT DEFAULT (datetime('now')),
-  synced_at TEXT
+  synced_at TEXT,
+  -- #408 atomic claim / lease (NULL = unowned; expired lease is reclaimable)
+  lease_owner TEXT,
+  lease_token TEXT,
+  lease_expires_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sync_queue_status_retry ON sync_queue(status, next_retry_at);
+CREATE INDEX IF NOT EXISTS idx_sync_queue_lease_exp ON sync_queue(lease_expires_at);
 
 -- Pro feature: Custom injection patterns
 CREATE TABLE IF NOT EXISTS custom_patterns (


### PR DESCRIPTION
## Summary
Closes **#408** (Athena HIGH): retry workers could SELECT the same pending row without an atomic claim/lease.

### Changes
- Schema: `lease_owner`, `lease_token`, `lease_expires_at` on `sync_queue` (+ upgrade migration)
- `claimRetryBatch()` — claim-one loop with conditional UPDATE
- `processRetryQueue` — claim then process; success/fail/retry updates require active token
- Expired leases reclaimable; stale tokens cannot complete after re-lease

### Tests
- 5 focused #408 tests
- Existing durability + sync-queue suites still green (30 total in related run)

Closes #408