### PR TITLE
fix(cloud): #409 transactional outbox for memory/graph sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **#409:** transactional outbox — memory/graph sync events written in the same SQLite transaction as the local mutation; delivery_key idempotency; dispatch after commit with durable ack/retry.
+
+### Fixed
 - **#408:** cloud sync retry queue uses atomic claim + lease (owner/token/expiry); completion/failure updates are claim-conditional; expired leases are reclaimable.
 
 ## [4.54.12] - 2026-08-25

--- a/src/api/__tests__/route-mutations.test.ts
+++ b/src/api/__tests__/route-mutations.test.ts
@@ -203,9 +203,13 @@ describe('API route mutation regressions', () => {
         enqueueFailedMemorySync: jest.fn(),
         enqueueFailedGraphSync: jest.fn(),
         enqueueFailedQuarantineSync: jest.fn(),
+        enqueueMemoryOutbox: jest.fn(() => ({ inserted: true, id: 1 })),
+        enqueueGraphOutbox: jest.fn(() => ({ inserted: true, id: 1 })),
         processRetryQueue: jest.fn(),
         purgeOldEntries: jest.fn(),
         reconcileSyncQueue: jest.fn(() => ({ removed: 0 })),
+        claimRetryBatch: jest.fn(() => []),
+        SYNC_QUEUE_LEASE_MS: 60_000,
       }));
 
       const routeModule = await import('../routes/system.js');

--- a/src/cloud/__tests__/quarantine-sync-controls.test.ts
+++ b/src/cloud/__tests__/quarantine-sync-controls.test.ts
@@ -44,6 +44,8 @@ async function loadModule() {
   // sync-queue is a leaf import; stub so a failed/queued path doesn't touch disk.
   jest.unstable_mockModule('../sync-queue.js', () => ({
     enqueueFailedQuarantineSync: jest.fn(),
+    enqueueMemoryOutbox: jest.fn(() => ({ inserted: true, id: 1 })),
+    enqueueGraphOutbox: jest.fn(() => ({ inserted: true, id: 1 })),
   }));
   return import('../quarantine-sync.js');
 }

--- a/src/cloud/__tests__/transactional-outbox-409.test.ts
+++ b/src/cloud/__tests__/transactional-outbox-409.test.ts
@@ -1,0 +1,257 @@
+/**
+ * #409 — transactional outbox: mutation + enqueue atomic; dispatch after commit.
+ */
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { closeDatabase, getDatabase, initDatabase } from '../../database/init.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('#409 transactional outbox', () => {
+  let configDir: string;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(async () => {
+    configDir = mkdtempSync(join(tmpdir(), 'shieldcortex-outbox-409-'));
+    process.env.SHIELDCORTEX_CONFIG_DIR = configDir;
+    process.env.SHIELDCORTEX_SKIP_EMBEDDINGS = '1';
+    initDatabase(join(configDir, 'memories.db'));
+    originalFetch = globalThis.fetch;
+
+    const { setCloudConfig } = await import('../config.js');
+    setCloudConfig({
+      cloudEnabled: true,
+      cloudApiKey: 'sc_test_key_not_real',
+      cloudBaseUrl: 'https://example.invalid',
+    });
+
+    // Feature gate cloud_sync on for store path
+    try {
+      const gate = await import('../../license/gate.js');
+      if (typeof (gate as { setFeatureOverride?: (k: string, v: boolean) => void }).setFeatureOverride === 'function') {
+        (gate as { setFeatureOverride: (k: string, v: boolean) => void }).setFeatureOverride('cloud_sync', true);
+      }
+    } catch { /* may already be enabled in test env */ }
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.SHIELDCORTEX_CONFIG_DIR;
+    delete process.env.SHIELDCORTEX_SKIP_EMBEDDINGS;
+    closeDatabase();
+    rmSync(configDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  function queueRows(): Array<{ status: string; delivery_key: string | null; payload: string }> {
+    return getDatabase()
+      .prepare('SELECT status, delivery_key, payload FROM sync_queue ORDER BY id ASC')
+      .all() as Array<{ status: string; delivery_key: string | null; payload: string }>;
+  }
+
+  it('rolled-back local mutation produces no outbox row', async () => {
+    const { enqueueMemoryOutbox } = await import('../sync-queue.js');
+    const { buildMemoryDeleteTombstone } = await import('../memory-sync.js');
+
+    const db = getDatabase();
+    expect(() => {
+      db.transaction(() => {
+        // Simulate mutation + outbox then abort
+        db.prepare(
+          `INSERT INTO memories (uuid, type, category, title, content, tags, salience, metadata, scope, transferable, status, pinned, defence_verdict, cloud_excluded, memory_purpose, memory_scope, updated_at)
+           VALUES ('rb-uuid', 'short_term', 'note', 't', 'c', '[]', 0.5, '{}', 'project', 0, 'active', 0, 'allow', 0, 'project', 'private', CURRENT_TIMESTAMP)`,
+        ).run();
+        enqueueMemoryOutbox(
+          {
+            external_id: 'rb-uuid',
+            local_id: 1,
+            type: 'short_term',
+            category: 'note',
+            title: 't',
+            content: 'c',
+            project: null,
+            tags: [],
+            salience: 0.5,
+            scope: 'project',
+            transferable: false,
+            trust_score: null,
+            sensitivity_level: 'INTERNAL',
+            source: null,
+            metadata: {},
+            cloud_excluded: false,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            deleted_at: null,
+          },
+          { deliveryKey: 'memory:rb-uuid:upsert:1', db, dueNow: true },
+        );
+        throw new Error('boom-rollback');
+      })();
+    }).toThrow(/boom-rollback/);
+
+    const mem = db.prepare(`SELECT COUNT(*) AS c FROM memories WHERE uuid = 'rb-uuid'`).get() as { c: number };
+    expect(mem.c).toBe(0);
+    expect(queueRows()).toHaveLength(0);
+  });
+
+  it('crash after mutation+outbox commit still has durable pending event (no live dispatch)', async () => {
+    const { writeMemorySyncOutbox } = await import('../memory-sync.js');
+    const db = getDatabase();
+
+    db.transaction(() => {
+      db.prepare(
+        `INSERT INTO memories (uuid, type, category, title, content, tags, salience, metadata, scope, transferable, status, pinned, defence_verdict, cloud_excluded, memory_purpose, memory_scope, sensitivity_level, updated_at)
+         VALUES ('dur-uuid', 'short_term', 'note', 'title', 'body', '[]', 0.5, '{}', 'project', 0, 'active', 0, 'allow', 0, 'project', 'private', 'INTERNAL', CURRENT_TIMESTAMP)`,
+      ).run();
+      const row = db.prepare('SELECT * FROM memories WHERE uuid = ?').get('dur-uuid') as Record<string, unknown>;
+      writeMemorySyncOutbox(
+        {
+          external_id: row.uuid as string,
+          local_id: row.id as number,
+          type: row.type as string,
+          category: row.category as string,
+          title: row.title as string,
+          content: row.content as string,
+          project: null,
+          tags: [],
+          salience: 0.5,
+          scope: 'project',
+          transferable: false,
+          trust_score: null,
+          sensitivity_level: 'INTERNAL',
+          source: null,
+          metadata: {},
+          cloud_excluded: false,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          deleted_at: null,
+        },
+        { op: 'upsert', db },
+      );
+    })();
+
+    // No dispatch called — simulates crash after commit before network.
+    const rows = queueRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('pending');
+    expect(rows[0].delivery_key).toMatch(/^memory:dur-uuid:upsert:/);
+    const mem = db.prepare(`SELECT COUNT(*) AS c FROM memories WHERE uuid = 'dur-uuid'`).get() as { c: number };
+    expect(mem.c).toBe(1);
+  });
+
+  it('replayed delivery_key is idempotent (single outbox row)', async () => {
+    const { writeMemorySyncOutbox } = await import('../memory-sync.js');
+    const record = {
+      external_id: 'idemp-uuid',
+      local_id: 42,
+      type: 'short_term',
+      category: 'note',
+      title: 't',
+      content: 'c',
+      project: null,
+      tags: [] as string[],
+      salience: 0.5,
+      scope: 'project',
+      transferable: false,
+      trust_score: null as number | null,
+      sensitivity_level: 'INTERNAL',
+      source: null as string | null,
+      metadata: {} as Record<string, unknown>,
+      cloud_excluded: false,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-02T00:00:00.000Z',
+      deleted_at: null as string | null,
+    };
+
+    const a = writeMemorySyncOutbox(record, { op: 'upsert' });
+    const b = writeMemorySyncOutbox(record, { op: 'upsert' });
+    expect(a.inserted).toBe(true);
+    expect(b.inserted).toBe(false);
+    expect(a.deliveryKey).toBe(b.deliveryKey);
+    expect(queueRows()).toHaveLength(1);
+  });
+
+  it('delete tombstone outbox preserves ordering key after memory row is gone', async () => {
+    const { writeMemorySyncOutbox, buildMemoryDeleteTombstone } = await import('../memory-sync.js');
+    const { writeGraphSyncOutbox, buildEnvelope } = await import('../graph-sync.js');
+    const db = getDatabase();
+
+    db.prepare(
+      `INSERT INTO memories (uuid, type, category, title, content, tags, salience, metadata, scope, transferable, status, pinned, defence_verdict, cloud_excluded, memory_purpose, memory_scope, sensitivity_level, updated_at)
+       VALUES ('del-uuid', 'short_term', 'note', 't', 'secret', '[]', 0.5, '{}', 'project', 0, 'active', 0, 'allow', 0, 'project', 'private', 'INTERNAL', CURRENT_TIMESTAMP)`,
+    ).run();
+    const memory = {
+      id: 1,
+      uuid: 'del-uuid',
+      type: 'short_term',
+      category: 'note',
+      title: 't',
+      content: 'secret',
+      project: null,
+      tags: [],
+      salience: 0.5,
+      scope: 'project',
+      transferable: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      cloudExcluded: false,
+      sensitivityLevel: 'INTERNAL',
+    } as never;
+
+    const tomb = buildMemoryDeleteTombstone(memory);
+    db.transaction(() => {
+      db.prepare('DELETE FROM memories WHERE uuid = ?').run('del-uuid');
+      writeMemorySyncOutbox(tomb, { op: 'delete', db });
+      const env = buildEnvelope([], [], [], ['del-uuid']);
+      writeGraphSyncOutbox(env, {
+        deliveryKey: `graph:prune:del-uuid:${tomb.deleted_at}`,
+        db,
+      });
+    })();
+
+    const rows = queueRows();
+    expect(rows).toHaveLength(2);
+    expect(rows[0].delivery_key).toMatch(/^memory:del-uuid:delete:/);
+    expect(rows[1].delivery_key).toMatch(/^graph:prune:del-uuid:/);
+    // Tombstone payload has empty content
+    const memPayload = JSON.parse(rows[0].payload);
+    expect(memPayload.entry.record.content).toBe('');
+    expect(memPayload.entry.record.deleted_at).toBeTruthy();
+    // Memory gone locally
+    const left = db.prepare(`SELECT COUNT(*) AS c FROM memories WHERE uuid = 'del-uuid'`).get() as { c: number };
+    expect(left.c).toBe(0);
+  });
+
+  it('successful dispatch acknowledges outbox row (idempotent worker path still ok)', async () => {
+    const { writeMemorySyncOutbox, dispatchMemoryOutboxBestEffort } = await import('../memory-sync.js');
+    const record = {
+      external_id: 'ack-uuid',
+      local_id: 7,
+      type: 'short_term',
+      category: 'note',
+      title: 't',
+      content: 'c',
+      project: null,
+      tags: [] as string[],
+      salience: 0.5,
+      scope: 'project',
+      transferable: false,
+      trust_score: null as number | null,
+      sensitivity_level: 'INTERNAL',
+      source: null as string | null,
+      metadata: {} as Record<string, unknown>,
+      cloud_excluded: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      deleted_at: null as string | null,
+    };
+    writeMemorySyncOutbox(record, { op: 'upsert' });
+    expect(queueRows()[0].status).toBe('pending');
+
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as unknown as typeof globalThis.fetch;
+    dispatchMemoryOutboxBestEffort(record);
+    // allow microtask
+    await new Promise((r) => setTimeout(r, 30));
+    expect(queueRows()[0].status).toBe('synced');
+  });
+});

--- a/src/cloud/__tests__/transactional-outbox-409.test.ts
+++ b/src/cloud/__tests__/transactional-outbox-409.test.ts
@@ -163,12 +163,51 @@ describe('#409 transactional outbox', () => {
       deleted_at: null as string | null,
     };
 
-    const a = writeMemorySyncOutbox(record, { op: 'upsert' });
-    const b = writeMemorySyncOutbox(record, { op: 'upsert' });
+    const key = 'memory:idemp-uuid:upsert:fixed-key';
+    const a = writeMemorySyncOutbox(record, { op: 'upsert', deliveryKey: key });
+    const b = writeMemorySyncOutbox(record, { op: 'upsert', deliveryKey: key });
     expect(a.inserted).toBe(true);
     expect(b.inserted).toBe(false);
-    expect(a.deliveryKey).toBe(b.deliveryKey);
+    expect(a.deliveryKey).toBe(key);
     expect(queueRows()).toHaveLength(1);
+  });
+
+  it('exact-key ack does not mark a later pending event synced', async () => {
+    const { writeMemorySyncOutbox, dispatchMemoryOutboxBestEffort } = await import('../memory-sync.js');
+    const base = {
+      external_id: 'multi-uuid',
+      local_id: 9,
+      type: 'short_term',
+      category: 'note',
+      title: 't1',
+      content: 'c1',
+      project: null,
+      tags: [] as string[],
+      salience: 0.5,
+      scope: 'project',
+      transferable: false,
+      trust_score: null as number | null,
+      sensitivity_level: 'INTERNAL',
+      source: null as string | null,
+      metadata: {} as Record<string, unknown>,
+      cloud_excluded: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      deleted_at: null as string | null,
+    };
+    const first = writeMemorySyncOutbox({ ...base, title: 't1' }, { op: 'upsert' });
+    const second = writeMemorySyncOutbox({ ...base, title: 't2', updated_at: new Date().toISOString() }, { op: 'upsert' });
+    expect(first.deliveryKey).not.toBe(second.deliveryKey);
+    expect(queueRows()).toHaveLength(2);
+
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as unknown as typeof globalThis.fetch;
+    dispatchMemoryOutboxBestEffort({ ...base, title: 't1' }, first.deliveryKey);
+    await new Promise((r) => setTimeout(r, 40));
+
+    const rows = queueRows();
+    const byKey = Object.fromEntries(rows.map((r) => [r.delivery_key, r.status]));
+    expect(byKey[first.deliveryKey!]).toBe('synced');
+    expect(byKey[second.deliveryKey!]).toBe('pending');
   });
 
   it('delete tombstone outbox preserves ordering key after memory row is gone', async () => {
@@ -245,11 +284,11 @@ describe('#409 transactional outbox', () => {
       updated_at: new Date().toISOString(),
       deleted_at: null as string | null,
     };
-    writeMemorySyncOutbox(record, { op: 'upsert' });
+    const { deliveryKey } = writeMemorySyncOutbox(record, { op: 'upsert' });
     expect(queueRows()[0].status).toBe('pending');
 
     globalThis.fetch = jest.fn().mockResolvedValue({ ok: true, status: 200 }) as unknown as typeof globalThis.fetch;
-    dispatchMemoryOutboxBestEffort(record);
+    dispatchMemoryOutboxBestEffort(record, deliveryKey);
     // allow microtask
     await new Promise((r) => setTimeout(r, 30));
     expect(queueRows()[0].status).toBe('synced');

--- a/src/cloud/graph-sync.ts
+++ b/src/cloud/graph-sync.ts
@@ -8,7 +8,7 @@ import {
   shouldSyncProject,
   updateLastSyncAt,
 } from './config.js';
-import { enqueueFailedGraphSync } from './sync-queue.js';
+import { enqueueFailedGraphSync, enqueueGraphOutbox } from './sync-queue.js';
 import type { Memory } from '../memory/types.js';
 import { deletionPolicyFromMemory, shouldSyncRecord } from './memory-sync.js';
 
@@ -99,7 +99,7 @@ function buildAllowedMemoryExternalIdSet(rows: Array<{
   );
 }
 
-function buildEnvelope(
+export function buildEnvelope(
   entities: SyncedGraphEntityRecord[],
   triples: SyncedGraphTripleRecord[],
   memoryEntities: SyncedGraphMemoryEntityRecord[],
@@ -251,6 +251,40 @@ function getMemoryScopedEnvelope(memoryId: number): GraphSyncEnvelope | null {
   );
 }
 
+
+/**
+ * #409 — durable outbox write for a graph envelope (upsert or prune).
+ */
+export function writeGraphSyncOutbox(
+  envelope: GraphSyncEnvelope,
+  options: {
+    deliveryKey: string;
+    db?: ReturnType<typeof getDatabase>;
+  },
+): { inserted: boolean; id: number | null; deliveryKey: string } {
+  const result = enqueueGraphOutbox(envelope, {
+    deliveryKey: options.deliveryKey,
+    db: options.db,
+    dueNow: true,
+  });
+  return { ...result, deliveryKey: options.deliveryKey };
+}
+
+export function dispatchGraphOutboxBestEffort(envelope: GraphSyncEnvelope, deliveryKey: string): void {
+  postGraphEnvelope(envelope).then((ok) => {
+    if (!ok) return;
+    try {
+      const db = getDatabase();
+      db.prepare(`
+        UPDATE sync_queue
+        SET status = 'synced', synced_at = ?, last_error = NULL,
+            lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL
+        WHERE status = 'pending' AND delivery_key = ?
+      `).run(new Date().toISOString(), deliveryKey);
+    } catch { /* worker retries */ }
+  }).catch(() => { /* outbox retains */ });
+}
+
 export function syncGraphForMemoryToCloud(memoryId: number): void {
   const config = getCloudConfig();
   if (!config.cloudEnabled || !config.cloudApiKey) return;
@@ -258,11 +292,14 @@ export function syncGraphForMemoryToCloud(memoryId: number): void {
   const envelope = getMemoryScopedEnvelope(memoryId);
   if (!envelope) return;
 
-  postGraphEnvelope(envelope).then((ok) => {
-    if (!ok) enqueueFailedGraphSync(envelope);
-  }).catch(() => {
-    enqueueFailedGraphSync(envelope);
-  });
+  // #409 outbox-first
+  const deliveryKey = `graph:upsert:${memoryId}:${Date.now()}`;
+  try {
+    writeGraphSyncOutbox(envelope, { deliveryKey });
+  } catch {
+    try { enqueueFailedGraphSync(envelope); } catch { /* silent */ }
+  }
+  dispatchGraphOutboxBestEffort(envelope, deliveryKey);
 }
 
 export function syncGraphDeleteForMemoryToCloud(memory: Memory): void {
@@ -276,11 +313,14 @@ export function syncGraphDeleteForMemoryToCloud(memory: Memory): void {
   if (!shouldSyncRecord(gate.policy)) return;
 
   const envelope = buildEnvelope([], [], [], [memory.uuid]);
-  postGraphEnvelope(envelope).then((ok) => {
-    if (!ok) enqueueFailedGraphSync(envelope);
-  }).catch(() => {
-    enqueueFailedGraphSync(envelope);
-  });
+  // #409 — delivery key ties prune to memory uuid so ordering is stable per delete
+  const deliveryKey = `graph:prune:${memory.uuid}:${new Date().toISOString()}`;
+  try {
+    writeGraphSyncOutbox(envelope, { deliveryKey });
+  } catch {
+    try { enqueueFailedGraphSync(envelope); } catch { /* silent */ }
+  }
+  dispatchGraphOutboxBestEffort(envelope, deliveryKey);
 }
 
 export async function syncAllGraphToCloud(): Promise<{

--- a/src/cloud/graph-sync.ts
+++ b/src/cloud/graph-sync.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import { getDatabase } from '../database/init.js';
 import {
   getCloudConfig,
@@ -293,7 +294,7 @@ export function syncGraphForMemoryToCloud(memoryId: number): void {
   if (!envelope) return;
 
   // #409 outbox-first
-  const deliveryKey = `graph:upsert:${memoryId}:${Date.now()}`;
+  const deliveryKey = `graph:upsert:${memoryId}:${Date.now()}:${randomBytes(6).toString('hex')}`;
   try {
     writeGraphSyncOutbox(envelope, { deliveryKey });
   } catch {
@@ -314,7 +315,7 @@ export function syncGraphDeleteForMemoryToCloud(memory: Memory): void {
 
   const envelope = buildEnvelope([], [], [], [memory.uuid]);
   // #409 — delivery key ties prune to memory uuid so ordering is stable per delete
-  const deliveryKey = `graph:prune:${memory.uuid}:${new Date().toISOString()}`;
+  const deliveryKey = `graph:prune:${memory.uuid}:${new Date().toISOString()}:${randomBytes(6).toString('hex')}`;
   try {
     writeGraphSyncOutbox(envelope, { deliveryKey });
   } catch {

--- a/src/cloud/graph-sync.ts
+++ b/src/cloud/graph-sync.ts
@@ -286,6 +286,28 @@ export function dispatchGraphOutboxBestEffort(envelope: GraphSyncEnvelope, deliv
   }).catch(() => { /* outbox retains */ });
 }
 
+
+/**
+ * #409 — write graph prune outbox for a memory delete inside the caller's txn.
+ * Returns null when cloud/policy blocks; otherwise delivery key + envelope for post-commit dispatch.
+ */
+export function writeGraphPruneOutboxForMemory(
+  memory: Memory,
+  options: { db?: ReturnType<typeof getDatabase>; deliveryKey?: string } = {},
+): { deliveryKey: string; envelope: GraphSyncEnvelope } | null {
+  const config = getCloudConfig();
+  if (!config.cloudEnabled || !config.cloudApiKey) return null;
+  const gate = deletionPolicyFromMemory(memory);
+  if (!gate.ok) return null;
+  if (!shouldSyncRecord(gate.policy)) return null;
+
+  const envelope = buildEnvelope([], [], [], [memory.uuid]);
+  const deliveryKey = options.deliveryKey
+    ?? `graph:prune:${memory.uuid}:${new Date().toISOString()}:${randomBytes(6).toString('hex')}`;
+  writeGraphSyncOutbox(envelope, { deliveryKey, db: options.db });
+  return { deliveryKey, envelope };
+}
+
 export function syncGraphForMemoryToCloud(memoryId: number): void {
   const config = getCloudConfig();
   if (!config.cloudEnabled || !config.cloudApiKey) return;

--- a/src/cloud/memory-sync.ts
+++ b/src/cloud/memory-sync.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import { getDatabase } from '../database/init.js';
 import {
   getCloudConfig,
@@ -197,12 +198,17 @@ export function writeMemorySyncOutbox(
   options: {
     op: 'upsert' | 'delete';
     db?: ReturnType<typeof getDatabase>;
+    /** Stable key for this logical event. Auto-minted unique when omitted. */
+    deliveryKey?: string;
   },
 ): { inserted: boolean; id: number | null; deliveryKey: string } {
+  // Unique per mutation (ms + nonce). Second-resolution updated_at alone collides
+  // and a LIKE ack would mark later pending rows synced without sending them.
   const stamp = options.op === 'delete'
     ? (record.deleted_at ?? new Date().toISOString())
     : (record.updated_at ?? new Date().toISOString());
-  const deliveryKey = `memory:${record.external_id}:${options.op}:${stamp}`;
+  const deliveryKey = options.deliveryKey
+    ?? `memory:${record.external_id}:${options.op}:${stamp}:${Date.now()}:${randomBytes(6).toString('hex')}`;
   const result = enqueueMemoryOutbox(record, {
     deliveryKey,
     db: options.db,
@@ -216,13 +222,15 @@ export function writeMemorySyncOutbox(
  * On failure the outbox row remains pending for processRetryQueue (#408).
  * Never throws into the store path.
  */
-export function dispatchMemoryOutboxBestEffort(record: SyncedMemoryRecord): void {
+export function dispatchMemoryOutboxBestEffort(
+  record: SyncedMemoryRecord,
+  deliveryKey?: string,
+): void {
   const envelope = buildEnvelope([record]);
   postEnvelope(envelope).then((ok) => {
     if (ok) {
-      // Mark matching pending outbox row(s) synced by external_id + deleted_at presence.
       try {
-        acknowledgeMemoryOutbox(record);
+        acknowledgeMemoryOutbox(deliveryKey);
       } catch { /* worker will retry */ }
     }
     // On !ok the durable outbox row stays pending — no second enqueue.
@@ -231,34 +239,31 @@ export function dispatchMemoryOutboxBestEffort(record: SyncedMemoryRecord): void
   });
 }
 
-function acknowledgeMemoryOutbox(record: SyncedMemoryRecord): void {
+/** #409 — ack exactly one outbox row. Never LIKE-prefix (would drop later events). */
+function acknowledgeMemoryOutbox(deliveryKey?: string): void {
+  if (!deliveryKey) return;
   const db = getDatabase();
-  // Prefer delivery_key prefix match for this external id + op.
-  const op = record.deleted_at ? 'delete' : 'upsert';
-  const prefix = `memory:${record.external_id}:${op}:`;
   db.prepare(`
     UPDATE sync_queue
     SET status = 'synced', synced_at = ?, last_error = NULL,
         lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL
-    WHERE status = 'pending'
-      AND delivery_key IS NOT NULL
-      AND delivery_key LIKE ?
-  `).run(new Date().toISOString(), prefix + '%');
+    WHERE status = 'pending' AND delivery_key = ?
+  `).run(new Date().toISOString(), deliveryKey);
 }
 
 export function syncMemoryUpsertToCloud(memory: Memory): void {
   // #409 — outbox-first even for non-transactional callers: durable row then dispatch.
   const record = buildMemoryUpsertOutboxRecord(memory.id);
   if (!record) return;
+  let deliveryKey: string | undefined;
   try {
-    writeMemorySyncOutbox(record, { op: 'upsert' });
+    deliveryKey = writeMemorySyncOutbox(record, { op: 'upsert' }).deliveryKey;
   } catch {
     // Degraded: outbox write failed (e.g. DB unavailable) — still try live
-    // dispatch, and legency-enqueue on network failure inside dispatch path
-    // is not automatic, so park a legacy row best-effort.
+    // dispatch; park a legacy row best-effort.
     try { enqueueFailedMemorySync(record); } catch { /* silent */ }
   }
-  dispatchMemoryOutboxBestEffort(record);
+  dispatchMemoryOutboxBestEffort(record, deliveryKey);
 }
 
 /**
@@ -324,12 +329,13 @@ export function syncMemoryDeleteToCloud(memory: Memory): void {
   // #409 outbox-first; #405 privacy gate stays inside buildMemoryDeleteOutboxRecord.
   const record = buildMemoryDeleteOutboxRecord(memory);
   if (!record) return;
+  let deliveryKey: string | undefined;
   try {
-    writeMemorySyncOutbox(record, { op: 'delete' });
+    deliveryKey = writeMemorySyncOutbox(record, { op: 'delete' }).deliveryKey;
   } catch {
     try { enqueueFailedMemorySync(record); } catch { /* silent */ }
   }
-  dispatchMemoryOutboxBestEffort(record);
+  dispatchMemoryOutboxBestEffort(record, deliveryKey);
 }
 
 export async function syncAllMemoriesToCloud(): Promise<{ total: number; synced: number; failed: number }> {

--- a/src/cloud/memory-sync.ts
+++ b/src/cloud/memory-sync.ts
@@ -8,7 +8,7 @@ import {
   shouldSyncProject,
   updateLastSyncAt,
 } from './config.js';
-import { enqueueFailedMemorySync } from './sync-queue.js';
+import { enqueueFailedMemorySync, enqueueMemoryOutbox } from './sync-queue.js';
 import type { Memory } from '../memory/types.js';
 
 export interface SyncedMemoryRecord {
@@ -161,23 +161,104 @@ async function postEnvelope(envelope: MemorySyncEnvelope): Promise<boolean> {
   }
 }
 
-export function syncMemoryUpsertToCloud(memory: Memory): void {
+
+/**
+ * #409 — build the outbound memory record for an upsert (policy-gated).
+ * Returns null when cloud sync is off or the record must not leave the host.
+ */
+export function buildMemoryUpsertOutboxRecord(memoryId: number): SyncedMemoryRecord | null {
   const config = getCloudConfig();
-  if (!config.cloudEnabled || !config.cloudApiKey) return;
+  if (!config.cloudEnabled || !config.cloudApiKey) return null;
+  const record = hydrateMemoryRecord(memoryId);
+  if (!record) return null;
+  if (!shouldSyncRecord(record)) return null;
+  return applyContentMode(record);
+}
 
-  const record = hydrateMemoryRecord(memory.id);
-  if (!record) return;
+/**
+ * #409 — build the outbound tombstone for a delete (policy-gated).
+ */
+export function buildMemoryDeleteOutboxRecord(memory: Memory): SyncedMemoryRecord | null {
+  const config = getCloudConfig();
+  if (!config.cloudEnabled || !config.cloudApiKey) return null;
+  const gate = deletionPolicyFromMemory(memory);
+  if (!gate.ok) return null;
+  if (!shouldSyncRecord(gate.policy)) return null;
+  return buildMemoryDeleteTombstone(memory);
+}
 
-  if (!shouldSyncRecord(record)) return;
-
-  const envelope = buildEnvelope([applyContentMode(record)]);
-  postEnvelope(envelope).then((ok) => {
-    if (!ok) {
-      enqueueFailedMemorySync(envelope.memories[0]);
-    }
-  }).catch(() => {
-    enqueueFailedMemorySync(envelope.memories[0]);
+/**
+ * #409 — durable outbox write for memory upsert/delete.
+ * Call inside the same SQLite transaction as the local mutation.
+ * delivery_key: memory:{uuid}:{op}:{updatedAt|deletedAt}
+ */
+export function writeMemorySyncOutbox(
+  record: SyncedMemoryRecord,
+  options: {
+    op: 'upsert' | 'delete';
+    db?: ReturnType<typeof getDatabase>;
+  },
+): { inserted: boolean; id: number | null; deliveryKey: string } {
+  const stamp = options.op === 'delete'
+    ? (record.deleted_at ?? new Date().toISOString())
+    : (record.updated_at ?? new Date().toISOString());
+  const deliveryKey = `memory:${record.external_id}:${options.op}:${stamp}`;
+  const result = enqueueMemoryOutbox(record, {
+    deliveryKey,
+    db: options.db,
+    dueNow: true,
   });
+  return { ...result, deliveryKey };
+}
+
+/**
+ * #409 — after the mutation transaction commits, attempt immediate dispatch.
+ * On failure the outbox row remains pending for processRetryQueue (#408).
+ * Never throws into the store path.
+ */
+export function dispatchMemoryOutboxBestEffort(record: SyncedMemoryRecord): void {
+  const envelope = buildEnvelope([record]);
+  postEnvelope(envelope).then((ok) => {
+    if (ok) {
+      // Mark matching pending outbox row(s) synced by external_id + deleted_at presence.
+      try {
+        acknowledgeMemoryOutbox(record);
+      } catch { /* worker will retry */ }
+    }
+    // On !ok the durable outbox row stays pending — no second enqueue.
+  }).catch(() => {
+    /* outbox retains the event */
+  });
+}
+
+function acknowledgeMemoryOutbox(record: SyncedMemoryRecord): void {
+  const db = getDatabase();
+  // Prefer delivery_key prefix match for this external id + op.
+  const op = record.deleted_at ? 'delete' : 'upsert';
+  const prefix = `memory:${record.external_id}:${op}:`;
+  db.prepare(`
+    UPDATE sync_queue
+    SET status = 'synced', synced_at = ?, last_error = NULL,
+        lease_owner = NULL, lease_token = NULL, lease_expires_at = NULL
+    WHERE status = 'pending'
+      AND delivery_key IS NOT NULL
+      AND delivery_key LIKE ?
+  `).run(new Date().toISOString(), prefix + '%');
+}
+
+export function syncMemoryUpsertToCloud(memory: Memory): void {
+  // #409 — outbox-first even for non-transactional callers: durable row then dispatch.
+  const record = buildMemoryUpsertOutboxRecord(memory.id);
+  if (!record) return;
+  try {
+    writeMemorySyncOutbox(record, { op: 'upsert' });
+  } catch {
+    // Degraded: outbox write failed (e.g. DB unavailable) — still try live
+    // dispatch, and legency-enqueue on network failure inside dispatch path
+    // is not automatic, so park a legacy row best-effort.
+    try { enqueueFailedMemorySync(record); } catch { /* silent */ }
+  }
+  dispatchMemoryOutboxBestEffort(record);
 }
 
 /**
@@ -240,23 +321,15 @@ export function deletionPolicyFromMemory(memory: Memory): {
 }
 
 export function syncMemoryDeleteToCloud(memory: Memory): void {
-  const config = getCloudConfig();
-  if (!config.cloudEnabled || !config.cloudApiKey) return;
-
-  // #405 — same privacy gate as upsert. Never reconstruct a full body on delete.
-  const gate = deletionPolicyFromMemory(memory);
-  if (!gate.ok) return;
-  if (!shouldSyncRecord(gate.policy)) return;
-
-  const record = buildMemoryDeleteTombstone(memory);
-  const envelope = buildEnvelope([record]);
-  postEnvelope(envelope).then((ok) => {
-    if (!ok) {
-      enqueueFailedMemorySync(record);
-    }
-  }).catch(() => {
-    enqueueFailedMemorySync(record);
-  });
+  // #409 outbox-first; #405 privacy gate stays inside buildMemoryDeleteOutboxRecord.
+  const record = buildMemoryDeleteOutboxRecord(memory);
+  if (!record) return;
+  try {
+    writeMemorySyncOutbox(record, { op: 'delete' });
+  } catch {
+    try { enqueueFailedMemorySync(record); } catch { /* silent */ }
+  }
+  dispatchMemoryOutboxBestEffort(record);
 }
 
 export async function syncAllMemoriesToCloud(): Promise<{ total: number; synced: number; failed: number }> {

--- a/src/cloud/sync-queue.ts
+++ b/src/cloud/sync-queue.ts
@@ -10,8 +10,6 @@ import { randomBytes } from 'node:crypto';
 import { hostname } from 'node:os';
 import { getDatabase } from '../database/init.js';
 import { getCloudConfig, getDeviceId, getDeviceName, updateLastSyncAt } from './config.js';
-import type { SyncedMemoryRecord } from './memory-sync.js';
-import type { GraphSyncEnvelope } from './graph-sync.js';
 
 export interface SyncEntry {
   source_type: string;
@@ -49,11 +47,11 @@ export interface QuarantineSyncEntry {
 type QueuePayload =
   | { kind: 'audit'; entry: SyncEntry }
   | { kind: 'quarantine'; entry: QuarantineSyncEntry }
-  | { kind: 'graph'; entry: GraphSyncEnvelope }
+  | { kind: 'graph'; entry: Record<string, unknown> }
   | {
       kind: 'memory';
       entry: {
-        record: SyncedMemoryRecord;
+        record: Record<string, unknown>;
         device_id: string;
         device_name: string;
         platform: string;
@@ -204,11 +202,11 @@ export function enqueueFailedQuarantineSync(entry: QuarantineSyncEntry): void {
 /**
  * Enqueue a failed memory sync entry for later retry.
  */
-export function enqueueFailedMemorySync(entry: SyncedMemoryRecord): void {
+export function enqueueFailedMemorySync(entry: object): void {
   enqueuePayload({
     kind: 'memory',
     entry: {
-      record: entry,
+      record: entry as Record<string, unknown>,
       device_id: getDeviceId(),
       device_name: getDeviceName(),
       platform: `${process.platform}/${process.arch}`,
@@ -216,13 +214,13 @@ export function enqueueFailedMemorySync(entry: SyncedMemoryRecord): void {
   });
 }
 
-export function enqueueFailedGraphSync(entry: GraphSyncEnvelope): void {
-  enqueuePayload({ kind: 'graph', entry });
+export function enqueueFailedGraphSync(entry: object): void {
+  enqueuePayload({ kind: 'graph', entry: entry as Record<string, unknown> });
 }
 
 /** #409 durable outbox enqueue for memory sync records (same txn as mutation). */
 export function enqueueMemoryOutbox(
-  entry: SyncedMemoryRecord,
+  entry: object,
   options: {
     deliveryKey: string;
     db?: ReturnType<typeof getDatabase>;
@@ -233,7 +231,7 @@ export function enqueueMemoryOutbox(
     {
       kind: 'memory',
       entry: {
-        record: entry,
+        record: entry as Record<string, unknown>,
         device_id: getDeviceId(),
         device_name: getDeviceName(),
         platform: `${process.platform}/${process.arch}`,
@@ -249,7 +247,7 @@ export function enqueueMemoryOutbox(
 
 /** #409 durable outbox enqueue for graph sync envelopes. */
 export function enqueueGraphOutbox(
-  entry: GraphSyncEnvelope,
+  entry: object,
   options: {
     deliveryKey: string;
     db?: ReturnType<typeof getDatabase>;
@@ -257,7 +255,7 @@ export function enqueueGraphOutbox(
   },
 ): { inserted: boolean; id: number | null } {
   return enqueuePayload(
-    { kind: 'graph', entry },
+    { kind: 'graph', entry: entry as Record<string, unknown> },
     {
       deliveryKey: options.deliveryKey,
       db: options.db,
@@ -424,7 +422,7 @@ function buildRetryRequest(payloadText: string): { path: string; body: string } 
     const payload = parsed as {
       kind: 'memory';
       entry: {
-        record: SyncedMemoryRecord;
+        record: Record<string, unknown>;
         device_id: string;
         device_name: string;
         platform: string;
@@ -450,7 +448,7 @@ function buildRetryRequest(payloadText: string): { path: string; body: string } 
     'kind' in parsed &&
     (parsed as { kind: string }).kind === 'graph'
   ) {
-    const payload = parsed as { kind: 'graph'; entry: GraphSyncEnvelope };
+    const payload = parsed as { kind: 'graph'; entry: Record<string, unknown> };
     return {
       path: '/v1/sync/graph',
       body: JSON.stringify(payload.entry),

--- a/src/cloud/sync-queue.ts
+++ b/src/cloud/sync-queue.ts
@@ -220,6 +220,53 @@ export function enqueueFailedGraphSync(entry: GraphSyncEnvelope): void {
   enqueuePayload({ kind: 'graph', entry });
 }
 
+/** #409 durable outbox enqueue for memory sync records (same txn as mutation). */
+export function enqueueMemoryOutbox(
+  entry: SyncedMemoryRecord,
+  options: {
+    deliveryKey: string;
+    db?: ReturnType<typeof getDatabase>;
+    dueNow?: boolean;
+  },
+): { inserted: boolean; id: number | null } {
+  return enqueuePayload(
+    {
+      kind: 'memory',
+      entry: {
+        record: entry,
+        device_id: getDeviceId(),
+        device_name: getDeviceName(),
+        platform: `${process.platform}/${process.arch}`,
+      },
+    },
+    {
+      deliveryKey: options.deliveryKey,
+      db: options.db,
+      dueNow: options.dueNow ?? true,
+    },
+  );
+}
+
+/** #409 durable outbox enqueue for graph sync envelopes. */
+export function enqueueGraphOutbox(
+  entry: GraphSyncEnvelope,
+  options: {
+    deliveryKey: string;
+    db?: ReturnType<typeof getDatabase>;
+    dueNow?: boolean;
+  },
+): { inserted: boolean; id: number | null } {
+  return enqueuePayload(
+    { kind: 'graph', entry },
+    {
+      deliveryKey: options.deliveryKey,
+      db: options.db,
+      dueNow: options.dueNow ?? true,
+    },
+  );
+}
+
+
 /**
  * Hard ceiling on total sync_queue rows. The 7-day TTL (purgeOldEntries) only
  * runs when the brain worker is alive; MCP-only installs have no worker, so
@@ -270,23 +317,62 @@ export function enforceQueueCap(maxRows: number = MAX_SYNC_QUEUE_ROWS): number {
   return removed;
 }
 
-function enqueuePayload(payload: QueuePayload): void {
-  const db = getDatabase();
-  const payloadJson = JSON.stringify(payload);
-  const nextRetryAt = new Date(Date.now() + 30_000).toISOString(); // First retry in 30s
+export interface EnqueueOptions {
+  /**
+   * #409 — when set, INSERT is idempotent on delivery_key (UNIQUE partial index).
+   * Same key re-enqueue is a no-op (one outbox row per logical event).
+   */
+  deliveryKey?: string;
+  /**
+   * Optional shared connection (same better-sqlite3 Database). When the caller
+   * is already inside db.transaction(), pass that db so the INSERT joins the
+   * outer transaction. Defaults to getDatabase().
+   */
+  db?: ReturnType<typeof getDatabase>;
+  /**
+   * When true, next_retry_at = now so the dispatcher can claim immediately.
+   * Outbox rows use this; legacy failed-after-live-send rows keep +30s.
+   */
+  dueNow?: boolean;
+}
 
-  db.prepare(`
+function enqueuePayload(payload: QueuePayload, options: EnqueueOptions = {}): { inserted: boolean; id: number | null } {
+  const db = options.db ?? getDatabase();
+  const payloadJson = JSON.stringify(payload);
+  const nextRetryAt = options.dueNow
+    ? new Date().toISOString()
+    : new Date(Date.now() + 30_000).toISOString(); // First retry in 30s
+  const deliveryKey = options.deliveryKey ?? null;
+
+  if (deliveryKey) {
+    // Idempotent insert — UNIQUE(delivery_key) WHERE NOT NULL
+    const info = db.prepare(`
+      INSERT OR IGNORE INTO sync_queue (payload, attempts, next_retry_at, status, delivery_key)
+      VALUES (?, 0, ?, 'pending', ?)
+    `).run(payloadJson, nextRetryAt, deliveryKey);
+    const inserted = Number(info.changes ?? 0) === 1;
+    let id: number | null = null;
+    if (inserted) {
+      id = Number(info.lastInsertRowid);
+    } else {
+      const row = db.prepare('SELECT id FROM sync_queue WHERE delivery_key = ?').get(deliveryKey) as { id: number } | undefined;
+      id = row?.id ?? null;
+    }
+    try { enforceQueueCap(); } catch { /* best-effort */ }
+    return { inserted, id };
+  }
+
+  const info = db.prepare(`
     INSERT INTO sync_queue (payload, attempts, next_retry_at, status)
     VALUES (?, 0, ?, 'pending')
   `).run(payloadJson, nextRetryAt);
 
-  // Keep the queue bounded even with no brain worker running. Best-effort:
-  // a failure here must never block the (already-completed) enqueue.
   try {
     enforceQueueCap();
   } catch {
     /* truly silent — fire-and-forget contract */
   }
+  return { inserted: true, id: Number(info.lastInsertRowid) };
 }
 
 function buildRetryRequest(payloadText: string): { path: string; body: string } {

--- a/src/database/inline-schema.ts
+++ b/src/database/inline-schema.ts
@@ -358,11 +358,14 @@ export function getInlineSchema(): string {
       synced_at TEXT,
       lease_owner TEXT,
       lease_token TEXT,
-      lease_expires_at TEXT
+      lease_expires_at TEXT,
+      delivery_key TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_sync_queue_status_retry ON sync_queue(status, next_retry_at);
     CREATE INDEX IF NOT EXISTS idx_sync_queue_lease_exp ON sync_queue(lease_expires_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_queue_delivery_key
+      ON sync_queue(delivery_key) WHERE delivery_key IS NOT NULL;
 
     CREATE TABLE IF NOT EXISTS custom_patterns (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -350,10 +350,13 @@ export function runMigrations(database: Database.Database): void {
         synced_at TEXT,
         lease_owner TEXT,
         lease_token TEXT,
-        lease_expires_at TEXT
+        lease_expires_at TEXT,
+        delivery_key TEXT
       );
       CREATE INDEX IF NOT EXISTS idx_sync_queue_status_retry ON sync_queue(status, next_retry_at);
       CREATE INDEX IF NOT EXISTS idx_sync_queue_lease_exp ON sync_queue(lease_expires_at);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_queue_delivery_key
+        ON sync_queue(delivery_key) WHERE delivery_key IS NOT NULL;
     `);
   } catch (err) {
     logIfUnexpectedDdlError(err, 'sync_queue table + index');
@@ -977,14 +980,17 @@ export function runMigrations(database: Database.Database): void {
     if (sq) {
       const cols = database.prepare('PRAGMA table_info(sync_queue)').all() as { name: string }[];
       const have = new Set(cols.map((c) => c.name));
-      for (const col of ['lease_owner', 'lease_token', 'lease_expires_at'] as const) {
+      for (const col of ['lease_owner', 'lease_token', 'lease_expires_at', 'delivery_key'] as const) {
         if (!have.has(col)) {
           database.exec(`ALTER TABLE sync_queue ADD COLUMN ${col} TEXT`);
         }
       }
       database.exec('CREATE INDEX IF NOT EXISTS idx_sync_queue_lease_exp ON sync_queue(lease_expires_at)');
+      database.exec(
+        'CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_queue_delivery_key ON sync_queue(delivery_key) WHERE delivery_key IS NOT NULL',
+      );
     }
   } catch (err) {
-    logIfUnexpectedDdlError(err, 'sync_queue lease columns (#408)');
+    logIfUnexpectedDdlError(err, 'sync_queue lease/outbox columns (#408/#409)');
   }
 }

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -429,11 +429,15 @@ CREATE TABLE IF NOT EXISTS sync_queue (
   -- #408 atomic claim / lease (NULL = unowned; expired lease is reclaimable)
   lease_owner TEXT,
   lease_token TEXT,
-  lease_expires_at TEXT
+  lease_expires_at TEXT,
+  -- #409 transactional outbox idempotency key (NULL for legacy failed-retry enqueues)
+  delivery_key TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sync_queue_status_retry ON sync_queue(status, next_retry_at);
 CREATE INDEX IF NOT EXISTS idx_sync_queue_lease_exp ON sync_queue(lease_expires_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_queue_delivery_key
+  ON sync_queue(delivery_key) WHERE delivery_key IS NOT NULL;
 
 -- Pro feature: Custom injection patterns
 CREATE TABLE IF NOT EXISTS custom_patterns (

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -6,6 +6,15 @@
  */
 
 import { randomUUID } from 'crypto';
+import { createRequire } from 'node:module';
+const requireCloud = createRequire(import.meta.url);
+/** Lazy cloud outbox APIs — createRequire avoids Jest ESM circular live-binding TDZ. */
+function cloudMemorySync(): typeof import('../cloud/memory-sync.js') {
+  return requireCloud('../cloud/memory-sync.js') as typeof import('../cloud/memory-sync.js');
+}
+function cloudGraphSync(): typeof import('../cloud/graph-sync.js') {
+  return requireCloud('../cloud/graph-sync.js') as typeof import('../cloud/graph-sync.js');
+}
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -52,19 +61,12 @@ import { runDefencePipeline, storeFragmentationData } from '../defence/index.js'
 import { resolveDisposition } from '../defence/disposition.js';
 import { syncQuarantineToCloud } from '../cloud/quarantine-sync.js';
 import {
-  buildEnvelope as buildGraphEnvelope,
-  dispatchGraphOutboxBestEffort,
   syncGraphDeleteForMemoryToCloud,
   syncGraphForMemoryToCloud,
-  writeGraphSyncOutbox,
 } from '../cloud/graph-sync.js';
 import {
-  buildMemoryDeleteOutboxRecord,
-  buildMemoryUpsertOutboxRecord,
-  dispatchMemoryOutboxBestEffort,
   syncMemoryDeleteToCloud,
   syncMemoryUpsertToCloud,
-  writeMemorySyncOutbox,
 } from '../cloud/memory-sync.js';
 import { isFeatureEnabled } from '../license/gate.js';
 import type { DefenceSource, DefencePipelineResult, AuditOperation } from '../defence/types.js';
@@ -737,9 +739,9 @@ export function addMemory(
 
     const id = result.lastInsertRowid as number;
     if (isFeatureEnabled('cloud_sync')) {
-      createOutboxRecord = buildMemoryUpsertOutboxRecord(id);
+      createOutboxRecord = cloudMemorySync().buildMemoryUpsertOutboxRecord(id);
       if (createOutboxRecord) {
-        createOutboxKey = writeMemorySyncOutbox(createOutboxRecord, { op: 'upsert', db }).deliveryKey;
+        createOutboxKey = cloudMemorySync().writeMemorySyncOutbox(createOutboxRecord, { op: 'upsert', db }).deliveryKey;
       }
     }
     return id;
@@ -789,7 +791,7 @@ export function addMemory(
   if (isFeatureEnabled('cloud_sync')) {
     // #409 — outbox row committed with the INSERT; dispatch best-effort now.
     if (createOutboxRecord) {
-      dispatchMemoryOutboxBestEffort(createOutboxRecord, createOutboxKey ?? undefined);
+      cloudMemorySync().dispatchMemoryOutboxBestEffort(createOutboxRecord, createOutboxKey ?? undefined);
     } else {
       // Policy excluded or cloud off mid-flight — legacy path is a no-op then.
       syncMemoryUpsertToCloud(memory);
@@ -1104,9 +1106,9 @@ export function updateMemory(
   db.transaction(() => {
     db.prepare(`UPDATE memories SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = ?`).run(...values);
     if (isFeatureEnabled('cloud_sync')) {
-      updateOutboxRecord = buildMemoryUpsertOutboxRecord(id);
+      updateOutboxRecord = cloudMemorySync().buildMemoryUpsertOutboxRecord(id);
       if (updateOutboxRecord) {
-        updateOutboxKey = writeMemorySyncOutbox(updateOutboxRecord, { op: 'upsert', db }).deliveryKey;
+        updateOutboxKey = cloudMemorySync().writeMemorySyncOutbox(updateOutboxRecord, { op: 'upsert', db }).deliveryKey;
       }
     }
   })();
@@ -1169,7 +1171,7 @@ export function updateMemory(
 
   if (isFeatureEnabled('cloud_sync')) {
     if (updateOutboxRecord) {
-      dispatchMemoryOutboxBestEffort(updateOutboxRecord, updateOutboxKey ?? undefined);
+      cloudMemorySync().dispatchMemoryOutboxBestEffort(updateOutboxRecord, updateOutboxKey ?? undefined);
     } else {
       syncMemoryUpsertToCloud(updatedMemory);
     }
@@ -1396,28 +1398,26 @@ export function deleteMemory(
   let deleteMemoryRecord: import('../cloud/memory-sync.js').SyncedMemoryRecord | null = null;
   let deleteMemoryKey: string | null = null;
   let deleteGraphDeliveryKey: string | null = null;
-  let deleteGraphEnvelope: ReturnType<typeof buildGraphEnvelope> | null = null;
+  let deleteGraphEnvelope: import('../cloud/graph-sync.js').GraphSyncEnvelope | null = null;
 
   const deleted = db.transaction(() => {
     const result = db.prepare('DELETE FROM memories WHERE id = ?').run(id);
     if (result.changes <= 0 || !memory) return false;
 
     if (isFeatureEnabled('cloud_sync')) {
-      deleteMemoryRecord = buildMemoryDeleteOutboxRecord(memory);
+      deleteMemoryRecord = cloudMemorySync().buildMemoryDeleteOutboxRecord(memory);
       if (deleteMemoryRecord) {
-        deleteMemoryKey = writeMemorySyncOutbox(deleteMemoryRecord, { op: 'delete', db }).deliveryKey;
-        // Graph prune outbox — same privacy gate as memory delete (record non-null).
-        // next_retry_at slightly after memory row so claim order prefers tombstone first.
-        deleteGraphEnvelope = buildGraphEnvelope([], [], [], [memory.uuid]);
-        deleteGraphDeliveryKey = `graph:prune:${memory.uuid}:${deleteMemoryRecord.deleted_at ?? new Date().toISOString()}:0`;
-        writeGraphSyncOutbox(deleteGraphEnvelope, {
-          deliveryKey: deleteGraphDeliveryKey,
-          db,
-        });
-        // Bump graph row retry a hair later for claim ORDER BY next_retry_at
-        db.prepare(
-          `UPDATE sync_queue SET next_retry_at = ? WHERE delivery_key = ? AND status = 'pending'`,
-        ).run(new Date(Date.now() + 5).toISOString(), deleteGraphDeliveryKey);
+        deleteMemoryKey = cloudMemorySync().writeMemorySyncOutbox(deleteMemoryRecord, { op: 'delete', db }).deliveryKey;
+        // Graph prune outbox via graph-sync helper (avoids circular ESM on buildEnvelope).
+        const prune = cloudGraphSync().writeGraphPruneOutboxForMemory(memory, { db });
+        if (prune) {
+          deleteGraphEnvelope = prune.envelope;
+          deleteGraphDeliveryKey = prune.deliveryKey;
+          // Bump graph row retry a hair later so claim ORDER BY prefers memory tombstone.
+          db.prepare(
+            `UPDATE sync_queue SET next_retry_at = ? WHERE delivery_key = ? AND status = 'pending'`,
+          ).run(new Date(Date.now() + 5).toISOString(), deleteGraphDeliveryKey);
+        }
       }
     }
     return true;
@@ -1433,10 +1433,10 @@ export function deleteMemory(
     }
     if (isFeatureEnabled('cloud_sync')) {
       if (deleteMemoryRecord) {
-        dispatchMemoryOutboxBestEffort(deleteMemoryRecord, deleteMemoryKey ?? undefined);
+        cloudMemorySync().dispatchMemoryOutboxBestEffort(deleteMemoryRecord, deleteMemoryKey ?? undefined);
       }
       if (deleteGraphEnvelope && deleteGraphDeliveryKey) {
-        dispatchGraphOutboxBestEffort(deleteGraphEnvelope, deleteGraphDeliveryKey);
+        cloudGraphSync().dispatchGraphOutboxBestEffort(deleteGraphEnvelope, deleteGraphDeliveryKey);
       }
     }
     emitMemoryDeleted(id, memory.title);

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -51,8 +51,21 @@ import type { TripleProvenance } from '../graph/resolve.js';
 import { runDefencePipeline, storeFragmentationData } from '../defence/index.js';
 import { resolveDisposition } from '../defence/disposition.js';
 import { syncQuarantineToCloud } from '../cloud/quarantine-sync.js';
-import { syncGraphDeleteForMemoryToCloud, syncGraphForMemoryToCloud } from '../cloud/graph-sync.js';
-import { syncMemoryDeleteToCloud, syncMemoryUpsertToCloud } from '../cloud/memory-sync.js';
+import {
+  buildEnvelope as buildGraphEnvelope,
+  dispatchGraphOutboxBestEffort,
+  syncGraphDeleteForMemoryToCloud,
+  syncGraphForMemoryToCloud,
+  writeGraphSyncOutbox,
+} from '../cloud/graph-sync.js';
+import {
+  buildMemoryDeleteOutboxRecord,
+  buildMemoryUpsertOutboxRecord,
+  dispatchMemoryOutboxBestEffort,
+  syncMemoryDeleteToCloud,
+  syncMemoryUpsertToCloud,
+  writeMemorySyncOutbox,
+} from '../cloud/memory-sync.js';
 import { isFeatureEnabled } from '../license/gate.js';
 import type { DefenceSource, DefencePipelineResult, AuditOperation } from '../defence/types.js';
 import { checkAccess } from '../defence/trust/access-control.js';
@@ -680,7 +693,9 @@ export function addMemory(
     truncatedLength: truncationResult.content.length,
   };
 
-  // Transaction: INSERT + defence UPDATE must be atomic to prevent wrong trust scores
+  // Transaction: INSERT + defence UPDATE + #409 memory outbox must be atomic so a
+  // crash cannot commit the local row without a durable outbound event (or vice versa).
+  let createOutboxRecord: import('../cloud/memory-sync.js').SyncedMemoryRecord | null = null;
   const insertedId = db.transaction(() => {
     const memoryUuid = randomUUID();
     const result = stmt.run(
@@ -719,7 +734,14 @@ export function addMemory(
       // >10KB memories too (where the STORED content is truncated).
       .run(defenceResult.trust.score, defenceResult.sensitivity.level, sourceDetails.sourceValue, createContentHash(input.content), result.lastInsertRowid);
 
-    return result.lastInsertRowid as number;
+    const id = result.lastInsertRowid as number;
+    if (isFeatureEnabled('cloud_sync')) {
+      createOutboxRecord = buildMemoryUpsertOutboxRecord(id);
+      if (createOutboxRecord) {
+        writeMemorySyncOutbox(createOutboxRecord, { op: 'upsert', db });
+      }
+    }
+    return id;
   })();
 
   const memory = getMemoryById(insertedId)!;
@@ -764,7 +786,13 @@ export function addMemory(
   dispatchWebhook('memory_created', { id: memory.id, title: memory.title, category: memory.category });
 
   if (isFeatureEnabled('cloud_sync')) {
-    syncMemoryUpsertToCloud(memory);
+    // #409 — outbox row committed with the INSERT; dispatch best-effort now.
+    if (createOutboxRecord) {
+      dispatchMemoryOutboxBestEffort(createOutboxRecord);
+    } else {
+      // Policy excluded or cloud off mid-flight — legacy path is a no-op then.
+      syncMemoryUpsertToCloud(memory);
+    }
   }
 
   // ORGANIC FEATURE: Auto-link to related memories
@@ -1069,7 +1097,17 @@ export function updateMemory(
   if (fields.length === 0) return existing;
 
   values.push(id);
-  db.prepare(`UPDATE memories SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = ?`).run(...values);
+  // #409 — UPDATE + memory outbox in one transaction.
+  let updateOutboxRecord: import('../cloud/memory-sync.js').SyncedMemoryRecord | null = null;
+  db.transaction(() => {
+    db.prepare(`UPDATE memories SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = ?`).run(...values);
+    if (isFeatureEnabled('cloud_sync')) {
+      updateOutboxRecord = buildMemoryUpsertOutboxRecord(id);
+      if (updateOutboxRecord) {
+        writeMemorySyncOutbox(updateOutboxRecord, { op: 'upsert', db });
+      }
+    }
+  })();
 
   const updatedMemory = getMemoryById(id)!;
 
@@ -1128,7 +1166,12 @@ export function updateMemory(
   persistEvent('memory_updated', { memory: updatedMemory });
 
   if (isFeatureEnabled('cloud_sync')) {
-    syncMemoryUpsertToCloud(updatedMemory);
+    if (updateOutboxRecord) {
+      dispatchMemoryOutboxBestEffort(updateOutboxRecord);
+    } else {
+      syncMemoryUpsertToCloud(updatedMemory);
+    }
+    // Graph refresh may depend on extraction above; still outbox-first inside helper.
     syncGraphForMemoryToCloud(updatedMemory.id);
   }
 
@@ -1347,10 +1390,33 @@ export function deleteMemory(
     }
   }
 
-  const result = db.prepare('DELETE FROM memories WHERE id = ?').run(id);
+  // #409 — DELETE + durable outbox rows in one SQLite transaction.
+  let deleteMemoryRecord: import('../cloud/memory-sync.js').SyncedMemoryRecord | null = null;
+  let deleteGraphDeliveryKey: string | null = null;
+  let deleteGraphEnvelope: ReturnType<typeof buildGraphEnvelope> | null = null;
+
+  const deleted = db.transaction(() => {
+    const result = db.prepare('DELETE FROM memories WHERE id = ?').run(id);
+    if (result.changes <= 0 || !memory) return false;
+
+    if (isFeatureEnabled('cloud_sync')) {
+      deleteMemoryRecord = buildMemoryDeleteOutboxRecord(memory);
+      if (deleteMemoryRecord) {
+        writeMemorySyncOutbox(deleteMemoryRecord, { op: 'delete', db });
+        // Graph prune outbox — same privacy gate as memory delete (record non-null).
+        deleteGraphEnvelope = buildGraphEnvelope([], [], [], [memory.uuid]);
+        deleteGraphDeliveryKey = `graph:prune:${memory.uuid}:${deleteMemoryRecord.deleted_at ?? new Date().toISOString()}`;
+        writeGraphSyncOutbox(deleteGraphEnvelope, {
+          deliveryKey: deleteGraphDeliveryKey,
+          db,
+        });
+      }
+    }
+    return true;
+  })();
 
   // Emit event for real-time dashboard (in-process)
-  if (result.changes > 0 && memory) {
+  if (deleted && memory) {
     // Provenance ledger: record the allowed delete (one row per memory) when the
     // caller is attributed. Internal source-less deletes (merge/consolidation)
     // are machinery, not user actions, so they're not audited here.
@@ -1358,15 +1424,19 @@ export function deleteMemory(
       logAllowedDelete(id, source, (memory.project as string | undefined) ?? null, aclOp, attested);
     }
     if (isFeatureEnabled('cloud_sync')) {
-      syncMemoryDeleteToCloud(memory);
-      syncGraphDeleteForMemoryToCloud(memory);
+      if (deleteMemoryRecord) {
+        dispatchMemoryOutboxBestEffort(deleteMemoryRecord);
+      }
+      if (deleteGraphEnvelope && deleteGraphDeliveryKey) {
+        dispatchGraphOutboxBestEffort(deleteGraphEnvelope, deleteGraphDeliveryKey);
+      }
     }
     emitMemoryDeleted(id, memory.title);
     // Persist event for cross-process IPC (MCP → Dashboard)
     persistEvent('memory_deleted', { memoryId: id, title: memory.title });
   }
 
-  return result.changes > 0;
+  return deleted;
 }
 
 

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -696,6 +696,7 @@ export function addMemory(
   // Transaction: INSERT + defence UPDATE + #409 memory outbox must be atomic so a
   // crash cannot commit the local row without a durable outbound event (or vice versa).
   let createOutboxRecord: import('../cloud/memory-sync.js').SyncedMemoryRecord | null = null;
+  let createOutboxKey: string | null = null;
   const insertedId = db.transaction(() => {
     const memoryUuid = randomUUID();
     const result = stmt.run(
@@ -738,7 +739,7 @@ export function addMemory(
     if (isFeatureEnabled('cloud_sync')) {
       createOutboxRecord = buildMemoryUpsertOutboxRecord(id);
       if (createOutboxRecord) {
-        writeMemorySyncOutbox(createOutboxRecord, { op: 'upsert', db });
+        createOutboxKey = writeMemorySyncOutbox(createOutboxRecord, { op: 'upsert', db }).deliveryKey;
       }
     }
     return id;
@@ -788,7 +789,7 @@ export function addMemory(
   if (isFeatureEnabled('cloud_sync')) {
     // #409 — outbox row committed with the INSERT; dispatch best-effort now.
     if (createOutboxRecord) {
-      dispatchMemoryOutboxBestEffort(createOutboxRecord);
+      dispatchMemoryOutboxBestEffort(createOutboxRecord, createOutboxKey ?? undefined);
     } else {
       // Policy excluded or cloud off mid-flight — legacy path is a no-op then.
       syncMemoryUpsertToCloud(memory);
@@ -1099,12 +1100,13 @@ export function updateMemory(
   values.push(id);
   // #409 — UPDATE + memory outbox in one transaction.
   let updateOutboxRecord: import('../cloud/memory-sync.js').SyncedMemoryRecord | null = null;
+  let updateOutboxKey: string | null = null;
   db.transaction(() => {
     db.prepare(`UPDATE memories SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = ?`).run(...values);
     if (isFeatureEnabled('cloud_sync')) {
       updateOutboxRecord = buildMemoryUpsertOutboxRecord(id);
       if (updateOutboxRecord) {
-        writeMemorySyncOutbox(updateOutboxRecord, { op: 'upsert', db });
+        updateOutboxKey = writeMemorySyncOutbox(updateOutboxRecord, { op: 'upsert', db }).deliveryKey;
       }
     }
   })();
@@ -1167,7 +1169,7 @@ export function updateMemory(
 
   if (isFeatureEnabled('cloud_sync')) {
     if (updateOutboxRecord) {
-      dispatchMemoryOutboxBestEffort(updateOutboxRecord);
+      dispatchMemoryOutboxBestEffort(updateOutboxRecord, updateOutboxKey ?? undefined);
     } else {
       syncMemoryUpsertToCloud(updatedMemory);
     }
@@ -1392,6 +1394,7 @@ export function deleteMemory(
 
   // #409 — DELETE + durable outbox rows in one SQLite transaction.
   let deleteMemoryRecord: import('../cloud/memory-sync.js').SyncedMemoryRecord | null = null;
+  let deleteMemoryKey: string | null = null;
   let deleteGraphDeliveryKey: string | null = null;
   let deleteGraphEnvelope: ReturnType<typeof buildGraphEnvelope> | null = null;
 
@@ -1402,14 +1405,19 @@ export function deleteMemory(
     if (isFeatureEnabled('cloud_sync')) {
       deleteMemoryRecord = buildMemoryDeleteOutboxRecord(memory);
       if (deleteMemoryRecord) {
-        writeMemorySyncOutbox(deleteMemoryRecord, { op: 'delete', db });
+        deleteMemoryKey = writeMemorySyncOutbox(deleteMemoryRecord, { op: 'delete', db }).deliveryKey;
         // Graph prune outbox — same privacy gate as memory delete (record non-null).
+        // next_retry_at slightly after memory row so claim order prefers tombstone first.
         deleteGraphEnvelope = buildGraphEnvelope([], [], [], [memory.uuid]);
-        deleteGraphDeliveryKey = `graph:prune:${memory.uuid}:${deleteMemoryRecord.deleted_at ?? new Date().toISOString()}`;
+        deleteGraphDeliveryKey = `graph:prune:${memory.uuid}:${deleteMemoryRecord.deleted_at ?? new Date().toISOString()}:0`;
         writeGraphSyncOutbox(deleteGraphEnvelope, {
           deliveryKey: deleteGraphDeliveryKey,
           db,
         });
+        // Bump graph row retry a hair later for claim ORDER BY next_retry_at
+        db.prepare(
+          `UPDATE sync_queue SET next_retry_at = ? WHERE delivery_key = ? AND status = 'pending'`,
+        ).run(new Date(Date.now() + 5).toISOString(), deleteGraphDeliveryKey);
       }
     }
     return true;
@@ -1425,7 +1433,7 @@ export function deleteMemory(
     }
     if (isFeatureEnabled('cloud_sync')) {
       if (deleteMemoryRecord) {
-        dispatchMemoryOutboxBestEffort(deleteMemoryRecord);
+        dispatchMemoryOutboxBestEffort(deleteMemoryRecord, deleteMemoryKey ?? undefined);
       }
       if (deleteGraphEnvelope && deleteGraphDeliveryKey) {
         dispatchGraphOutboxBestEffort(deleteGraphEnvelope, deleteGraphDeliveryKey);


### PR DESCRIPTION
## Summary
Closes **#409** (Athena HIGH): local memory mutation and cloud-sync enqueue were not one durable transaction.

### Changes
- `sync_queue.delivery_key` + partial UNIQUE index (idempotent outbox)
- `enqueueMemoryOutbox` / `enqueueGraphOutbox` (txn-joinable)
- `writeMemorySyncOutbox` / `writeGraphSyncOutbox` + post-commit dispatch/ack
- `store` create/update/delete: mutation + outbox in the same `db.transaction()`
- Delete: memory tombstone + graph prune outbox share the DELETE txn (#405 privacy retained)

### Acceptance
- Crash after mutation+outbox commit → durable pending event
- Rolled-back mutation → no outbox row
- Replayed delivery_key → single row
- Delete/tombstone ordering keys preserved

### Tests
- 5 focused #409 tests
- #405 / #408 / sync-queue suites still green (33 related)

Closes #409