### PR TITLE
release: v4.54.13 — cloud sync durability (#408 #409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Fixed
-- **#409:** transactional outbox — memory/graph sync events written in the same SQLite transaction as the local mutation; delivery_key idempotency; dispatch after commit with durable ack/retry.
+## [4.54.13] - 2026-08-25
+
+**Cloud sync durability patch.** Ships the last two Athena HIGHs that sit on the host engine: atomic retry claim/lease and a transactional outbox so local memory mutations cannot commit without a durable outbound event (and vice versa).
 
 ### Fixed
-- **#408:** cloud sync retry queue uses atomic claim + lease (owner/token/expiry); completion/failure updates are claim-conditional; expired leases are reclaimable.
+- **#409:** transactional outbox — memory/graph sync events written in the same SQLite transaction as the local mutation; unique `delivery_key` per event with exact-key ack (no LIKE prefix); dispatch after commit; failures stay on the #408 retry path.
+- **#408:** cloud sync retry queue uses atomic claim + lease (owner/token/expiry); claim-one-then-send vs batch budget; completion/failure updates are claim-conditional; expired leases are reclaimable.
 
 ## [4.54.12] - 2026-08-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.12",
+  "version": "4.54.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.54.12",
+      "version": "4.54.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.12",
+  "version": "4.54.13",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.54.12",
+  "version": "4.54.13",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.54.12",
+  "version": "4.54.13",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "pack:verify": "npm pack --dry-run",
-    "prepublishOnly": "node -e \"if(!require('fs').existsSync('dist/index.js'))throw new Error('plugin dist/index.js missing — run `npm run build:ts` from the repo root before publishing')\""
+    "prepublishOnly": "node -e \"if(!require('fs').existsSync('dist/index.js'))throw new Error('plugin dist/index.js missing \u2014 run `npm run build:ts` from the repo root before publishing')\""
   },
   "peerDependencies": {
     "shieldcortex": "^4.54.8",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.54.12
+  version: 4.54.13
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Summary
Patch cut **4.54.13** so npm/hosts get the last two Athena HIGHs that live on the host engine.

### Ships
| Issue | Fix |
|---|---|
| **#408** | atomic claim + lease on cloud sync retry queue |
| **#409** | transactional outbox (mutation + enqueue same SQLite txn; exact-key ack) |

### Context
- **4.54.12** already shipped #405–#407/#410–#412 + DNP UX + intent-first docs
- Cloud API **v162** already runs engine **4.54.12**
- This cut is required before fleet cloud memory sync can be considered — host durability, not cloud pin alone

### Release mechanics
- root `package.json` → `4.54.13`
- `node scripts/sync-plugin-version.mjs` (plugin package + manifest + skill FM)
- CHANGELOG Unreleased → `[4.54.13]`

### After merge
1. Tag `v4.54.13` on the merge commit (triggers publish.yml)
2. Verify npm `shieldcortex@4.54.13` + `@drakon-systems/shieldcortex-realtime@4.54.13`
3. Cloud/site train pins to `^4.54.13`
4. **Keep fleet cloud memory sync OFF** until hosts are on 4.54.13+ and operator greenlights