### PR TITLE
feat(guard): #401 work-lane pack v1 (lan-diag + denial doors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **#401:** work-lane pack v1 — pin-able `lan-diag` template (`templates/work-lanes/lan-diag.sh`: read-mostly status, private-only bounded ping/GET, fails closed on public destinations), `lan-diag` lane in the work-lane hint catalog (after vita-ci/jotform; pin + external-egress + lan-shaped cwd or network tool), and a denial→door matrix test (`denial-doors-401.test.ts`) locking "no deny without a door": catastrophic stays a hard stop, DNP digests always carry `shieldcortex approve --denial`, no siren-only class. Runbook: `docs/runbooks/work-lane-pack-v1.md`.
+
 ## [4.54.13] - 2026-08-25
 
 **Cloud sync durability patch.** Ships the last two Athena HIGHs that sit on the host engine: atomic retry claim/lease and a transactional outbox so local memory mutations cannot commit without a durable outbound event (and vice versa).

--- a/docs/runbooks/work-lane-pack-v1.md
+++ b/docs/runbooks/work-lane-pack-v1.md
@@ -1,0 +1,80 @@
+# Runbook — Work-lane pack v1 (#401)
+
+**Audience:** operators of a ShieldCortex-guarded host whose agent keeps getting
+held on a known class of work (the post-Edith stop-bleed: LAN diagnostics with
+no door).
+
+**Design:** `docs/design/2026-08-24-memory-sota-defence-work-not-frustration.md`
+§5–6 — *no deny without a door*. A repeated hold class without a lane is a
+product defect, not an operator-skill issue.
+
+## What ships
+
+| Lane id | Script | Trigger (hint) |
+|---|---|---|
+| `vita-ci` | operator's own `gh-ci.sh` | pin + vita-shaped cwd + `external-egress` |
+| `jotform` | operator's own jotform toolkit | pin + jotform cwd/signal + `external-egress` |
+| `lan-diag` | `templates/work-lanes/lan-diag.sh` (this package) | pin + (lan/diag/network/connectivity/wifi cwd **or** a network tool such as ping/traceroute/ip/dig) + `external-egress` |
+
+Hints are advisory copy on the denial digest. They never approve anything, and
+they never name a path that is not actually pinned on the host (#399 law).
+
+`lan-diag.sh` is read-mostly and fails closed:
+
+- no args / `status` — `ip -br addr` + `ip route` (read-only)
+- `<host-or-ip>` — `ping -c 2 -W 2`, **only** loopback, link-local, or RFC1918
+- `GET <url>` — http(s) GET, `--max-time 3`, same private-only destination rule,
+  no redirects, no request body
+- everything else refuses (exit 2): public or global-IPv6 destinations,
+  hostnames with any public address, nmap/tcpdump/ssh/sudo/writes/captures
+
+## Install the lan-diag lane
+
+All three steps happen on the target host, **from a real TTY** — the allowlist
+CLI refuses non-interactive callers by design.
+
+1. Copy the template out of the installed package onto a stable path:
+
+   ```bash
+   mkdir -p ~/.shieldcortex/work-lanes
+   cp "$(npm root -g)/shieldcortex/templates/work-lanes/lan-diag.sh" \
+      ~/.shieldcortex/work-lanes/lan-diag.sh
+   chmod 0755 ~/.shieldcortex/work-lanes/lan-diag.sh
+   ```
+
+2. Pin it (review it first — the pin is the operator saying *I read this*):
+
+   ```bash
+   shieldcortex allowlist add ~/.shieldcortex/work-lanes/lan-diag.sh
+   ```
+
+3. Retry the held job through the pin instead of freehand curl/nmap:
+
+   ```bash
+   ~/.shieldcortex/work-lanes/lan-diag.sh status
+   ~/.shieldcortex/work-lanes/lan-diag.sh 192.168.1.1
+   ~/.shieldcortex/work-lanes/lan-diag.sh GET http://192.168.1.1/health
+   ```
+
+Once pinned, the next `external-egress` denial from lan-shaped work carries a
+`Lane:` line pointing at exactly this path. Shipping the template does **not**
+pre-approve it — a host with no pin gets no hint and no allowlist entry.
+
+## Verifying the doors
+
+The denial→door matrix is locked by
+`src/defence/iron-dome/__tests__/denial-doors-401.test.ts`:
+
+- `catastrophic` — hard stop; no retry, no `approve --denial` in its copy
+- `denied_no_prompt_surface` — always `shieldcortex approve --denial <actionId>`
+  + honest-TTY copy; plus the `Lane:` line when a pin matches
+- `approval_requested` — Approve/Deny one-shot commands
+
+## Non-goals
+
+- **`enforce: false`** — degrading the guard is not a door.
+- **Fleet-wide `retryCards`** — stays off until Approve/Deny spend is proven on
+  that host class (design §5 defaults).
+- **Invented paths** — a hint may only name a path that exists in the pin list.
+  No pin, no lane line, ever.
+- **memories.db salvage** — separate runbook, separate concern.

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "scripts/lib/inject-pack.mjs",
     "scripts/lib/capture-distill.mjs",
     "scripts/lib/openclaw-distill-auth.mjs",
-    "scripts/lib/openclaw-extract.mjs"
+    "scripts/lib/openclaw-extract.mjs",
+    "templates/work-lanes"
   ]
 }

--- a/src/defence/iron-dome/__tests__/denial-doors-401.test.ts
+++ b/src/defence/iron-dome/__tests__/denial-doors-401.test.ts
@@ -1,0 +1,274 @@
+/**
+ * #401 — denial→door matrix (design §5: "no deny without a door").
+ *
+ * Every Action Guard hold class must map to ≥1 door:
+ *   work_lane     — reviewed, pinned script the agent can run instead
+ *   approve_once  — #310 card or `shieldcortex approve --denial <actionId>`
+ *   honest_tty    — honest "run this from a real terminal" copy
+ *   hard_stop     — catastrophic: no retry, no approve, and copy that says so
+ *
+ * No siren-only class: a digest without a lane still carries the approve
+ * command, and catastrophic copy must not dangle `approve --denial` as if it
+ * were spendable there.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { brokerDecision, type BrokerInput } from '../approval-broker.js';
+import { formatDnpDigestText, type DnpDigestFormatOpts, type DnpDigestSummary } from '../dnp-digest.js';
+import { formatOperatorNotification, type OperatorNotification } from '../operator-notify.js';
+import { suggestWorkLane, WORK_LANE_PACK_V1 } from '../work-lane-hints.js';
+
+const LAN_PIN = '/home/edith/.shieldcortex/work-lanes/lan-diag.sh';
+const VITA_PIN = '/home/edith/scripts/vita-site/gh-ci.sh';
+
+function summary(over: Partial<DnpDigestSummary> = {}): DnpDigestSummary {
+  return {
+    count: 1,
+    windowMs: 900_000,
+    windowStartMs: 0,
+    bySignal: { 'external-egress': 1 },
+    byTool: { Bash: 1 },
+    lastActionIds: ['act-0123456789abcdef'],
+    lastSessionIds: [],
+    coalescedAfterNotify: false,
+    ...over,
+  };
+}
+
+function catastrophicInput(over: Partial<BrokerInput['verdict']> = {}): BrokerInput {
+  return {
+    tool: 'Bash',
+    toolInput: { command: 'redacted' },
+    verdict: {
+      decision: 'block',
+      severity: 'catastrophic',
+      family: 'exec',
+      action: 'exec',
+      reason: 'catastrophic-tier rule hit',
+      signals: ['recursive-force-delete'],
+      ...over,
+    },
+    judge: null,
+  };
+}
+
+function notification(event: OperatorNotification['event']): OperatorNotification {
+  const shortHash = 'abcdef012345';
+  return {
+    event,
+    hash: `${shortHash}${'0'.repeat(52)}`,
+    shortHash,
+    tool: 'Bash',
+    command: 'redacted-surface',
+    signals: ['external-egress'],
+    severity: 'dangerous',
+    reason: 'external egress held for review',
+    judge: null,
+    fallbackHint: `shieldcortex approve ${shortHash}`,
+  };
+}
+
+describe('catastrophic → hard_stop', () => {
+  it('is never brokered and can never auto-approve', () => {
+    const d = brokerDecision(catastrophicInput());
+    expect(d.outcome).toBe('not_brokerable');
+    expect(d.canAutoApproveOnTimeout).toBe(false);
+  });
+
+  it('hard-stops on severity alone, even without decision block', () => {
+    const d = brokerDecision(catastrophicInput({ decision: 'require_approval' }));
+    expect(d.outcome).toBe('not_brokerable');
+  });
+
+  it('copy does not offer approve --denial as spendable', () => {
+    const d = brokerDecision(catastrophicInput());
+    expect(d.reason).not.toMatch(/approve --denial/);
+    expect(d.reason).not.toMatch(/shieldcortex approve/);
+    expect(d.reason).toMatch(/blocked by rule, never brokered/);
+  });
+});
+
+describe('denied_no_prompt_surface → approve_once + honest_tty', () => {
+  const variants: Array<[string, DnpDigestSummary, DnpDigestFormatOpts]> = [
+    ['with actionId', summary(), { actionId: 'act-abcdef0123456789' }],
+    ['without any actionId', summary({ lastActionIds: [] }), {}],
+    ['coalesced', summary({ coalescedAfterNotify: true, count: 4 }), {}],
+    ['retry card raised', summary(), { retryCardRaised: true }],
+    ['retry card refused', summary(), { retryCardReason: 'budget exhausted' }],
+    [
+      'with a lane',
+      summary(),
+      { signals: ['external-egress'], cwd: '/home/edith/lan-checks', reviewedScriptPaths: [LAN_PIN] },
+    ],
+    ['without a lane (no siren-only class)', summary(), { reviewedScriptPaths: [] }],
+  ];
+
+  it.each(variants)('digest %s always carries approve --denial', (_name, sum, opts) => {
+    const text = formatDnpDigestText(sum, opts);
+    expect(text).toMatch(/shieldcortex approve --denial/);
+  });
+
+  it.each(variants)('digest %s always carries the honest-TTY copy', (_name, sum, opts) => {
+    const text = formatDnpDigestText(sum, opts);
+    expect(text).toMatch(/real terminal/);
+    expect(text).toMatch(/not a tappable Approve surface/);
+  });
+
+  it('digest opens the work-lane door when a pin matches', () => {
+    const text = formatDnpDigestText(summary(), {
+      actionId: 'act-abcdef0123456789',
+      signals: ['external-egress'],
+      cwd: '/home/edith/lan-checks',
+      reviewedScriptPaths: [LAN_PIN],
+    });
+    expect(text).toMatch(/Lane: {2}\S/);
+    expect(text).toContain(`${LAN_PIN} status`);
+    // The lane never replaces the approve door — both stay open.
+    expect(text).toMatch(/approve --denial act-abcdef0123456789/);
+  });
+
+  it('denial notification points at YOUR terminal and drops the dead Deny half', () => {
+    const text = formatOperatorNotification(notification('denied_no_prompt_surface'));
+    expect(text).toMatch(/shieldcortex approve abcdef012345/);
+    expect(text).toMatch(/YOUR terminal/);
+    expect(text).not.toMatch(/\[Deny\]/);
+  });
+});
+
+describe('approval_requested → approve_once', () => {
+  it('notification offers both approve and deny commands', () => {
+    const text = formatOperatorNotification(notification('approval_requested'));
+    expect(text).toMatch(/\[Approve\] {2}shieldcortex approve abcdef012345/);
+    expect(text).toMatch(/\[Deny\] {5}shieldcortex deny abcdef012345/);
+  });
+});
+
+describe('lan-diag lane (#401, work-lane pack v1)', () => {
+  it('ships in the pack id list', () => {
+    expect([...WORK_LANE_PACK_V1]).toEqual(['vita-ci', 'jotform', 'lan-diag']);
+  });
+
+  it('hints on pin + lan-shaped cwd', () => {
+    const h = suggestWorkLane({
+      signals: ['external-egress'],
+      cwd: '/home/edith/lan-checks',
+      reviewedScriptPaths: [LAN_PIN],
+    });
+    expect(h?.command).toBe(`${LAN_PIN} status`);
+    expect(h?.reason).toMatch(/LAN diagnostics.*pinned script/);
+  });
+
+  it('hints on pin + network tool from an unrelated cwd', () => {
+    const h = suggestWorkLane({
+      signals: ['external-egress'],
+      cwd: '/tmp/scratch',
+      tool: 'ping',
+      reviewedScriptPaths: [LAN_PIN],
+    });
+    expect(h?.command).toBe(`${LAN_PIN} status`);
+  });
+
+  it('accepts a /lan-diag/ directory pin fragment', () => {
+    const pin = '/opt/lanes/lan-diag/run.sh';
+    const h = suggestWorkLane({
+      signals: ['external-egress'],
+      cwd: '/home/edith/wifi-triage',
+      reviewedScriptPaths: [pin],
+    });
+    expect(h?.command).toBe(`${pin} status`);
+  });
+
+  it('never invents a path without a pin', () => {
+    const h = suggestWorkLane({
+      signals: ['external-egress'],
+      cwd: '/home/edith/lan-checks',
+      tool: 'ping',
+      reviewedScriptPaths: [],
+    });
+    expect(h).toBeNull();
+  });
+
+  it('does not fire on pin alone (unrelated cwd, non-network tool)', () => {
+    const h = suggestWorkLane({
+      signals: ['external-egress'],
+      cwd: '/tmp/unrelated',
+      tool: 'gh',
+      reviewedScriptPaths: [LAN_PIN],
+    });
+    expect(h).toBeNull();
+  });
+
+  it('does not treat plan/finland as a lan cwd', () => {
+    for (const cwd of ['/tmp/plan', '/home/finland/work', '/opt/planner']) {
+      const h = suggestWorkLane({
+        signals: ['external-egress'],
+        cwd,
+        reviewedScriptPaths: [LAN_PIN],
+      });
+      expect(h).toBeNull();
+    }
+  });
+
+  it('requires exact external-egress, not secret-egress', () => {
+    const h = suggestWorkLane({
+      signals: ['secret-egress'],
+      cwd: '/home/edith/lan-checks',
+      tool: 'ping',
+      reviewedScriptPaths: [LAN_PIN],
+    });
+    expect(h).toBeNull();
+  });
+
+  it('does not steal the vita lane on a vita cwd', () => {
+    const h = suggestWorkLane({
+      signals: ['external-egress'],
+      cwd: '/home/edith/.openclaw/workspace/tmp/vita-mobile-hero',
+      reviewedScriptPaths: [LAN_PIN, VITA_PIN],
+    });
+    expect(h?.command).toMatch(/gh-ci\.sh status staging/);
+  });
+});
+
+describe('denial→door matrix', () => {
+  type Door = 'work_lane' | 'approve_once' | 'honest_tty' | 'hard_stop';
+
+  /** Doors derived from ACTUAL behaviour, not from a table someone hand-wrote. */
+  function doorsFor(holdClass: string): Door[] {
+    const doors: Door[] = [];
+    if (holdClass === 'catastrophic') {
+      const d = brokerDecision(catastrophicInput());
+      if (d.outcome === 'not_brokerable' && !d.canAutoApproveOnTimeout) doors.push('hard_stop');
+      return doors;
+    }
+    if (holdClass === 'denied_no_prompt_surface') {
+      const text = formatDnpDigestText(summary(), {
+        signals: ['external-egress'],
+        cwd: '/home/edith/lan-checks',
+        reviewedScriptPaths: [LAN_PIN],
+      });
+      if (/Lane: {2}\S/.test(text)) doors.push('work_lane');
+      if (/shieldcortex approve --denial/.test(text)) doors.push('approve_once');
+      if (/real terminal/.test(text)) doors.push('honest_tty');
+      return doors;
+    }
+    if (holdClass === 'approval_requested') {
+      const text = formatOperatorNotification(notification('approval_requested'));
+      if (/\[Approve\] {2}shieldcortex approve/.test(text)) doors.push('approve_once');
+      return doors;
+    }
+    return doors;
+  }
+
+  it('every hold class has at least one door', () => {
+    for (const holdClass of ['catastrophic', 'denied_no_prompt_surface', 'approval_requested']) {
+      expect(doorsFor(holdClass).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('catastrophic is exactly a hard stop — no spendable door', () => {
+    expect(doorsFor('catastrophic')).toEqual(['hard_stop']);
+  });
+
+  it('denied_no_prompt_surface has all three forward doors', () => {
+    expect(doorsFor('denied_no_prompt_surface')).toEqual(['work_lane', 'approve_once', 'honest_tty']);
+  });
+});

--- a/src/defence/iron-dome/__tests__/lan-diag-script-401.test.ts
+++ b/src/defence/iron-dome/__tests__/lan-diag-script-401.test.ts
@@ -15,13 +15,17 @@
  * before any socket opens or targets 127.0.0.1.
  */
 import { execFileSync, spawnSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 import { join } from 'path';
 
 const SCRIPT = join(process.cwd(), 'templates', 'work-lanes', 'lan-diag.sh');
 
+// Execute the script FILE (not '/bin/bash SCRIPT'): the interpreter line is
+// '#!/bin/bash -p' and invoking bash explicitly would strip privileged mode,
+// re-opening the startup-file hole the shebang closes (SOL round 3).
 function run(args: string[], extraEnv: Record<string, string> = {}): { code: number; out: string } {
-  const res = spawnSync('/bin/bash', [SCRIPT, ...args], {
+  const res = spawnSync(SCRIPT, args, {
     encoding: 'utf-8',
     timeout: 10_000,
     env: { ...process.env, ...extraEnv },
@@ -91,10 +95,20 @@ describe('lan-diag.sh script-level refusal contract (#401)', () => {
     expect(run(['GET', 'http://127.0.0.1/', 'extra']).code).toBe(2);
   });
 
-  test('inherited startup-file var cannot inject code (env scrub re-exec)', () => {
-    // If the variable survived, bash would try to source this path and fail.
-    const r = run(['help'], { BASH_ENV: '/nonexistent/hostile-startup.sh' });
-    expect(r.code).toBe(0);
+  test('inherited startup-file var cannot inject code (bash -p + scrub)', () => {
+    // A REAL payload that would print a marker and exit 73 if it ever ran.
+    // bash -p refuses to process the startup-file variable, so the lane must
+    // run clean with no marker in the output (SOL round 3: a missing file is
+    // silently ignored — only a live payload proves the hole is closed).
+    const evil = join(tmpdir(), `lan-diag-evil-${process.pid}.sh`);
+    writeFileSync(evil, 'echo STARTUP_PAYLOAD_RAN; exit 73\n', { mode: 0o755 });
+    try {
+      const r = run(['help'], { BASH_ENV: evil, ENV: evil });
+      expect(r.code).toBe(0);
+      expect(r.out).not.toContain('STARTUP_PAYLOAD_RAN');
+    } finally {
+      rmSync(evil, { force: true });
+    }
   });
 
   test('inherited proxy environment cannot route the GET (env scrub re-exec)', () => {

--- a/src/defence/iron-dome/__tests__/lan-diag-script-401.test.ts
+++ b/src/defence/iron-dome/__tests__/lan-diag-script-401.test.ts
@@ -1,0 +1,115 @@
+/**
+ * #401 — script-level tests for the lan-diag work-lane template.
+ *
+ * The TypeScript door matrix (denial-doors-401.test.ts) exercises the hint
+ * catalog; it never executes the template. These tests run the actual shell
+ * script and lock the refusal contract reviewers flagged:
+ *   - public destinations refuse (ping + GET)
+ *   - GET refuses link-local/IMDS ranges even though ping allows link-local
+ *   - ambiguous leading-zero IPv4 literals refuse
+ *   - inherited environment (startup-file vars, curl proxy vars, PATH) cannot
+ *     alter behaviour — the script re-execs itself with a scrubbed environment
+ *   - loopback status/help paths still work (the lane stays useful)
+ *
+ * No network I/O beyond loopback is attempted: every case below either refuses
+ * before any socket opens or targets 127.0.0.1.
+ */
+import { execFileSync, spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+const SCRIPT = join(process.cwd(), 'templates', 'work-lanes', 'lan-diag.sh');
+
+function run(args: string[], extraEnv: Record<string, string> = {}): { code: number; out: string } {
+  const res = spawnSync('/bin/bash', [SCRIPT, ...args], {
+    encoding: 'utf-8',
+    timeout: 10_000,
+    env: { ...process.env, ...extraEnv },
+  });
+  return { code: res.status ?? -1, out: `${res.stdout ?? ''}${res.stderr ?? ''}` };
+}
+
+describe('lan-diag.sh script-level refusal contract (#401)', () => {
+  test('template exists and is valid bash', () => {
+    expect(existsSync(SCRIPT)).toBe(true);
+    expect(() => execFileSync('/bin/bash', ['-n', SCRIPT])).not.toThrow();
+  });
+
+  test('help and status run clean', () => {
+    expect(run(['help']).code).toBe(0);
+    const st = run(['status']);
+    expect(st.code).toBe(0);
+    expect(st.out).toContain('# interfaces');
+  });
+
+  test('public IPv4 destination refuses (ping form)', () => {
+    const r = run(['8.8.8.8']);
+    expect(r.code).toBe(2);
+    expect(r.out).toContain('refused');
+  });
+
+  test('public URL refuses (GET form)', () => {
+    const r = run(['GET', 'http://8.8.8.8/']);
+    expect(r.code).toBe(2);
+    expect(r.out).toContain('refused');
+  });
+
+  test('GET refuses IMDS / link-local even though ping allows link-local', () => {
+    const r = run(['GET', 'http://169.254.169.254/latest/meta-data/']);
+    expect(r.code).toBe(2);
+    expect(r.out).toMatch(/link-local|IMDS/);
+  });
+
+  test('GET refuses IPv6 link-local IMDS alias', () => {
+    const r = run(['GET', 'http://[fe80::a9fe:a9fe]/']);
+    expect(r.code).toBe(2);
+  });
+
+  test('ambiguous leading-zero IPv4 literal refuses (octal confusion)', () => {
+    const r = run(['010.0.0.1']);
+    expect(r.code).toBe(2);
+    expect(r.out).toContain('refused');
+  });
+
+  test('non-http(s) scheme refuses', () => {
+    const r = run(['GET', 'ftp://192.168.1.1/']);
+    expect(r.code).toBe(2);
+  });
+
+  test('userinfo URL refuses', () => {
+    const r = run(['GET', 'http://user@192.168.1.1/']);
+    expect(r.code).toBe(2);
+  });
+
+  test('unknown flags refuse', () => {
+    expect(run(['--interactive']).code).toBe(2);
+    expect(run(['-x']).code).toBe(2);
+  });
+
+  test('extra arguments refuse', () => {
+    expect(run(['status', 'extra']).code).toBe(2);
+    expect(run(['GET', 'http://127.0.0.1/', 'extra']).code).toBe(2);
+  });
+
+  test('inherited startup-file var cannot inject code (env scrub re-exec)', () => {
+    // If the variable survived, bash would try to source this path and fail.
+    const r = run(['help'], { BASH_ENV: '/nonexistent/hostile-startup.sh' });
+    expect(r.code).toBe(0);
+  });
+
+  test('inherited proxy environment cannot route the GET (env scrub re-exec)', () => {
+    // A proxy pointing at a dead loopback port would fail the request if
+    // honoured; the scrubbed env + --noproxy makes the refusal identical.
+    const r = run(['GET', 'http://8.8.8.8/'], {
+      http_proxy: 'http://127.0.0.1:1',
+      https_proxy: 'http://127.0.0.1:1',
+      ALL_PROXY: 'http://127.0.0.1:1',
+    });
+    expect(r.code).toBe(2); // refused on destination, never reaches curl
+  });
+
+  test('hostile PATH cannot shadow tools (env scrub re-exec)', () => {
+    const r = run(['help'], { PATH: '/nonexistent-bin' });
+    expect(r.code).toBe(0);
+  });
+});

--- a/src/defence/iron-dome/__tests__/lan-diag-script-401.test.ts
+++ b/src/defence/iron-dome/__tests__/lan-diag-script-401.test.ts
@@ -112,4 +112,25 @@ describe('lan-diag.sh script-level refusal contract (#401)', () => {
     const r = run(['help'], { PATH: '/nonexistent-bin' });
     expect(r.code).toBe(0);
   });
+
+  test('spoofed scrub sentinel with hostile PATH still gets scrubbed (SOL round 2)', () => {
+    const r = run(['help'], { LAN_DIAG_REEXEC: '1', PATH: '/nonexistent-bin' });
+    expect(r.code).toBe(0);
+  });
+
+  test('octal-form IPv4 literal refuses instead of canonicalising (SOL round 2)', () => {
+    const r = run(['0177.0.0.1']);
+    expect(r.code).toBe(2);
+    expect(r.out).toContain('refused');
+  });
+
+  test('decimal-int IPv4 literal refuses (2130706433 = 127.0.0.1)', () => {
+    const r = run(['2130706433']);
+    expect(r.code).toBe(2);
+  });
+
+  test('hex-form IPv4 literal refuses', () => {
+    const r = run(['0x7f.0.0.1']);
+    expect(r.code).toBe(2);
+  });
 });

--- a/src/defence/iron-dome/work-lane-hints.ts
+++ b/src/defence/iron-dome/work-lane-hints.ts
@@ -31,7 +31,17 @@ function norm(s: unknown): string {
 }
 
 function findPin(paths: string[], frag: string): string | undefined {
-  return paths.find((p) => p.includes(frag));
+  return paths.find((p) => {
+    // Exact basename match ("lan-diag.sh") or a full directory segment
+    // ("/lan-diag/"). Substring inclusion would let "not-lan-diag.sh.backup"
+    // masquerade as the lane (SOL review).
+    const norm = p.replace(/\\/g, '/');
+    if (frag.startsWith('/') && frag.endsWith('/')) {
+      return norm.includes(frag);
+    }
+    const base = norm.slice(norm.lastIndexOf('/') + 1);
+    return base === frag;
+  });
 }
 
 /** cwd tokens that read as LAN/connectivity work (lowercased input).

--- a/src/defence/iron-dome/work-lane-hints.ts
+++ b/src/defence/iron-dome/work-lane-hints.ts
@@ -7,6 +7,10 @@
  * reviewedScriptPaths (or omit the lane entirely).
  */
 
+/** Lane ids shipped in work-lane pack v1 (#401) — the denial→door matrix
+ *  test asserts each has a working hint path. */
+export const WORK_LANE_PACK_V1 = ['vita-ci', 'jotform', 'lan-diag'] as const;
+
 export interface WorkLaneHintInput {
   signals?: string[];
   cwd?: string | null;
@@ -29,6 +33,20 @@ function norm(s: unknown): string {
 function findPin(paths: string[], frag: string): string | undefined {
   return paths.find((p) => p.includes(frag));
 }
+
+/** cwd tokens that read as LAN/connectivity work (lowercased input).
+ *  Bounded so `plan` / `finland` / `planner` do not match `lan`. */
+const LAN_DIAG_CWD_WORDS = ['lan', 'diag', 'diagnostics', 'network', 'connectivity', 'wifi'];
+
+function cwdHasWord(cwd: string, word: string): boolean {
+  return new RegExp(`(^|[^a-z0-9])${word}([^a-z0-9]|$)`).test(cwd);
+}
+
+/** Network diagnostic programs whose denial should point at the lane. */
+const LAN_DIAG_TOOLS = new Set([
+  'ping', 'traceroute', 'tracepath', 'mtr', 'ip', 'ss', 'dig', 'nslookup',
+  'nmcli', 'iw', 'iwconfig', 'arp',
+]);
 
 /**
  * Suggest a reviewed work lane for a denial, or null if unknown.
@@ -64,6 +82,21 @@ export function suggestWorkLane(input: WorkLaneHintInput): WorkLaneHint | null {
       return {
         command: `python3 ${pin} --help`,
         reason: 'Jotform — use the pinned toolkit path, not freehand API/curl',
+      };
+    }
+  }
+
+  // LAN diagnostics (#401 — the Edith gap). Checked AFTER vita/jotform so it
+  // never steals their lanes. Pin required, plus a lan-shaped cwd or a network
+  // tool name — external-egress alone must not fire this on unrelated work.
+  const lanPin = findPin(paths, 'lan-diag.sh') ?? findPin(paths, '/lan-diag/');
+  if (lanPin) {
+    const cwdLooksLan = LAN_DIAG_CWD_WORDS.some((w) => cwdHasWord(cwd, w));
+    const toolIsLan = LAN_DIAG_TOOLS.has(norm(input.tool));
+    if (cwdLooksLan || toolIsLan) {
+      return {
+        command: `${lanPin} status`,
+        reason: 'LAN diagnostics — use the pinned script, not freehand curl/nmap',
       };
     }
   }

--- a/templates/work-lanes/lan-diag.sh
+++ b/templates/work-lanes/lan-diag.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# ShieldCortex work-lane template — lan-diag v1 (#401)
+#
+# Read-mostly LAN diagnostics with a bounded, private-only reachability check.
+# Shipping this file inside the shieldcortex npm package does NOT approve it:
+# Action Guard only honours a pin the operator added themselves.
+#
+# Install (operator, from a real terminal on the host):
+#   mkdir -p ~/.shieldcortex/work-lanes
+#   cp templates/work-lanes/lan-diag.sh ~/.shieldcortex/work-lanes/lan-diag.sh
+#   chmod 0755 ~/.shieldcortex/work-lanes/lan-diag.sh
+#   shieldcortex allowlist add ~/.shieldcortex/work-lanes/lan-diag.sh
+#
+# Scope — anything not listed below refuses (fail closed):
+#   lan-diag.sh                  interface + route status (read-only)
+#   lan-diag.sh status           same
+#   lan-diag.sh help             usage
+#   lan-diag.sh <host-or-ip>     ping -c 2 -W 2 — loopback / link-local / RFC1918 only
+#   lan-diag.sh GET <url>        http(s) GET, 3s cap, same private-only destination rule
+#
+# Never: nmap, tcpdump, ssh, sudo, file writes, packet capture, public-internet
+# probes, request bodies, redirects. A hostname with ANY public address refuses.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+lan-diag.sh — ShieldCortex lan-diag work lane (read-mostly, private-only)
+
+  lan-diag.sh                 interface + route status (read-only)
+  lan-diag.sh status          same
+  lan-diag.sh help            this text
+  lan-diag.sh <host-or-ip>    ping -c 2 -W 2; loopback / link-local / RFC1918 only
+  lan-diag.sh GET <url>       http(s) GET, 3s cap, same private-only destination rule
+
+Refuses everything else: public or global-IPv6 destinations, hostnames with any
+public address, redirects, request bodies, scans, captures.
+EOF
+}
+
+refuse() {
+  echo "lan-diag: refused — $*" >&2
+  exit 2
+}
+
+is_private_ipv4() {
+  local ip="$1" a b c d o
+  [[ "$ip" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] || return 1
+  a="${BASH_REMATCH[1]}" b="${BASH_REMATCH[2]}" c="${BASH_REMATCH[3]}" d="${BASH_REMATCH[4]}"
+  for o in "$a" "$b" "$c" "$d"; do
+    (( 10#$o <= 255 )) || return 1
+  done
+  a=$((10#$a)) b=$((10#$b))
+  (( a == 127 )) && return 0                     # loopback
+  (( a == 10 )) && return 0                      # RFC1918
+  (( a == 172 && b >= 16 && b <= 31 )) && return 0
+  (( a == 192 && b == 168 )) && return 0
+  (( a == 169 && b == 254 )) && return 0         # link-local
+  return 1
+}
+
+is_private_ipv6() {
+  local ip
+  ip="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  [[ "$ip" == "::1" ]] && return 0               # loopback
+  case "$ip" in                                  # link-local fe80::/10
+    fe8?:*|fe9?:*|fea?:*|feb?:*) return 0 ;;
+  esac
+  return 1                                       # global + ULA + everything else
+}
+
+is_private_literal() {
+  is_private_ipv4 "$1" || is_private_ipv6 "$1"
+}
+
+# Print one vetted address for "$1". A literal passes on its own range; a
+# hostname must resolve to at least one address with EVERY address private.
+resolve_private() {
+  local host="$1" addrs addr
+  if is_private_literal "$host"; then
+    printf '%s\n' "$host"
+    return 0
+  fi
+  [[ "$host" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]{0,252})$ ]] || return 1
+  addrs="$(getent ahosts "$host" 2>/dev/null | awk '{print $1}' | sort -u)" || return 1
+  [[ -n "$addrs" ]] || return 1
+  while IFS= read -r addr; do
+    is_private_literal "$addr" || return 1
+  done <<< "$addrs"
+  printf '%s\n' "$addrs" | head -n 1
+}
+
+show_status() {
+  echo "# interfaces"
+  ip -br addr 2>/dev/null || ip addr
+  echo
+  echo "# routes"
+  ip route 2>/dev/null || true
+}
+
+do_ping() {
+  local dest="$1" host="$1" zone="" addr
+  if [[ "$host" == *%* ]]; then                  # fe80::1%eth0 — zone on the literal only
+    zone="%${host#*%}"
+    host="${host%%\%*}"
+    is_private_ipv6 "$host" || refuse "zone ids are only accepted on link-local IPv6 literals"
+  fi
+  addr="$(resolve_private "$host")" \
+    || refuse "'$dest' is not loopback, link-local, or RFC1918 (or resolves to a public address)"
+  if [[ "$addr" == *:* ]]; then
+    ping -6 -c 2 -W 2 "${addr}${zone}"
+  else
+    ping -c 2 -W 2 "$addr"
+  fi
+}
+
+do_get() {
+  local url="$1" rest hostport host port="" addr resolve_args=()
+  case "$url" in
+    http://*)  rest="${url#http://}"  port=80 ;;
+    https://*) rest="${url#https://}" port=443 ;;
+    *) refuse "GET accepts http:// or https:// URLs only" ;;
+  esac
+  hostport="${rest%%/*}"
+  [[ "$hostport" == *@* ]] && refuse "userinfo in URLs is not accepted"
+  if [[ "$hostport" == \[* ]]; then              # [::1]:8080
+    host="${hostport%%]*}"
+    host="${host#[}"
+    local after="${hostport#*]}"
+    [[ "$after" == :* ]] && port="${after#:}"
+  elif [[ "$hostport" == *:* ]]; then
+    host="${hostport%%:*}"
+    port="${hostport##*:}"
+  else
+    host="$hostport"
+  fi
+  [[ -n "$host" ]] || refuse "URL has no host"
+  [[ "$port" =~ ^[0-9]{1,5}$ ]] && (( port >= 1 && port <= 65535 )) || refuse "bad port '$port'"
+  addr="$(resolve_private "$host")" \
+    || refuse "'$host' is not loopback, link-local, or RFC1918 (or resolves to a public address)"
+  if ! is_private_literal "$host"; then
+    # Pin the vetted DNS answer so check-time and connect-time agree.
+    [[ "$addr" == *:* ]] && addr="[$addr]"
+    resolve_args=(--resolve "${host}:${port}:${addr}")
+  fi
+  curl --silent --fail --max-time 3 --proto '=http,https' --max-redirs 0 \
+    "${resolve_args[@]}" \
+    --output /dev/null --write-out "GET ${url} -> HTTP %{http_code} (%{time_total}s)\n" \
+    "$url"
+}
+
+main() {
+  local cmd="${1:-status}"
+  case "$cmd" in
+    status)
+      [[ $# -le 1 ]] || refuse "status takes no arguments"
+      show_status
+      ;;
+    help|-h|--help)
+      usage
+      ;;
+    GET|get)
+      [[ $# -eq 2 ]] || refuse "usage: lan-diag.sh GET <url>"
+      do_get "$2"
+      ;;
+    -*)
+      refuse "unknown option '$cmd'"
+      ;;
+    *)
+      [[ $# -eq 1 ]] || refuse "the ping form takes exactly one destination"
+      do_ping "$cmd"
+      ;;
+  esac
+}
+
+main "$@"

--- a/templates/work-lanes/lan-diag.sh
+++ b/templates/work-lanes/lan-diag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -p
 #
 # ShieldCortex work-lane template — lan-diag v1 (#401)
 #
@@ -22,17 +22,24 @@
 # Never: nmap, tcpdump, ssh, sudo, file writes, packet capture, public-internet
 # probes, request bodies, redirects. A hostname with ANY public address refuses.
 
-# SOL review hardening: a pinned hash does not pin the interpreter or its
-# startup environment. Re-exec once under /bin/bash with a scrubbed env so
-# BASH_ENV/ENV/PATH/curl/proxy config inherited from the caller cannot alter
-# behaviour before set -euo pipefail takes effect.
-if [[ -z "${LAN_DIAG_REEXEC:-}" ]]; then
+# SOL review hardening (round 2): a pinned hash does not pin the interpreter
+# or its startup environment.
+#  - The shebang runs bash in privileged mode (-p): BASH_ENV/ENV are NOT
+#    processed and functions imported from the environment are ignored, so a
+#    hostile startup payload cannot run before this line.
+#  - PATH/proxy/locale scrub is verified, not sentinel-trusted: a caller who
+#    fakes the sentinel but keeps a hostile environment still fails the check
+#    below and gets re-exec'd into the scrubbed state. Termination is
+#    guaranteed because the re-exec constructs exactly the state the check
+#    requires.
+LAN_DIAG_PATH=/usr/sbin:/usr/bin:/sbin:/bin
+if [[ "${PATH:-}" != "$LAN_DIAG_PATH" || -n "${BASH_ENV:-}" || -n "${ENV:-}" \
+      || -n "${http_proxy:-}${https_proxy:-}${HTTP_PROXY:-}${HTTPS_PROXY:-}${ALL_PROXY:-}${all_proxy:-}${NO_PROXY:-}${no_proxy:-}${CURL_HOME:-}${XDG_CONFIG_HOME:-}" ]]; then
   exec /usr/bin/env -i \
-    LAN_DIAG_REEXEC=1 \
-    PATH=/usr/sbin:/usr/bin:/sbin:/bin \
+    PATH="$LAN_DIAG_PATH" \
     HOME="${HOME:-/root}" \
     LANG=C LC_ALL=C \
-    /bin/bash "$0" "$@"
+    /bin/bash -p "$0" "$@"
 fi
 
 set -euo pipefail
@@ -99,7 +106,20 @@ resolve_private() {
     printf '%s\n' "$host"
     return 0
   fi
+  # inet_aton-style numeric literals ("0177.0.0.1", "2130706433", "0x7f.0.0.1")
+  # must not fall through to getent where the OS canonicalises them. A token
+  # whose every dot-label is decimal/octal/hex-numeric is an ADDRESS LITERAL:
+  # it already failed the strict dotted-quad decimal parser — refuse it
+  # (SOL review round 2).
+  local __label __all_numeric=1
+  IFS='.' read -ra __labels <<< "$host"
+  for __label in "${__labels[@]}"; do
+    [[ "$__label" =~ ^(0[xX][0-9a-fA-F]+|[0-9]+)$ ]] || { __all_numeric=0; break; }
+  done
+  (( __all_numeric )) && return 1
+  [[ "$host" == *:* ]] && return 1
   [[ "$host" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]{0,252})$ ]] || return 1
+  [[ "$host" =~ [A-Za-z] ]] || return 1
   addrs="$(getent ahosts "$host" 2>/dev/null | awk '{print $1}' | sort -u)" || return 1
   [[ -n "$addrs" ]] || return 1
   while IFS= read -r addr; do

--- a/templates/work-lanes/lan-diag.sh
+++ b/templates/work-lanes/lan-diag.sh
@@ -110,10 +110,18 @@ resolve_private() {
 
 show_status() {
   echo "# interfaces"
-  ip -br addr 2>/dev/null || ip addr
+  if command -v ip >/dev/null 2>&1; then
+    ip -br addr 2>/dev/null || ip addr
+  else
+    ifconfig 2>/dev/null || true               # macOS / BSD hosts have no iproute2
+  fi
   echo
   echo "# routes"
-  ip route 2>/dev/null || true
+  if command -v ip >/dev/null 2>&1; then
+    ip route 2>/dev/null || true
+  else
+    netstat -rn 2>/dev/null || true
+  fi
 }
 
 do_ping() {

--- a/templates/work-lanes/lan-diag.sh
+++ b/templates/work-lanes/lan-diag.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # ShieldCortex work-lane template — lan-diag v1 (#401)
 #
@@ -17,10 +17,23 @@
 #   lan-diag.sh status           same
 #   lan-diag.sh help             usage
 #   lan-diag.sh <host-or-ip>     ping -c 2 -W 2 — loopback / link-local / RFC1918 only
-#   lan-diag.sh GET <url>        http(s) GET, 3s cap, same private-only destination rule
+#   lan-diag.sh GET <url>        http(s) GET, 3s cap, private-only; link-local/IMDS refused
 #
 # Never: nmap, tcpdump, ssh, sudo, file writes, packet capture, public-internet
 # probes, request bodies, redirects. A hostname with ANY public address refuses.
+
+# SOL review hardening: a pinned hash does not pin the interpreter or its
+# startup environment. Re-exec once under /bin/bash with a scrubbed env so
+# BASH_ENV/ENV/PATH/curl/proxy config inherited from the caller cannot alter
+# behaviour before set -euo pipefail takes effect.
+if [[ -z "${LAN_DIAG_REEXEC:-}" ]]; then
+  exec /usr/bin/env -i \
+    LAN_DIAG_REEXEC=1 \
+    PATH=/usr/sbin:/usr/bin:/sbin:/bin \
+    HOME="${HOME:-/root}" \
+    LANG=C LC_ALL=C \
+    /bin/bash "$0" "$@"
+fi
 
 set -euo pipefail
 
@@ -32,7 +45,7 @@ lan-diag.sh — ShieldCortex lan-diag work lane (read-mostly, private-only)
   lan-diag.sh status          same
   lan-diag.sh help            this text
   lan-diag.sh <host-or-ip>    ping -c 2 -W 2; loopback / link-local / RFC1918 only
-  lan-diag.sh GET <url>       http(s) GET, 3s cap, same private-only destination rule
+  lan-diag.sh GET <url>       http(s) GET, 3s cap, private-only; link-local/IMDS refused
 
 Refuses everything else: public or global-IPv6 destinations, hostnames with any
 public address, redirects, request bodies, scans, captures.
@@ -49,6 +62,10 @@ is_private_ipv4() {
   [[ "$ip" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] || return 1
   a="${BASH_REMATCH[1]}" b="${BASH_REMATCH[2]}" c="${BASH_REMATCH[3]}" d="${BASH_REMATCH[4]}"
   for o in "$a" "$b" "$c" "$d"; do
+    # Reject leading-zero octets outright: "010.0.0.1" is decimal 10 here but
+    # octal 8 to many network stacks — ambiguous literals are refused, not
+    # normalised (SOL review).
+    [[ "$o" =~ ^0[0-9]+$ ]] && return 1
     (( 10#$o <= 255 )) || return 1
   done
   a=$((10#$a)) b=$((10#$b))
@@ -115,6 +132,24 @@ do_ping() {
   fi
 }
 
+# GET-path destination rule is stricter than ping: link-local (169.254/16,
+# fe80::/10) is REFUSED because an allowlisted HTTP client to link-local is an
+# IMDS credential grab (169.254.169.254, [fd00:ec2::254], [fe80::a9fe:a9fe])
+# with a TTY pin on it (Grok review). Ping keeps link-local for LAN diagnosis.
+is_get_dest_allowed() {
+  local ip="$1" a b
+  if [[ "$ip" == *:* ]]; then
+    # IPv6: loopback only for GET. fe80::/10 refused (IMDS aliases live there);
+    # ULA/global were never allowed.
+    [[ "$(printf '%s' "$ip" | tr '[:upper:]' '[:lower:]')" == "::1" ]]
+    return
+  fi
+  [[ "$ip" =~ ^([0-9]{1,3})\.([0-9]{1,3})\. ]] || return 1
+  a=$((10#${BASH_REMATCH[1]})) b=$((10#${BASH_REMATCH[2]}))
+  (( a == 169 && b == 254 )) && return 1         # IMDS / link-local refused on GET
+  return 0
+}
+
 do_get() {
   local url="$1" rest hostport host port="" addr resolve_args=()
   case "$url" in
@@ -139,12 +174,16 @@ do_get() {
   [[ "$port" =~ ^[0-9]{1,5}$ ]] && (( port >= 1 && port <= 65535 )) || refuse "bad port '$port'"
   addr="$(resolve_private "$host")" \
     || refuse "'$host' is not loopback, link-local, or RFC1918 (or resolves to a public address)"
+  is_get_dest_allowed "$addr" \
+    || refuse "GET to link-local/IMDS ranges (169.254/16, fe80::/10) is not allowed — use the ping form for reachability"
   if ! is_private_literal "$host"; then
     # Pin the vetted DNS answer so check-time and connect-time agree.
     [[ "$addr" == *:* ]] && addr="[$addr]"
     resolve_args=(--resolve "${host}:${port}:${addr}")
   fi
-  curl --silent --fail --max-time 3 --proto '=http,https' --max-redirs 0 \
+  # -q ignores ~/.curlrc; --noproxy '*' + scrubbed env stop proxy routing;
+  # --disable is the long form of -q kept explicit for readability on review.
+  curl -q --noproxy '*' --silent --fail --max-time 3 --proto '=http,https' --max-redirs 0 \
     "${resolve_args[@]}" \
     --output /dev/null --write-out "GET ${url} -> HTTP %{http_code} (%{time_total}s)\n" \
     "$url"


### PR DESCRIPTION
## Why

Phase 0 of the post-Edith stop-bleed (#401). Edith uninstalled because LAN-diag work had **no door** — `work-lane-hints.ts` only knew vita `gh-ci.sh` and jotform. A repeated hold class without a lane is a product defect.

## Approach

- Ship `templates/work-lanes/lan-diag.sh`: read-mostly status, private-only bounded ping/GET, fail-closed on public dest. **Not auto-approved** — operator pins via `shieldcortex allowlist add` from a TTY.
- Catalog `lan-diag` after vita/jotform. Hint only with a real pin + `external-egress` + (lan-shaped cwd **or** network tool). Token-bounded cwd so `plan`/`finland` do not match `lan`.
- Denial→door matrix test: catastrophic = hard stop (no spendable `approve --denial`); DNP digest always carries `shieldcortex approve --denial` even without a lane; no siren-only class.
- Runbook: `docs/runbooks/work-lane-pack-v1.md`. Template included in npm `files`.

## Tests

- `npm run build:ts` exit 0
- focused 50/50: `work-lane-hints`, `denial-doors-401`, `dnp-digest-331`
- host probe: `lan-diag.sh 127.0.0.1` ok; `8.8.8.8` exit 2 refuse

## Not in this PR

- Living-host Approve/Deny *spend* proof (#310 receipts) — still open on #401
- memories.db salvage runbook
- `retryCards` fleet default (stays off)
- Track A T1–T3 / #402

Closes nothing. Partial #401.