### PR TITLE
fix(action,docs): #426 fail-closed CI gate + #427 authenticated REST examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,10 +524,13 @@ Dream Mode runs three passes:
 2. **Archive** — identifies stale memories that haven't been accessed or reinforced, and moves them out of active recall
 3. **Contradict** — surfaces memory pairs that conflict so you can resolve them before they cause confusion
 
-Also available as an API call for programmatic use:
+Also available as an API call for programmatic use. Every `/api/*` endpoint except `/api/health` requires a Bearer token — the server writes one to `~/.shieldcortex/.api-token` on start (from the same machine you can also fetch it from the loopback-only `GET /api/auth/session-token`):
 
 ```bash
-curl -X POST http://localhost:3001/api/consolidate
+TOKEN=$(cat ~/.shieldcortex/.api-token)
+
+curl -X POST http://localhost:3001/api/consolidate \
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 Schedule it nightly, run it before important sessions, or let the auto-consolidation timer handle it. Either way, your memory store stays lean and contradiction-free.

--- a/action.yml
+++ b/action.yml
@@ -40,35 +40,93 @@ runs:
     - name: Run ShieldCortex Audit
       id: audit
       shell: bash
+      env:
+        FAIL_ON_HIGH: ${{ inputs.fail-on-high }}
       run: |
-        # Run audit in JSON mode
-        REPORT=$(npx -y shieldcortex@latest audit --json 2>/dev/null || true)
+        # Run the audit through the CLI's real CI gate: --ci prints the JSON
+        # report on stdout and exits 1 when critical/high findings exist,
+        # 0 otherwise. A scanner failure also exits non-zero but produces no
+        # parseable report — that distinction drives the fail-closed handling
+        # below. stderr is left alone so scanner errors reach the job log.
+        set +e
+        npx -y shieldcortex@latest audit --ci > shieldcortex-report.json
+        AUDIT_EXIT=$?
+        set -e
 
-        # Extract grade and findings count
-        GRADE=$(echo "$REPORT" | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');const r=JSON.parse(d);console.log(r.grade)" 2>/dev/null || echo "?")
-        FINDINGS=$(echo "$REPORT" | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');const r=JSON.parse(d);console.log(r.totalFindings)" 2>/dev/null || echo "0")
-        CRITICAL=$(echo "$REPORT" | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');const r=JSON.parse(d);console.log(r.bySeverity.critical||0)" 2>/dev/null || echo "0")
-        HIGH=$(echo "$REPORT" | node -e "const d=require('fs').readFileSync('/dev/stdin','utf8');const r=JSON.parse(d);console.log(r.bySeverity.high||0)" 2>/dev/null || echo "0")
+        # Grade and counts only ever come from a report that parses as JSON
+        # with the expected fields — never from a fallback value.
+        if PARSED=$(node -e '
+          const r = JSON.parse(require("fs").readFileSync("shieldcortex-report.json", "utf8"));
+          const num = (v, name) => {
+            if (typeof v !== "number" || !Number.isFinite(v)) throw new Error("report missing numeric " + name);
+            return v;
+          };
+          if (typeof r.grade !== "string" || r.grade.length === 0) throw new Error("report missing grade");
+          if (typeof r.bySeverity !== "object" || r.bySeverity === null) throw new Error("report missing bySeverity");
+          console.log("grade=" + r.grade);
+          console.log("findings=" + num(r.totalFindings, "totalFindings"));
+          console.log("critical=" + num(r.bySeverity.critical, "bySeverity.critical"));
+          console.log("high=" + num(r.bySeverity.high, "bySeverity.high"));
+        '); then
+          echo "$PARSED" >> "$GITHUB_OUTPUT"
+          echo "gate=$AUDIT_EXIT" >> "$GITHUB_OUTPUT"
+          echo "scan_ok=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "report<<SHIELDCORTEX_REPORT_EOF"
+            cat shieldcortex-report.json
+            echo "SHIELDCORTEX_REPORT_EOF"
+          } >> "$GITHUB_OUTPUT"
+        else
+          echo "scan_ok=false" >> "$GITHUB_OUTPUT"
+          if [ "$FAIL_ON_HIGH" = "true" ]; then
+            echo "::error::ShieldCortex audit did not produce a valid JSON report (scanner exit code: $AUDIT_EXIT) — failing closed. See the log above for scanner output."
+            exit 1
+          fi
+          echo "::warning::ShieldCortex audit did not produce a valid JSON report (scanner exit code: $AUDIT_EXIT). fail-on-high is disabled, so the job continues WITHOUT a security verdict."
+        fi
 
-        echo "grade=$GRADE" >> $GITHUB_OUTPUT
-        echo "findings=$FINDINGS" >> $GITHUB_OUTPUT
-        echo "critical=$CRITICAL" >> $GITHUB_OUTPUT
-        echo "high=$HIGH" >> $GITHUB_OUTPUT
-        echo "report=$REPORT" >> $GITHUB_OUTPUT
-
-        # Generate markdown for PR comment
-        MARKDOWN=$(npx -y shieldcortex@latest audit --markdown 2>/dev/null || echo "ShieldCortex scan failed")
-        echo "$MARKDOWN" >> $GITHUB_STEP_SUMMARY
+        # Markdown step summary — cosmetic, never gates the job. The CLI exits
+        # non-zero on poor grades even when output is fine, so presence of
+        # output is the success signal here, not the exit code.
+        set +e
+        MARKDOWN=$(npx -y shieldcortex@latest audit --markdown)
+        MD_EXIT=$?
+        set -e
+        if [ -n "$MARKDOWN" ]; then
+          echo "$MARKDOWN" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "::warning::ShieldCortex markdown summary generation failed (exit code: $MD_EXIT)"
+          echo "ShieldCortex scan summary unavailable — see the job log." >> "$GITHUB_STEP_SUMMARY"
+        fi
 
     - name: Generate SARIF
+      id: sarif
       if: ${{ inputs.upload-sarif == 'true' }}
       shell: bash
+      env:
+        FAIL_ON_HIGH: ${{ inputs.fail-on-high }}
       run: |
-        # Pure SARIF on stdout — write it to a file for upload.
-        npx -y shieldcortex@latest audit --sarif > shieldcortex.sarif 2>/dev/null || echo '{}' > shieldcortex.sarif
+        # --ci --sarif keeps SARIF output with CI exit semantics (exit 1 on
+        # critical/high), so a non-zero exit alongside a valid document is not
+        # a scanner failure. Never upload a fabricated/empty document.
+        set +e
+        npx -y shieldcortex@latest audit --ci --sarif > shieldcortex.sarif
+        SARIF_EXIT=$?
+        set -e
+
+        if node -e 'JSON.parse(require("fs").readFileSync("shieldcortex.sarif", "utf8"))'; then
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "ok=false" >> "$GITHUB_OUTPUT"
+          if [ "$FAIL_ON_HIGH" = "true" ]; then
+            echo "::error::ShieldCortex SARIF generation did not produce valid JSON (scanner exit code: $SARIF_EXIT) — failing closed."
+            exit 1
+          fi
+          echo "::warning::ShieldCortex SARIF generation did not produce valid JSON (scanner exit code: $SARIF_EXIT); skipping the Code Scanning upload."
+        fi
 
     - name: Upload SARIF to GitHub Code Scanning
-      if: ${{ inputs.upload-sarif == 'true' && github.repository != '' }}
+      if: ${{ inputs.upload-sarif == 'true' && github.repository != '' && steps.sarif.outputs.ok == 'true' }}
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: shieldcortex.sarif
@@ -78,12 +136,21 @@ runs:
       if: ${{ always() && inputs.fail-on-high == 'true' }}
       shell: bash
       env:
+        SCAN_OK: ${{ steps.audit.outputs.scan_ok }}
+        GATE: ${{ steps.audit.outputs.gate }}
         CRITICAL: ${{ steps.audit.outputs.critical }}
         HIGH: ${{ steps.audit.outputs.high }}
       run: |
-        # Fail the check if critical/high findings exist. Runs after SARIF
-        # upload so findings still reach the Security tab when the gate fails.
-        if [ "${CRITICAL:-0}" -gt 0 ] || [ "${HIGH:-0}" -gt 0 ]; then
-          echo "::error::ShieldCortex found ${CRITICAL:-0} critical and ${HIGH:-0} high severity findings"
+        # Runs after SARIF upload so findings still reach the Security tab when
+        # the gate fails. Fail closed: no verified report means no green check.
+        if [ "$SCAN_OK" != "true" ]; then
+          echo "::error::ShieldCortex gate: the audit did not produce a verified report — failing closed."
+          exit 1
+        fi
+        # Belt and braces: both the CLI's own --ci gate (exit 1 on critical or
+        # high findings) and the counts parsed from the verified JSON must be
+        # clean. A non-numeric count aborts this step, which also fails closed.
+        if [ "$GATE" != "0" ] || [ "$CRITICAL" -gt 0 ] || [ "$HIGH" -gt 0 ]; then
+          echo "::error::ShieldCortex found $CRITICAL critical and $HIGH high severity findings (audit --ci exit code: $GATE)"
           exit 1
         fi


### PR DESCRIPTION
## Summary
Fixes two defects from the external QA audit:

### #426 — Action gate fail-opens
\`action.yml\` swallowed scanner failure (\`|| true\`, counts defaulting to 0), so \`fail-on-high: true\` stayed green on a no-op scan. Now:
- audit runs \`--ci\` with stderr visible; a verified JSON report (grade + numeric severity counts) is required
- scanner/parse failure => job FAILS when gating; loud \`::warning::\` (continuing WITHOUT a security verdict) when not
- severity gate fails closed when no verified report exists; SARIF step never fabricates \`{}\` and upload is conditioned on valid output
- fixed latent multiline \`report=\$REPORT\` output bug (heredoc syntax)

Dry-run harness extracted the real \`run:\` scripts from action.yml and exercised clean / findings / bad-JSON / crash × fail-on-high true/false — every failure path red or loudly warned, findings still flow to gate + SARIF (results in PR discussion if wanted).

### #427 — dead REST example
README Dream Mode curl hit Bearer-auth'd \`/api/consolidate\` with no token (always 401). Example now documents the auth rule and acquires the token from \`~/.shieldcortex/.api-token\` (verified against \`src/api/visualization-server.ts\`). Repo-wide grep found no other dead curl examples.

(#425 dead \`@v1\` ref was fixed by publishing the floating tag — already closed.)

Fixes #426. Fixes #427.