### PR TITLE
feat(memory): #394 add plane teeth and dual-plane drift doctor

### DIFF
--- a/docs/design/2026-08-17-memory-plane-policy-amin.md
+++ b/docs/design/2026-08-17-memory-plane-policy-amin.md
@@ -70,7 +70,7 @@ If config claims `sc_only` / `disable_native_inject` but native Memory Search / 
 
 - `inject.mode ≠ off` without legal `nativeContract`
 - `plane=sc_canonical` + native automatic memory still on the bus
-- `plane=sc_canonical` + inject off on a bound host claiming SOTA canonicity without honest sidecar posture
+- `plane=sc_canonical` + inject off or turn-only (no automatic start bus); honest sidecar posture is valid only with `dual_legacy`
 - `plane=import_only` or `sc_canonical` + bidirectional/export-back-to-native-as-SoT flags
 - `plane=dual_legacy` after import-once completed **and** grace elapsed on that host (warn first, then fail next release window)
 - Any plane + SC library path that writes durable agent truth **only** to native MD under `import_only`/`sc_canonical` without SC store admit
@@ -105,6 +105,51 @@ Distinct check from empty-brain. Signals (normative intent):
 | `dual_legacy` | WARN (time-boxed defect) |
 | `import_only` / `sc_canonical` | FAIL |
 
+### Shipped shape (#394 T2)
+
+`checkMemoryPlaneDrift` (evidence) → `evaluatePlaneDrift`
+(`src/memory/plane-drift.ts`, pure decision), same split as the host-contract
+proof. Signal order is **positive evidence before gaps**: a native brain doctor
+can see growing is a decided defect even when the SC side is only partly
+countable; only when no signal fires do the gaps speak, and a gap is
+`cannot determine` (WARN on every plane), never PASS.
+
+Signal 3 uses the shared `selectInjectCandidates` + `isInjectEligible` path from
+`scripts/lib/inject-pack.mjs` — the exact deterministic top-64 window, row
+shape, and predicate both start emitters use. Doctor reports eligibility
+unknown when a session project is required but unavailable; it never presents
+a project-agnostic upper bound as an exact positive. A bound SC bus (legal
+`nativeContract` + start-capable mode) holding durable rows that the real gate
+admits **none** of is drift: the store looks healthy by row count and delivers
+nothing. With a signed honest `mcp_sidecar_no_inject` posture and inject explicitly off,
+native bus/SoT/activity are expected and the drift check reports that posture
+as healthy. `import_only`/`sc_canonical` plus sidecar is contradictory and
+fails; a copied/unsigned posture string gets no exemption.
+
+`requireScope` is read from the same config keys the runtime reads and defaults
+to deny. It is never derived from the data; an unscoped store reports
+`unscoped_excluded=N` and refuses to PASS.
+
+### FP fixtures — operator scratchpad vs agent SoT
+
+Drift counts only what a host actually loads as its agent brain. The FP column
+is the reason each acceptance test exists (`doctor-plane-drift-394.test.ts`).
+
+| Artifact | Drift? | Why |
+|---|---|---|
+| `<oc workspace>/MEMORY.md`, `memory.md` | **yes when non-empty** | OpenClaw loads non-empty bootstrap memory; a zero-byte bootstrap contains no memory and is ignored as drift |
+| `<oc workspace>/memory/*` | **yes** | the workspace memory store |
+| `<oc workspace-\<agentId\>>/…` | **yes** | per-agent brains, enumerated with the host contract's own workspace resolver |
+| `~/.claude/memory/*`, `~/.claude/projects/<key>/memory/*` | **yes** | Claude's memory-tool store |
+| `~/.hermes/MEMORY.md`, `~/.hermes/memories/*`, profile stores | **yes** | Hermes native store |
+| `~/MEMORY.md`, `~/notes/…`, a stray `.md` in a workspace | **no** | operator scratchpad — no host loads it as a brain |
+| `CLAUDE.md` / `AGENTS.md` preambles | **no** | project instructions, graded by the host-contract check (#393). Developers edit them constantly; drift is memory growth, not instruction edits |
+
+Native **bus** state is reported only when PROVEN on (shared reader:
+`resolveOpenClawMemorySearchState`, `parseHermesMemoryBlock`). Unknown bus
+belongs to the host-contract check, which already caps at unknown and fails
+there — drift is not a second host-contract parser.
+
 ## Import law (A3 — when T3 lands)
 
 - Single chokepoint: parse → **full** defence pipeline → admit only on allow  
@@ -136,6 +181,13 @@ Position until rewire: **deprecate + doctor-fail when used as agent SoT path**; 
 **Cut default:** native files may remain writable as **untrusted I/O**, not competing SoT.  
 SC wins on trust for durable agent facts once `import_only` / `sc_canonical`.  
 Hand-edits to projection/archive files are non-authoritative.
+
+## Staged rollout and backout
+
+1. Ship the shared candidate selector and doctor first; run doctor while the host remains `dual_legacy` and inspect candidate/native evidence without claiming canonicity.
+2. Prove the bound runtime's automatic start bus and native-memory switches, then move that host to `import_only` with a signed CLI write. Soak before any canonical claim.
+3. Move to `sc_canonical` only after start-pack delivery, recursive native-store scans, profile switches, and telemetry are all attestable and green.
+4. Back out with a signed `--memory-plane dual_legacy` write. If the host cannot support automatic inject, declare the signed `mcp_sidecar_no_inject` posture instead; never hand-edit the posture string or signature.
 
 ## Related
 

--- a/docs/design/2026-08-22-memory-sota-track-a-residual.md
+++ b/docs/design/2026-08-22-memory-sota-track-a-residual.md
@@ -191,10 +191,10 @@ Until then: **keep #348 open. No false close.**
 |---|---|
 | B1 attestation≠trust + salience + unverified | **Landed** (this PR) |
 | B2 signed `--memory-plane` + planeSetAt | **Landed** (this PR) |
-| B3 drift doctor + scope not data-derived | **Landed** (this PR) — drift signals heuristic; deepen with host telemetry as available |
+| B3 drift doctor + scope not data-derived | **Landed**; deepened by #394 — real `isInjectEligible` counting, runtime-aware native SoT scan, gaps say cannot-determine |
 | B4 side-car API position | **Deferred** — no dedicated doctor check yet; do not claim doctor-fail for GuardedMemoryBridge |
 | T1 #393 host contract enforcement | **Initial** doctor proof (`checkMemoryHostContract`) — deepen per-host disable of Memory Search |
-| T2 #394 | Partially overlapped by B2/B3; keep open until fail/warn matrix + FP fixtures complete |
+| T2 #394 | **Landed** — fail/warn matrix, FP fixtures (`doctor-plane-drift-394.test.ts`), real inject-eligibility counting, illegal plane × bus combos, telemetry cannot-determine. Residual: no `dual_legacy`-after-import escalation (needs T3), no export-back-to-native flag check (no such flag exists yet) |
 | T3 #395 | **Not started** (blocked) |
 
 ---

--- a/hooks/openclaw/cortex-memory/handler.ts
+++ b/hooks/openclaw/cortex-memory/handler.ts
@@ -8,6 +8,7 @@
  */
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -611,10 +612,10 @@ async function maybeInjectBootstrapPack(context: any, wsDir: string, event: any)
   }
 
   const hookDir = path.dirname(fileURLToPath(import.meta.url));
-  const packageRoot = await resolvePackageRoot();
+  const resolvedPackageRoot = await resolvePackageRoot();
   const candidates = [
     path.join(hookDir, "inject-pack.mjs"),
-    ...(packageRoot ? [path.join(packageRoot, "scripts", "lib", "inject-pack.mjs")] : []),
+    ...(resolvedPackageRoot ? [path.join(resolvedPackageRoot, "scripts", "lib", "inject-pack.mjs")] : []),
     path.join(hookDir, "..", "..", "..", "scripts", "lib", "inject-pack.mjs"),
     path.join(homedir(), ".npm-global", "lib", "node_modules", "shieldcortex", "scripts", "lib", "inject-pack.mjs"),
   ];
@@ -622,26 +623,42 @@ async function maybeInjectBootstrapPack(context: any, wsDir: string, event: any)
   let buildStartPack;
   let readInjectConfig;
   let selectInjectCandidates;
+  let selectedInjectHelperPath = null;
   for (const c of candidates) {
     try {
-      if (!fsSync.existsSync(c)) continue;
-      const mod = await import(pathToFileURL(c).href);
+      const helperPath = path.resolve(c);
+      if (!fsSync.existsSync(helperPath)) continue;
+      const mod = await import(pathToFileURL(helperPath).href);
+      if (!mod.buildStartPack || !mod.readInjectConfig || !mod.selectInjectCandidates) continue;
       buildStartPack = mod.buildStartPack;
       readInjectConfig = mod.readInjectConfig;
       selectInjectCandidates = mod.selectInjectCandidates;
-      if (buildStartPack && readInjectConfig && selectInjectCandidates) break;
+      selectedInjectHelperPath = helperPath;
+      break;
     } catch {
       /* try next */
     }
   }
-  if (!buildStartPack || !readInjectConfig || !selectInjectCandidates) return;
+  if (!buildStartPack || !readInjectConfig || !selectInjectCandidates || !selectedInjectHelperPath) return;
 
   const injectCfg = readInjectConfig(raw);
   if (!injectCfg.nativeContract || injectCfg.mode === "off" || injectCfg.mode === "turn") {
     return;
   }
 
-  const Database = (await import("better-sqlite3")).default;
+  // The hook normally lives outside ShieldCortex's dependency tree. Resolve
+  // the native driver from the package that supplied inject-pack.mjs, never
+  // relative to this copied/self-healed handler. Prefer package.json as the
+  // package-root anchor; the selected helper remains a correct ancestry anchor
+  // for global/legacy layouts where package.json cannot be resolved.
+  const packageJsonPath = resolvedPackageRoot
+    ? path.join(resolvedPackageRoot, "package.json")
+    : null;
+  const dependencyAnchor = packageJsonPath && fsSync.existsSync(packageJsonPath)
+    ? packageJsonPath
+    : selectedInjectHelperPath;
+  const packageRequire = createRequire(pathToFileURL(dependencyAnchor).href);
+  const Database = packageRequire("better-sqlite3");
   const dbPath = path.join(scDir, "memories.db");
   if (!fsSync.existsSync(dbPath)) return;
   const db = new Database(dbPath, { readonly: true, timeout: 3000 });

--- a/hooks/openclaw/cortex-memory/handler.ts
+++ b/hooks/openclaw/cortex-memory/handler.ts
@@ -618,18 +618,20 @@ async function maybeInjectBootstrapPack(context, wsDir, event) {
 
   let buildStartPack;
   let readInjectConfig;
+  let selectInjectCandidates;
   for (const c of candidates) {
     try {
       if (!fsSync.existsSync(c)) continue;
       const mod = await import(pathToFileURL(c).href);
       buildStartPack = mod.buildStartPack;
       readInjectConfig = mod.readInjectConfig;
-      if (buildStartPack && readInjectConfig) break;
+      selectInjectCandidates = mod.selectInjectCandidates;
+      if (buildStartPack && readInjectConfig && selectInjectCandidates) break;
     } catch {
       /* try next */
     }
   }
-  if (!buildStartPack || !readInjectConfig) return;
+  if (!buildStartPack || !readInjectConfig || !selectInjectCandidates) return;
 
   const injectCfg = readInjectConfig(raw);
   if (!injectCfg.nativeContract || injectCfg.mode === "off" || injectCfg.mode === "turn") {
@@ -642,26 +644,7 @@ async function maybeInjectBootstrapPack(context, wsDir, event) {
   const db = new Database(dbPath, { readonly: true, timeout: 3000 });
   let rows = [];
   try {
-    const cols = db.prepare("PRAGMA table_info(memories)").all().map((c) => c.name);
-    if (cols.includes("host_id")) {
-      rows = db.prepare(`
-        SELECT id, title, content, salience, pinned, trust_score, sensitivity_level, status,
-               source, defence_verdict, host_id, agent_id, project, transferable, created_at
-        FROM memories
-        WHERE COALESCE(status,'active') NOT IN ('archived','suppressed')
-        ORDER BY pinned DESC, salience DESC
-        LIMIT 64
-      `).all();
-    } else {
-      rows = db.prepare(`
-        SELECT id, title, content, salience, pinned, trust_score, sensitivity_level, status,
-               source, defence_verdict, project, created_at
-        FROM memories
-        WHERE COALESCE(status,'active') NOT IN ('archived','suppressed')
-        ORDER BY pinned DESC, salience DESC
-        LIMIT 64
-      `).all();
-    }
+    rows = selectInjectCandidates(db);
   } finally {
     db.close();
   }

--- a/hooks/openclaw/cortex-memory/handler.ts
+++ b/hooks/openclaw/cortex-memory/handler.ts
@@ -597,9 +597,10 @@ async function onSessionStop(event) {
  * Budgeted SC start pack for OpenClaw bootstrap (inject v2).
  * Requires memory.inject.nativeContract = sc_only | disable_native_inject.
  */
-async function maybeInjectBootstrapPack(context, wsDir, event) {
+async function maybeInjectBootstrapPack(context: any, wsDir: string, event: any) {
   const fsSync = await import("node:fs");
-  const cfgPath = path.join(homedir(), ".shieldcortex", "config.json");
+  const scDir = process.env.SHIELDCORTEX_CONFIG_DIR?.trim() || path.join(homedir(), ".shieldcortex");
+  const cfgPath = path.join(scDir, "config.json");
   let raw = {};
   try {
     if (fsSync.existsSync(cfgPath)) {
@@ -610,8 +611,10 @@ async function maybeInjectBootstrapPack(context, wsDir, event) {
   }
 
   const hookDir = path.dirname(fileURLToPath(import.meta.url));
+  const packageRoot = await resolvePackageRoot();
   const candidates = [
     path.join(hookDir, "inject-pack.mjs"),
+    ...(packageRoot ? [path.join(packageRoot, "scripts", "lib", "inject-pack.mjs")] : []),
     path.join(hookDir, "..", "..", "..", "scripts", "lib", "inject-pack.mjs"),
     path.join(homedir(), ".npm-global", "lib", "node_modules", "shieldcortex", "scripts", "lib", "inject-pack.mjs"),
   ];
@@ -639,7 +642,7 @@ async function maybeInjectBootstrapPack(context, wsDir, event) {
   }
 
   const Database = (await import("better-sqlite3")).default;
-  const dbPath = path.join(homedir(), ".shieldcortex", "memories.db");
+  const dbPath = path.join(scDir, "memories.db");
   if (!fsSync.existsSync(dbPath)) return;
   const db = new Database(dbPath, { readonly: true, timeout: 3000 });
   let rows = [];
@@ -650,7 +653,7 @@ async function maybeInjectBootstrapPack(context, wsDir, event) {
   }
 
   const sessionKey = String(event?.sessionKey || event?.sessionId || context?.sessionId || "bootstrap");
-  const stateDir = path.join(homedir(), ".shieldcortex", "state");
+  const stateDir = path.join(scDir, "state");
   const statePath = path.join(
     stateDir,
     `inject-oc-${sessionKey.replace(/[^a-zA-Z0-9._-]+/g, "_").slice(0, 100)}.json`,

--- a/hooks/openclaw/cortex-memory/runtime.mjs
+++ b/hooks/openclaw/cortex-memory/runtime.mjs
@@ -25,7 +25,7 @@ export function isSelfHealEnabled(config, env = process.env) {
 
 export function createOpenClawRuntime({
   logPrefix = "[shieldcortex]",
-  configPath = path.join(homedir(), ".shieldcortex", "config.json"),
+  configPath = path.join(process.env.SHIELDCORTEX_CONFIG_DIR?.trim() || path.join(homedir(), ".shieldcortex"), "config.json"),
 } = {}) {
   let shieldConfig = null;
   let shieldConfigMtime = 0;

--- a/scripts/lib/inject-pack.mjs
+++ b/scripts/lib/inject-pack.mjs
@@ -48,7 +48,7 @@ function dbBooleanTrue(value) {
  * - modern scoped schemas select the global top-64 and let eligibility apply
  *   host/agent/project rules;
  * - legacy schemas have no host/agent scope, so the session hook retains its
- *   historical `(project = ? OR project IS NULL)` candidate restriction;
+ *   project restriction while admitting strict integer-1 transferable rows;
  * - consumers without a project (OpenClaw bootstrap) do not invent one.
  *
  * @param {{ prepare(sql: string): { all(...params: unknown[]): object[] } }} db
@@ -69,7 +69,8 @@ export function selectInjectCandidates(db, options = {}) {
   const params = [];
   let projectClause = '';
   if (!hasScopeColumns && cols.has('project') && options.project != null && options.project !== '') {
-    projectClause = ' AND ("project" = ? OR "project" IS NULL)';
+    const transferableClause = cols.has('transferable') ? ' OR "transferable" = 1' : '';
+    projectClause = ` AND ("project" = ? OR "project" IS NULL${transferableClause})`;
     params.push(String(options.project));
   }
   const pinnedOrder = cols.has('pinned') ? `CASE WHEN "pinned" = 1 THEN 1 ELSE 0 END` : 'CASE WHEN 1 THEN 0 END';

--- a/scripts/lib/inject-pack.mjs
+++ b/scripts/lib/inject-pack.mjs
@@ -4,7 +4,8 @@
  * Pure helpers for budgeted, fact-only, scoped session-start packs.
  * Normative law: docs/design/2026-08-17-memory-sota-program-r2-appendix.md
  *
- * No network. No DB. Callers supply candidate rows + session state.
+ * No network. The selector is the one read-only DB seam; pack builders remain
+ * pure over caller-supplied candidate rows + session state.
  */
 
 export const INJECT_MODE = Object.freeze({
@@ -19,6 +20,65 @@ export const NATIVE_INJECT_CONTRACT = Object.freeze({
   DISABLE_NATIVE: 'disable_native_inject',
   SC_ONLY: 'sc_only',
 });
+
+/** The runtime candidate window. Selection happens before eligibility. */
+export const INJECT_CANDIDATE_LIMIT = 64;
+
+/**
+ * One DB row shape for every automatic-start consumer and doctor. Missing
+ * legacy columns are projected as NULL so `isInjectEligible` always sees the
+ * same keys instead of changing semantics with each caller's SELECT list.
+ */
+export const INJECT_CANDIDATE_FIELDS = Object.freeze([
+  'id', 'title', 'content', 'fact', 'status', 'quarantined', 'in_quarantine',
+  'sensitivity_level', 'sensitivity', 'content_form', 'trust_score', 'trust',
+  'defence_verdict', 'source_attested', 'pinned', 'host_id', 'agent_id',
+  'project', 'transferable', 'salience', 'source', 'created_at',
+]);
+
+/** Strict SQLite boolean semantics: only the JSON boolean or integer 1 is on. */
+function dbBooleanTrue(value) {
+  return value === true || value === 1;
+}
+
+/**
+ * Select the exact pre-eligibility window used by the real start emitters.
+ *
+ * Project semantics intentionally preserve the two runtime shapes:
+ * - modern scoped schemas select the global top-64 and let eligibility apply
+ *   host/agent/project rules;
+ * - legacy schemas have no host/agent scope, so the session hook retains its
+ *   historical `(project = ? OR project IS NULL)` candidate restriction;
+ * - consumers without a project (OpenClaw bootstrap) do not invent one.
+ *
+ * @param {{ prepare(sql: string): { all(...params: unknown[]): object[] } }} db
+ * @param {{ project?: string|null }} [options]
+ * @returns {object[]}
+ */
+export function selectInjectCandidates(db, options = {}) {
+  const cols = new Set(db.prepare('PRAGMA table_info(memories)').all().map((c) => String(c.name)));
+  if (!cols.has('id')) throw new Error('memories table has no id column');
+
+  const projection = INJECT_CANDIDATE_FIELDS
+    .map((field) => cols.has(field) ? `"${field}"` : `NULL AS "${field}"`)
+    .join(', ');
+  const statusClause = cols.has('status')
+    ? `COALESCE("status", 'active') NOT IN ('archived', 'suppressed')`
+    : '1=1';
+  const hasScopeColumns = cols.has('host_id') || cols.has('agent_id');
+  const params = [];
+  let projectClause = '';
+  if (!hasScopeColumns && cols.has('project') && options.project != null && options.project !== '') {
+    projectClause = ' AND ("project" = ? OR "project" IS NULL)';
+    params.push(String(options.project));
+  }
+  const pinnedOrder = cols.has('pinned') ? `CASE WHEN "pinned" = 1 THEN 1 ELSE 0 END` : 'CASE WHEN 1 THEN 0 END';
+  const salienceOrder = cols.has('salience') ? `COALESCE("salience", 0)` : 'CASE WHEN 1 THEN 0 END';
+  return db.prepare(
+    `SELECT ${projection} FROM memories WHERE ${statusClause}${projectClause} `
+    + `ORDER BY ${pinnedOrder} DESC, ${salienceOrder} DESC, "id" ASC LIMIT ${INJECT_CANDIDATE_LIMIT}`,
+  ).all(...params);
+}
 
 /**
  * Pack wording law (#393 T1). The header states what the pack IS on this box:
@@ -252,7 +312,7 @@ export function isInjectEligible(row, scope = {}) {
   if (status === 'archived' || status === 'suppressed' || status === 'deleted' || status === 'forgotten') {
     return false;
   }
-  if (row.quarantined === true || row.in_quarantine === true) return false;
+  if (dbBooleanTrue(row.quarantined) || dbBooleanTrue(row.in_quarantine)) return false;
   const sens = String(row.sensitivity_level || row.sensitivity || 'INTERNAL').toUpperCase();
   if (sens === 'RESTRICTED') return false;
 
@@ -264,8 +324,8 @@ export function isInjectEligible(row, scope = {}) {
   // Trust floor (Opus B1 / #348): attestation is channel identity, NOT trust.
   // source_attested alone must not bypass the floor for non-pin rows.
   // Escape: source_attested AND pinned AND trust_score >= 0.5 (or missing trust with allow verdict).
-  const attested = row.source_attested === true || row.sourceAttested === true;
-  const pinned = row.pinned === true || row.pinned === 1;
+  const attested = dbBooleanTrue(row.source_attested) || dbBooleanTrue(row.sourceAttested);
+  const pinned = dbBooleanTrue(row.pinned);
   let trustOk = false;
   if (typeof row.trust_score === 'number') {
     trustOk = row.trust_score >= 0.5;
@@ -310,7 +370,7 @@ export function isInjectEligible(row, scope = {}) {
     if (scope.agentId != null && String(agent) !== String(scope.agentId)) return false;
     if (scope.project != null && scope.project !== '' && project != null && String(project) !== String(scope.project)) {
       // allow project-null rows as transferable only if row.transferable
-      if (!row.transferable) return false;
+      if (!dbBooleanTrue(row.transferable)) return false;
     }
   }
   return true;
@@ -461,12 +521,13 @@ export function serializeItem(item) {
  */
 export function stableRank(rows) {
   return [...rows].sort((a, b) => {
-    const pa = a.pinned ? 1 : 0;
-    const pb = b.pinned ? 1 : 0;
+    const pa = dbBooleanTrue(a.pinned) ? 1 : 0;
+    const pb = dbBooleanTrue(b.pinned) ? 1 : 0;
     if (pb !== pa) return pb - pa;
     const sa = typeof a.salience === 'number' ? a.salience : 0;
     const sb = typeof b.salience === 'number' ? b.salience : 0;
     if (sb !== sa) return sb - sa;
+    if (typeof a.id === 'number' && typeof b.id === 'number' && a.id !== b.id) return a.id - b.id;
     const ia = String(a.id);
     const ib = String(b.id);
     return ia < ib ? -1 : ia > ib ? 1 : 0;

--- a/scripts/session-start-hook.mjs
+++ b/scripts/session-start-hook.mjs
@@ -26,7 +26,7 @@ import { deriveProjectKey } from './lib/project-key.mjs';
 import { truncatePreservingWords } from './lib/truncate.mjs';
 import { orderByEffectiveSalience } from './lib/session-context.mjs';
 import { defendRecallRows, loadRecallDefence, ensureRecallAuditDb, emitRecallAudit } from './lib/recall-defence.mjs';
-import { buildStartPack, readInjectConfig, PACK_HEADER } from './lib/inject-pack.mjs';
+import { buildStartPack, readInjectConfig, selectInjectCandidates, PACK_HEADER } from './lib/inject-pack.mjs';
 
 const NEW_DB_DIR = join(homedir(), '.shieldcortex');
 const LEGACY_DB_DIR = join(homedir(), '.claude-cortex');
@@ -254,35 +254,13 @@ process.stdin.on('end', async () => {
       const db = new Database(DB_PATH, { readonly: true, timeout: 5000 });
       // Over-fetch candidates for inject pack / legacy formatter
       memories = getProjectContext(db, project);
-      // Wider pool for inject v2 when host/agent scope columns exist
-      let injectCandidates = memories;
+      // The shared helper is also used by OpenClaw and doctor: one row shape,
+      // one deterministic pre-eligibility window, no SQL parity theatre.
+      let injectCandidates = [];
       try {
-        const cols = db.prepare('PRAGMA table_info(memories)').all().map((c) => c.name);
-        if (cols.includes('host_id') || cols.includes('agent_id')) {
-          injectCandidates = db.prepare(`
-            SELECT id, title, content, category, type, salience, tags, created_at,
-                   pinned, access_count, last_accessed, trust_score, sensitivity_level,
-                   metadata, reviewed_at, status, source, defence_verdict,
-                   host_id, agent_id, project, transferable, source_attested
-            FROM memories
-            WHERE COALESCE(status, 'active') NOT IN ('archived', 'suppressed')
-            ORDER BY pinned DESC, salience DESC
-            LIMIT 64
-          `).all();
-        } else {
-          injectCandidates = db.prepare(`
-            SELECT id, title, content, category, type, salience, tags, created_at,
-                   pinned, trust_score, sensitivity_level, metadata, reviewed_at,
-                   status, source, defence_verdict, project
-            FROM memories
-            WHERE (project = ? OR project IS NULL)
-              AND COALESCE(status, 'active') NOT IN ('archived', 'suppressed')
-            ORDER BY pinned DESC, salience DESC
-            LIMIT 64
-          `).all(project);
-        }
+        injectCandidates = selectInjectCandidates(db, { project });
       } catch {
-        injectCandidates = memories;
+        injectCandidates = [];
       }
       db.close();
 

--- a/skills/shieldcortex/bundled/cortex-memory-hook/handler.ts
+++ b/skills/shieldcortex/bundled/cortex-memory-hook/handler.ts
@@ -10,7 +10,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { createOpenClawRuntime, SELF_HEAL_SKIP_ENV } from "./runtime.mjs";
 
 // ==================== SERVER COMMAND RESOLUTION ====================
@@ -485,19 +485,132 @@ async function onSessionStop(event) {
 /**
  * Handle agent:bootstrap — inject past context into agent
  *
- * NOTE: Context injection disabled as of v2026.2.26.
- * OpenClaw's native Memory Search now handles context recall at bootstrap.
- * The old get_context injection caused ~40x duplication of CORTEX_MEMORY.md
- * in the system prompt, eating the entire context window.
+ * NOTE: Unbounded CORTEX_MEMORY dump remains disabled (v2026.2.26 40x class).
+ * Memory SOTA B: budgeted inject pack may run when memory.inject.nativeContract
+ * is set (sc_only | disable_native_inject). Without contract, no bus reclaim.
  * Hook remains active for keyword triggers + session-end auto-save.
  */
+
+/**
+ * Budgeted SC start pack for OpenClaw bootstrap (inject v2).
+ * Requires memory.inject.nativeContract = sc_only | disable_native_inject.
+ */
+async function maybeInjectBootstrapPack(context: any, wsDir: string, event: any) {
+  const fsSync = await import("node:fs");
+  const scDir = process.env.SHIELDCORTEX_CONFIG_DIR?.trim() || path.join(homedir(), ".shieldcortex");
+  const cfgPath = path.join(scDir, "config.json");
+  let raw = {};
+  try {
+    if (fsSync.existsSync(cfgPath)) {
+      raw = JSON.parse(fsSync.readFileSync(cfgPath, "utf-8"));
+    }
+  } catch {
+    return;
+  }
+
+  const hookDir = path.dirname(fileURLToPath(import.meta.url));
+  const packageRoot = await resolvePackageRoot();
+  const candidates = [
+    path.join(hookDir, "inject-pack.mjs"),
+    ...(packageRoot ? [path.join(packageRoot, "scripts", "lib", "inject-pack.mjs")] : []),
+    path.join(hookDir, "..", "..", "..", "scripts", "lib", "inject-pack.mjs"),
+    path.join(homedir(), ".npm-global", "lib", "node_modules", "shieldcortex", "scripts", "lib", "inject-pack.mjs"),
+  ];
+
+  let buildStartPack;
+  let readInjectConfig;
+  let selectInjectCandidates;
+  for (const c of candidates) {
+    try {
+      if (!fsSync.existsSync(c)) continue;
+      const mod = await import(pathToFileURL(c).href);
+      buildStartPack = mod.buildStartPack;
+      readInjectConfig = mod.readInjectConfig;
+      selectInjectCandidates = mod.selectInjectCandidates;
+      if (buildStartPack && readInjectConfig && selectInjectCandidates) break;
+    } catch {
+      /* try next */
+    }
+  }
+  if (!buildStartPack || !readInjectConfig || !selectInjectCandidates) return;
+
+  const injectCfg = readInjectConfig(raw);
+  if (!injectCfg.nativeContract || injectCfg.mode === "off" || injectCfg.mode === "turn") {
+    return;
+  }
+
+  const Database = (await import("better-sqlite3")).default;
+  const dbPath = path.join(scDir, "memories.db");
+  if (!fsSync.existsSync(dbPath)) return;
+  const db = new Database(dbPath, { readonly: true, timeout: 3000 });
+  let rows = [];
+  try {
+    rows = selectInjectCandidates(db);
+  } finally {
+    db.close();
+  }
+
+  const sessionKey = String(event?.sessionKey || event?.sessionId || context?.sessionId || "bootstrap");
+  const stateDir = path.join(scDir, "state");
+  const statePath = path.join(
+    stateDir,
+    `inject-oc-${sessionKey.replace(/[^a-zA-Z0-9._-]+/g, "_").slice(0, 100)}.json`,
+  );
+  let sessionState = null;
+  try {
+    if (fsSync.existsSync(statePath)) {
+      sessionState = JSON.parse(fsSync.readFileSync(statePath, "utf-8"));
+    }
+  } catch {
+    /* ignore */
+  }
+
+  const pack = buildStartPack(rows, {
+    mode: injectCfg.mode,
+    nativeContract: injectCfg.nativeContract,
+    scope: {
+      hostId: injectCfg.hostId,
+      agentId: injectCfg.agentId,
+      // #348 B3: config default-true — never data-derive from unscoped rows
+      requireScope: injectCfg.requireScope !== false,
+    },
+    budgets: injectCfg.budgets,
+    sessionState,
+    rehydrate: false,
+    compactSignaled: false,
+  });
+  try {
+    if (!fsSync.existsSync(stateDir)) fsSync.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    fsSync.writeFileSync(statePath, JSON.stringify(pack.sessionState), { mode: 0o600 });
+  } catch {
+    /* ignore */
+  }
+
+  if (!pack.text || !Array.isArray(context.bootstrapFiles)) return;
+
+  context.bootstrapFiles.push({
+    name: "SHIELDCORTEX_INJECT_PACK.md",
+    path: path.join(wsDir, "SHIELDCORTEX_INJECT_PACK.md"),
+    content: `${pack.text}\n`,
+  });
+  console.log(
+    `[cortex-memory] inject pack: ${pack.items.length} rows, ~${pack.tokens} tokens (${injectCfg.nativeContract})`,
+  );
+}
+
 async function onBootstrap(event) {
   const context = event.context || {};
   if (!Array.isArray(context.bootstrapFiles)) return;
 
   const wsDir = context.workspaceDir || event?.workspaceDir || "/tmp";
 
-  // Context injection removed — native OpenClaw Memory Search handles this now.
+  // Memory SOTA B: budgeted inject pack only when host nativeContract is set.
+  // Without contract, do not reclaim the bus (freeze law). No unbounded dump.
+  try {
+    await maybeInjectBootstrapPack(context, wsDir, event);
+  } catch (injErr) {
+    console.warn("[cortex-memory] inject pack skipped:", (injErr as Error)?.message ?? injErr);
+  }
 
   // Scan installed hooks for threats (still useful)
   try {

--- a/skills/shieldcortex/bundled/cortex-memory-hook/handler.ts
+++ b/skills/shieldcortex/bundled/cortex-memory-hook/handler.ts
@@ -8,6 +8,7 @@
  */
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -509,10 +510,10 @@ async function maybeInjectBootstrapPack(context: any, wsDir: string, event: any)
   }
 
   const hookDir = path.dirname(fileURLToPath(import.meta.url));
-  const packageRoot = await resolvePackageRoot();
+  const resolvedPackageRoot = await resolvePackageRoot();
   const candidates = [
     path.join(hookDir, "inject-pack.mjs"),
-    ...(packageRoot ? [path.join(packageRoot, "scripts", "lib", "inject-pack.mjs")] : []),
+    ...(resolvedPackageRoot ? [path.join(resolvedPackageRoot, "scripts", "lib", "inject-pack.mjs")] : []),
     path.join(hookDir, "..", "..", "..", "scripts", "lib", "inject-pack.mjs"),
     path.join(homedir(), ".npm-global", "lib", "node_modules", "shieldcortex", "scripts", "lib", "inject-pack.mjs"),
   ];
@@ -520,26 +521,42 @@ async function maybeInjectBootstrapPack(context: any, wsDir: string, event: any)
   let buildStartPack;
   let readInjectConfig;
   let selectInjectCandidates;
+  let selectedInjectHelperPath = null;
   for (const c of candidates) {
     try {
-      if (!fsSync.existsSync(c)) continue;
-      const mod = await import(pathToFileURL(c).href);
+      const helperPath = path.resolve(c);
+      if (!fsSync.existsSync(helperPath)) continue;
+      const mod = await import(pathToFileURL(helperPath).href);
+      if (!mod.buildStartPack || !mod.readInjectConfig || !mod.selectInjectCandidates) continue;
       buildStartPack = mod.buildStartPack;
       readInjectConfig = mod.readInjectConfig;
       selectInjectCandidates = mod.selectInjectCandidates;
-      if (buildStartPack && readInjectConfig && selectInjectCandidates) break;
+      selectedInjectHelperPath = helperPath;
+      break;
     } catch {
       /* try next */
     }
   }
-  if (!buildStartPack || !readInjectConfig || !selectInjectCandidates) return;
+  if (!buildStartPack || !readInjectConfig || !selectInjectCandidates || !selectedInjectHelperPath) return;
 
   const injectCfg = readInjectConfig(raw);
   if (!injectCfg.nativeContract || injectCfg.mode === "off" || injectCfg.mode === "turn") {
     return;
   }
 
-  const Database = (await import("better-sqlite3")).default;
+  // The hook normally lives outside ShieldCortex's dependency tree. Resolve
+  // the native driver from the package that supplied inject-pack.mjs, never
+  // relative to this copied/self-healed handler. Prefer package.json as the
+  // package-root anchor; the selected helper remains a correct ancestry anchor
+  // for global/legacy layouts where package.json cannot be resolved.
+  const packageJsonPath = resolvedPackageRoot
+    ? path.join(resolvedPackageRoot, "package.json")
+    : null;
+  const dependencyAnchor = packageJsonPath && fsSync.existsSync(packageJsonPath)
+    ? packageJsonPath
+    : selectedInjectHelperPath;
+  const packageRequire = createRequire(pathToFileURL(dependencyAnchor).href);
+  const Database = packageRequire("better-sqlite3");
   const dbPath = path.join(scDir, "memories.db");
   if (!fsSync.existsSync(dbPath)) return;
   const db = new Database(dbPath, { readonly: true, timeout: 3000 });

--- a/skills/shieldcortex/bundled/cortex-memory-hook/runtime.mjs
+++ b/skills/shieldcortex/bundled/cortex-memory-hook/runtime.mjs
@@ -25,7 +25,7 @@ export function isSelfHealEnabled(config, env = process.env) {
 
 export function createOpenClawRuntime({
   logPrefix = "[shieldcortex]",
-  configPath = path.join(homedir(), ".shieldcortex", "config.json"),
+  configPath = path.join(process.env.SHIELDCORTEX_CONFIG_DIR?.trim() || path.join(homedir(), ".shieldcortex"), "config.json"),
 } = {}) {
   let shieldConfig = null;
   let shieldConfigMtime = 0;

--- a/src/__tests__/config-memory-inject-contract-cli.test.ts
+++ b/src/__tests__/config-memory-inject-contract-cli.test.ts
@@ -215,6 +215,25 @@ describe('config --memory-plane (signed Track A / #348)', () => {
     expect(fs.existsSync(configFile())).toBe(false);
   });
 
+  it('re-setting the plane advances planeSetAt — the drift time-box must not read a stale stamp (#394)', () => {
+    handleCloudConfig(['--memory-plane', 'dual_legacy']);
+    const first = readOnDisk().memory.planeSetAt as string;
+    // Rewind the stamp on disk the way an aged install looks, then re-sign by
+    // going back through the signed setter.
+    const rewound = new Date(Date.parse(first) - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const rawCfg = readOnDisk();
+    rawCfg.memory.planeSetAt = rewound;
+    fs.writeFileSync(configFile(), `${JSON.stringify(rawCfg, null, 2)}\n`);
+    clearCloudConfigCache();
+    handleCloudConfig(['--memory-plane', 'import_only']);
+    const after = readOnDisk();
+    expect(after.memory.plane).toBe('import_only');
+    expect(Date.parse(after.memory.planeSetAt as string)).toBeGreaterThan(Date.parse(rewound));
+    expect(after._sig).toMatch(/^[0-9a-f]{64}$/);
+    clearCloudConfigCache();
+    expect(isConfigTampered()).toBe(false);
+  });
+
   it('preserves inject sibling keys when setting plane', () => {
     fs.writeFileSync(configFile(), JSON.stringify({
       memory: {

--- a/src/__tests__/openclaw-bundled-inject-runtime.test.ts
+++ b/src/__tests__/openclaw-bundled-inject-runtime.test.ts
@@ -1,0 +1,132 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import ts from 'typescript';
+
+const repoRoot = path.resolve(process.cwd());
+
+describe('bundled OpenClaw hook — start-pack runtime', () => {
+  const originalEnv = { ...process.env };
+  let tmpHome: string | null = null;
+  let tmpSourceDir: string | null = null;
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.resetModules();
+    if (tmpHome) fs.rmSync(tmpHome, { recursive: true, force: true });
+    if (tmpSourceDir) fs.rmSync(tmpSourceDir, { recursive: true, force: true });
+    tmpHome = null;
+    tmpSourceDir = null;
+  });
+
+  it('emits only for a legal start bus from a skills-only source sandbox', async () => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-bundled-inject-'));
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    process.env.SHIELDCORTEX_SKIP_SELF_HEAL = '1';
+
+    const scDir = path.join(tmpHome, '.shieldcortex');
+    process.env.SHIELDCORTEX_CONFIG_DIR = scDir;
+    const fakePackage = path.join(tmpHome, 'shieldcortex-package');
+    fs.mkdirSync(path.join(fakePackage, 'dist'), { recursive: true });
+    fs.mkdirSync(path.join(fakePackage, 'scripts', 'lib'), { recursive: true });
+    fs.mkdirSync(scDir, { recursive: true });
+    fs.writeFileSync(path.join(fakePackage, 'dist', 'index.js'), '#!/usr/bin/env node\n');
+    fs.copyFileSync(
+      path.join(repoRoot, 'scripts', 'lib', 'inject-pack.mjs'),
+      path.join(fakePackage, 'scripts', 'lib', 'inject-pack.mjs'),
+    );
+
+    const db = new Database(path.join(scDir, 'memories.db'));
+    db.exec(`
+      CREATE TABLE memories (
+        id INTEGER PRIMARY KEY,
+        title TEXT,
+        content TEXT,
+        content_form TEXT,
+        status TEXT,
+        sensitivity_level TEXT,
+        trust_score REAL,
+        defence_verdict TEXT,
+        source_attested INTEGER,
+        pinned INTEGER,
+        quarantined INTEGER,
+        in_quarantine INTEGER,
+        host_id TEXT,
+        agent_id TEXT,
+        project TEXT,
+        transferable INTEGER,
+        salience REAL,
+        source TEXT,
+        created_at TEXT
+      );
+      INSERT INTO memories (
+        title, content, content_form, status, sensitivity_level, trust_score,
+        defence_verdict, source_attested, pinned, quarantined, in_quarantine,
+        host_id, agent_id, project, transferable, salience, source, created_at
+      ) VALUES (
+        'Runtime fact', 'The bundled handler emits the defended start pack.', 'fact',
+        'active', 'INTERNAL', 0.9, 'allow', 1, 0, 0, 0,
+        'host-a', 'agent-a', NULL, 0, 0.8, 'test', datetime('now')
+      );
+    `);
+    db.close();
+
+    const writeConfig = (inject: Record<string, unknown>): void => {
+      fs.writeFileSync(path.join(scDir, 'config.json'), JSON.stringify({
+        binaryPath: path.join(fakePackage, 'dist', 'index.js'),
+        memory: { inject },
+      }, null, 2));
+    };
+    writeConfig({ mode: 'start', nativeContract: 'sc_only', hostId: 'host-a', agentId: 'agent-a' });
+
+    // OpenClaw jiti-loads handler.ts. Transpile that exact bundled source into
+    // this isolated skills-only directory, preserving its runtime.mjs sibling,
+    // then execute the resulting module rather than a test double.
+    // Keep the transient module under the repo so its bare better-sqlite3
+    // import resolves exactly as the packaged hook's does.
+    tmpSourceDir = fs.mkdtempSync(path.join(repoRoot, '.jest-bundled-hook-'));
+    const skillsDir = tmpSourceDir;
+    const bundledDir = path.join(repoRoot, 'skills', 'shieldcortex', 'bundled', 'cortex-memory-hook');
+    const transpiled = ts.transpileModule(
+      fs.readFileSync(path.join(bundledDir, 'handler.ts'), 'utf-8'),
+      { compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 } },
+    ).outputText;
+    fs.writeFileSync(path.join(skillsDir, 'handler.mjs'), transpiled);
+    fs.copyFileSync(path.join(bundledDir, 'runtime.mjs'), path.join(skillsDir, 'runtime.mjs'));
+
+    jest.resetModules();
+    const handlerUrl = pathToFileURL(path.join(skillsDir, 'handler.mjs')).href;
+    const { default: handler } = await import(handlerUrl);
+    const run = async (sessionKey: string): Promise<Array<Record<string, unknown>>> => {
+      const bootstrapFiles: Array<Record<string, unknown>> = [];
+      await handler({
+        type: 'agent',
+        action: 'bootstrap',
+        sessionKey,
+        context: { workspaceDir: tmpHome, bootstrapFiles },
+      });
+      return bootstrapFiles.filter((f) => f.name === 'SHIELDCORTEX_INJECT_PACK.md');
+    };
+
+    const start = await run('start');
+    expect(start).toHaveLength(1);
+    expect(start[0].content).toMatch(/ShieldCortex memory pack/);
+    expect(start[0].content).toMatch(/bundled handler emits the defended start pack/i);
+
+    writeConfig({ mode: 'both', nativeContract: 'sc_only', hostId: 'host-a', agentId: 'agent-a' });
+    expect(await run('both')).toHaveLength(1);
+
+    for (const [label, inject] of [
+      ['off', { mode: 'off', nativeContract: 'sc_only', hostId: 'host-a', agentId: 'agent-a' }],
+      ['turn', { mode: 'turn', nativeContract: 'sc_only', hostId: 'host-a', agentId: 'agent-a' }],
+      ['no-contract', { mode: 'start', hostId: 'host-a', agentId: 'agent-a' }],
+    ] as const) {
+      writeConfig(inject);
+      expect(await run(label)).toHaveLength(0);
+    }
+  });
+});

--- a/src/__tests__/openclaw-bundled-inject-runtime.test.ts
+++ b/src/__tests__/openclaw-bundled-inject-runtime.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { createRequire } from 'module';
 import os from 'os';
 import path from 'path';
 import { pathToFileURL } from 'url';
@@ -33,11 +34,20 @@ describe('bundled OpenClaw hook — start-pack runtime', () => {
     const fakePackage = path.join(tmpHome, 'shieldcortex-package');
     fs.mkdirSync(path.join(fakePackage, 'dist'), { recursive: true });
     fs.mkdirSync(path.join(fakePackage, 'scripts', 'lib'), { recursive: true });
+    fs.mkdirSync(path.join(fakePackage, 'node_modules'), { recursive: true });
     fs.mkdirSync(scDir, { recursive: true });
+    fs.writeFileSync(path.join(fakePackage, 'package.json'), JSON.stringify({ name: 'shieldcortex-test-package' }));
     fs.writeFileSync(path.join(fakePackage, 'dist', 'index.js'), '#!/usr/bin/env node\n');
     fs.copyFileSync(
       path.join(repoRoot, 'scripts', 'lib', 'inject-pack.mjs'),
       path.join(fakePackage, 'scripts', 'lib', 'inject-pack.mjs'),
+    );
+    const testRequire = createRequire(import.meta.url);
+    const realBetterSqlite3 = path.resolve(path.dirname(testRequire.resolve('better-sqlite3')), '..');
+    fs.symlinkSync(
+      realBetterSqlite3,
+      path.join(fakePackage, 'node_modules', 'better-sqlite3'),
+      process.platform === 'win32' ? 'junction' : 'dir',
     );
 
     const db = new Database(path.join(scDir, 'memories.db'));
@@ -84,11 +94,10 @@ describe('bundled OpenClaw hook — start-pack runtime', () => {
     writeConfig({ mode: 'start', nativeContract: 'sc_only', hostId: 'host-a', agentId: 'agent-a' });
 
     // OpenClaw jiti-loads handler.ts. Transpile that exact bundled source into
-    // this isolated skills-only directory, preserving its runtime.mjs sibling,
+    // an isolated skills-only directory OUTSIDE the repository (and therefore
+    // outside its node_modules ancestry), preserving its runtime.mjs sibling,
     // then execute the resulting module rather than a test double.
-    // Keep the transient module under the repo so its bare better-sqlite3
-    // import resolves exactly as the packaged hook's does.
-    tmpSourceDir = fs.mkdtempSync(path.join(repoRoot, '.jest-bundled-hook-'));
+    tmpSourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-isolated-bundled-hook-'));
     const skillsDir = tmpSourceDir;
     const bundledDir = path.join(repoRoot, 'skills', 'shieldcortex', 'bundled', 'cortex-memory-hook');
     const transpiled = ts.transpileModule(
@@ -97,6 +106,14 @@ describe('bundled OpenClaw hook — start-pack runtime', () => {
     ).outputText;
     fs.writeFileSync(path.join(skillsDir, 'handler.mjs'), transpiled);
     fs.copyFileSync(path.join(bundledDir, 'runtime.mjs'), path.join(skillsDir, 'runtime.mjs'));
+
+    // Guard the regression instrument itself: a bare import from this handler
+    // location cannot resolve, while the fake ShieldCortex package anchor can.
+    // Reverting the emitter to import("better-sqlite3") therefore fails here.
+    const isolatedRequire = createRequire(pathToFileURL(path.join(skillsDir, 'handler.mjs')));
+    expect(() => isolatedRequire.resolve('better-sqlite3')).toThrow();
+    const packageRequire = createRequire(pathToFileURL(path.join(fakePackage, 'package.json')));
+    expect(() => packageRequire.resolve('better-sqlite3')).not.toThrow();
 
     jest.resetModules();
     const handlerUrl = pathToFileURL(path.join(skillsDir, 'handler.mjs')).href;

--- a/src/__tests__/openclaw-hook-selfheal.test.ts
+++ b/src/__tests__/openclaw-hook-selfheal.test.ts
@@ -53,6 +53,15 @@ function selfHealSource(dir: string): string {
   return source.slice(start, end);
 }
 
+function bootstrapEmitterSource(dir: string): string {
+  const source = fs.readFileSync(path.join(dir, 'handler.ts'), 'utf-8');
+  const start = source.indexOf('async function maybeInjectBootstrapPack');
+  const end = source.indexOf('\n\nasync function onBootstrap', start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end).trimEnd();
+}
+
 describe('cortex-memory self-heal — copied file set is complete (#109)', () => {
   const manifest = manifestOf(HOOK_DIR);
 
@@ -75,6 +84,15 @@ describe('cortex-memory self-heal — copied file set is complete (#109)', () =>
     // The bundled copy is the one that most often runs from an unexpected path
     // (skills-only installs), i.e. the copy that actually performs a migration.
     expect(manifestOf(BUNDLED_HOOK_DIR)).toEqual(manifest);
+  });
+
+  it('the bundled self-heal source carries the exact managed start-pack emitter', () => {
+    const managed = bootstrapEmitterSource(HOOK_DIR);
+    const bundled = bootstrapEmitterSource(BUNDLED_HOOK_DIR);
+    expect(bundled).toBe(managed);
+    expect(bundled).toMatch(/buildStartPack/);
+    expect(bundled).toMatch(/readInjectConfig/);
+    expect(bundled).toMatch(/selectInjectCandidates/);
   });
 
   it('the installer copies the same set the hook expects', () => {

--- a/src/cli/__tests__/doctor-memory-plane-348.test.ts
+++ b/src/cli/__tests__/doctor-memory-plane-348.test.ts
@@ -1591,6 +1591,11 @@ describe('checkMemoryPlaneDrift + checkMemoryHostContract', () => {
     const cloud = await import('../../cloud/config.js');
     cloud.setMemoryHostRuntimes(['hermes']);
     cloud.setMemoryHostPosture('mcp_sidecar_no_inject');
+    const signedRaw = JSON.parse(fs.readFileSync(path.join(scDir, 'config.json'), 'utf-8'));
+    expect(cloud.hasTrustedMemorySidecarPosture(
+      signedRaw,
+      path.join(scDir, 'wrong-config.json'),
+    )).toBe(false);
     const sidecar = await runHost();
     expect(sidecar.status).toBe('pass');
     expect(sidecar.message).toMatch(/honest sidecar/);
@@ -1605,6 +1610,37 @@ describe('checkMemoryPlaneDrift + checkMemoryHostContract', () => {
     const both = await runHost();
     expect(both.status).toBe('fail');
     expect(both.message).toMatch(/mutually exclusive/);
+  });
+
+  it('legacy first-read adoption cannot mint sidecar trust for either doctor row', async () => {
+    writeHermes({ memoryEnabled: true, userProfile: true });
+    writeConfig({
+      memory: {
+        plane: 'dual_legacy',
+        hostContract: { posture: 'mcp_sidecar_no_inject', runtimes: ['hermes'] },
+        inject: { mode: 'off', hostId: 'tars', agentId: 'hermes-primary' },
+      },
+    });
+
+    // Match full runDoctor ordering: checkAutoMemoryHooks reaches this exact
+    // reader before the drift and host-contract rows. General config migration
+    // may adopt the unsigned legacy bytes by writing an external signature,
+    // but that compatibility artefact must not become operator-intent proof.
+    const cloud = await import('../../cloud/config.js');
+    const legacySigPath = path.join(scDir, '.config-sig');
+    expect(fs.existsSync(legacySigPath)).toBe(false);
+    cloud.readRawConfig();
+    expect(fs.existsSync(legacySigPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(path.join(scDir, 'config.json'), 'utf-8'))._sig).toBeUndefined();
+
+    const drift = await runDrift();
+    expect(drift.status).toBe('fail');
+    expect(drift.message).toMatch(/untrusted sidecar posture/i);
+
+    const host = await runHost();
+    expect(host.status).toBe('fail');
+    expect(host.message).toMatch(/untrusted/i);
+    expect(host.message).not.toMatch(/honest sidecar/);
   });
 
   it('host contract rejects unsigned and forged sidecar posture declarations', async () => {

--- a/src/cli/__tests__/doctor-memory-plane-348.test.ts
+++ b/src/cli/__tests__/doctor-memory-plane-348.test.ts
@@ -4,6 +4,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { createHmac } from 'crypto';
 import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
@@ -25,6 +26,10 @@ describe('checkMemoryPlaneDrift + checkMemoryHostContract', () => {
     originalEnv = { ...process.env };
     process.env.HOME = tmpHome;
     process.env.USERPROFILE = tmpHome;
+    // cloud/config imports homedir as a stable binding while doctor probes via
+    // os.homedir(); pin the product-supported override so both rows and signed
+    // setters grade the same sandboxed bytes.
+    process.env.SHIELDCORTEX_CONFIG_DIR = scDir;
     // Hermeticity: a developer box with these set would silently relocate
     // every fixture's evidence root.
     delete process.env.OPENCLAW_STATE_DIR;
@@ -52,6 +57,13 @@ describe('checkMemoryPlaneDrift + checkMemoryHostContract', () => {
 
   function writeConfig(cfg: Record<string, unknown>): void {
     fs.writeFileSync(path.join(scDir, 'config.json'), `${JSON.stringify(cfg, null, 2)}\n`);
+  }
+
+  function writeSignedConfig(cfg: Record<string, unknown>): void {
+    const key = fs.readFileSync(path.join(scDir, '.integrity-key'), 'utf-8').trim();
+    const body = JSON.stringify(cfg, null, 2);
+    const sig = createHmac('sha256', key).update(body, 'utf-8').digest('hex');
+    writeConfig({ ...cfg, _sig: sig });
   }
 
   function openDb(): Database.Database {
@@ -1574,20 +1586,16 @@ describe('checkMemoryPlaneDrift + checkMemoryHostContract', () => {
     expect(r.fix).toMatch(/mcp_sidecar_no_inject/);
   });
 
-  it('host contract passes an honest sidecar and rejects sidecar-plus-contract', async () => {
+  it('host contract passes a signed honest sidecar and rejects sidecar-plus-contract', async () => {
     writeHermes({ memoryEnabled: true, userProfile: true });
-    writeConfig({
-      memory: {
-        plane: 'dual_legacy',
-        hostContract: { posture: 'mcp_sidecar_no_inject', runtimes: ['hermes'] },
-        inject: { mode: 'off', hostId: 'tars', agentId: 'hermes-primary' },
-      },
-    });
+    const cloud = await import('../../cloud/config.js');
+    cloud.setMemoryHostRuntimes(['hermes']);
+    cloud.setMemoryHostPosture('mcp_sidecar_no_inject');
     const sidecar = await runHost();
     expect(sidecar.status).toBe('pass');
     expect(sidecar.message).toMatch(/honest sidecar/);
 
-    writeConfig({
+    writeSignedConfig({
       memory: {
         plane: 'dual_legacy',
         hostContract: { posture: 'mcp_sidecar_no_inject' },
@@ -1597,6 +1605,28 @@ describe('checkMemoryPlaneDrift + checkMemoryHostContract', () => {
     const both = await runHost();
     expect(both.status).toBe('fail');
     expect(both.message).toMatch(/mutually exclusive/);
+  });
+
+  it('host contract rejects unsigned and forged sidecar posture declarations', async () => {
+    writeHermes({ memoryEnabled: true, userProfile: true });
+    const sidecar = {
+      memory: {
+        plane: 'dual_legacy',
+        hostContract: { posture: 'mcp_sidecar_no_inject', runtimes: ['hermes'] },
+        inject: { mode: 'off', hostId: 'tars', agentId: 'hermes-primary' },
+      },
+    };
+    writeConfig(sidecar);
+    const unsigned = await runHost();
+    expect(unsigned.status).toBe('fail');
+    expect(unsigned.message).toMatch(/untrusted/);
+    expect(unsigned.message).not.toMatch(/honest sidecar/);
+
+    writeConfig({ ...sidecar, _sig: 'forged' });
+    const forged = await runHost();
+    expect(forged.status).toBe('fail');
+    expect(forged.message).toMatch(/untrusted/);
+    expect(forged.message).not.toMatch(/honest sidecar/);
   });
 
   it('host contract fails a hand-crafted posture-only blob — sidecar needs inject.mode explicitly off (SOL r2 B4)', async () => {

--- a/src/cli/__tests__/doctor-plane-drift-394.test.ts
+++ b/src/cli/__tests__/doctor-plane-drift-394.test.ts
@@ -1,0 +1,753 @@
+/**
+ * #394 T2 residual — dual-plane drift doctor teeth.
+ *
+ * Three laws under test, none of which the #397 partial landing enforced:
+ *
+ *  1. REAL injectable counting. The drift check must count injectables with the
+ *     SAME predicate the session-start hook injects with (`isInjectEligible` in
+ *     scripts/lib/inject-pack.mjs), not a coarse SQL approximation — and that
+ *     count must be teeth, not decoration. A store full of rows the real gate
+ *     rejects (unverified legacy, directive form, unscoped) delivers NOTHING on
+ *     the SC bus, which is exactly the green-wash the residual plan names.
+ *  2. FP law. Only native artifacts that actually feed the bound agent's SoT
+ *     count as drift. An operator scratchpad — `~/MEMORY.md`, `~/notes/…`, a
+ *     stray `.md` in a workspace, a project `CLAUDE.md` preamble — must not.
+ *  3. Scope law. `requireScope` is deny-by-default CONFIG. Unscoped/scratch
+ *     data can never trick the doctor into PASS, and can never turn the gate off.
+ *
+ * Plus: telemetry gaps say "cannot determine" instead of PASSing, and illegal
+ * plane × contract combos fail.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import {
+  INJECT_CANDIDATE_FIELDS,
+  buildStartPack,
+  isInjectEligible,
+  selectInjectCandidates,
+} from '../../../scripts/lib/inject-pack.mjs';
+
+describe('checkMemoryPlaneDrift — #394 T2 teeth', () => {
+  let tmpHome: string;
+  let scDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sc-394-home-'));
+    scDir = path.join(tmpHome, '.shieldcortex');
+    fs.mkdirSync(scDir, { recursive: true, mode: 0o700 });
+    originalEnv = { ...process.env };
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    delete process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_CONFIG_PATH;
+    delete process.env.OPENCLAW_PROFILE;
+    delete process.env.OPENCLAW_HOME;
+    delete process.env.CLAWDBOT_STATE_DIR;
+    delete process.env.CLAWDBOT_CONFIG_PATH;
+    // Signed config writers resolve their destination before runDrift installs
+    // the os.homedir spy. Pin them to the same sandbox as doctor's live read so
+    // these tests prove signature semantics without touching the real host.
+    process.env.SHIELDCORTEX_CONFIG_DIR = scDir;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  function writeConfig(cfg: Record<string, unknown>): void {
+    fs.writeFileSync(path.join(scDir, 'config.json'), `${JSON.stringify(cfg, null, 2)}\n`);
+  }
+
+  /** Plane config with the inject bus on and a legal contract. */
+  function planeConfig(plane: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      memory: {
+        plane,
+        inject: { mode: 'start', nativeContract: 'sc_only', hostId: 'tars', agentId: 'hermes-primary' },
+        ...extra,
+      },
+    };
+  }
+
+  /**
+   * Superset of the columns the REAL inject predicate reads. A doctor that only
+   * knows status/sensitivity/trust cannot answer "would this row be injected".
+   */
+  function openDb(): Database.Database {
+    const db = new Database(path.join(scDir, 'memories.db'));
+    db.exec(`
+      CREATE TABLE memories (
+        id INTEGER PRIMARY KEY,
+        title TEXT, content TEXT, status TEXT, sensitivity_level TEXT,
+        content_form TEXT, trust_score REAL, defence_verdict TEXT,
+        source_attested INTEGER, pinned INTEGER, quarantined INTEGER, in_quarantine INTEGER,
+        host_id TEXT, agent_id TEXT, project TEXT, transferable INTEGER,
+        salience REAL, created_at TEXT
+      );
+      CREATE TABLE session_events (id INTEGER PRIMARY KEY, created_at TEXT);
+    `);
+    return db;
+  }
+
+  interface RowSpec {
+    title?: string;
+    content?: string;
+    status?: string;
+    sensitivity_level?: string;
+    content_form?: string | null;
+    trust_score?: number | null;
+    defence_verdict?: string | null;
+    source_attested?: number;
+    pinned?: number;
+    quarantined?: number;
+    in_quarantine?: number;
+    host_id?: string | null;
+    agent_id?: string | null;
+    project?: string | null;
+    transferable?: number;
+    salience?: number;
+    ageDays?: number;
+  }
+
+  /** A row the REAL predicate accepts, unless a field is overridden. */
+  function insertRow(db: Database.Database, spec: RowSpec = {}): void {
+    db.prepare(
+      `INSERT INTO memories
+        (title, content, status, sensitivity_level, content_form, trust_score,
+         defence_verdict, source_attested, pinned, quarantined, in_quarantine,
+         host_id, agent_id, project, transferable, salience, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now', ?))`,
+    ).run(
+      spec.title ?? 'deploy note',
+      spec.content ?? 'The staging deploy runs from the release branch.',
+      spec.status ?? 'active',
+      spec.sensitivity_level ?? 'INTERNAL',
+      spec.content_form === undefined ? 'fact' : spec.content_form,
+      spec.trust_score === undefined ? 0.9 : spec.trust_score,
+      spec.defence_verdict === undefined ? 'allow' : spec.defence_verdict,
+      spec.source_attested ?? 0,
+      spec.pinned ?? 0,
+      spec.quarantined ?? 0,
+      spec.in_quarantine ?? 0,
+      spec.host_id === undefined ? 'tars' : spec.host_id,
+      spec.agent_id === undefined ? 'hermes-primary' : spec.agent_id,
+      spec.project === undefined ? null : spec.project,
+      spec.transferable ?? 0,
+      spec.salience ?? 0.5,
+      `-${spec.ageDays ?? 0} days`,
+    );
+  }
+
+  function addActivity(db: Database.Database, n = 3): void {
+    for (let i = 0; i < n; i++) {
+      db.prepare(`INSERT INTO session_events (created_at) VALUES (datetime('now'))`).run();
+    }
+  }
+
+  async function runDrift() {
+    jest.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+    const mod = await import('../doctor.js');
+    return mod.checkMemoryPlaneDrift();
+  }
+
+  // ── 1. Real injectable counting ────────────────────────────────
+
+  it('counts injectables with the real inject predicate, not an approximation', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    insertRow(db, { title: 'second' });
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('pass');
+    // An honest count, not a "≈" hedge over a weaker SQL predicate.
+    expect(r.message).toMatch(/injectable=2\b/);
+    expect(r.message).not.toMatch(/injectable≈/);
+  });
+
+  it('fails import_only when the store holds durable rows the real gate rejects as unverified legacy', async () => {
+    // Coarse SQL (status + sensitivity + trust_score >= 0.5) counts these as
+    // injectable. The real predicate never injects an unverified row (Opus B1),
+    // so the SC bus delivers nothing while the plane claims canonicity.
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db, { defence_verdict: 'unverified' });
+    insertRow(db, { defence_verdict: 'unverified', title: 'second' });
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/injectable=0\b/);
+    expect(r.message).toMatch(/inject eligibility|delivers nothing/i);
+  });
+
+  it('fails import_only when every durable row is directive-form — the form key is part of real eligibility', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db, { content_form: 'directive', pinned: 1 });
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/injectable=0\b/);
+  });
+
+  it('warns rather than fails on the same zero-injectable store under dual_legacy', async () => {
+    writeConfig(planeConfig('dual_legacy'));
+    const db = openDb();
+    insertRow(db, { defence_verdict: 'unverified' });
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/injectable=0\b/);
+  });
+
+  it('honours the attestation-is-not-trust escape exactly as the injector does', async () => {
+    // source_attested + pinned + no numeric trust + allow verdict is the ONE
+    // sanctioned pin escape; a coarse COALESCE(trust_score, 0) >= 0.5 filter
+    // would undercount it to zero and manufacture drift.
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db, { trust_score: null, source_attested: 1, pinned: 1, defence_verdict: 'allow' });
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/injectable=1\b/);
+  });
+
+  it('does not let attestation alone carry a row under the trust floor', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db, { trust_score: 0.3, source_attested: 1, pinned: 1 });
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/injectable=0\b/);
+  });
+
+  it('counts durable admits inside the configured host/agent scope, not another hosts rows in a shared DB', async () => {
+    // A shared/legacy DB where the last week of admits all belong to a
+    // DIFFERENT host must not read as "this box captured into SC".
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db, { host_id: 'other-box', agent_id: 'other-agent' });
+    insertRow(db, { host_id: 'other-box', agent_id: 'other-agent', title: 'second' });
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/sc_durable_admits_7d=0\b/);
+    expect(r.message).toMatch(/injectable=0\b/);
+  });
+
+  it('uses one candidate row shape/window for doctor and both start consumers', () => {
+    for (const sourcePath of [
+      'scripts/session-start-hook.mjs',
+      'hooks/openclaw/cortex-memory/handler.ts',
+    ]) {
+      const source = fs.readFileSync(path.join(process.cwd(), sourcePath), 'utf-8');
+      expect(source).toMatch(/selectInjectCandidates\(db/);
+      expect(source).not.toMatch(/LIMIT 64/);
+    }
+    const db = openDb();
+    insertRow(db, { title: 'fact', source_attested: 1, pinned: 1 });
+    insertRow(db, { title: 'directive', content_form: 'directive', pinned: 1 });
+    const rows = selectInjectCandidates(db) as Array<Record<string, unknown>>;
+    db.close();
+    expect(Object.keys(rows[0]).sort()).toEqual([...INJECT_CANDIDATE_FIELDS].sort());
+    expect(rows.map((r) => r.id)).toEqual([1, 2]);
+    const runtimeScope = { hostId: 'tars', agentId: 'hermes-primary', requireScope: true };
+    const eligibleIds = rows.filter((r) => isInjectEligible(r, runtimeScope)).map((r) => r.id);
+    const sessionPack = buildStartPack(rows, {
+      mode: 'start', nativeContract: 'sc_only', scope: runtimeScope,
+    });
+    const openClawPack = buildStartPack(rows, {
+      mode: 'start', nativeContract: 'sc_only', scope: runtimeScope,
+    });
+    expect(eligibleIds).toEqual([1]);
+    expect(sessionPack.items.map((r: { id: unknown }) => r.id)).toEqual(eligibleIds);
+    expect(openClawPack.items.map((r: { id: unknown }) => r.id)).toEqual(eligibleIds);
+  });
+
+  it('grades the real top-64 window — an eligible row at rank 65 is not on the bus', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    for (let i = 0; i < 64; i++) {
+      insertRow(db, { title: `directive-${i}`, content_form: 'directive', salience: 1 });
+    }
+    insertRow(db, { title: 'eligible-rank-65', content_form: 'fact', salience: 0 });
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/injectable=0\b/);
+    expect(r.message).toMatch(/delivers nothing/);
+  });
+
+  it('treats SQLite quarantine booleans as true for integer 1', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db, { quarantined: 1 });
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/injectable=0\b/);
+  });
+
+  it('reports eligibility unknown when a session project is required but doctor has none', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db, { project: 'project-a', transferable: 0 });
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/real inject eligibility cannot be evaluated/);
+    expect(r.message).toMatch(/injectable=unknown/);
+  });
+
+  // ── 2. Scope law: deny-by-default is config, never data-derived ──
+
+  it('reports unscoped rows as excluded and refuses to PASS an unscoped shared DB', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db, { host_id: null, agent_id: null });
+    insertRow(db, { host_id: null, agent_id: null, title: 'second' });
+    insertRow(db, { host_id: 'tars', agent_id: null, title: 'half-scoped' });
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/injectable=0\b/);
+    expect(r.message).toMatch(/unscoped_excluded=3\b/);
+    expect(r.message).toMatch(/requireScope=true/);
+  });
+
+  it('keeps requireScope deny-by-default when the whole store is unscoped — a gate that self-disables is not a gate', async () => {
+    // Every row unscoped: the data-derived off-switch the residual plan bans
+    // would flip requireScope off here and mint a green PASS.
+    writeConfig(planeConfig('dual_legacy'));
+    const db = openDb();
+    for (let i = 0; i < 5; i++) insertRow(db, { host_id: null, agent_id: null, title: `row-${i}` });
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).not.toBe('pass');
+    expect(r.message).toMatch(/requireScope=true/);
+    expect(r.message).toMatch(/injectable=0\b/);
+  });
+
+  it('refuses to PASS a quiet all-unscoped store without relying on activity rows', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db, { host_id: null, agent_id: null });
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/scope gate excluded 1 unscoped row/);
+    expect(r.message).toMatch(/activity_7d=0/);
+  });
+
+  it('turns the scope gate off only on explicit config, and then counts what the injector would really inject', async () => {
+    writeConfig({
+      memory: {
+        plane: 'import_only',
+        inject: {
+          mode: 'start', nativeContract: 'sc_only',
+          hostId: 'tars', agentId: 'hermes-primary',
+          requireScope: false,
+        },
+      },
+    });
+    const db = openDb();
+    insertRow(db, { host_id: null, agent_id: null });
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/requireScope=false/);
+    expect(r.message).toMatch(/injectable=1\b/);
+  });
+
+  // ── 3. FP fixtures: operator scratchpad is not agent SoT ─────────
+
+  it('does not treat an operator scratchpad as agent SoT drift', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    // Home-dir notes, a personal memory folder, and a stray file inside an
+    // OpenClaw workspace. None of these is a file any host loads as its brain.
+    fs.writeFileSync(path.join(tmpHome, 'MEMORY.md'), '# my own notes\n'.repeat(40));
+    fs.mkdirSync(path.join(tmpHome, 'notes'), { recursive: true });
+    fs.writeFileSync(path.join(tmpHome, 'notes', 'MEMORY.md'), '# scratch\n'.repeat(40));
+    const ws = path.join(tmpHome, '.openclaw', 'workspace');
+    fs.mkdirSync(ws, { recursive: true });
+    fs.writeFileSync(path.join(ws, 'scratchpad.md'), '# todo\n'.repeat(40));
+    const r = await runDrift();
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/native_sot_touched_7d=false/);
+  });
+
+  it('does not treat a project CLAUDE.md preamble as memory-plane drift', async () => {
+    // A project instructions file is host-contract evidence (#393), not native
+    // memory growth. Developers edit it constantly; drift must not fire.
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    fs.mkdirSync(path.join(tmpHome, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(tmpHome, '.claude', 'CLAUDE.md'), '# project rules\n'.repeat(40));
+    const r = await runDrift();
+    expect(r.status).toBe('pass');
+  });
+
+  // ── 4. Native SoT true positives, per plane ──────────────────────
+
+  it('fails import_only on a touched OpenClaw workspace memory directory', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    const memDir = path.join(tmpHome, '.openclaw', 'workspace', 'memory');
+    fs.mkdirSync(memDir, { recursive: true });
+    fs.writeFileSync(path.join(memDir, 'notes.md'), '# still the brain\n'.repeat(20));
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/native/i);
+    expect(r.message).toMatch(/native_sot_touched_7d=true/);
+  });
+
+  it('ignores a fresh zero-byte native bootstrap file', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    const ws = path.join(tmpHome, '.openclaw', 'workspace');
+    fs.mkdirSync(ws, { recursive: true });
+    fs.writeFileSync(path.join(ws, 'MEMORY.md'), '');
+    const r = await runDrift();
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/native_sot_touched_7d=false/);
+  });
+
+  it('detects nested native memory growth recursively', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    const nested = path.join(tmpHome, '.openclaw', 'workspace', 'memory', 'year', 'month');
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(nested, 'notes.md'), '# nested native brain\n');
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/year.*month.*notes\.md/);
+  });
+
+  it('warns cannot-determine when native recursion exceeds the depth cap', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    db.close();
+    let nested = path.join(tmpHome, '.openclaw', 'workspace', 'memory');
+    for (let i = 0; i < 10; i++) nested = path.join(nested, `level-${i}`);
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(nested, 'notes.md'), '# beyond bounded scan\n');
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/cannot determine/);
+    expect(r.message).toMatch(/exceeds native store recursion depth/);
+  });
+
+  it('fails import_only on a touched IMPLICIT per-agent OpenClaw workspace brain', async () => {
+    // Reuses the host contract's workspace enumeration: a workspace-<agentId>
+    // brain must not hide behind the stock workspace being clean.
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    fs.mkdirSync(path.join(tmpHome, '.openclaw'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, '.openclaw', 'openclaw.json'),
+      JSON.stringify({ agents: { list: [{ id: 'main', default: true }, { id: 'case' }] } }, null, 2),
+    );
+    const implicitWs = path.join(tmpHome, '.openclaw', 'workspace-case');
+    fs.mkdirSync(implicitWs, { recursive: true });
+    fs.writeFileSync(path.join(implicitWs, 'MEMORY.md'), '# implicit brain\n'.repeat(10));
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/workspace-case/);
+  });
+
+  it('fails sc_canonical on a touched Claude Code native memory store', async () => {
+    writeConfig(planeConfig('sc_canonical'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    const store = path.join(tmpHome, '.claude', 'memory');
+    fs.mkdirSync(store, { recursive: true });
+    fs.writeFileSync(path.join(store, 'MEMORY.md'), '# native brain\n'.repeat(20));
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/native_sot_touched_7d=true/);
+  });
+
+  it('fails import_only on a touched Hermes native memory store', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    const store = path.join(tmpHome, '.hermes', 'memories');
+    fs.mkdirSync(store, { recursive: true });
+    fs.writeFileSync(path.join(store, 'MEMORY.md'), '# hermes brain\n'.repeat(20));
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/native_sot_touched_7d=true/);
+  });
+
+  it('detects a Hermes profile re-enabling default-on native memory', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    fs.mkdirSync(path.join(tmpHome, '.hermes'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, '.hermes', 'config.yaml'),
+      'memory:\n  memory_enabled: false\n  user_profile_enabled: false\n',
+    );
+    const profile = path.join(tmpHome, '.hermes', 'profiles', 'research');
+    fs.mkdirSync(profile, { recursive: true });
+    fs.writeFileSync(path.join(profile, 'config.yaml'), 'memory:\n  memory_enabled: true\n');
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/Hermes profile research.*memory_enabled=true/);
+  });
+
+  it('cannot determine drift when a Hermes profile config is unreadable', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    fs.mkdirSync(path.join(tmpHome, '.hermes'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, '.hermes', 'config.yaml'),
+      'memory:\n  memory_enabled: false\n  user_profile_enabled: false\n',
+    );
+    fs.mkdirSync(path.join(tmpHome, '.hermes', 'profiles', 'mystery', 'config.yaml'), { recursive: true });
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/cannot determine/);
+    expect(r.message).toMatch(/Hermes profile mystery config\.yaml cannot be read/);
+  });
+
+  it('warns — never fails — on the same native SoT growth under dual_legacy', async () => {
+    writeConfig(planeConfig('dual_legacy'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    const ws = path.join(tmpHome, '.openclaw', 'workspace');
+    fs.mkdirSync(ws, { recursive: true });
+    fs.writeFileSync(path.join(ws, 'MEMORY.md'), '# dual brain\n'.repeat(20));
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/dual_legacy/);
+  });
+
+  it('ignores native SoT files last written before the window', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    const ws = path.join(tmpHome, '.openclaw', 'workspace');
+    fs.mkdirSync(ws, { recursive: true });
+    const stale = path.join(ws, 'MEMORY.md');
+    fs.writeFileSync(stale, '# archived brain\n'.repeat(20));
+    const old = Date.now() - 60 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(stale, old / 1000, old / 1000);
+    const r = await runDrift();
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/native_sot_touched_7d=false/);
+  });
+
+  it('fails import_only when the native memory bus is provably still switched on', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    fs.mkdirSync(path.join(tmpHome, '.openclaw'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, '.openclaw', 'openclaw.json'),
+      JSON.stringify({ agents: { defaults: { memorySearch: { enabled: true } } } }, null, 2),
+    );
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/native (memory )?bus/i);
+  });
+
+  // ── 5. Telemetry gaps never PASS silently ────────────────────────
+
+  it('cannot determine drift when there is no activity telemetry at all', async () => {
+    writeConfig(planeConfig('import_only'));
+    const db = new Database(path.join(scDir, 'memories.db'));
+    db.exec(`
+      CREATE TABLE memories (
+        id INTEGER PRIMARY KEY,
+        title TEXT, content TEXT, status TEXT, sensitivity_level TEXT,
+        content_form TEXT, trust_score REAL, defence_verdict TEXT,
+        source_attested INTEGER, pinned INTEGER, quarantined INTEGER, in_quarantine INTEGER,
+        host_id TEXT, agent_id TEXT, project TEXT, transferable INTEGER,
+        salience REAL, created_at TEXT
+      );
+    `);
+    insertRow(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/cannot determine/i);
+    expect(r.message).toMatch(/activity_7d=unknown/);
+  });
+
+  it('cannot determine drift when the memories table is unreadable', async () => {
+    writeConfig(planeConfig('dual_legacy'));
+    const db = new Database(path.join(scDir, 'memories.db'));
+    db.exec(`CREATE TABLE session_events (id INTEGER PRIMARY KEY, created_at TEXT);`);
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/cannot determine/i);
+  });
+
+  it('cannot determine drift when the native SoT tree is unprobeable', async () => {
+    // A relative OPENCLAW_STATE_DIR resolves against the OpenClaw process cwd,
+    // so doctor cannot know where the native brain lives. It used to skip the
+    // candidates and certify green off the SC side alone.
+    process.env.OPENCLAW_STATE_DIR = './somewhere-relative';
+    writeConfig(planeConfig('import_only'));
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).toMatch(/cannot determine/i);
+  });
+
+  // ── 6. Illegal plane × contract combos ───────────────────────────
+
+  it('fails sc_canonical with no inject bus configured at all', async () => {
+    writeConfig({ memory: { plane: 'sc_canonical' } });
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/sc_canonical/);
+  });
+
+  it('fails sc_canonical with inject explicitly off — canonicity without a bus', async () => {
+    writeConfig({
+      memory: { plane: 'sc_canonical', inject: { mode: 'off', nativeContract: 'sc_only' } },
+    });
+    const db = openDb();
+    insertRow(db);
+    addActivity(db);
+    db.close();
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/sc_canonical/);
+  });
+
+  it('fails sc_canonical with turn-only inject — turn is not an automatic start bus', async () => {
+    writeConfig({
+      memory: { plane: 'sc_canonical', inject: { mode: 'turn', nativeContract: 'sc_only' } },
+    });
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/without an automatic start bus/);
+  });
+
+  it('passes a signed honest sidecar even when native memory is live', async () => {
+    const cloud = await import('../../cloud/config.js');
+    cloud.setMemoryHostPosture('mcp_sidecar_no_inject');
+    fs.mkdirSync(path.join(tmpHome, '.hermes'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, '.hermes', 'config.yaml'),
+      'memory:\n  memory_enabled: true\n  user_profile_enabled: true\n',
+    );
+    const r = await runDrift();
+    expect(r.status).toBe('pass');
+    expect(r.message).toMatch(/honest sidecar/);
+    expect(r.message).toMatch(/native_bus_active=true/);
+  });
+
+  it('fails signed sidecar posture combined with import ownership', async () => {
+    const cloud = await import('../../cloud/config.js');
+    cloud.setMemoryPlane('import_only');
+    cloud.setMemoryHostPosture('mcp_sidecar_no_inject');
+    const r = await runDrift();
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/contradicts posture/);
+  });
+
+  it('does not exempt an unsigned handcrafted sidecar posture', async () => {
+    writeConfig({
+      memory: {
+        plane: 'dual_legacy',
+        hostContract: { posture: 'mcp_sidecar_no_inject' },
+        inject: { mode: 'off' },
+      },
+    });
+    const db = openDb();
+    insertRow(db);
+    db.close();
+    const store = path.join(tmpHome, '.hermes', 'memories');
+    fs.mkdirSync(store, { recursive: true });
+    fs.writeFileSync(path.join(store, 'MEMORY.md'), '# native remains live\n');
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).not.toMatch(/honest sidecar/);
+  });
+
+  it('does not exempt a posture carrying a forged embedded signature', async () => {
+    writeConfig({
+      _sig: 'forged',
+      memory: {
+        plane: 'dual_legacy',
+        hostContract: { posture: 'mcp_sidecar_no_inject' },
+        inject: { mode: 'off' },
+      },
+    });
+    const db = openDb();
+    insertRow(db);
+    db.close();
+    const store = path.join(tmpHome, '.hermes', 'memories');
+    fs.mkdirSync(store, { recursive: true });
+    fs.writeFileSync(path.join(store, 'MEMORY.md'), '# native remains live\n');
+    const r = await runDrift();
+    expect(r.status).toBe('warn');
+    expect(r.message).not.toMatch(/honest sidecar/);
+  });
+});

--- a/src/cli/__tests__/doctor-plane-drift-394.test.ts
+++ b/src/cli/__tests__/doctor-plane-drift-394.test.ts
@@ -279,6 +279,36 @@ describe('checkMemoryPlaneDrift — #394 T2 teeth', () => {
     expect(openClawPack.items.map((r: { id: unknown }) => r.id)).toEqual(eligibleIds);
   });
 
+  it('includes only strict integer-1 transferable cross-project rows in a legacy project window', () => {
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE memories (
+        id INTEGER PRIMARY KEY,
+        title TEXT,
+        content TEXT,
+        content_form TEXT,
+        status TEXT,
+        trust_score REAL,
+        defence_verdict TEXT,
+        project TEXT,
+        transferable,
+        pinned INTEGER,
+        salience REAL
+      );
+      INSERT INTO memories
+        (id, title, content, content_form, status, trust_score, defence_verdict, project, transferable, pinned, salience)
+      VALUES
+        (1, 'current', 'current project fact', 'fact', 'active', 0.9, 'allow', 'project-a', 0, 0, 0.9),
+        (2, 'global', 'projectless fact', 'fact', 'active', 0.9, 'allow', NULL, 0, 0, 0.8),
+        (3, 'transferable', 'cross project fact', 'fact', 'active', 0.9, 'allow', 'project-b', 1, 0, 0.7),
+        (4, 'private', 'private cross project fact', 'fact', 'active', 0.9, 'allow', 'project-b', 0, 0, 0.6),
+        (5, 'loose', 'loosely truthy cross project fact', 'fact', 'active', 0.9, 'allow', 'project-b', '1', 0, 0.5);
+    `);
+    const rows = selectInjectCandidates(db, { project: 'project-a' }) as Array<{ id: number }>;
+    db.close();
+    expect(rows.map((row) => row.id)).toEqual([1, 2, 3]);
+  });
+
   it('grades the real top-64 window — an eligible row at rank 65 is not on the bus', async () => {
     writeConfig(planeConfig('import_only'));
     const db = openDb();

--- a/src/cli/__tests__/doctor-plane-drift-394.test.ts
+++ b/src/cli/__tests__/doctor-plane-drift-394.test.ts
@@ -757,7 +757,8 @@ describe('checkMemoryPlaneDrift — #394 T2 teeth', () => {
     fs.mkdirSync(store, { recursive: true });
     fs.writeFileSync(path.join(store, 'MEMORY.md'), '# native remains live\n');
     const r = await runDrift();
-    expect(r.status).toBe('warn');
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/untrusted sidecar posture/i);
     expect(r.message).not.toMatch(/honest sidecar/);
   });
 
@@ -777,7 +778,8 @@ describe('checkMemoryPlaneDrift — #394 T2 teeth', () => {
     fs.mkdirSync(store, { recursive: true });
     fs.writeFileSync(path.join(store, 'MEMORY.md'), '# native remains live\n');
     const r = await runDrift();
-    expect(r.status).toBe('warn');
+    expect(r.status).toBe('fail');
+    expect(r.message).toMatch(/untrusted sidecar posture/i);
     expect(r.message).not.toMatch(/honest sidecar/);
   });
 });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3111,9 +3111,19 @@ export async function checkMemoryPlaneDrift(): Promise<CheckResult> {
   // The sidecar exemption is intentionally narrower than string equality. The
   // signed setter writes an embedded signature and explicit mode=off; a bare,
   // copied, malformed, or legacy posture blob does not get to suppress drift.
-  const trustedSidecar = cfg.posture === SIDECAR_POSTURE
-    && cfg.postureIllegal === undefined
+  const sidecarDeclared = cfg.posture === SIDECAR_POSTURE
+    && cfg.postureIllegal === undefined;
+  const trustedSidecar = sidecarDeclared
     && hasTrustedMemorySidecarPosture(raw, configPath);
+  if (sidecarDeclared && !trustedSidecar) {
+    return {
+      label,
+      status: 'fail',
+      message:
+        `untrusted sidecar posture (${SIDECAR_POSTURE}) — the declaration is not covered by a valid embedded config signature`,
+      fix: 'Run `shieldcortex config --memory-host-posture mcp_sidecar_no_inject` so the signed setter records the declaration; a legacy .config-sig is not operator-intent proof',
+    };
+  }
   if (trustedSidecar) {
     if (cfg.plane === 'import_only' || cfg.plane === 'sc_canonical') {
       return {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -46,7 +46,9 @@ import {
   resolveClaudeCodeEvidence,
   resolveHermesEvidence,
   resolveOpenClawEvidence,
+  resolveOpenClawMemorySearchState,
   INJECT_MODES,
+  SIDECAR_POSTURE,
   type ArtifactProbe,
   type HermesProfileProbe,
   type HostRuntimeEvidence,
@@ -54,6 +56,12 @@ import {
   type OpenClawHookArtifacts,
   type ProbeRead,
 } from '../memory/host-contract.js';
+import {
+  evaluatePlaneDrift,
+  type MemoryPlane,
+  type NativeSotEvidence,
+  type PlaneDriftCounts,
+} from '../memory/plane-drift.js';
 import { getCanonicalSchema } from '../database/init.js';
 import { runMigrations } from '../database/migrations.js';
 import { detectStaleDashboard, realDeps } from '../service/dashboard-staleness.js';
@@ -72,7 +80,7 @@ import {
 // transport (cli-invoker.js) and the explainer (doctor-explainer.js) are
 // loaded with a runtime `import()` inside runDoctorAiSection() below, so a
 // plain `shieldcortex doctor` never touches either module.
-import { getConfigDir, readRawConfig, migrateInterceptorActionGuardAlias } from '../cloud/config.js';
+import { getConfigDir, readRawConfig, isConfigTampered, migrateInterceptorActionGuardAlias } from '../cloud/config.js';
 import { validateOpenClawConfig } from '../integrations/openclaw-config-validate.js';
 import type { OpenClawConfigVerdict, ValidateDeps } from '../integrations/openclaw-config-validate.js';
 import type { ModelInvoker } from '../defence/iron-dome/approval-judge.js';
@@ -2923,7 +2931,7 @@ export async function checkMemoryPlaneEmptyBrain(): Promise<CheckResult> {
 
 const MEMORY_PLANE_LEGAL = new Set(['dual_legacy', 'import_only', 'sc_canonical']);
 
-function readMemoryPlaneFromConfig(raw: Record<string, unknown>): {
+export function readMemoryPlaneFromConfig(raw: Record<string, unknown>): {
   plane: string;
   planeSetAt: string | null;
   illegal: boolean;
@@ -3031,9 +3039,21 @@ function readMemoryPlaneFromConfig(raw: Record<string, unknown>): {
 }
 
 /**
- * Dual-plane drift (#348 T2 / Opus B3).
- * Distinct from empty-brain: catches "SC has rows but native is still the brain"
- * and illegal plane values. Telemetry missing → warn cannot determine, never PASS.
+ * Dual-plane drift (#348 T2 / #394, Opus B3).
+ *
+ * Distinct from empty-brain: this catches "SC has rows but native is still the
+ * brain", and — the #394 residual — "SC has rows the REAL inject gate admits
+ * none of", which is a bus that delivers nothing while every row count looks
+ * healthy. Doctor gathers evidence here; `src/memory/plane-drift.ts` decides.
+ *
+ * Three laws this must not break:
+ *  - the injectable count uses `isInjectEligible` from
+ *    scripts/lib/inject-pack.mjs — the SAME predicate the session-start hook
+ *    injects with, not a weaker SQL approximation that grades itself green;
+ *  - only artifacts a host actually loads as its agent brain are drift (an
+ *    operator scratchpad is not, a project preamble is host-contract's business);
+ *  - `requireScope` is deny-by-default CONFIG. Nothing about the data may turn
+ *    it off, and an unscoped store must report what it excluded, never PASS.
  */
 export async function checkMemoryPlaneDrift(): Promise<CheckResult> {
   const label = 'Memory plane (dual-plane drift)';
@@ -3075,17 +3095,61 @@ export async function checkMemoryPlaneDrift(): Promise<CheckResult> {
     };
   }
 
-  // sc_canonical + inject off on bound auto-memory host claiming product use
-  if (cfg.plane === 'sc_canonical' && cfg.openclawAuto && (cfg.injectMode === 'off' || !cfg.injectConfigured)) {
+  const startBusOn = Boolean(cfg.nativeContract)
+    && (cfg.injectMode === 'start' || cfg.injectMode === 'both');
+
+  const dbPath = getDbPath();
+  const nowMs = Date.now();
+  const native = scanNativeAgentSot(os.homedir(), nowMs);
+
+  // The sidecar exemption is intentionally narrower than string equality. The
+  // signed setter writes an embedded signature and explicit mode=off; a bare,
+  // copied, malformed, or legacy posture blob does not get to suppress drift.
+  let trustedSidecar = false;
+  if (cfg.posture === SIDECAR_POSTURE && cfg.postureIllegal === undefined) {
+    const hasEmbeddedSignature = typeof raw._sig === 'string';
+    const trusted = readRawConfig();
+    trustedSidecar = hasEmbeddedSignature
+      && path.resolve(getConfigDir()) === path.resolve(getShieldCortexDir())
+      && !isConfigTampered()
+      && readMemoryPlaneFromConfig(trusted).posture === SIDECAR_POSTURE
+      && cfg.injectConfigured
+      && cfg.injectModeExplicit
+      && cfg.injectMode === 'off';
+  }
+  if (trustedSidecar) {
+    if (cfg.plane === 'import_only' || cfg.plane === 'sc_canonical') {
+      return {
+        label,
+        status: 'fail',
+        message: `plane=${cfg.plane} contradicts posture=${SIDECAR_POSTURE} — sidecar leaves native memory authoritative and claims no SC canonicity/import ownership`,
+        fix: 'Use plane=dual_legacy for the honest sidecar, or remove sidecar posture and establish a legal automatic start bus',
+      };
+    }
     return {
       label,
-      status: 'fail',
-      message: 'plane=sc_canonical with openclawAutoMemory on but inject off — fake canonicity (no SC bus)',
-      fix: 'Enable inject with a legal nativeContract, or set plane to dual_legacy / honest sidecar posture',
+      status: 'pass',
+      message:
+        `honest sidecar (${SIDECAR_POSTURE}): signed posture, SC inject explicitly off; native memory is expected `
+        + `(native_sot_touched_7d=${native.touched7d} native_sot_bytes=${native.bytes} `
+        + `native_bus_active=${native.busActive.length > 0}${native.unattestable.length > 0 ? ` native_scan_notes=${native.unattestable.length}` : ''})`,
     };
   }
 
-  const dbPath = getDbPath();
+  // sc_canonical requires a REAL automatic start bus. mode=turn is not one.
+  // Keep this after the trusted-sidecar contradiction so signed posture/plane
+  // conflicts get the precise diagnosis rather than a generic missing-bus one.
+  if (cfg.plane === 'sc_canonical' && !startBusOn) {
+    return {
+      label,
+      status: 'fail',
+      message:
+        `plane=sc_canonical with SC inject mode=${cfg.injectMode} — canonicity claimed without an automatic start bus`
+        + `${cfg.openclawAuto ? ' while openclawAutoMemory is on' : ''}`,
+      fix: 'Enable inject with a legal nativeContract, or set plane to dual_legacy / declare the honest sidecar posture',
+    };
+  }
+
   if (!fs.existsSync(dbPath)) {
     return {
       label,
@@ -3094,190 +3158,446 @@ export async function checkMemoryPlaneDrift(): Promise<CheckResult> {
     };
   }
 
+  // The REAL inject law, loaded from the module the hook injects with. A
+  // failure to load leaves `injectable` unknown — which surfaces as
+  // "cannot determine", never as a passing zero.
+  let injectPack: InjectPackModule | null = null;
+  try {
+    // @ts-expect-error — importing a .mjs hook util that has no .d.ts
+    injectPack = await import('../../scripts/lib/inject-pack.mjs') as InjectPackModule;
+  } catch {
+    injectPack = null;
+  }
+  const injectCfg = injectPack ? injectPack.readInjectConfig(raw) : null;
+  // Deny-by-default when the config reader is unavailable: the gate's absence
+  // must never read as the gate being off (Opus B3).
+  const scope: DriftScope = {
+    hostId: injectCfg?.hostId ?? null,
+    agentId: injectCfg?.agentId ?? null,
+    requireScope: injectCfg ? injectCfg.requireScope !== false : true,
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const Database = (await import('better-sqlite3')).default;
   let db: InstanceType<typeof Database> | null = null;
   try {
     db = new Database(dbPath, { readonly: true, timeout: 3000, fileMustExist: true });
-    const countOf = (sql: string, params: unknown[] = []): number => {
-      const row = db!.prepare(sql).get(...params) as { c?: number } | undefined;
-      return Number(row?.c ?? 0);
-    };
-
-    let durableAdmits7d = 0;
-    let telemetryOk = true;
-    try {
-      // Prefer source_kind / created_at when present
-      const cols = (db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name: string }>).map((c) => c.name);
-      if (cols.includes('created_at')) {
-        durableAdmits7d = countOf(
-          `SELECT COUNT(*) AS c FROM memories
-           WHERE COALESCE(status, 'active') NOT IN ('archived', 'suppressed', 'deleted', 'forgotten')
-             AND COALESCE(sensitivity_level, 'INTERNAL') != 'RESTRICTED'
-             AND created_at >= datetime('now', '-7 days')`,
-        );
-      } else {
-        telemetryOk = false;
-      }
-    } catch {
-      telemetryOk = false;
-    }
-
-    let activity = 0;
-    try {
-      activity += countOf(`SELECT COUNT(*) AS c FROM session_events WHERE created_at >= datetime('now', '-7 days')`);
-    } catch { /* optional */ }
-    try {
-      activity += countOf(`SELECT COUNT(*) AS c FROM hook_invocations WHERE invoked_at >= datetime('now', '-7 days')`);
-    } catch { /* optional */ }
-
-    // Native artifact growth (OpenClaw MEMORY.md / memory.md / memory dir),
-    // under the same state root the host contract reads (#393 SOL r2 B6). An
-    // unresolvable override (r3 B6) yields no root: skip the OpenClaw
-    // candidates rather than probing a guessed tree — the weak-telemetry
-    // guard below already refuses to PASS a quiet box.
-    const home = os.homedir();
-    const ocRoot = openClawStateRoot(home).root;
-    const ocWorkspace = ocRoot === null ? null : path.join(ocRoot, 'workspace');
-    const nativeCandidates = [
-      ...(ocWorkspace === null ? [] : [
-        path.join(ocWorkspace, 'MEMORY.md'),
-        path.join(ocWorkspace, 'memory.md'),
-        path.join(ocWorkspace, 'memory'),
-      ]),
-      path.join(home, 'MEMORY.md'),
-    ];
-    let nativeTouched7d = false;
-    let nativeBytes = 0;
-    const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-    for (const pth of nativeCandidates) {
-      try {
-        const st = fs.statSync(pth);
-        if (st.isFile()) {
-          nativeBytes += st.size;
-          if (st.mtimeMs >= weekAgo) nativeTouched7d = true;
-        } else if (st.isDirectory()) {
-          // shallow: any file mtime in dir
-          for (const name of fs.readdirSync(pth).slice(0, 50)) {
-            try {
-              const cst = fs.statSync(path.join(pth, name));
-              if (cst.isFile()) {
-                nativeBytes += cst.size;
-                if (cst.mtimeMs >= weekAgo) nativeTouched7d = true;
-              }
-            } catch { /* skip */ }
-          }
-        }
-      } catch { /* absent */ }
-    }
-
-    // Unscoped / injectable counts (best-effort; columns may be absent)
-    let unscoped = 0;
-    let injectableApprox = 0;
-    try {
-      const cols = (db.prepare(`PRAGMA table_info(memories)`).all() as Array<{ name: string }>).map((c) => c.name);
-      if (cols.includes('host_id') && cols.includes('agent_id')) {
-        unscoped = countOf(
-          `SELECT COUNT(*) AS c FROM memories
-           WHERE COALESCE(status, 'active') NOT IN ('archived', 'suppressed', 'deleted', 'forgotten')
-             AND (host_id IS NULL OR host_id = '' OR agent_id IS NULL OR agent_id = '')`,
-        );
-        // Approx inject-eligible: scoped + not restricted + trust floor when column exists
-        if (cols.includes('trust_score')) {
-          injectableApprox = countOf(
-            `SELECT COUNT(*) AS c FROM memories
-             WHERE COALESCE(status, 'active') NOT IN ('archived', 'suppressed', 'deleted', 'forgotten')
-               AND COALESCE(sensitivity_level, 'INTERNAL') != 'RESTRICTED'
-               AND host_id IS NOT NULL AND host_id != ''
-               AND agent_id IS NOT NULL AND agent_id != ''
-               AND COALESCE(trust_score, 0) >= 0.5`,
-          );
-        } else {
-          injectableApprox = countOf(
-            `SELECT COUNT(*) AS c FROM memories
-             WHERE COALESCE(status, 'active') NOT IN ('archived', 'suppressed', 'deleted', 'forgotten')
-               AND COALESCE(sensitivity_level, 'INTERNAL') != 'RESTRICTED'
-               AND host_id IS NOT NULL AND host_id != ''
-               AND agent_id IS NOT NULL AND agent_id != ''`,
-          );
-        }
-      } else {
-        telemetryOk = false;
-      }
-    } catch {
-      telemetryOk = false;
-    }
-
-    const detail =
-      `native_touched_7d=${nativeTouched7d} native_bytes≈${nativeBytes} ` +
-      `sc_durable_admits_7d=${durableAdmits7d} activity_7d=${activity} ` +
-      `injectable≈${injectableApprox} unscoped=${unscoped}`;
-
-    // Quiet host with no native signal and weak telemetry → cannot determine (never PASS)
-    if (!telemetryOk && activity === 0 && !nativeTouched7d) {
-      return {
-        label,
-        status: 'warn',
-        message: `plane=${cfg.plane}: cannot determine drift — insufficient telemetry (${detail})`,
-      };
-    }
-
-    // Canonical planes: native SoT growth/touch is FAIL even if SC also has admits
-    // (that is dual-brain, not "healthy because SC has rows").
-    if ((cfg.plane === 'import_only' || cfg.plane === 'sc_canonical') && nativeTouched7d) {
-      return {
-        label,
-        status: 'fail',
-        message: `dual-plane drift under plane=${cfg.plane}: native memory artifact touched while plane forbids native SoT (${detail})`,
-        fix: 'Stop native MEMORY.md / memory-dir growth as agent brain; import via defended path or archive — docs/design/2026-08-22-memory-sota-track-a-residual.md',
-      };
-    }
-
-    // Empty-SC-under-activity (all planes)
-    const emptyScUnderActivity = (activity > 0 || nativeTouched7d) && durableAdmits7d === 0;
-    if (emptyScUnderActivity) {
-      if (cfg.plane === 'import_only' || cfg.plane === 'sc_canonical') {
-        return {
-          label,
-          status: 'fail',
-          message: `dual-plane drift under plane=${cfg.plane}: ${detail}`,
-          fix: 'Capture/import into SC or stop claiming canonicity; see residual plan',
-        };
-      }
-      let aged = false;
-      if (cfg.planeSetAt) {
-        const setMs = Date.parse(cfg.planeSetAt);
-        if (!Number.isNaN(setMs) && Date.now() - setMs > 14 * 24 * 60 * 60 * 1000) aged = true;
-      }
-      return {
-        label,
-        status: 'warn',
-        message: `dual_legacy defect: activity bypasses SC (${detail})${aged ? ' — planeSetAt older than 14d' : ''}`,
-        fix: 'Run T1–T3 then `shieldcortex config --memory-plane import_only` — dual_legacy is not steady state',
-      };
-    }
-
-    // dual_legacy + native touch + SC admits still WARN (defect mode, not PASS green-wash)
-    if (cfg.plane === 'dual_legacy' && nativeTouched7d && activity > 0) {
-      return {
-        label,
-        status: 'warn',
-        message: `dual_legacy: native still active alongside SC (${detail})`,
-        fix: 'Time-box dual_legacy; move to import_only after host contract + import',
-      };
-    }
-
+    const counts = readPlaneDriftCounts(
+      db,
+      scope,
+      injectPack?.isInjectEligible ?? null,
+      injectPack?.selectInjectCandidates ?? null,
+    );
+    const verdict = evaluatePlaneDrift({
+      plane: cfg.plane as MemoryPlane,
+      planeSetAt: cfg.planeSetAt,
+      // Eligibility only decides delivery when the v2 pack IS the automatic
+      // session-start payload: a legal contract plus a start-capable mode.
+      injectOn: startBusOn,
+      requireScope: scope.requireScope,
+      counts,
+      native,
+      nowMs,
+    });
     return {
       label,
-      status: 'pass',
-      message: `plane=${cfg.plane}: no dual-plane drift signal (${detail})`,
+      status: verdict.status,
+      message: verdict.message,
+      ...(verdict.fix ? { fix: verdict.fix } : {}),
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    return { label, status: 'warn', message: `cannot determine drift — ${msg}` };
+    return { label, status: 'warn', message: `plane=${cfg.plane}: cannot determine drift — ${msg}` };
   } finally {
     try { db?.close(); } catch { /* ignore */ }
   }
+}
+
+/** The two helpers doctor borrows from the runtime inject module. */
+interface InjectPackModule {
+  isInjectEligible(row: unknown, scope: unknown): boolean;
+  selectInjectCandidates(db: unknown, options?: { project?: string | null }): unknown[];
+  readInjectConfig(config: Record<string, unknown>): {
+    hostId: string | null;
+    agentId: string | null;
+    requireScope: boolean;
+  };
+}
+
+interface DriftScope {
+  hostId: string | null;
+  agentId: string | null;
+  requireScope: boolean;
+}
+
+/** Structural view of the readonly handle — keeps the counter unit-testable. */
+interface DriftDb {
+  prepare(sql: string): {
+    get(...params: unknown[]): unknown;
+    all(...params: unknown[]): unknown[];
+  };
+}
+
+/**
+ * SC-side counts for the drift model. Every count is honest-or-null: a zero
+ * that means "could not count" is exactly how absence becomes proof.
+ *
+ * Doctor runs outside any session, so project-dependent eligibility remains
+ * null rather than being presented as an exact positive upper bound.
+ */
+export function readPlaneDriftCounts(
+  db: DriftDb,
+  scope: DriftScope,
+  isInjectEligible: ((row: unknown, scope: unknown) => boolean) | null,
+  selectInjectCandidates: ((db: unknown, options?: { project?: string | null }) => unknown[]) | null = null,
+): PlaneDriftCounts {
+  const counts: PlaneDriftCounts = {
+    durableAdmits7d: null,
+    durableRows: null,
+    injectable: null,
+    unscopedExcluded: null,
+    activity7d: null,
+  };
+
+  // Activity telemetry: null when NEITHER source exists on this store, so
+  // "quiet box" and "no telemetry" stop looking identical.
+  let activity: number | null = null;
+  for (const sql of [
+    `SELECT COUNT(*) AS c FROM session_events WHERE created_at >= datetime('now', '-7 days')`,
+    `SELECT COUNT(*) AS c FROM hook_invocations WHERE invoked_at >= datetime('now', '-7 days')`,
+  ]) {
+    try {
+      const row = db.prepare(sql).get() as { c?: number } | undefined;
+      activity = (activity ?? 0) + Number(row?.c ?? 0);
+    } catch { /* table absent on this store */ }
+  }
+  counts.activity7d = activity;
+
+  let cols: Set<string>;
+  try {
+    cols = new Set((db.prepare('PRAGMA table_info(memories)').all() as Array<{ name: string }>).map((c) => c.name));
+  } catch {
+    cols = new Set();
+  }
+  // No memories table (or unreadable): every SC count stays unknown.
+  if (cols.size === 0) return counts;
+
+  const statusClause = cols.has('status')
+    ? `COALESCE(status, 'active') NOT IN ('archived', 'suppressed', 'deleted', 'forgotten')`
+    : '1=1';
+  const sensClause = cols.has('sensitivity_level')
+    ? `COALESCE(sensitivity_level, 'INTERNAL') != 'RESTRICTED'`
+    : '1=1';
+  const hasScopeCols = cols.has('host_id') && cols.has('agent_id');
+
+  // Scope predicate mirrors isInjectEligible's: both keys present, and equal to
+  // the configured value when one is configured. With the gate on and no scope
+  // columns, NO row can be in scope — that is the honest answer, not a reason
+  // to relax the gate.
+  const scopeParams: unknown[] = [];
+  let scopeClause = '1=1';
+  if (scope.requireScope) {
+    if (!hasScopeCols) {
+      scopeClause = '1=0';
+    } else {
+      const parts = [`host_id IS NOT NULL AND host_id != ''`, `agent_id IS NOT NULL AND agent_id != ''`];
+      if (scope.hostId != null) {
+        parts.push('host_id = ?');
+        scopeParams.push(scope.hostId);
+      }
+      if (scope.agentId != null) {
+        parts.push('agent_id = ?');
+        scopeParams.push(scope.agentId);
+      }
+      scopeClause = parts.join(' AND ');
+    }
+  }
+
+  const countOf = (sql: string, params: unknown[] = []): number | null => {
+    try {
+      const row = db.prepare(sql).get(...params) as { c?: number } | undefined;
+      return Number(row?.c ?? 0);
+    } catch {
+      return null;
+    }
+  };
+
+  counts.durableRows = countOf(
+    `SELECT COUNT(*) AS c FROM memories WHERE ${statusClause} AND ${sensClause} AND ${scopeClause}`,
+    scopeParams,
+  );
+  counts.durableAdmits7d = cols.has('created_at')
+    ? countOf(
+      `SELECT COUNT(*) AS c FROM memories
+       WHERE ${statusClause} AND ${sensClause} AND ${scopeClause}
+         AND created_at >= datetime('now', '-7 days')`,
+      scopeParams,
+    )
+    : null;
+  counts.unscopedExcluded = hasScopeCols
+    ? countOf(
+      `SELECT COUNT(*) AS c FROM memories
+       WHERE ${statusClause}
+         AND (host_id IS NULL OR host_id = '' OR agent_id IS NULL OR agent_id = '')`,
+    )
+    // Without the columns every active row is unscoped by construction.
+    : countOf(`SELECT COUNT(*) AS c FROM memories WHERE ${statusClause}`);
+
+  if (!isInjectEligible || !selectInjectCandidates) return counts;
+  let rows: Array<Record<string, unknown>>;
+  try {
+    rows = selectInjectCandidates(db) as Array<Record<string, unknown>>;
+  } catch {
+    return counts;
+  }
+  // Doctor has no session project. If project changes eligibility for any row
+  // in the real top-64 window, an exact result is unknowable; never present an
+  // upper-bound positive as PASS.
+  if (rows.some((row) => row.project != null && row.project !== ''
+    && row.transferable !== true && row.transferable !== 1)) {
+    return counts;
+  }
+  let injectable = 0;
+  for (const row of rows) {
+    if (isInjectEligible(row, {
+      hostId: scope.hostId,
+      agentId: scope.agentId,
+      requireScope: scope.requireScope,
+    })) {
+      injectable++;
+    }
+  }
+  counts.injectable = injectable;
+  return counts;
+}
+
+/**
+ * Native agent-SoT scan for #394 drift.
+ *
+ * FP law — what counts and what deliberately does not:
+ *
+ *  | Artifact                                        | Drift? | Why |
+ *  |---|---|---|
+ *  | `<oc workspace>/MEMORY.md`, `memory.md`         | non-empty | OpenClaw bootstraps non-empty content; a zero-byte placeholder is not memory |
+ *  | `<oc workspace>/memory/*`                       | yes | the workspace memory store |
+ *  | `~/.claude/memory/*`, `~/.claude/projects/<key>/memory/*` | yes | Claude's memory-tool store |
+ *  | `~/.hermes/{MEMORY.md,memories/*}`, profile stores | yes | Hermes native store |
+ *  | `~/MEMORY.md`, `~/notes/…`, a stray workspace `.md` | **no** | operator scratchpad — no host loads it as a brain |
+ *  | `CLAUDE.md` / `AGENTS.md` preambles             | **no** | project instructions, graded by the host-contract check (#393); developers edit them constantly |
+ *
+ * Every reading distinguishes absent from unreadable: a tree doctor could not
+ * probe goes on `unattestable`, and the model turns that into "cannot
+ * determine" rather than the silence reading as "native is quiet".
+ *
+ * Native bus state is only reported when PROVEN on — unknown belongs to the
+ * host-contract check, which already caps at unknown and fails there. Drift is
+ * not a second host-contract parser.
+ */
+const NATIVE_SOT_DIR_ENTRY_CAP = 200;
+const NATIVE_SOT_DIR_DEPTH_CAP = 8;
+const NATIVE_SOT_PROJECT_CAP = 200;
+
+function scanNativeAgentSot(home: string, nowMs: number): NativeSotEvidence {
+  const weekAgo = nowMs - 7 * 24 * 60 * 60 * 1000;
+  const touched: Array<{ path: string; mtimeMs: number }> = [];
+  const unattestable: string[] = [];
+  const busActive: string[] = [];
+  const seen = new Set<string>();
+  const seenDirs = new Set<string>();
+  const directoryBudget = { visited: 0, overflowed: false };
+  let bytes = 0;
+
+  const considerFile = (target: string): void => {
+    if (seen.has(target)) return;
+    seen.add(target);
+    const probe = probePath(target);
+    if (probe.kind === 'absent') return;
+    if (probe.kind !== 'present') {
+      unattestable.push(
+        `${tildify(target)} cannot be read (${probe.code}: ${probe.message}) — native growth there cannot be ruled out`,
+      );
+      return;
+    }
+    if (!probe.stat.isFile()) return;
+    bytes += probe.stat.size;
+    // Match the host load rule: a zero-byte bootstrap contains no memory and
+    // therefore cannot prove native SoT growth merely by having a fresh mtime.
+    if (probe.stat.size > 0 && probe.stat.mtimeMs >= weekAgo) {
+      touched.push({ path: tildify(target), mtimeMs: probe.stat.mtimeMs });
+    }
+  };
+
+  /** Probe already gathered by a #393 scanner (per-profile Hermes stores). */
+  const considerProbe = (probe: ArtifactProbe): void => {
+    if (probe.kind === 'absent' || seen.has(probe.path)) return;
+    seen.add(probe.path);
+    if (probe.kind === 'unreadable') {
+      unattestable.push(`${tildify(probe.path)} cannot be read (${probe.detail}) — native growth there cannot be ruled out`);
+      return;
+    }
+    bytes += probe.size;
+    if (probe.size > 0 && probe.mtimeMs >= weekAgo) touched.push({ path: tildify(probe.path), mtimeMs: probe.mtimeMs });
+  };
+
+  const considerDir = (
+    dir: string,
+    depth = 0,
+    budget: { visited: number; overflowed: boolean } = directoryBudget,
+  ): void => {
+    if (seenDirs.has(dir)) return;
+    seenDirs.add(dir);
+    if (depth > NATIVE_SOT_DIR_DEPTH_CAP) {
+      unattestable.push(`${tildify(dir)} exceeds native store recursion depth ${NATIVE_SOT_DIR_DEPTH_CAP}`);
+      return;
+    }
+    const probe = probePath(dir);
+    if (probe.kind === 'absent') return;
+    if (probe.kind !== 'present') {
+      unattestable.push(`${tildify(dir)} cannot be inspected (${probe.code}: ${probe.message})`);
+      return;
+    }
+    if (!probe.stat.isDirectory()) {
+      considerFile(dir);
+      return;
+    }
+    let names: string[];
+    try {
+      names = fs.readdirSync(dir);
+    } catch (err: unknown) {
+      unattestable.push(`${tildify(dir)} cannot be listed (${err instanceof Error ? err.message : String(err)})`);
+      return;
+    }
+    names.sort();
+    for (const name of names) {
+      if (budget.visited++ >= NATIVE_SOT_DIR_ENTRY_CAP) {
+        if (!budget.overflowed) {
+          budget.overflowed = true;
+          unattestable.push(
+            `${tildify(dir)} exceeds ${NATIVE_SOT_DIR_ENTRY_CAP} recursive entries — the native store scan is truncated`,
+          );
+        }
+        return;
+      }
+      const child = path.join(dir, name);
+      const childProbe = probePath(child);
+      if (childProbe.kind === 'present' && childProbe.stat.isDirectory()) {
+        considerDir(child, depth + 1, budget);
+      } else {
+        considerFile(child);
+      }
+    }
+  };
+
+  // ── OpenClaw: every workspace the host could resolve, same binding the
+  //    host-contract proof grades.
+  const binding = resolveOpenClawBinding();
+  if (binding.unresolvable) {
+    unattestable.push(
+      `OpenClaw: ${binding.unresolvable} — doctor will not probe a guessed tree for native memory growth`,
+    );
+  } else if (binding.stateRoot.root !== null && binding.ocHome !== null) {
+    const ws = openClawWorkspacePaths(binding.ocHome, binding.stateRoot.root, binding.config);
+    if (!ws.complete) {
+      unattestable.push(
+        'OpenClaw agent workspaces could not be fully enumerated — a workspace brain outside the scan cannot be ruled out',
+      );
+    }
+    for (const dir of ws.paths) {
+      // Both spellings: OpenClaw bootstraps MEMORY.md AND memory.md.
+      considerFile(path.join(dir, 'MEMORY.md'));
+      considerFile(path.join(dir, 'memory.md'));
+      considerDir(path.join(dir, 'memory'));
+    }
+    // Bus state: only a PROVEN-on switch is drift evidence here. A legacy-bound
+    // or unreadable config leaves it unknown, which the host-contract check
+    // owns — drift must not grow a second verdict for it.
+    if (!binding.legacyConfig) {
+      const ms = resolveOpenClawMemorySearchState(binding.config);
+      if (ms.state === 'on') busActive.push(`OpenClaw Memory Search is on (${ms.proof.join('; ')})`);
+    }
+  }
+
+  // ── Claude Code: the memory-tool stores ONLY. CLAUDE.md preambles are
+  //    host-contract evidence, not memory growth (the FP law above).
+  considerDir(path.join(home, '.claude', 'memory'));
+  const projectsDir = path.join(home, '.claude', 'projects');
+  const projectsProbe = probePath(projectsDir);
+  if (projectsProbe.kind === 'present' && projectsProbe.stat.isDirectory()) {
+    let entries: string[] = [];
+    try {
+      entries = fs.readdirSync(projectsDir);
+    } catch (err: unknown) {
+      unattestable.push(`${tildify(projectsDir)} cannot be listed (${err instanceof Error ? err.message : String(err)})`);
+    }
+    if (entries.length > NATIVE_SOT_PROJECT_CAP) {
+      unattestable.push(`${tildify(projectsDir)} holds more than ${NATIVE_SOT_PROJECT_CAP} project keys — the scan is truncated`);
+    }
+    for (const entry of entries.slice(0, NATIVE_SOT_PROJECT_CAP)) {
+      considerDir(path.join(projectsDir, entry, 'memory'));
+    }
+  } else if (projectsProbe.kind === 'denied' || projectsProbe.kind === 'error') {
+    unattestable.push(`${tildify(projectsDir)} cannot be inspected (${projectsProbe.code}: ${projectsProbe.message})`);
+  }
+
+  // ── Hermes: root store, root MEMORY.md, and every per-profile store.
+  considerDir(path.join(home, '.hermes', 'memories'));
+  considerFile(path.join(home, '.hermes', 'MEMORY.md'));
+  const profileScan = scanHermesProfiles(home);
+  for (const probe of profileScan.artifacts) considerProbe(probe);
+  for (const profile of profileScan.profiles) {
+    considerDir(path.join(home, '.hermes', 'profiles', profile.name, 'memories'));
+  }
+  if (!profileScan.scanComplete) {
+    unattestable.push(
+      'Hermes profiles could not be fully enumerated — a per-profile native store outside the scan cannot be ruled out',
+    );
+  }
+  const reportHermesSwitches = (label: string, config: ProbeRead<ReturnType<typeof parseHermesMemoryBlock>>): void => {
+    if (config.kind === 'unreadable') {
+      unattestable.push(`${label} config.yaml cannot be read (${config.detail}) — native bus state cannot be determined`);
+      return;
+    }
+    if (config.kind === 'absent') {
+      unattestable.push(`${label} has no config.yaml — native memory defaults cannot be proven off`);
+      return;
+    }
+    const switches = config.value;
+    if (!switches.blockFound) {
+      unattestable.push(`${label} config.yaml has no memory block — native memory defaults cannot be proven off`);
+      return;
+    }
+    const on: string[] = [];
+    if (switches.memoryEnabled !== false) {
+      on.push(`memory_enabled=${switches.memoryEnabled === null ? 'unset (default ON)' : 'true'}`);
+    }
+    if (switches.userProfileEnabled !== false) {
+      on.push(`user_profile_enabled=${switches.userProfileEnabled === null ? 'unset (default ON)' : 'true'}`);
+    }
+    if (on.length > 0) busActive.push(`${label}: ${on.join(', ')}`);
+  };
+  const hermesCfg = readTextProbe(path.join(home, '.hermes', 'config.yaml'));
+  const hermesNativePresent = probePath(path.join(home, '.hermes', 'memories')).kind !== 'absent'
+    || probePath(path.join(home, '.hermes', 'MEMORY.md')).kind !== 'absent';
+  if (hermesCfg.kind !== 'absent' || hermesNativePresent || profileScan.profiles.length > 0 || !profileScan.scanComplete) {
+    reportHermesSwitches(
+      'Hermes root',
+      hermesCfg.kind === 'present'
+        ? { kind: 'present', value: parseHermesMemoryBlock(hermesCfg.value) }
+        : hermesCfg,
+    );
+  }
+  for (const profile of profileScan.profiles) {
+    reportHermesSwitches(`Hermes profile ${profile.name}`, profile.config);
+  }
+
+  touched.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return {
+    touched7d: touched.length > 0,
+    touchedPaths: touched.map((t) => t.path),
+    bytes,
+    unattestable,
+    busActive,
+  };
 }
 
 /**
@@ -3544,21 +3864,26 @@ function scanHermesProfiles(home: string): {
       const dir = path.join(profilesDir, entry);
       const dirProbe = probePath(dir);
       if (dirProbe.kind === 'denied' || dirProbe.kind === 'error') {
+        out.scanComplete = false;
         out.profiles.push({
           name: entry,
           config: { kind: 'unreadable', detail: `${dirProbe.code}: ${dirProbe.message}` },
         });
+        out.artifacts.push({ kind: 'unreadable', path: dir, detail: `${dirProbe.code}: ${dirProbe.message}` });
         continue;
       }
       if (dirProbe.kind !== 'present' || !dirProbe.stat.isDirectory()) continue; // stray file, not a profile
       const text = readTextProbe(path.join(dir, 'config.yaml'));
+      if (text.kind === 'unreadable') out.scanComplete = false;
       out.profiles.push({
         name: entry,
         config: text.kind === 'present'
           ? { kind: 'present', value: parseHermesMemoryBlock(text.value) }
           : text,
       });
-      out.artifacts.push(artifactProbe(path.join(dir, 'memories', 'MEMORY.md')));
+      const artifact = artifactProbe(path.join(dir, 'memories', 'MEMORY.md'));
+      if (artifact.kind === 'unreadable') out.scanComplete = false;
+      out.artifacts.push(artifact);
     }
   } catch (err: unknown) {
     out.scanComplete = false;
@@ -4196,6 +4521,72 @@ export function probeOpenClawScHookArtifacts(
   }
 }
 
+/**
+ * Where OpenClaw's config actually lives on this box, and what reading it
+ * yields — the single resolution of that precedence chain (#393 SOL r3 B6 /
+ * r6 B1), shared by the host-contract proof and the #394 plane-drift scan so
+ * the two checks can never disagree about which tree they are grading.
+ *
+ * `unresolvable` set means every OpenClaw reading below is a guess: the caller
+ * must cap its evidence at unknown rather than probe a tree the host may not
+ * be using.
+ */
+interface OpenClawBinding {
+  /** OpenClaw-effective home, or null when it cannot be resolved. */
+  ocHome: string | null;
+  stateRoot: { root: string | null; detail?: string };
+  /** The config file doctor grades, or null when there is none to grade. */
+  configPath: string | null;
+  config: ProbeRead<Record<string, unknown>>;
+  unresolvable?: string;
+  /** Set when OpenClaw binds a config candidate doctor deliberately does not grade. */
+  legacyConfig?: string;
+}
+
+function resolveOpenClawBinding(): OpenClawBinding {
+  const ocHomeRes = openClawEffectiveHome();
+  const ocHome = 'home' in ocHomeRes ? ocHomeRes.home : null;
+  const stateRoot: { root: string | null; detail?: string } = 'unresolvable' in ocHomeRes
+    ? { root: null, detail: ocHomeRes.unresolvable }
+    : openClawStateRoot(ocHomeRes.home);
+  let unresolvable = stateRoot.detail;
+  let configPath: string | null = null;
+  let legacyConfig: string | undefined;
+  if (!unresolvable) {
+    const cfgPrimary = process.env.OPENCLAW_CONFIG_PATH?.trim();
+    const cfgOverride = cfgPrimary || process.env.CLAWDBOT_CONFIG_PATH?.trim();
+    if (cfgOverride) {
+      const resolved = resolveOpenClawUserPath(cfgOverride, ocHome);
+      if ('path' in resolved) configPath = resolved.path;
+      else {
+        unresolvable =
+          `${cfgPrimary ? 'OPENCLAW_CONFIG_PATH' : 'CLAWDBOT_CONFIG_PATH'}="${cfgOverride}" is unresolvable: ${resolved.unresolvable}`;
+      }
+    } else {
+      configPath = path.join(stateRoot.root as string, 'openclaw.json');
+      // #393 SOL r6 B1: the host binds the FIRST existing candidate across
+      // current and legacy filenames/state dirs — a clawdbot-era config is a
+      // live OpenClaw whose graded openclaw.json is absent.
+      const hasStateOverride = Boolean(
+        process.env.OPENCLAW_STATE_DIR?.trim() || process.env.CLAWDBOT_STATE_DIR?.trim(),
+      );
+      const candidate = openClawBoundConfigCandidate(ocHome as string, stateRoot.root as string, hasStateOverride);
+      if (candidate.kind === 'ungraded') legacyConfig = candidate.path;
+    }
+  }
+  const config: ProbeRead<Record<string, unknown>> = configPath === null
+    ? { kind: 'absent' }
+    : readJsonProbe(configPath);
+  return {
+    ocHome,
+    stateRoot,
+    configPath,
+    config,
+    ...(unresolvable ? { unresolvable } : {}),
+    ...(legacyConfig ? { legacyConfig } : {}),
+  };
+}
+
 export async function checkMemoryHostContract(): Promise<CheckResult> {
   const label = 'Memory plane (host contract)';
   let raw: Record<string, unknown> = {};
@@ -4221,39 +4612,10 @@ export async function checkMemoryHostContract(): Promise<CheckResult> {
   // overrides) makes EVERY OpenClaw reading a guess — the probe is marked
   // unresolvable and the evidence model caps OpenClaw at unknown instead of
   // probing a wrong tree it could vanish from.
-  const ocHomeRes = openClawEffectiveHome();
-  const ocHome = 'home' in ocHomeRes ? ocHomeRes.home : null;
-  const stateRoot: { root: string | null; detail?: string } = 'unresolvable' in ocHomeRes
-    ? { root: null, detail: ocHomeRes.unresolvable }
-    : openClawStateRoot(ocHomeRes.home);
-  let ocUnresolvable = stateRoot.detail;
-  let ocPath: string | null = null;
-  let ocLegacyConfig: string | undefined;
-  if (!ocUnresolvable) {
-    const cfgPrimary = process.env.OPENCLAW_CONFIG_PATH?.trim();
-    const cfgOverride = cfgPrimary || process.env.CLAWDBOT_CONFIG_PATH?.trim();
-    if (cfgOverride) {
-      const resolved = resolveOpenClawUserPath(cfgOverride, ocHome);
-      if ('path' in resolved) ocPath = resolved.path;
-      else {
-        ocUnresolvable =
-          `${cfgPrimary ? 'OPENCLAW_CONFIG_PATH' : 'CLAWDBOT_CONFIG_PATH'}="${cfgOverride}" is unresolvable: ${resolved.unresolvable}`;
-      }
-    } else {
-      ocPath = path.join(stateRoot.root as string, 'openclaw.json');
-      // #393 SOL r6 B1: the host binds the FIRST existing candidate across
-      // current and legacy filenames/state dirs — a clawdbot-era config is a
-      // live OpenClaw whose graded openclaw.json is absent.
-      const hasStateOverride = Boolean(
-        process.env.OPENCLAW_STATE_DIR?.trim() || process.env.CLAWDBOT_STATE_DIR?.trim(),
-      );
-      const candidate = openClawBoundConfigCandidate(ocHome as string, stateRoot.root as string, hasStateOverride);
-      if (candidate.kind === 'ungraded') ocLegacyConfig = candidate.path;
-    }
-  }
-  const ocConfig: ProbeRead<Record<string, unknown>> = ocPath === null
-    ? { kind: 'absent' }
-    : readJsonProbe(ocPath);
+  const binding = resolveOpenClawBinding();
+  const { ocHome, stateRoot, config: ocConfig } = binding;
+  const ocUnresolvable = binding.unresolvable;
+  const ocLegacyConfig = binding.legacyConfig;
   const ocWorkspaces = stateRoot.root === null || ocHome === null
     ? { paths: [], complete: false }
     : openClawWorkspacePaths(ocHome, stateRoot.root, ocConfig);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -80,7 +80,12 @@ import {
 // transport (cli-invoker.js) and the explainer (doctor-explainer.js) are
 // loaded with a runtime `import()` inside runDoctorAiSection() below, so a
 // plain `shieldcortex doctor` never touches either module.
-import { getConfigDir, readRawConfig, isConfigTampered, migrateInterceptorActionGuardAlias } from '../cloud/config.js';
+import {
+  getConfigDir,
+  hasTrustedMemorySidecarPosture,
+  readRawConfig,
+  migrateInterceptorActionGuardAlias,
+} from '../cloud/config.js';
 import { validateOpenClawConfig } from '../integrations/openclaw-config-validate.js';
 import type { OpenClawConfigVerdict, ValidateDeps } from '../integrations/openclaw-config-validate.js';
 import type { ModelInvoker } from '../defence/iron-dome/approval-judge.js';
@@ -3058,8 +3063,9 @@ export function readMemoryPlaneFromConfig(raw: Record<string, unknown>): {
 export async function checkMemoryPlaneDrift(): Promise<CheckResult> {
   const label = 'Memory plane (dual-plane drift)';
   let raw: Record<string, unknown> = {};
+  const configPath = path.join(getConfigDir(), 'config.json');
   try {
-    raw = JSON.parse(fs.readFileSync(path.join(getShieldCortexDir(), 'config.json'), 'utf-8')) as Record<string, unknown>;
+    raw = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
   } catch {
     return { label, status: 'info', message: 'no config yet' };
   }
@@ -3105,18 +3111,9 @@ export async function checkMemoryPlaneDrift(): Promise<CheckResult> {
   // The sidecar exemption is intentionally narrower than string equality. The
   // signed setter writes an embedded signature and explicit mode=off; a bare,
   // copied, malformed, or legacy posture blob does not get to suppress drift.
-  let trustedSidecar = false;
-  if (cfg.posture === SIDECAR_POSTURE && cfg.postureIllegal === undefined) {
-    const hasEmbeddedSignature = typeof raw._sig === 'string';
-    const trusted = readRawConfig();
-    trustedSidecar = hasEmbeddedSignature
-      && path.resolve(getConfigDir()) === path.resolve(getShieldCortexDir())
-      && !isConfigTampered()
-      && readMemoryPlaneFromConfig(trusted).posture === SIDECAR_POSTURE
-      && cfg.injectConfigured
-      && cfg.injectModeExplicit
-      && cfg.injectMode === 'off';
-  }
+  const trustedSidecar = cfg.posture === SIDECAR_POSTURE
+    && cfg.postureIllegal === undefined
+    && hasTrustedMemorySidecarPosture(raw, configPath);
   if (trustedSidecar) {
     if (cfg.plane === 'import_only' || cfg.plane === 'sc_canonical') {
       return {
@@ -4590,8 +4587,9 @@ function resolveOpenClawBinding(): OpenClawBinding {
 export async function checkMemoryHostContract(): Promise<CheckResult> {
   const label = 'Memory plane (host contract)';
   let raw: Record<string, unknown> = {};
+  const configPath = path.join(getConfigDir(), 'config.json');
   try {
-    raw = JSON.parse(fs.readFileSync(path.join(getShieldCortexDir(), 'config.json'), 'utf-8')) as Record<string, unknown>;
+    raw = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
   } catch {
     return { label, status: 'info', message: 'no config yet' };
   }
@@ -4726,6 +4724,7 @@ export async function checkMemoryHostContract(): Promise<CheckResult> {
       ? cfg.nativeContract
       : null,
     postureRaw: cfg.posture,
+    postureTrusted: hasTrustedMemorySidecarPosture(raw, configPath),
     postureIllegal: cfg.postureIllegal,
     declaredRuntimesIllegal: cfg.declaredRuntimesIllegal,
     runtimes,

--- a/src/cloud/config.ts
+++ b/src/cloud/config.ts
@@ -451,10 +451,11 @@ export function readRawConfig(): Record<string, unknown> {
  * Whether this exact raw config is the signed honest-sidecar posture.
  *
  * This is the single trust decision used by both memory-plane doctor rows. It
- * deliberately does not route through readRawConfig(): that reader adopts a
- * previously unsigned legacy config on first read, which is correct for
- * backwards compatibility but is not proof that the signed posture setter
- * created this declaration.
+ * deliberately requires a valid EMBEDDED `_sig`: readRawConfig() may adopt a
+ * previously unsigned legacy config by minting `.config-sig`, which is correct
+ * compatibility trust for ordinary config reads but is not proof that the
+ * signed posture setter created this operator-intent declaration. External
+ * legacy signatures therefore never certify the sidecar exemption.
  */
 export function hasTrustedMemorySidecarPosture(
   raw: Record<string, unknown>,
@@ -469,10 +470,11 @@ export function hasTrustedMemorySidecarPosture(
     // The caller must be grading the same bytes whose signature is checked.
     if (JSON.stringify(parsed) !== JSON.stringify(raw)) return false;
 
-    // Unsigned legacy adoption is not strong enough for the sidecar exemption.
-    // Accept either product-supported signature format when it already exists.
-    const signaturePresent = typeof parsed._sig === 'string' || existsSync(getSigFile());
-    if (!signaturePresent || checkConfigIntegrity(parsed, content) === 'tampered') return false;
+    // Only a currently valid embedded signature can carry operator intent.
+    // `self-heal` means the embedded signature is invalid even if a legacy
+    // external signature authenticates the general config bytes, so it is not
+    // sufficient here either.
+    if (typeof parsed._sig !== 'string' || checkConfigIntegrity(parsed, content) !== 'valid') return false;
 
     const memory = parsed.memory && typeof parsed.memory === 'object' && !Array.isArray(parsed.memory)
       ? parsed.memory as Record<string, unknown>

--- a/src/cloud/config.ts
+++ b/src/cloud/config.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, chmodSync, statSync, renameSync, rmSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { homedir, hostname } from 'os';
 import { randomUUID, randomBytes, createHmac, timingSafeEqual } from 'crypto';
 import type { RankerConfig, RankerEngine, RankerWeights } from '../memory/types.js';
@@ -445,6 +445,50 @@ function readRawConfigState(): RawConfigState {
 
 export function readRawConfig(): Record<string, unknown> {
   return readRawConfigState().data;
+}
+
+/**
+ * Whether this exact raw config is the signed honest-sidecar posture.
+ *
+ * This is the single trust decision used by both memory-plane doctor rows. It
+ * deliberately does not route through readRawConfig(): that reader adopts a
+ * previously unsigned legacy config on first read, which is correct for
+ * backwards compatibility but is not proof that the signed posture setter
+ * created this declaration.
+ */
+export function hasTrustedMemorySidecarPosture(
+  raw: Record<string, unknown>,
+  configPath: string = getConfigFile(),
+): boolean {
+  try {
+    const effectivePath = getConfigFile();
+    if (resolve(configPath) !== resolve(effectivePath)) return false;
+
+    const content = readFileSync(effectivePath, 'utf-8');
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    // The caller must be grading the same bytes whose signature is checked.
+    if (JSON.stringify(parsed) !== JSON.stringify(raw)) return false;
+
+    // Unsigned legacy adoption is not strong enough for the sidecar exemption.
+    // Accept either product-supported signature format when it already exists.
+    const signaturePresent = typeof parsed._sig === 'string' || existsSync(getSigFile());
+    if (!signaturePresent || checkConfigIntegrity(parsed, content) === 'tampered') return false;
+
+    const memory = parsed.memory && typeof parsed.memory === 'object' && !Array.isArray(parsed.memory)
+      ? parsed.memory as Record<string, unknown>
+      : null;
+    if (!memory) return false;
+    const hostContract = memory.hostContract && typeof memory.hostContract === 'object'
+      && !Array.isArray(memory.hostContract)
+      ? memory.hostContract as Record<string, unknown>
+      : null;
+    const inject = memory.inject && typeof memory.inject === 'object' && !Array.isArray(memory.inject)
+      ? memory.inject as Record<string, unknown>
+      : null;
+    return hostContract?.posture === 'mcp_sidecar_no_inject' && inject?.mode === 'off';
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/memory/__tests__/host-contract-393.test.ts
+++ b/src/memory/__tests__/host-contract-393.test.ts
@@ -1199,7 +1199,7 @@ describe('contract verdict', () => {
   });
 
   it('rejects sidecar posture and a bus contract together (never both)', () => {
-    const v = verdictFor([provenOc], { postureRaw: SIDECAR_POSTURE });
+    const v = verdictFor([provenOc], { postureRaw: SIDECAR_POSTURE, postureTrusted: true });
     expect(v.status).toBe('fail');
     expect(v.message).toMatch(/mutually exclusive/);
   });
@@ -1241,6 +1241,7 @@ describe('contract verdict', () => {
       injectMode: 'off',
       nativeContract: null,
       postureRaw: SIDECAR_POSTURE,
+      postureTrusted: true,
     });
     expect(v.status).toBe('pass');
     expect(v.message).toMatch(/honest sidecar/);
@@ -1254,6 +1255,7 @@ describe('contract verdict', () => {
       injectMode: 'off',
       nativeContract: null,
       postureRaw: SIDECAR_POSTURE,
+      postureTrusted: true,
     });
     expect(v.status).toBe('fail');
     expect(v.message).toMatch(/contradicts posture/);
@@ -1269,6 +1271,7 @@ describe('contract verdict', () => {
       injectModeExplicit: false,
       nativeContract: null,
       postureRaw: SIDECAR_POSTURE,
+      postureTrusted: true,
     });
     expect(blob.status).toBe('fail');
     expect(blob.message).toMatch(/not explicitly off/);
@@ -1281,9 +1284,22 @@ describe('contract verdict', () => {
       injectModeExplicit: true,
       nativeContract: null,
       postureRaw: SIDECAR_POSTURE,
+      postureTrusted: true,
     });
     expect(legit.status).toBe('pass');
     expect(legit.message).toMatch(/explicitly off/);
+  });
+
+  it('fails closed when a declared sidecar posture omits trust', () => {
+    const v = verdictFor([liveHermes], {
+      injectConfigured: true,
+      injectMode: 'off',
+      nativeContract: null,
+      postureRaw: SIDECAR_POSTURE,
+    });
+    expect(v.status).toBe('fail');
+    expect(v.message).toMatch(/untrusted/);
+    expect(v.fix).toMatch(/signed write/);
   });
 
   it('stays info when inject is simply off with no posture declared', () => {

--- a/src/memory/__tests__/host-contract-393.test.ts
+++ b/src/memory/__tests__/host-contract-393.test.ts
@@ -1186,6 +1186,12 @@ describe('contract verdict', () => {
     expect(verdictFor([offScUnknown], { injectMode: 'turn' }).status).toBe('warn');
   });
 
+  it('rejects turn-only sc_canonical because turn is not an automatic start bus', () => {
+    const v = verdictFor([provenOc], { plane: 'sc_canonical', injectMode: 'turn' });
+    expect(v.status).toBe('fail');
+    expect(v.message).toMatch(/without an automatic start bus/);
+  });
+
   it('fails inject-on without a legal contract', () => {
     const v = verdictFor([provenOc], { nativeContract: null });
     expect(v.status).toBe('fail');
@@ -1239,6 +1245,18 @@ describe('contract verdict', () => {
     expect(v.status).toBe('pass');
     expect(v.message).toMatch(/honest sidecar/);
     expect(v.message).toMatch(/no canonicity claimed/);
+  });
+
+  it('rejects honest-sidecar posture with import ownership', () => {
+    const v = verdictFor([liveHermes], {
+      plane: 'import_only',
+      injectConfigured: true,
+      injectMode: 'off',
+      nativeContract: null,
+      postureRaw: SIDECAR_POSTURE,
+    });
+    expect(v.status).toBe('fail');
+    expect(v.message).toMatch(/contradicts posture/);
   });
 
   it('fails sidecar posture unless inject mode is EXPLICITLY off — a posture-only blob is not a sidecar (SOL r2 B4)', () => {

--- a/src/memory/__tests__/inject-pack-v2.test.ts
+++ b/src/memory/__tests__/inject-pack-v2.test.ts
@@ -17,6 +17,7 @@ import {
   normalizeNativeContract,
   packHeaderFor,
   readInjectConfig,
+  stableRank,
   toPackItem,
 } from '../../../scripts/lib/inject-pack.mjs';
 
@@ -79,6 +80,16 @@ describe('inject-pack v2', () => {
     expect(isInjectEligible(row({ quarantined: true }), scope)).toBe(false);
     expect(isInjectEligible(row({ trust_score: 0.1, source_attested: false }), scope)).toBe(false);
     expect(isInjectEligible(row(), scope)).toBe(true);
+  });
+
+  it('uses strict SQLite boolean semantics (only true/1 are on)', () => {
+    expect(isInjectEligible(row({ quarantined: 1 }), scope)).toBe(false);
+    expect(isInjectEligible(row({ in_quarantine: 1 }), scope)).toBe(false);
+    expect(isInjectEligible(row({ quarantined: '1' }), scope)).toBe(true);
+    expect(isInjectEligible(row({ project: 'other', transferable: 1 }), scope)).toBe(true);
+    expect(isInjectEligible(row({ project: 'other', transferable: '1' }), scope)).toBe(false);
+    expect(stableRank([row({ id: 2, pinned: '1' }), row({ id: 1, pinned: 1 })]).map((r: { id: number }) => r.id))
+      .toEqual([1, 2]);
   });
 
   it('attestation alone does not bypass trust floor (Opus B1 / #348)', () => {

--- a/src/memory/__tests__/plane-drift-394.test.ts
+++ b/src/memory/__tests__/plane-drift-394.test.ts
@@ -1,0 +1,183 @@
+/**
+ * #394 T2 — plane-law regressions the audit of the shipped surfaces found
+ * missing, plus the pure drift model's precedence rules.
+ *
+ * The signed CLI, the closed enum and `planeSetAt` all shipped in #397 and are
+ * covered in config-memory-inject-contract-cli.test.ts. What was NOT covered:
+ *
+ *  - TWO readers exist for one signed enum (`readMemoryPlane` in cloud/config
+ *    and `readMemoryPlaneFromConfig` in cli/doctor). If they ever disagree, the
+ *    CLI can write a value the doctor calls illegal, or worse, the doctor can
+ *    grade a plane the operator never set. Nothing pinned them together.
+ *  - the drift model's signal precedence: positive native evidence must outrank
+ *    telemetry gaps, and a gap must never resolve to PASS.
+ *  - the dual_legacy 14d time-box escalation note.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { readMemoryPlane } from '../../cloud/config.js';
+import { readMemoryPlaneFromConfig } from '../../cli/doctor.js';
+import {
+  evaluatePlaneDrift,
+  DUAL_LEGACY_GRACE_MS,
+  type NativeSotEvidence,
+  type PlaneDriftCounts,
+  type PlaneDriftInput,
+} from '../plane-drift.js';
+
+describe('plane reader parity (#394 audit)', () => {
+  const cases: Array<{ name: string; raw: Record<string, unknown>; illegal: boolean; plane?: string }> = [
+    { name: 'absent → dual_legacy default', raw: {}, illegal: false, plane: 'dual_legacy' },
+    { name: 'empty string → dual_legacy default', raw: { memory: { plane: '' } }, illegal: false, plane: 'dual_legacy' },
+    { name: 'dual_legacy', raw: { memory: { plane: 'dual_legacy' } }, illegal: false, plane: 'dual_legacy' },
+    { name: 'import_only', raw: { memory: { plane: 'import_only' } }, illegal: false, plane: 'import_only' },
+    { name: 'sc_canonical', raw: { memory: { plane: 'sc_canonical' } }, illegal: false, plane: 'sc_canonical' },
+    { name: 'legacy memoryPlane alias', raw: { memoryPlane: 'import_only' }, illegal: false, plane: 'import_only' },
+    // The retired / forbidden values must be illegal in BOTH readers.
+    { name: 'coexist_dedup is out of P0', raw: { memory: { plane: 'coexist_dedup' } }, illegal: true },
+    { name: 'junk string', raw: { memory: { plane: 'multi_master' } }, illegal: true },
+    { name: 'non-string junk', raw: { memory: { plane: ['import_only'] } }, illegal: true },
+    { name: 'numeric junk', raw: { memory: { plane: 3 } }, illegal: true },
+  ];
+
+  for (const c of cases) {
+    it(`agrees on ${c.name}`, () => {
+      const fromConfig = readMemoryPlane(c.raw);
+      const fromDoctor = readMemoryPlaneFromConfig(c.raw);
+      expect(fromDoctor.illegal).toBe(c.illegal);
+      expect(fromConfig.illegal).toBe(c.illegal);
+      if (!c.illegal) {
+        expect(fromDoctor.plane).toBe(c.plane);
+        expect(fromConfig.plane).toBe(c.plane);
+      }
+    });
+  }
+
+  it('carries planeSetAt through both readers so the time-box has one source', () => {
+    const raw = { memory: { plane: 'dual_legacy', planeSetAt: '2026-01-01T00:00:00.000Z' } };
+    expect(readMemoryPlane(raw).planeSetAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(readMemoryPlaneFromConfig(raw).planeSetAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+});
+
+describe('evaluatePlaneDrift precedence', () => {
+  const NOW = Date.parse('2026-08-27T12:00:00.000Z');
+
+  const cleanNative: NativeSotEvidence = {
+    touched7d: false, touchedPaths: [], bytes: 0, unattestable: [], busActive: [],
+  };
+  const healthyCounts: PlaneDriftCounts = {
+    durableAdmits7d: 4, durableRows: 12, injectable: 6, unscopedExcluded: 0, activity7d: 40,
+  };
+
+  function input(over: Partial<PlaneDriftInput> = {}): PlaneDriftInput {
+    return {
+      plane: 'import_only',
+      planeSetAt: null,
+      injectOn: true,
+      requireScope: true,
+      counts: healthyCounts,
+      native: cleanNative,
+      nowMs: NOW,
+      ...over,
+    };
+  }
+
+  it('passes only when every reading is known and no signal fires', () => {
+    const v = evaluatePlaneDrift(input());
+    expect(v.status).toBe('pass');
+    expect(v.message).toMatch(/no dual-plane drift signal/);
+  });
+
+  it('lets positive native evidence outrank an unknown SC side — a defect is decided, not deferred', () => {
+    const v = evaluatePlaneDrift(input({
+      counts: { ...healthyCounts, durableAdmits7d: null, injectable: null, activity7d: null },
+      native: { ...cleanNative, touched7d: true, touchedPaths: ['~/.openclaw/workspace/MEMORY.md'] },
+    }));
+    expect(v.status).toBe('fail');
+    expect(v.message).toMatch(/native agent SoT written inside the window/);
+    expect(v.message).not.toMatch(/cannot determine/);
+  });
+
+  it('never resolves a telemetry gap to PASS, on any plane', () => {
+    for (const plane of ['dual_legacy', 'import_only', 'sc_canonical'] as const) {
+      for (const gap of [
+        { durableAdmits7d: null },
+        { durableRows: null },
+        { injectable: null },
+        { unscopedExcluded: null },
+        { activity7d: null },
+      ]) {
+        const v = evaluatePlaneDrift(input({ plane, counts: { ...healthyCounts, ...gap } }));
+        expect(v.status).toBe('warn');
+        expect(v.message).toMatch(/cannot determine drift/);
+      }
+      const v = evaluatePlaneDrift(input({
+        plane,
+        native: { ...cleanNative, unattestable: ['OpenClaw state root is unresolvable'] },
+      }));
+      expect(v.status).toBe('warn');
+      expect(v.message).toMatch(/cannot determine drift/);
+    }
+  });
+
+  it('suppresses the zero-injectable signal when SC is not on the automatic bus (honest sidecar)', () => {
+    // An honest `mcp_sidecar_no_inject` host has inject off by design (#393).
+    // Nothing is delivered from SC on purpose, so an empty injectable set is
+    // not a delivery defect — calling it one would punish the honest posture.
+    const v = evaluatePlaneDrift(input({
+      plane: 'dual_legacy',
+      injectOn: false,
+      counts: { ...healthyCounts, injectable: 0 },
+    }));
+    expect(v.status).toBe('pass');
+  });
+
+  it('still fails a bound SC bus that delivers none of its own rows', () => {
+    const v = evaluatePlaneDrift(input({ counts: { ...healthyCounts, injectable: 0 } }));
+    expect(v.status).toBe('fail');
+    expect(v.message).toMatch(/real inject eligibility admits none/);
+  });
+
+  it('never green-washes a quiet all-unscoped store when scope is required', () => {
+    const quiet = {
+      ...healthyCounts,
+      durableAdmits7d: 0,
+      durableRows: 0,
+      injectable: 0,
+      unscopedExcluded: 12,
+      activity7d: 0,
+    };
+    expect(evaluatePlaneDrift(input({ plane: 'dual_legacy', counts: quiet })).status).toBe('warn');
+    for (const plane of ['import_only', 'sc_canonical'] as const) {
+      const v = evaluatePlaneDrift(input({ plane, counts: quiet }));
+      expect(v.status).toBe('fail');
+      expect(v.message).toMatch(/scope gate excluded 12 unscoped row/);
+    }
+  });
+
+  it('names the 14d time-box once dual_legacy has aged past the grace window', () => {
+    const aged = new Date(NOW - DUAL_LEGACY_GRACE_MS - 1000).toISOString();
+    const fresh = new Date(NOW - 1000).toISOString();
+    const drifting = {
+      plane: 'dual_legacy' as const,
+      counts: { ...healthyCounts, durableAdmits7d: 0 },
+    };
+    expect(evaluatePlaneDrift(input({ ...drifting, planeSetAt: aged })).message)
+      .toMatch(/planeSetAt older than 14d/);
+    expect(evaluatePlaneDrift(input({ ...drifting, planeSetAt: fresh })).message)
+      .not.toMatch(/planeSetAt older than 14d/);
+    // A junk stamp must not throw or invent an age.
+    expect(evaluatePlaneDrift(input({ ...drifting, planeSetAt: 'not-a-date' })).message)
+      .not.toMatch(/planeSetAt older than/);
+  });
+
+  it('renders unknown counts as unknown, never as a passing zero', () => {
+    const v = evaluatePlaneDrift(input({
+      counts: { durableAdmits7d: null, durableRows: null, injectable: null, unscopedExcluded: null, activity7d: null },
+    }));
+    expect(v.message).toMatch(/sc_durable_admits_7d=unknown/);
+    expect(v.message).toMatch(/injectable=unknown/);
+    expect(v.message).toMatch(/unscoped_excluded=unknown/);
+    expect(v.message).toMatch(/activity_7d=unknown/);
+  });
+});

--- a/src/memory/host-contract.ts
+++ b/src/memory/host-contract.ts
@@ -1033,6 +1033,8 @@ export interface HostContractInput {
   nativeContract: 'sc_only' | 'disable_native_inject' | null;
   /** Raw `memory.hostContract.posture`, so junk values fail instead of vanishing. */
   postureRaw: string | null;
+  /** True only when the exact effective config carries a valid signed sidecar posture. */
+  postureTrusted?: boolean;
   /**
    * Printable description of a PRESENT non-string `memory.hostContract.posture`
    * (#393 SOL r3 nit). Kept separate from postureRaw on purpose: coercing junk
@@ -1174,6 +1176,13 @@ export function evaluateHostContract(input: HostContractInput): HostContractVerd
             'the emitter defaults to mode=start and still emits legacy sidecar recall on the session-start bus, ' +
             'so the sidecar promise is not proven',
           fix: `Run \`shieldcortex config --memory-host-posture ${SIDECAR_POSTURE}\` — the signed setter forces memory.inject.mode=off; do not hand-edit config.json`,
+        };
+      }
+      if (input.postureTrusted !== true) {
+        return {
+          status: 'fail',
+          message: `posture=${SIDECAR_POSTURE} is untrusted — the declaration is unsigned, forged, tampered, or not from the effective config path`,
+          fix: `Run \`shieldcortex config --memory-host-posture ${SIDECAR_POSTURE}\` — signed write; do not hand-edit config.json`,
         };
       }
       return {

--- a/src/memory/host-contract.ts
+++ b/src/memory/host-contract.ts
@@ -323,6 +323,57 @@ function openClawHookConfigEnabled(
   return obj(entry).enabled === false ? 'entry_off' : 'enabled';
 }
 
+/**
+ * OpenClaw's Memory Search state as decided from its config alone — the ONE
+ * reading of that switch precedence in the codebase (#394: the plane-drift
+ * doctor must not grow a second, disagreeing parser). `agents.defaults`
+ * resolves default-ON, any per-agent `memorySearch: true` re-enables past a
+ * defaults-off entry, and anything doctor cannot attest from the raw file (no
+ * config, unreadable, `$include` deep-merge) is `unknown` — never off_proven.
+ */
+export function resolveOpenClawMemorySearchState(
+  config: ProbeRead<Record<string, unknown>>,
+): { state: NativeBusState; proof: string[] } {
+  if (config.kind !== 'present') return { state: 'unknown', proof: [] };
+  if (openClawConfigUsesInclude(config.value)) return { state: 'unknown', proof: [] };
+  const oc = config.value;
+  const agents = oc.agents && typeof oc.agents === 'object' && !Array.isArray(oc.agents)
+    ? (oc.agents as Record<string, unknown>)
+    : {};
+  const defaults = agents.defaults && typeof agents.defaults === 'object' && !Array.isArray(agents.defaults)
+    ? (agents.defaults as Record<string, unknown>)
+    : {};
+  const defaultOn = resolveMemorySearchFlag(defaults.memorySearch);
+  const reEnabled: string[] = [];
+  const list = Array.isArray(agents.list) ? (agents.list as unknown[]) : [];
+  list.forEach((entry, i) => {
+    if (!entry || typeof entry !== 'object') return;
+    const e = entry as Record<string, unknown>;
+    const ms = e.memorySearch;
+    if (ms === true || (ms && typeof ms === 'object' && !Array.isArray(ms)
+      && (ms as Record<string, unknown>).enabled === true)) {
+      reEnabled.push(typeof e.name === 'string' ? e.name : `agents.list[${i}]`);
+    }
+  });
+
+  const proof: string[] = [];
+  if (reEnabled.length > 0) {
+    proof.push(`per-agent memorySearch re-enabled for ${reEnabled.join(', ')} — a defaults-off entry does not cover them`);
+    if (defaultOn) proof.push('agents.defaults.memorySearch also resolves ON');
+    return { state: 'on', proof };
+  }
+  if (defaultOn) {
+    proof.push(
+      defaults.memorySearch === undefined
+        ? 'agents.defaults.memorySearch unset — OpenClaw Memory Search runs default-ON'
+        : 'agents.defaults.memorySearch resolves ON',
+    );
+    return { state: 'on', proof };
+  }
+  proof.push('agents.defaults.memorySearch.enabled=false and no per-agent re-enable');
+  return { state: 'off_proven', proof };
+}
+
 export function resolveOpenClawEvidence(
   probe: OpenClawProbe,
   ctx: { contract: string; plane: string; nowMs: number },
@@ -406,41 +457,9 @@ export function resolveOpenClawEvidence(
     proof.push('openclaw.json uses $include — OpenClaw evaluates the deep-merged config, which doctor cannot attest from the raw file, so Memory Search cannot be proven off');
     remediation = `${cap.label}: inline the $include'd config into openclaw.json (or retire the includes) so doctor can attest the merged result, then prove ${cap.nativeOffSetting}`;
   } else {
-    const oc = probe.config.value;
-    const agents = oc.agents && typeof oc.agents === 'object' && !Array.isArray(oc.agents)
-      ? (oc.agents as Record<string, unknown>)
-      : {};
-    const defaults = agents.defaults && typeof agents.defaults === 'object' && !Array.isArray(agents.defaults)
-      ? (agents.defaults as Record<string, unknown>)
-      : {};
-    const defaultOn = resolveMemorySearchFlag(defaults.memorySearch);
-    const reEnabled: string[] = [];
-    const list = Array.isArray(agents.list) ? (agents.list as unknown[]) : [];
-    list.forEach((entry, i) => {
-      if (!entry || typeof entry !== 'object') return;
-      const e = entry as Record<string, unknown>;
-      const ms = e.memorySearch;
-      if (ms === true || (ms && typeof ms === 'object' && !Array.isArray(ms)
-        && (ms as Record<string, unknown>).enabled === true)) {
-        reEnabled.push(typeof e.name === 'string' ? e.name : `agents.list[${i}]`);
-      }
-    });
-
-    if (reEnabled.length > 0) {
-      nativeBus = 'on';
-      proof.push(`per-agent memorySearch re-enabled for ${reEnabled.join(', ')} — a defaults-off entry does not cover them`);
-      if (defaultOn) proof.push('agents.defaults.memorySearch also resolves ON');
-    } else if (defaultOn) {
-      nativeBus = 'on';
-      proof.push(
-        defaults.memorySearch === undefined
-          ? 'agents.defaults.memorySearch unset — OpenClaw Memory Search runs default-ON'
-          : 'agents.defaults.memorySearch resolves ON',
-      );
-    } else {
-      nativeBus = 'off_proven';
-      proof.push('agents.defaults.memorySearch.enabled=false and no per-agent re-enable');
-    }
+    const ms = resolveOpenClawMemorySearchState(probe.config);
+    nativeBus = ms.state;
+    proof.push(...ms.proof);
     if (nativeBus === 'on') {
       remediation = `${cap.label}: set ${cap.nativeOffSetting} and clear per-agent memorySearch overrides`;
     }
@@ -1106,6 +1125,8 @@ export function evaluateHostContract(input: HostContractInput): HostContractVerd
   }
 
   const injectOn = input.injectConfigured && input.injectMode !== 'off';
+  const startBusOn = input.injectConfigured
+    && (input.injectMode === 'start' || input.injectMode === 'both');
   const modeLabel = input.injectModeExplicit === false
     ? `${input.injectMode} (emitter default)`
     : input.injectMode;
@@ -1122,6 +1143,15 @@ export function evaluateHostContract(input: HostContractInput): HostContractVerd
   }
 
   if (!injectOn) {
+    if (posture === SIDECAR_POSTURE && input.plane !== 'dual_legacy') {
+      return {
+        status: 'fail',
+        message:
+          `plane=${input.plane} contradicts posture=${SIDECAR_POSTURE} — honest sidecar leaves native memory authoritative `
+          + 'and claims no SC canonicity/import ownership',
+        fix: 'Use plane=dual_legacy for the honest sidecar, or remove sidecar posture and establish a legal automatic start bus',
+      };
+    }
     if (input.plane === 'sc_canonical') {
       return {
         status: 'fail',
@@ -1169,6 +1199,17 @@ export function evaluateHostContract(input: HostContractInput): HostContractVerd
       status: 'info',
       message: 'inject mode=off — SC is not on the automatic bus, so no host contract is claimed',
       fix: `Declare it explicitly with \`shieldcortex config --memory-host-posture ${SIDECAR_POSTURE}\` if this box runs SC as a sidecar`,
+    };
+  }
+
+  // `turn` is injection, but it is not the automatic session-start memory bus.
+  // Preserve #393 handling for non-canonical planes; canonicity specifically
+  // cannot be established by a turn-only path.
+  if (input.plane === 'sc_canonical' && !startBusOn) {
+    return {
+      status: 'fail',
+      message: `plane=sc_canonical with SC inject mode=${modeLabel} — canonicity claimed without an automatic start bus`,
+      fix: 'Set memory.inject.mode=start|both with a legal nativeContract, or stop claiming sc_canonical',
     };
   }
 

--- a/src/memory/plane-drift.ts
+++ b/src/memory/plane-drift.ts
@@ -1,0 +1,237 @@
+/**
+ * Dual-plane drift model (#348 T2 / #394, Opus B3).
+ *
+ * Distinct from the empty-brain check: empty-brain asks "did anything land in
+ * SC at all", drift asks "is the NATIVE plane still the brain while config
+ * claims SC is". A store full of rows says nothing about which plane the agent
+ * actually reads from — that is exactly the green-wash the residual plan names.
+ *
+ * Same split as `host-contract.ts`: this module is the pure decision, doctor
+ * gathers the evidence. Every count is `number | null` and every native reading
+ * carries its own unattestable list, because "could not look" must never render
+ * as "nothing there" — the #393 lesson applied to the plane surface.
+ */
+
+/** Legal plane values this model grades (illegal values fail before here). */
+export type MemoryPlane = 'dual_legacy' | 'import_only' | 'sc_canonical';
+
+export interface PlaneDriftCounts {
+  /**
+   * Active rows admitted in the last 7d INSIDE the configured host/agent scope.
+   * A shared DB whose weekly admits all belong to another box has not captured
+   * anything here, so the scope filter is part of the honest answer.
+   * null = the memories table could not be counted.
+   */
+  durableAdmits7d: number | null;
+  /** Active rows in scope at any age — the denominator for "holds rows, injects none". */
+  durableRows: number | null;
+  /**
+   * Rows the REAL inject predicate (`isInjectEligible`, the one the session-start
+   * hook injects with) would admit for this host/agent scope. A weaker doctor
+   * predicate here is how a store of unverified/directive/unscoped rows reads as
+   * a healthy SC bus. null = eligibility could not be evaluated.
+   */
+  injectable: number | null;
+  /** Active rows excluded for carrying no host/agent scope (reported, per B3). */
+  unscopedExcluded: number | null;
+  /** Session/hook events in the last 7d. null = NO activity telemetry exists. */
+  activity7d: number | null;
+}
+
+export interface NativeSotEvidence {
+  /** A native agent-SoT artifact was written inside the window. */
+  touched7d: boolean;
+  /** Human-readable paths of the touched artifacts, freshest listed first. */
+  touchedPaths: string[];
+  /** Total bytes of present native SoT artifacts. */
+  bytes: number;
+  /**
+   * Reasons the native scan could not be completed — an unresolvable state
+   * root, an unreadable store, a listing past the cap. Non-empty means doctor
+   * does not know whether native is growing, which is never a PASS.
+   */
+  unattestable: string[];
+  /** Native automatic memory bus PROVEN still on, with the proof. Unknown is not listed. */
+  busActive: string[];
+}
+
+export interface PlaneDriftInput {
+  plane: MemoryPlane;
+  planeSetAt: string | null;
+  /**
+   * True when the SC v2 pack is actually the automatic session-start payload —
+   * a legal nativeContract plus a start-capable mode. Only then does inject
+   * eligibility decide what the agent receives, so only then is a zero
+   * injectable count a delivery defect rather than a non-sequitur.
+   */
+  injectOn: boolean;
+  /** Resolved deny-by-default scope gate — CONFIG, never data-derived (B3). */
+  requireScope: boolean;
+  counts: PlaneDriftCounts;
+  native: NativeSotEvidence;
+  nowMs: number;
+}
+
+export interface PlaneDriftVerdict {
+  status: 'pass' | 'warn' | 'fail';
+  message: string;
+  fix?: string;
+}
+
+/** dual_legacy is time-boxed: past this, the defect warning names the age. */
+export const DUAL_LEGACY_GRACE_MS = 14 * 24 * 60 * 60 * 1000;
+
+const RESIDUAL_DOC = 'docs/design/2026-08-22-memory-sota-track-a-residual.md';
+const DUAL_LEGACY_FIX =
+  'Time-box dual_legacy: land the host contract + defended import, then '
+  + '`shieldcortex config --memory-plane import_only` — dual_legacy is a migration escape, not steady state';
+const NATIVE_SOT_FIX =
+  'Stop native MEMORY.md / memory-store growth as the agent brain — import it through the defended path or '
+  + `archive it, or drop back to \`shieldcortex config --memory-plane dual_legacy\` and be honest (${RESIDUAL_DOC})`;
+const NATIVE_BUS_FIX =
+  'Turn the host native memory bus off (OpenClaw agents.defaults.memorySearch.enabled=false, '
+  + 'Hermes memory.memory_enabled=false) — see the `Memory plane (host contract)` check for the per-runtime proof';
+const EMPTY_SC_FIX =
+  'Capture or import into SC on this host/agent scope, or stop claiming a plane SC does not hold';
+const NO_INJECTABLE_FIX =
+  'Fix the rows, not the doctor: stamp content_form, run the defence pipeline over never-scanned legacy rows, '
+  + 'and scope writes with hostId/agentId — or set `memory.inject.requireScope` false deliberately if this DB is single-tenant';
+const UNSCOPED_STORE_FIX =
+  'Scope writes with hostId/agentId, or explicitly disable memory.inject.requireScope only for a genuinely single-tenant DB';
+
+/** `warn` for the deprecated-but-tolerated plane, `fail` where canonicity is claimed. */
+function severityFor(plane: MemoryPlane): 'warn' | 'fail' {
+  return plane === 'dual_legacy' ? 'warn' : 'fail';
+}
+
+function headlineFor(plane: MemoryPlane): string {
+  return plane === 'dual_legacy'
+    ? 'dual_legacy dual-plane drift (time-boxed defect)'
+    : `dual-plane drift under plane=${plane}`;
+}
+
+function num(v: number | null): string {
+  return v === null ? 'unknown' : String(v);
+}
+
+/**
+ * The evidence line every verdict carries. Unknowns render as `unknown`, never
+ * as `0` — a zero that means "could not count" is how absence becomes proof.
+ */
+export function formatPlaneDriftDetail(input: PlaneDriftInput): string {
+  const { counts, native } = input;
+  return [
+    `native_sot_touched_7d=${native.touched7d}`,
+    `native_sot_bytes=${native.bytes}`,
+    `sc_durable_admits_7d=${num(counts.durableAdmits7d)}`,
+    `activity_7d=${num(counts.activity7d)}`,
+    `injectable=${num(counts.injectable)}`,
+    `unscoped_excluded=${num(counts.unscopedExcluded)}`,
+    `requireScope=${input.requireScope}`,
+  ].join(' ');
+}
+
+function agedNote(input: PlaneDriftInput): string {
+  if (input.plane !== 'dual_legacy' || !input.planeSetAt) return '';
+  const setMs = Date.parse(input.planeSetAt);
+  if (Number.isNaN(setMs)) return '';
+  return input.nowMs - setMs > DUAL_LEGACY_GRACE_MS ? ' — planeSetAt older than 14d' : '';
+}
+
+function listPaths(paths: string[]): string {
+  const shown = paths.slice(0, 3).join(', ');
+  return paths.length > 3 ? `${shown}, +${paths.length - 3} more` : shown;
+}
+
+/**
+ * Signal order is deliberate: POSITIVE drift evidence outranks unknowns.
+ * A native brain doctor can see growing is a decided defect even when the SC
+ * side is only partly countable; only when nothing fires do the gaps decide,
+ * and a gap is `cannot determine` (never PASS, per the #394 telemetry law).
+ */
+export function evaluatePlaneDrift(input: PlaneDriftInput): PlaneDriftVerdict {
+  const { plane, counts, native } = input;
+  const detail = formatPlaneDriftDetail(input);
+  const sev = severityFor(plane);
+  const aged = agedNote(input);
+
+  // 1. Native agent SoT written inside the window (primary signal, B3).
+  if (native.touched7d) {
+    return {
+      status: sev,
+      message:
+        `${headlineFor(plane)}: native agent SoT written inside the window — `
+        + `${listPaths(native.touchedPaths)} (${detail})${aged}`,
+      fix: plane === 'dual_legacy' ? DUAL_LEGACY_FIX : NATIVE_SOT_FIX,
+    };
+  }
+
+  // 2. Native automatic memory bus provably still on (signal 2).
+  if (native.busActive.length > 0) {
+    return {
+      status: sev,
+      message:
+        `${headlineFor(plane)}: native memory bus still switched on — `
+        + `${native.busActive.join('; ')} (${detail})${aged}`,
+      fix: plane === 'dual_legacy' ? DUAL_LEGACY_FIX : NATIVE_BUS_FIX,
+    };
+  }
+
+  // 3. Activity bypassing SC entirely — nothing admitted in scope this week.
+  if (counts.durableAdmits7d === 0 && (counts.activity7d ?? 0) > 0) {
+    return {
+      status: sev,
+      message:
+        `${headlineFor(plane)}: activity bypasses SC — zero durable admits in the last 7d `
+        + `for this host/agent scope (${detail})${aged}`,
+      fix: plane === 'dual_legacy' ? DUAL_LEGACY_FIX : EMPTY_SC_FIX,
+    };
+  }
+
+  // 4. SC holds rows the REAL inject gate admits none of (signal 3). The store
+  //    looks healthy by row count and delivers nothing on the bus.
+  if (input.injectOn && counts.injectable === 0 && (counts.durableRows ?? 0) > 0) {
+    return {
+      status: sev,
+      message:
+        `${headlineFor(plane)}: SC holds ${counts.durableRows} durable row(s) but real inject eligibility `
+        + `admits none — the SC bus delivers nothing (${detail})${aged}`,
+      fix: NO_INJECTABLE_FIX,
+    };
+  }
+
+  // 5. A deny-by-default scope gate excluding rows is itself plane evidence.
+  // Quiet/all-unscoped stores must not green-wash merely because no activity
+  // table happened to record a session this week.
+  if (input.requireScope && (counts.unscopedExcluded ?? 0) > 0) {
+    return {
+      status: sev,
+      message:
+        `${headlineFor(plane)}: scope gate excluded ${counts.unscopedExcluded} unscoped row(s) — `
+        + `an unscoped/quiet store cannot prove this plane (${detail})${aged}`,
+      fix: plane === 'dual_legacy' ? DUAL_LEGACY_FIX : UNSCOPED_STORE_FIX,
+    };
+  }
+
+  // 6. Nothing fired. Only now may gaps speak — and they say "cannot determine".
+  const unknowns: string[] = [];
+  if (counts.durableAdmits7d === null || counts.durableRows === null) {
+    unknowns.push('SC durable admits cannot be counted');
+  }
+  if (counts.injectable === null) unknowns.push('real inject eligibility cannot be evaluated');
+  if (counts.unscopedExcluded === null) unknowns.push('scope-exclusion telemetry cannot be counted');
+  if (counts.activity7d === null) unknowns.push('no session activity telemetry on this store');
+  unknowns.push(...native.unattestable);
+  if (unknowns.length > 0) {
+    return {
+      status: 'warn',
+      message: `plane=${plane}: cannot determine drift — ${unknowns.join('; ')} (${detail})`,
+      fix: 'Restore the missing telemetry / make the native tree probeable — a plane doctor cannot certify what it cannot read',
+    };
+  }
+
+  return {
+    status: 'pass',
+    message: `plane=${plane}: no dual-plane drift signal (${detail})`,
+  };
+}


### PR DESCRIPTION
## Summary
- make doctor count the exact shared top-64 inject candidate window used by both automatic-start emitters
- enforce plane/scope/telemetry/native-SoT/start-bus drift law without scratchpad false positives
- require embedded signed honest-sidecar posture across both doctor rows
- wire the bundled/self-healing OpenClaw hook to the defended start pack with package-anchored SQLite resolution

## Verification
- `npm run build:ts`
- focused closure: 6 suites / 225 tests
- full matrix: 52 suites / 706 tests
- `git diff --check` and runtime syntax checks
- Grok 4.6 review: APPROVE_WITH_NITS; selector nit folded
- SOL final closure review: APPROVE, no blockers or nits

Closes #394