### PR TITLE
fix(guard): #436 Claude shell-control schema + non-catastrophic door

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- **#436:** Claude Code `BashOutput` / `KillShell` / `KillBash` no longer hard-block as invalid exec input. They get a native closed schema (handle keys only — not `EXEC_KEYS`), so unknown fields still fail closed and a control tool cannot smuggle a command. Non-catastrophic `block` (schema rejection) falls through the existing one-shot retry / approval door; schema failure still scans known extractor fields so a catastrophic command plus an unknown key stays terminal with no grant. Schema/effect signals and the three tool names survive denial sanitisation instead of collapsing to `tool` / `redacted-signal`.
 - **#428:** bump the bundled dashboard `next` / `eslint-config-next` from 16.1.4 to **16.2.12** (latest 16.2 patch). 16.1.4 sat inside published GHSA ranges, including HIGH [GHSA-p9j2-gv94-2wf4](https://github.com/advisories/GHSA-p9j2-gv94-2wf4) (rewrite SSRF, patched 16.2.11). Medium CSRF/DoS/smuggling GHSAs already patched at 16.1.7. Dashboard `next.config.ts` has no `rewrites`, so the HIGH is defense-in-depth, not a proven local exploit. Did not jump to 16.3.3 (current `latest`) to keep the Frontend/QA surface a single minor.
 
 ### Added

--- a/plugins/openclaw/interceptor.ts
+++ b/plugins/openclaw/interceptor.ts
@@ -1322,7 +1322,14 @@ export function createInterceptor(
     const severity: Severity = v.severity === 'catastrophic' ? 'critical' : 'high';
 
     // Catastrophic / exfil — hard block, always enforced when the guard is enabled.
-    if (v.decision === 'block') {
+    // #436: the door-less throw is for that tier only. A sub-catastrophic `block`
+    // (schema rejection) falls through to requireApproval so the operator can
+    // still say yes. autoApprove and enforce:false must not widen an unscanned
+    // call — they skip below.
+    const terminalBlock = v.decision === 'block'
+      && (v.severity === 'catastrophic' || v.severity === 'critical');
+    const unscannedBlock = v.decision === 'block' && !terminalBlock;
+    if (terminalBlock) {
       // #227: release any lease this call minted early — a blocked action must
       // not leave a hold on that scope (self-heals at TTL if release fails).
       if (leaseGate?.acquired) {
@@ -1342,7 +1349,7 @@ export function createInterceptor(
     // legitimate dangerous work. It NEVER applies to catastrophic ops — those
     // hard-block above, before this branch is reached.
     const autoApprove = actionGuardCfg.autoApprove ?? [];
-    if (autoApprove.length > 0) {
+    if (autoApprove.length > 0 && !unscannedBlock) {
       const hay = [v.family, v.action, ...v.signals].map(s => String(s).toLowerCase());
       const matched = autoApprove.some(a => {
         const n = a.toLowerCase();
@@ -1356,7 +1363,8 @@ export function createInterceptor(
 
     // require_approval — ENFORCED by default (P1/WS1). `enforce:false` opts back
     // down to warn-and-allow (advisory) for operators who want the old behaviour.
-    if (!actionGuardCfg.enforce) {
+    // #436: an unscanned schema rejection must not become an advisory allow.
+    if (!actionGuardCfg.enforce && !unscannedBlock) {
       log.warn(`[shieldcortex] ⚠️ Action Guard: ${context.toolName} — ${v.reason}`);
       emitAudit({ ...base, action: 'warn', outcome: 'warned' });
       return;
@@ -1380,7 +1388,7 @@ export function createInterceptor(
       throw new Error(`ShieldCortex: tool call blocked — ${brokered.reason}`);
     }
 
-    if (brokered?.outcome === 'pre_clear') {
+    if (brokered?.outcome === 'pre_clear' && !unscannedBlock) {
       // Reversible, on-host, in-context, judge-confident: proceed without
       // waiting. Loud on purpose — a release nobody approved must never be a
       // silent one, because the audit row is the only thing that will ever tell

--- a/scripts/pre-tool-hook.mjs
+++ b/scripts/pre-tool-hook.mjs
@@ -572,6 +572,9 @@ async function pingOperator(notify, { toolName, toolInput, verdict, hash, noProm
 const SAFE_TOOL_NAMES = new Set([
   'Bash', 'Edit', 'MultiEdit', 'Write', 'Read', 'Glob', 'Grep', 'LS', 'Task',
   'TodoWrite', 'WebFetch', 'WebSearch', 'NotebookEdit', 'Workflow',
+  // #436: the native background-shell control plane. Without these, every
+  // control-tool row collapsed to a nameless "tool" in the forensic record.
+  'BashOutput', 'KillShell', 'KillBash', 'TaskOutput', 'TaskStop',
 ]);
 const SAFE_SIGNALS = new Set([
   // Generic / legacy summary names kept for older rows and broker payloads.
@@ -595,7 +598,21 @@ const SAFE_SIGNALS = new Set([
   'recursive-find-delete', 'external-egress', 'oversized-command',
   'opaque-script-invocation', 'opaque-script', 'secret-egress-fold',
   'force-push', 'force-push-invocation',
+  // #436: schema-rejection (#412) and the other verdicts that were reaching
+  // denials.jsonl as "redacted-signal" — none of these carry operator data,
+  // they are the guard's own reason codes and are the whole content of the row.
+  'invalid-tool-input', 'unknown-keys', 'not-object', 'nested-invalid',
+  'type-coercion', 'missing-handle', 'write-content-catastrophic',
+  'write-content-dangerous', 'delete-critical-path', 'session-lease',
 ]);
+/**
+ * #436 — the only tiers that deny with no operator affordance. Everything the
+ * guard rates below this is refusable, but must leave a door (ask, or DNP plus
+ * a one-shot #310 retry fingerprint) rather than dead-ending the operator.
+ * `critical` is carried for hosts that normalise the severity name before the
+ * verdict reaches this hook; the guard's own union emits `catastrophic`.
+ */
+const TERMINAL_BLOCK_SEVERITIES = new Set(['catastrophic', 'critical']);
 const MAX_SESSION_SALT_RECOVERY_ATTEMPTS = 256;
 const GUARD_DEGRADED_OUTCOMES = new Set(['auto_denied', 'denied_no_prompt_surface', 'failure_denied', 'warned', 'failure_allowed']);
 const SAFE_BROKER_OUTCOMES = new Set(['harden', 'pre_clear', 'hold', 'unavailable', 'not_brokerable']);
@@ -2085,7 +2102,16 @@ process.stdin.on('end', async () => {
     }
 
     // Catastrophic — hard deny, always enforced while the guard is enabled.
-    if (verdict.decision === 'block') {
+    //
+    // #436: the door-less deny is for THAT tier only. A `block` the guard rates
+    // below catastrophic (today: `invalid_tool_input`, severity `dangerous`)
+    // used to land here too, which left an operator with a refusal and no
+    // affordance — `approve --denial` listed nothing, because nothing was
+    // minted. Those fall through to the require_approval path below and get
+    // the ordinary door: `ask` where a prompt can be raised, DNP plus the
+    // #310/#378 one-shot exact-call fingerprint where it cannot. Catastrophic
+    // still returns here, so it can never mint or consume a retry grant.
+    if (verdict.decision === 'block' && TERMINAL_BLOCK_SEVERITIES.has(verdict.severity)) {
       // #227: the action is refused, so release any lease this call minted
       // early — a blocked action must not leave a hold on that scope. (A
       // frozen scope was already refused above and acquired nothing.)
@@ -2110,11 +2136,21 @@ process.stdin.on('end', async () => {
       process.exit(0);
     }
 
+    // #436: a sub-catastrophic `block` reaching here is NOT an ordinary
+    // dangerous verdict — schema rejection means the guard never got to SCAN
+    // the call. So it takes the DOOR below (one-shot approval, retry grant,
+    // broker, ask/DNP) but skips the two operator WIDENINGS immediately
+    // following: `autoApprove` and `enforce:false` advisory mode. Neither may
+    // turn "could not look" into "allowed" — otherwise `{command:'…', evil:'…'}`
+    // would run unscanned on an advisory host, and allowlisting the signal
+    // `unknown-keys` would become a blanket bypass of the #412 closed schema.
+    const unscannedBlock = verdict.decision === 'block';
+
     // require_approval — the dangerous tier.
     // Per-operator autoApprove allowlist (family / action / signal match, same
     // matching as the plugin). Never applies to catastrophic — that returned above.
     const autoApprove = cfg.autoApprove ?? [];
-    if (autoApprove.length > 0) {
+    if (autoApprove.length > 0 && !unscannedBlock) {
       const hay = [verdict.family, verdict.action, ...verdict.signals].map((s) => String(s).toLowerCase());
       const matched = autoApprove.some((a) => {
         const n = a.toLowerCase();
@@ -2126,7 +2162,7 @@ process.stdin.on('end', async () => {
       }
     }
 
-    if (!cfg.enforce) {
+    if (!cfg.enforce && !unscannedBlock) {
       const actionId = writeTerminalOutcomeAudit(toolName, verdict, toolInput, 'warn', 'warned', 'action_guard_warning', baseExtra);
       const notified = await alertGuardOutcome(getNotify(), {
         toolName,
@@ -2244,7 +2280,7 @@ process.stdin.on('end', async () => {
       process.exit(0);
     }
 
-    if (brokered?.outcome === 'pre_clear') {
+    if (brokered?.outcome === 'pre_clear' && !unscannedBlock) {
       const brokerAudit = safeBrokerAudit(brokered.audit);
       writeAuditEntry(safeToolName(toolName), safeAllowAuditVerdict(verdict, 'approved'), redactedAuditArgs(toolName, toolInput), 'require_approval', 'approved', { ...baseExtra, ...(brokerAudit ? { broker: brokerAudit } : {}) });
       console.error(`[shieldcortex] approval broker PRE-CLEARED ${safeToolName(toolName)}: ${safeDiagnosticReason(brokered.reason)} [${safeSignalList(verdict.signals).join(', ')}]`);

--- a/src/__tests__/deny-evidence-allowlist-parity-436.test.ts
+++ b/src/__tests__/deny-evidence-allowlist-parity-436.test.ts
@@ -1,0 +1,33 @@
+/**
+ * #436 — schema/effect signals and Claude control-plane tool names must
+ * appear on both the hook and operator-notify allowlists.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('#436 deny-evidence allowlist parity', () => {
+  const hook = readFileSync(resolve(root, 'scripts/pre-tool-hook.mjs'), 'utf8');
+  const notify = readFileSync(resolve(root, 'src/defence/iron-dome/operator-notify.ts'), 'utf8');
+
+  it('control-plane tool names are quoted on both allowlists', () => {
+    for (const name of ['BashOutput', 'KillShell', 'KillBash']) {
+      expect(hook).toContain(`'${name}'`);
+      expect(notify).toContain(`'${name}'`);
+    }
+  });
+
+  it('schema/effect signals are quoted on both allowlists', () => {
+    for (const signal of [
+      'invalid-tool-input', 'unknown-keys', 'not-object', 'nested-invalid',
+      'type-coercion', 'missing-handle', 'write-content-catastrophic',
+      'write-content-dangerous', 'delete-critical-path', 'session-lease',
+    ]) {
+      expect(hook).toContain(`'${signal}'`);
+      expect(notify).toContain(`'${signal}'`);
+    }
+  });
+});

--- a/src/__tests__/pre-tool-hook-shell-control-436.test.ts
+++ b/src/__tests__/pre-tool-hook-shell-control-436.test.ts
@@ -1,0 +1,214 @@
+/**
+ * #436 — live Claude control-plane tools through the REAL PreToolUse hook.
+ *
+ * Isolation copied from pre-tool-hook-retry-310.test.ts: fake HOME, shimmed
+ * dist, never the operator's live audit/approvals.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
+import { execSync, spawnSync } from 'node:child_process';
+import {
+  chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { grantRetry } from '../defence/iron-dome/retry-control.js';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const HOOK = join(repoRoot, 'scripts', 'pre-tool-hook.mjs');
+const REAL_DIST = join(repoRoot, 'dist', 'defence', 'iron-dome');
+
+const CATASTROPHIC = { command: ['r', 'm', ' ', '-', 'r', 'f', ' ', '/'].join('') };
+
+interface HookResult { decision?: string; reason?: string; stderr: string }
+interface RetryStore {
+  rows: Array<{
+    id: string;
+    hash: string;
+    tool: string;
+    grant?: { consumedAt?: number };
+    claim?: unknown;
+  }>;
+}
+
+describe('#436 — shell control through the real Claude Code hook', () => {
+  let home: string;
+  let distRoot: string;
+  let jobCwd: string;
+  let evidenceFile: string;
+  let openclawBin: string;
+  let decisionFile: string;
+
+  beforeAll(() => {
+    const probes = [
+      'tool-action-guard.js', 'action-approvals.js', 'notify-config.js', 'operator-notify.js',
+      'webhook-notify-channel.js', 'dnp-digest.js', 'retry-control.js', 'dnp-retry-waiter.js',
+    ].map((f) => join(REAL_DIST, f));
+    if (!probes.every((p) => existsSync(p))) {
+      execSync('npm run build:ts', { cwd: repoRoot, stdio: 'ignore' });
+    }
+  }, 300_000);
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'sc-436-hook-'));
+    mkdirSync(join(home, '.shieldcortex'), { recursive: true });
+    jobCwd = mkdtempSync(join(tmpdir(), 'sc-436-cwd-'));
+    evidenceFile = join(home, 'webhook-evidence.jsonl');
+
+    distRoot = mkdtempSync(join(tmpdir(), 'sc-436-dist-'));
+    const ironDomeDir = join(distRoot, 'defence', 'iron-dome');
+    mkdirSync(ironDomeDir, { recursive: true });
+    for (const f of [
+      'tool-action-guard.js', 'action-approvals.js', 'notify-config.js', 'operator-notify.js',
+      'script-source-resolver.js', 'dnp-digest.js', 'retry-control.js', 'dnp-retry-waiter.js',
+      'openclaw-approval-channel.js',
+    ]) {
+      const real = join(REAL_DIST, f);
+      if (existsSync(real)) {
+        writeFileSync(join(ironDomeDir, f), `export * from ${JSON.stringify(pathToFileURL(real).href)};\n`);
+      }
+    }
+    writeFileSync(
+      join(ironDomeDir, 'webhook-notify-channel.js'),
+      [
+        "import { appendFileSync as af } from 'node:fs';",
+        'export function createWebhookNotifyChannel(opts) {',
+        '  return {',
+        "    name: 'webhook',",
+        '    async send(notification) {',
+        '      const u = new URL(opts.url);',
+        "      const evidencePath = u.searchParams.get('evidence');",
+        "      if (evidencePath) af(evidencePath, JSON.stringify(notification) + '\\n');",
+        '      return { delivered: true };',
+        '    },',
+        '  };',
+        '}',
+      ].join('\n'),
+    );
+
+    decisionFile = join(home, 'decision.json');
+    writeFileSync(decisionFile, JSON.stringify({ decision: null }));
+    openclawBin = join(home, 'fake-openclaw');
+    writeFileSync(openclawBin, `#!/bin/sh\ncat ${JSON.stringify(decisionFile)}\n`, { mode: 0o755 });
+    chmodSync(openclawBin, 0o755);
+
+    writeFileSync(
+      join(home, '.shieldcortex', 'config.json'),
+      JSON.stringify({
+        actionGuard: {
+          enabled: true,
+          enforce: true,
+          notify: { enabled: true, webhookUrl: `http://fake-webhook.invalid/hook?evidence=${encodeURIComponent(evidenceFile)}` },
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    for (const dir of [home, distRoot, jobCwd]) {
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  function runHook(
+    input: Record<string, unknown>,
+    opts: { tool?: string; cwd?: string; permissionMode?: string } = {},
+  ): HookResult {
+    const payload = JSON.stringify({
+      session_id: '436-session',
+      cwd: opts.cwd ?? jobCwd,
+      hook_event_name: 'PreToolUse',
+      permission_mode: opts.permissionMode ?? 'bypassPermissions',
+      tool_name: opts.tool ?? 'Bash',
+      tool_input: input,
+    });
+    const run = spawnSync('node', [HOOK], {
+      input: payload,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        SHIELDCORTEX_DIST_ROOT: distRoot,
+        SHIELDCORTEX_OPENCLAW_BIN: openclawBin,
+      } as NodeJS.ProcessEnv,
+      timeout: 30_000,
+      encoding: 'utf8',
+    });
+    const stdout = run.stdout ?? '';
+    if (!stdout.trim()) return { stderr: run.stderr ?? '' };
+    const out = JSON.parse(stdout).hookSpecificOutput ?? {};
+    return { decision: out.permissionDecision, reason: out.permissionDecisionReason, stderr: run.stderr ?? '' };
+  }
+
+  function store(): RetryStore | null {
+    const p = join(home, '.shieldcortex', 'approvals', 'retry-control.json');
+    return existsSync(p) ? (JSON.parse(readFileSync(p, 'utf8')) as RetryStore) : null;
+  }
+
+  function denialRows(): Array<Record<string, unknown>> {
+    const file = join(home, '.shieldcortex', 'denials.jsonl');
+    return existsSync(file)
+      ? readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l))
+      : [];
+  }
+
+  it('BashOutput {bash_id,filter} is allowed under bypassPermissions', () => {
+    const r = runHook({ bash_id: 'bash_1', filter: 'ready' }, { tool: 'BashOutput' });
+    expect(r.decision).toBeUndefined();
+    expect(store()?.rows ?? []).toHaveLength(0);
+  });
+
+  it('KillShell {shell_id} is allowed', () => {
+    const r = runHook({ shell_id: 'shell_1' }, { tool: 'KillShell' });
+    expect(r.decision).toBeUndefined();
+    expect(store()?.rows ?? []).toHaveLength(0);
+  });
+
+  it('KillBash {shell_id} is allowed', () => {
+    const r = runHook({ shell_id: 'shell_1' }, { tool: 'KillBash' });
+    expect(r.decision).toBeUndefined();
+  });
+
+  it('unknown field on BashOutput denies but mints a retry fingerprint', () => {
+    const r = runHook({ bash_id: 'bash_1', evil_payload: 'x' }, { tool: 'BashOutput' });
+    expect(r.decision).toBe('deny');
+    const rows = store()?.rows ?? [];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].tool).toBe('BashOutput');
+    expect(rows[0].grant).toBeUndefined();
+
+    const denials = denialRows();
+    expect(denials.length).toBeGreaterThan(0);
+    const blob = JSON.stringify(denials);
+    expect(blob).toContain('BashOutput');
+    expect(blob).toMatch(/invalid-tool-input|unknown-keys/);
+    expect(blob).not.toContain('evil_payload');
+  });
+
+  it('schema-invalid denial is grantable once; different input cannot spend it', () => {
+    const bad = { bash_id: 'bash_1', evil_payload: 'x' };
+    expect(runHook(bad, { tool: 'BashOutput' }).decision).toBe('deny');
+    const row = store()!.rows[0];
+    const granted = grantRetry({ id: row.id }, { isInteractive: true }, { home });
+    expect(granted.ok).toBe(true);
+
+    const retried = runHook(bad, { tool: 'BashOutput' });
+    expect(retried.decision).toBeUndefined();
+    expect(retried.stderr).toContain('consumed operator RETRY grant');
+
+    expect(runHook(bad, { tool: 'BashOutput' }).decision).toBe('deny');
+    expect(runHook({ bash_id: 'bash_1', evil_payload: 'other' }, { tool: 'BashOutput' }).decision).toBe('deny');
+  });
+
+  it('catastrophic Bash still denies with no retry row', () => {
+    const r = runHook(CATASTROPHIC, { tool: 'Bash' });
+    expect(r.decision).toBe('deny');
+    expect(store()?.rows ?? []).toHaveLength(0);
+  });
+
+  it('catastrophic Bash plus an unknown key still mints no retry row', () => {
+    const r = runHook({ ...CATASTROPHIC, evil_payload: 'x' }, { tool: 'Bash' });
+    expect(r.decision).toBe('deny');
+    expect(store()?.rows ?? []).toHaveLength(0);
+  });
+});

--- a/src/defence/iron-dome/__tests__/shell-control-schema-436.test.ts
+++ b/src/defence/iron-dome/__tests__/shell-control-schema-436.test.ts
@@ -88,12 +88,27 @@ describe('#436 acceptance 2 — schema stays CLOSED', () => {
     const r = enforceToolInput('BashOutput', {});
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('MISSING_HANDLE');
+    const v = evaluateToolCall('BashOutput', {});
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('dangerous');
+    expect(v.action).toBe('invalid_tool_input');
   });
 
   it('filter-only BashOutput fails closed (no handle)', () => {
     const r = enforceToolInput('BashOutput', { filter: 'ready' });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.code).toBe('MISSING_HANDLE');
+    const v = evaluateToolCall('BashOutput', { filter: 'ready' });
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('dangerous');
+    expect(v.action).toBe('invalid_tool_input');
+  });
+
+  it('non-string handle fails closed without throwing', () => {
+    const v = evaluateToolCall('BashOutput', { bash_id: 1 });
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('dangerous');
+    expect(v.action).toBe('invalid_tool_input');
   });
 
   it('filter must be a string', () => {

--- a/src/defence/iron-dome/__tests__/shell-control-schema-436.test.ts
+++ b/src/defence/iron-dome/__tests__/shell-control-schema-436.test.ts
@@ -1,0 +1,117 @@
+/**
+ * #436 — Claude Code background-shell control plane vs the #412 closed schema.
+ *
+ * BashOutput / KillShell / KillBash substring-matched as exec, then inherited
+ * EXEC_KEYS which omitted their only legitimate fields. Closed-schema enforce
+ * hard-blocked every live control call. These tools do not start an OS process;
+ * they get a NARROWER closed bag, not extra EXEC_KEYS.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { enforceToolInput } from '../tool-input-schema.js';
+import { evaluateToolCall } from '../tool-action-guard.js';
+
+describe('#436 acceptance 1 — live control shapes are not invalid-tool-input', () => {
+  const LIVE: Array<[string, Record<string, unknown>]> = [
+    ['BashOutput', { bash_id: 'bash_1', filter: 'ready' }],
+    ['BashOutput', { bash_id: 'bash_1' }],
+    ['BashOutput', { task_id: 'task_1' }],
+    ['BashOutput', { agentId: 'agent_1' }],
+    ['KillShell', { shell_id: 'shell_1' }],
+    ['KillShell', { task_id: 'task_1' }],
+    ['KillBash', { shell_id: 'shell_1' }],
+    ['KillBash', { task_id: 'task_1' }],
+  ];
+
+  it.each(LIVE)('%s %j is not an invalid-tool-input hard block', (tool, args) => {
+    const v = evaluateToolCall(tool, args);
+    expect(v.action).not.toBe('invalid_tool_input');
+    expect(v.decision).not.toBe('block');
+    expect(v.signals).not.toContain('invalid-tool-input');
+  });
+
+  it.each(LIVE)('%s %j survives closed-schema enforcement', (tool, args) => {
+    const r = enforceToolInput(tool, args);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(args);
+  });
+});
+
+describe('#436 acceptance 2 — schema stays CLOSED', () => {
+  it('rejects an unknown field on BashOutput', () => {
+    const r = enforceToolInput('BashOutput', { bash_id: 'bash_1', evil_payload: 'x' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('UNKNOWN_KEYS');
+      expect(r.unknownKeys).toContain('evil_payload');
+    }
+  });
+
+  it.each([
+    ['KillShell', { shell_id: 'shell_1', evil_payload: 'x' }],
+    ['KillBash', { shell_id: 'shell_1', evil_payload: 'x' }],
+  ])('rejects an unknown field on %s via evaluateToolCall', (tool, args) => {
+    const v = evaluateToolCall(tool, args);
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('dangerous');
+    expect(v.action).toBe('invalid_tool_input');
+    expect(v.signals).toEqual(expect.arrayContaining(['invalid-tool-input', 'unknown-keys']));
+  });
+
+  it('is narrower than EXEC_KEYS — a control tool cannot smuggle a command', () => {
+    for (const key of ['command', 'cmd', 'script', 'code', 'run', 'shell', 'input', 'env', 'stdin']) {
+      const r = enforceToolInput('BashOutput', { bash_id: 'bash_1', [key]: 'x' });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.code).toBe('UNKNOWN_KEYS');
+    }
+  });
+
+  it('still rejects prototype pollution', () => {
+    const raw = JSON.parse('{"bash_id":"bash_1","__proto__":{"polluted":true}}') as Record<string, unknown>;
+    const r = enforceToolInput('BashOutput', raw);
+    expect(r.ok).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('does not leak the narrow schema to a namespaced look-alike', () => {
+    const r = enforceToolInput('mcp__thirdparty__BashOutput', { bash_id: 'bash_1' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('real Bash unknown-field enforcement is unchanged', () => {
+    expect(evaluateToolCall('Bash', { command: 'printf ok' }).decision).toBe('allow');
+    const v = evaluateToolCall('Bash', { command: 'printf ok', evil_payload: 'x' });
+    expect(v.decision).toBe('block');
+    expect(v.action).toBe('invalid_tool_input');
+  });
+
+  it('empty control input fails closed (no handle)', () => {
+    const r = enforceToolInput('BashOutput', {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_HANDLE');
+  });
+
+  it('filter-only BashOutput fails closed (no handle)', () => {
+    const r = enforceToolInput('BashOutput', { filter: 'ready' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_HANDLE');
+  });
+
+  it('filter must be a string', () => {
+    const r = enforceToolInput('BashOutput', { bash_id: 'bash_1', filter: 1 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('whitespace-only handle fails closed', () => {
+    const r = enforceToolInput('BashOutput', { bash_id: '   ' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_HANDLE');
+  });
+
+  it('unknown extra key cannot demote a catastrophic Bash command', () => {
+    const wipe = ['r', 'm', ' ', '-', 'r', 'f', ' ', '/'].join('');
+    const v = evaluateToolCall('Bash', { command: wipe, evil_payload: 'x' });
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('catastrophic');
+    expect(v.action).not.toBe('invalid_tool_input');
+  });
+});

--- a/src/defence/iron-dome/operator-notify.ts
+++ b/src/defence/iron-dome/operator-notify.ts
@@ -400,6 +400,9 @@ export interface ActionGuardOutcomeInput {
 const SAFE_ACTION_GUARD_TOOLS = new Set([
   'Bash', 'Edit', 'MultiEdit', 'Write', 'Read', 'Glob', 'Grep', 'LS', 'Task',
   'TodoWrite', 'WebFetch', 'WebSearch', 'NotebookEdit', 'Workflow',
+  // #436: keep parity with the hook's SAFE_TOOL_NAMES — the native
+  // background-shell control plane must be nameable on a notify/denial row.
+  'BashOutput', 'KillShell', 'KillBash', 'TaskOutput', 'TaskStop',
 ]);
 const SAFE_ACTION_GUARD_SIGNALS = new Set([
   'secret-egress', 'approval-required', 'fallback-scan', 'privilege-escalation',
@@ -420,6 +423,11 @@ const SAFE_ACTION_GUARD_SIGNALS = new Set([
   'recursive-find-delete', 'external-egress', 'oversized-command',
   'opaque-script-invocation', 'opaque-script', 'secret-egress-fold',
   'force-push', 'force-push-invocation',
+  // #436: parity with the hook's SAFE_SIGNALS. Guard reason codes, not
+  // operator data — redacting them left the row with nothing to act on.
+  'invalid-tool-input', 'unknown-keys', 'not-object', 'nested-invalid',
+  'type-coercion', 'missing-handle', 'write-content-catastrophic',
+  'write-content-dangerous', 'delete-critical-path', 'session-lease',
 ]);
 const SAFE_ACTION_GUARD_OUTCOMES = new Set([
   'auto_denied', 'denied_no_prompt_surface', 'failure_denied', 'warned', 'failure_allowed',

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -4143,12 +4143,13 @@ export function evaluateToolCall(
   args: Record<string, unknown> = {},
   config?: IronDomeConfig,
   options?: ToolGuardOptions,
+  skipSchema = false,
 ): ToolGuardVerdict {
   // #412 — close the tool-input bag before extractors run.
   // Exec/git: enforce (unknown keys fail closed — smuggled payloads cannot hide).
   // Other families: annotate (strip unknowns) so messaging/read tools with
   // free-form fields are not false-positive blocked; extractors never see junk keys.
-  {
+  if (!skipSchema) {
     // Enforce iff the SCHEMA family is exec/git, or the guard family is exec.
     // Do NOT use classifyFamily==='git': that regex includes substring `github`,
     // which would fail-closed GitHub-API tools under EXEC_KEYS (title/labels).
@@ -4161,14 +4162,15 @@ export function evaluateToolCall(
     if (!validated.ok) {
       // #436: schema rejection must not mask a catastrophic payload. Annotate
       // the RAW bag (strip unknown keys, keep extractor fields) and reuse the
-      // full evaluator. If that is catastrophic, keep it terminal. Otherwise
-      // the original schema failure stands — dangerous, with a door.
+      // full evaluator with the schema gate skipped. If that is catastrophic,
+      // keep it terminal. Otherwise the original schema failure stands.
       const annotated = validateToolInput(toolName, args, 'annotate');
       const inner = evaluateToolCall(
         toolName,
         annotated.ok ? annotated.args : {},
         config,
         options,
+        true,
       );
       if (inner.severity === 'catastrophic') return inner;
       return verdict(

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -4159,6 +4159,18 @@ export function evaluateToolCall(
       : 'annotate';
     const validated = validateToolInput(toolName, args, mode);
     if (!validated.ok) {
+      // #436: schema rejection must not mask a catastrophic payload. Annotate
+      // the RAW bag (strip unknown keys, keep extractor fields) and reuse the
+      // full evaluator. If that is catastrophic, keep it terminal. Otherwise
+      // the original schema failure stands — dangerous, with a door.
+      const annotated = validateToolInput(toolName, args, 'annotate');
+      const inner = evaluateToolCall(
+        toolName,
+        annotated.ok ? annotated.args : {},
+        config,
+        options,
+      );
+      if (inner.severity === 'catastrophic') return inner;
       return verdict(
         'block',
         'dangerous',

--- a/src/defence/iron-dome/tool-input-schema.ts
+++ b/src/defence/iron-dome/tool-input-schema.ts
@@ -25,7 +25,7 @@ export interface ToolInputValidationOk {
 export interface ToolInputValidationErr {
   ok: false;
   reason: string;
-  code: 'NOT_OBJECT' | 'UNKNOWN_KEYS' | 'NESTED_INVALID' | 'TYPE_COERCION';
+  code: 'NOT_OBJECT' | 'UNKNOWN_KEYS' | 'NESTED_INVALID' | 'TYPE_COERCION' | 'MISSING_HANDLE';
   unknownKeys?: string[];
 }
 
@@ -92,6 +92,52 @@ const UNKNOWN_FAMILY_KEYS = new Set([
   'path', 'file_path', 'filePath', 'file', 'url', 'uri',
 ]);
 
+/**
+ * #436 — Claude Code's own background-shell CONTROL plane. `BashOutput` reads
+ * an already-running shell's buffered output; `KillShell`/`KillBash` stop it.
+ * Neither starts an OS process: the originating `Bash` call was scanned when it
+ * was made. Their handle keys (`bash_id`/`shell_id`/`task_id`) are absent from
+ * EXEC_KEYS, so the substring `bash`/`shell` match sent every live control call
+ * to `invalid_tool_input` — a hard block on the guard's own read-and-stop path.
+ *
+ * The schema stays CLOSED and deliberately omits every exec key: a control tool
+ * must not be able to smuggle a command through this bag. Nothing here is added
+ * to EXEC_KEYS, so real `Bash` enforcement is untouched.
+ */
+interface ShellControlSchema {
+  /** Closed allowed-key set. */
+  allowed: Set<string>;
+  /** At least one of these must carry a non-empty string, else fail closed. */
+  handles: string[];
+}
+
+/** Claude 2.1.233's TaskOutput reads `task_id ?? agentId ?? bash_id`; `filter` is an output regex — data, not a command. */
+const SHELL_CONTROL_OUTPUT: ShellControlSchema = {
+  allowed: new Set(['bash_id', 'task_id', 'agentId', 'filter']),
+  handles: ['bash_id', 'task_id', 'agentId'],
+};
+
+/** TaskStop reads `task_id ?? shell_id`. */
+const SHELL_CONTROL_STOP: ShellControlSchema = {
+  allowed: new Set(['shell_id', 'task_id']),
+  handles: ['shell_id', 'task_id'],
+};
+
+/**
+ * EXACT native tool names only — the WHOLE name, case-insensitively. A
+ * namespaced `mcp__thirdparty__BashOutput` is a third-party tool that merely
+ * borrowed the name, so it keeps EXEC_KEYS and still fails closed on `bash_id`.
+ * That is stricter than the last-segment matching used elsewhere, on purpose.
+ */
+function shellControlSchemaFor(toolName: string): ShellControlSchema | null {
+  switch (String(toolName ?? '').trim().toLowerCase()) {
+    case 'bashoutput': return SHELL_CONTROL_OUTPUT;
+    case 'killshell':
+    case 'killbash': return SHELL_CONTROL_STOP;
+    default: return null;
+  }
+}
+
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === 'object' && !Array.isArray(v) && Object.getPrototypeOf(v) === Object.prototype;
 }
@@ -123,6 +169,9 @@ export function schemaFamilyForTool(
 }
 
 function allowedKeysFor(toolName: string): Set<string> {
+  // #436: the native control plane is narrower than its exec family, not wider.
+  const control = shellControlSchemaFor(toolName);
+  if (control) return control.allowed;
   const fam = schemaFamilyForTool(toolName);
   switch (fam) {
     case 'exec':
@@ -211,6 +260,7 @@ export function validateToolInput(
     }
   }
 
+  const control = shellControlSchemaFor(toolName);
   const allowed = allowedKeysFor(toolName);
   const strippedKeys: string[] = [];
   const out: Record<string, unknown> = {};
@@ -240,7 +290,10 @@ export function validateToolInput(
     // Command/path/url scanners only accept strings. Object/array/number/boolean
     // cannot be scanned (extractors are pickString) so they must not fail open.
     // `content`/`body`/`text` stay out of STRING_SCAN_KEYS (structured messages).
-    if (STRING_SCAN_KEYS.has(key) && typeof value !== 'string') {
+    // #436: every field a control tool is allowed to carry is a handle or an
+    // output `filter` — both strings. A number/object here is not a shape the
+    // host ever sends, so it fails closed rather than reaching the extractors.
+    if ((STRING_SCAN_KEYS.has(key) || control) && typeof value !== 'string') {
       return {
         ok: false,
         code: typeof value === 'object' ? 'NESTED_INVALID' : 'TYPE_COERCION',
@@ -260,6 +313,16 @@ export function validateToolInput(
       code: 'UNKNOWN_KEYS',
       reason: `Unknown tool input field "${unknown[0]}" rejected`,
       unknownKeys: unknown,
+    };
+  }
+
+  // #436: a control call that names no shell is not a control call. Fail closed
+  // rather than let an empty bag through on a tool whose whole job is a handle.
+  if (control && !control.handles.some((k) => typeof out[k] === 'string' && out[k].trim() !== '')) {
+    return {
+      ok: false,
+      code: 'MISSING_HANDLE',
+      reason: `Tool input must name a shell (${control.handles.join(' | ')})`,
     };
   }
 


### PR DESCRIPTION
## Why

Jarvis on 4.54.13 hard-blocked nine Claude Code background-shell control actions (`BashOutput` / `KillShell` / `KillBash`). `approve --denial` listed none.

Root cause: #412 closed exec schema substring-matches `bash`/`shell`, so these control-plane tools inherit `EXEC_KEYS` (no `bash_id` / `shell_id` / `filter`). Every live call is `invalid_tool_input`. The pre-tool hook then treats **every** `decision=block` as a catastrophic no-door deny.

Closes #436.

## What changed

- Native exact-name closed schema for `BashOutput` / `KillShell` / `KillBash` (handle keys only — **not** added to `EXEC_KEYS`). Unknown fields still fail closed. A control tool cannot smuggle `command`/`script`. Namespaced lookalikes stay on `EXEC_KEYS`.
- Non-catastrophic `block` falls through the existing #310/#378 one-shot door (ask / DNP + fingerprint). `autoApprove`, `enforce:false`, and broker `pre_clear` cannot widen an unscanned schema rejection.
- Schema rejection reuses the **full** evaluator on annotated args, so `{command: <catastrophic>, evil_payload: x}` stays terminal with no grant.
- Allowlists: tool names + schema/effect signals survive denial sanitisation.

## Verification

```
npm run build:ts
node scripts/run-jest.mjs \
  src/defence/iron-dome/__tests__/shell-control-schema-436.test.ts \
  src/defence/iron-dome/__tests__/tool-input-schema-412.test.ts \
  src/defence/iron-dome/__tests__/tool-input-schema-412-followup.test.ts \
  src/__tests__/pre-tool-hook-shell-control-436.test.ts \
  src/__tests__/pre-tool-hook-retry-310.test.ts \
  src/defence/iron-dome/__tests__/denial-doors-401.test.ts
```

110 focused tests passed, including live control allow, unknown-key retry fingerprint + one-shot grant, catastrophic Bash no retry row, catastrophic+unknown-key still grantless.

`npm run test:dist` OK. Secret scan of the diff: none.

## Review

Independent SOL Pro review found the unknown-key catastrophic demotion; folded by reusing the full evaluator. Grok 4.6 review timed out this run — not treated as approval.

Do not merge until CI is green on this head and an independent reviewer flips the current SHA.
