### PR TITLE
chore(release): 4.54.14

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,6 +122,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Skip root publish (already exists)
+        if: steps.version_check.outputs.already_published == 'true'
+        run: echo "⚠️ Skipping root npm publish - shieldcortex version already exists on npm"
+
       # Plugin is a second npm package (`@drakon-systems/shieldcortex-realtime`)
       # under `plugins/openclaw/`. Historically published manually, which meant
       # the plugin repeatedly drifted behind the main package — v4.11.0 shipped
@@ -129,9 +133,13 @@ jobs:
       # Assumes plugin version has been bumped in lockstep with the main package
       # (memory 2080: bump root, plugin package, openclaw.plugin.json, SKILL.md
       # together on every release).
+      #
+      # Recovery is per-package. Root already_published must NOT skip plugin
+      # check/publish, both-package verification, or GitHub Release: if root
+      # landed and plugin failed, a rerun has to finish the missing plugin and
+      # still create/update the release. ClawHub stays independent below.
       - name: Check plugin version
         id: plugin_version_check
-        if: steps.version_check.outputs.already_published == 'false'
         run: |
           PLUGIN_VERSION=$(node -p "require('./plugins/openclaw/package.json').version")
           MAIN_VERSION=$(node -p "require('./package.json').version")
@@ -148,10 +156,14 @@ jobs:
           fi
 
       - name: Publish plugin to npm
-        if: steps.version_check.outputs.already_published == 'false' && steps.plugin_version_check.outputs.plugin_already_published == 'false'
+        if: steps.plugin_version_check.outputs.plugin_already_published == 'false'
         run: cd plugins/openclaw && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Skip plugin publish (already exists)
+        if: steps.plugin_version_check.outputs.plugin_already_published == 'true'
+        run: echo "⚠️ Skipping plugin npm publish - @drakon-systems/shieldcortex-realtime version already exists on npm"
 
       # Verify both packages actually landed on npm at the expected version,
       # AND that the plugin tarball has the shape OpenClaw 2026.5.4+ requires
@@ -163,7 +175,6 @@ jobs:
       # bug where the plugin technically published but couldn't be installed.
       # Registry propagation lags metadata by up to 3 min after publish; poll.
       - name: Verify both packages landed on npm at the expected version
-        if: steps.version_check.outputs.already_published == 'false'
         env:
           MAIN_VERSION: ${{ steps.tag.outputs.version }}
         run: |
@@ -226,11 +237,12 @@ jobs:
           fi
           echo "Plugin tarball shape OK: dist/index.js present, openclaw.extensions=${PLUGIN_PKG_EXT}"
 
-      # Create the GitHub Release immediately after npm publish so a later
+      # Create or update the GitHub Release after npm publish so a later
       # ClawHub auth failure can't skip it. (Hit this on v4.10.0 — CLAWHUB_TOKEN
       # was stale, Release step was skipped, had to be created manually.)
+      # Always runs: a rerun after partial npm success must still create the
+      # missing release; the action updates an existing one in place.
       - name: Create GitHub Release
-        if: steps.version_check.outputs.already_published == 'false'
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
@@ -275,7 +287,3 @@ jobs:
       - name: Skip ClawHub sync (missing token)
         if: env.HAS_CLAWHUB_TOKEN != 'true'
         run: echo "⚠️ CLAWHUB_TOKEN secret missing, skipping ClawHub auto-sync"
-
-      - name: Skip publish (already exists)
-        if: steps.version_check.outputs.already_published == 'true'
-        run: echo "⚠️ Skipping publish - version already exists on npm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.54.14] - 2026-08-29
+
 ### Security
 - **#436:** Claude Code `BashOutput` / `KillShell` / `KillBash` no longer hard-block as invalid exec input. They get a native closed schema (handle keys only — not `EXEC_KEYS`), so unknown fields still fail closed and a control tool cannot smuggle a command. Non-catastrophic `block` (schema rejection) falls through the existing one-shot retry / approval door; schema failure still scans known extractor fields so a catastrophic command plus an unknown key stays terminal with no grant. Schema/effect signals and the three tool names survive denial sanitisation instead of collapsing to `tool` / `redacted-signal`.
 - **#428:** bump the bundled dashboard `next` / `eslint-config-next` from 16.1.4 to **16.2.12** (latest 16.2 patch). 16.1.4 sat inside published GHSA ranges, including HIGH [GHSA-p9j2-gv94-2wf4](https://github.com/advisories/GHSA-p9j2-gv94-2wf4) (rewrite SSRF, patched 16.2.11). Medium CSRF/DoS/smuggling GHSAs already patched at 16.1.7. Dashboard `next.config.ts` has no `rewrites`, so the HIGH is defense-in-depth, not a proven local exploit. Did not jump to 16.3.3 (current `latest`) to keep the Frontend/QA surface a single minor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.13",
+  "version": "4.54.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.54.13",
+      "version": "4.54.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.13",
+  "version": "4.54.14",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.54.13",
+  "version": "4.54.14",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "pack:verify": "npm pack --dry-run",
-    "prepublishOnly": "node -e \"if(!require('fs').existsSync('dist/index.js'))throw new Error('plugin dist/index.js missing — run `npm run build:ts` from the repo root before publishing')\""
+    "prepublishOnly": "node -e \"if(!require('fs').existsSync('dist/index.js'))throw new Error('plugin dist/index.js missing \u2014 run `npm run build:ts` from the repo root before publishing')\""
   },
   "peerDependencies": {
     "shieldcortex": "^4.54.8",

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.54.13",
+  "version": "4.54.14",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "pack:verify": "npm pack --dry-run",
-    "prepublishOnly": "node -e \"if(!require('fs').existsSync('dist/index.js'))throw new Error('plugin dist/index.js missing \u2014 run `npm run build:ts` from the repo root before publishing')\""
+    "prepublishOnly": "node -e \"if(!require('fs').existsSync('dist/index.js'))throw new Error('plugin dist/index.js missing — run `npm run build:ts` from the repo root before publishing')\""
   },
   "peerDependencies": {
     "shieldcortex": "^4.54.8",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.54.13
+  version: 4.54.14
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]

--- a/src/__tests__/publish-workflow.test.ts
+++ b/src/__tests__/publish-workflow.test.ts
@@ -1,0 +1,164 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from '@jest/globals';
+
+/**
+ * Partial-publish recovery — root npm success + plugin failure used to green
+ * on rerun. `.github/workflows/publish.yml` gated plugin check/publish,
+ * both-package verification, and GitHub Release on root
+ * `already_published == false`. GitHub Actions treats skipped-step outputs as
+ * empty, so the plugin publish `if:` never became true and the job could skip
+ * the missing plugin.
+ *
+ * These tests parse the workflow and evaluate `if:` the way Actions does.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'publish.yml');
+const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+type Step = {
+  name: string;
+  id?: string;
+  if?: string;
+  body: string;
+};
+
+function parseNamedSteps(src: string): Step[] {
+  const steps: Step[] = [];
+  const chunks = src.split(/\n      - name: /).slice(1);
+  for (const chunk of chunks) {
+    const nl = chunk.indexOf('\n');
+    const name = (nl === -1 ? chunk : chunk.slice(0, nl)).trim();
+    const body = nl === -1 ? '' : chunk.slice(nl + 1);
+    const headerEnd = body.search(/^\s{8}(?:run|uses):/m);
+    const header = headerEnd === -1 ? body : body.slice(0, headerEnd);
+    const id = header.match(/^\s{8}id: (\S+)/m)?.[1];
+    const ifExpr = header.match(/^\s{8}if: (.+)$/m)?.[1]?.trim();
+    steps.push({ name, id, if: ifExpr, body });
+  }
+  return steps;
+}
+
+function unquote(token: string): string {
+  return token.slice(1, -1);
+}
+
+function evalAtom(atom: string): boolean {
+  const m = atom
+    .trim()
+    .match(/^("(?:\\.|[^"])*"|'(?:\\.|[^'])*')\s*(==|!=)\s*("(?:\\.|[^"])*"|'(?:\\.|[^'])*')$/);
+  if (!m) {
+    throw new Error(`unhandled GitHub if atom: ${atom}`);
+  }
+  const left = unquote(m[1]);
+  const right = unquote(m[3]);
+  return m[2] === '==' ? left === right : left !== right;
+}
+
+function evalGhIf(
+  expr: string | undefined,
+  outputs: Record<string, Record<string, string>>,
+  env: Record<string, string>,
+): boolean {
+  if (!expr) return true;
+  const resolved = expr
+    .replace(/steps\.([A-Za-z0-9_]+)\.outputs\.([A-Za-z0-9_]+)/g, (_all, step: string, key: string) =>
+      JSON.stringify(outputs[step]?.[key] ?? ''),
+    )
+    .replace(/env\.([A-Za-z0-9_]+)/g, (_all, key: string) => JSON.stringify(env[key] ?? ''));
+  return resolved.split('&&').every((part) => evalAtom(part));
+}
+
+function simulate(opts: { rootPublished: boolean; pluginPublished: boolean; hasClawhub?: boolean }): Record<string, boolean> {
+  const steps = parseNamedSteps(workflow);
+  const outputs: Record<string, Record<string, string>> = {};
+  const env = { HAS_CLAWHUB_TOKEN: opts.hasClawhub === false ? '' : 'true' };
+  const ran: Record<string, boolean> = {};
+
+  for (const step of steps) {
+    const shouldRun = evalGhIf(step.if, outputs, env);
+    ran[step.name] = shouldRun;
+    if (!shouldRun) continue;
+    if (step.id === 'version_check') {
+      outputs.version_check = { already_published: opts.rootPublished ? 'true' : 'false' };
+    }
+    if (step.id === 'plugin_version_check') {
+      outputs.plugin_version_check = {
+        plugin_already_published: opts.pluginPublished ? 'true' : 'false',
+      };
+    }
+    if (step.id === 'tag') {
+      outputs.tag = { tag: 'v4.54.14', version: '4.54.14' };
+    }
+  }
+  return ran;
+}
+
+const steps = parseNamedSteps(workflow);
+const byName = Object.fromEntries(steps.map((s) => [s.name, s]));
+
+describe('publish.yml — per-package recovery', () => {
+  it('rerun with root existing and plugin missing still checks, publishes, verifies plugin, and creates release', () => {
+    const ran = simulate({ rootPublished: true, pluginPublished: false });
+    expect(ran['Publish to npm']).toBe(false);
+    expect(ran['Check plugin version']).toBe(true);
+    expect(ran['Publish plugin to npm']).toBe(true);
+    expect(ran['Verify both packages landed on npm at the expected version']).toBe(true);
+    expect(ran['Create GitHub Release']).toBe(true);
+    expect(ran['Skip root publish (already exists)']).toBe(true);
+    expect(ran['Skip plugin publish (already exists)']).toBe(false);
+  });
+
+  it('root publish only runs when the root package is missing', () => {
+    expect(simulate({ rootPublished: false, pluginPublished: false })['Publish to npm']).toBe(true);
+    expect(simulate({ rootPublished: true, pluginPublished: false })['Publish to npm']).toBe(false);
+  });
+
+  it('plugin check is not gated on root already_published', () => {
+    expect(byName['Check plugin version']?.if).toBeUndefined();
+  });
+
+  it('plugin publish depends only on the plugin missing', () => {
+    expect(byName['Publish plugin to npm']?.if).toBe(
+      "steps.plugin_version_check.outputs.plugin_already_published == 'false'",
+    );
+    expect(byName['Publish plugin to npm']?.if).not.toMatch(/version_check\.outputs\.already_published/);
+  });
+
+  it('both-package verification always runs and requires exact root+plugin versions', () => {
+    const verify = byName['Verify both packages landed on npm at the expected version'];
+    expect(verify?.if).toBeUndefined();
+    expect(verify?.body).toContain('if [ "$MAIN_LATEST" != "$MAIN" ]');
+    expect(verify?.body).toContain('if [ "$PLUGIN_LATEST" != "$PLUGIN" ]');
+    expect(simulate({ rootPublished: true, pluginPublished: false })[verify!.name]).toBe(true);
+    expect(simulate({ rootPublished: true, pluginPublished: true })[verify!.name]).toBe(true);
+  });
+
+  it('GitHub Release creation/update always runs', () => {
+    expect(byName['Create GitHub Release']?.if).toBeUndefined();
+    expect(simulate({ rootPublished: true, pluginPublished: false })['Create GitHub Release']).toBe(true);
+    expect(simulate({ rootPublished: true, pluginPublished: true })['Create GitHub Release']).toBe(true);
+  });
+
+  it('skip messages name the package that is actually skipped', () => {
+    const rootSkip = byName['Skip root publish (already exists)'];
+    const pluginSkip = byName['Skip plugin publish (already exists)'];
+    expect(rootSkip?.body).toMatch(/Skipping root npm publish/);
+    expect(rootSkip?.body).not.toMatch(/Skipping publish - version already exists/);
+    expect(pluginSkip?.body).toMatch(/Skipping plugin npm publish/);
+    expect(pluginSkip?.body).toMatch(/shieldcortex-realtime/);
+  });
+
+  it('ClawHub remains independent of npm already_published', () => {
+    expect(byName['Install ClawHub CLI']?.if).toBe("env.HAS_CLAWHUB_TOKEN == 'true'");
+    expect(byName['Sync + verify ClawHub']?.if).toBe("env.HAS_CLAWHUB_TOKEN == 'true'");
+    expect(byName['Skip ClawHub sync (missing token)']?.if).toBe("env.HAS_CLAWHUB_TOKEN != 'true'");
+    const ran = simulate({ rootPublished: true, pluginPublished: false, hasClawhub: true });
+    expect(ran['Sync + verify ClawHub']).toBe(true);
+    const noToken = simulate({ rootPublished: false, pluginPublished: false, hasClawhub: false });
+    expect(noToken['Sync + verify ClawHub']).toBe(false);
+    expect(noToken['Skip ClawHub sync (missing token)']).toBe(true);
+  });
+});


### PR DESCRIPTION
## Release

ShieldCortex **4.54.14**.

### Included since 4.54.13
- #436 Claude Code shell-control schema and non-catastrophic retry door.
- #395 defended native import-once.
- #394 dual-plane memory drift enforcement.
- #428 dashboard Next.js GHSA floor.
- #401 work-lane pack and other reviewed mainline fixes documented in CHANGELOG.

### Verification
- Build passed, including dashboard.
- Full serial suite: **519 suites passed; 6,790 tests passed, 7 skipped**.
- Core and OpenClaw plugin dry-run package shapes passed at 4.54.14.
- Version surfaces synced: root, plugin package/manifest, skill frontmatter.
- #436 exact head CI green and independently approved before merge.

The first local full-suite attempt was invalid because build and tests were run concurrently while build recreates `dist`; the serial rerun above is the valid result.

Tag after merge: annotated `v4.54.14` (publish workflow owns npm, plugin npm, GitHub Release, and ClawHub).