### PR TITLE
fix(doctor): un-gate the denial-sink check and FAIL the armed no-sink (#354)

### DIFF
--- a/src/cli/__tests__/doctor-action-guard.test.ts
+++ b/src/cli/__tests__/doctor-action-guard.test.ts
@@ -205,10 +205,15 @@ describe('doctor — Action Guard notify channel (#242)', () => {
     expect(results.find((r) => /webhookUrl|notify channel/i.test(r.message))).toBeUndefined();
   });
 
-  it('warns when notify.openclaw alone is set — not a DNP denial sink (#354)', async () => {
+  it('FAILS when armed with notify.openclaw alone — not a DNP denial sink (#354)', async () => {
+    // Severity is the point: `notify.enabled: true` + `openclaw: true` reads as
+    // configured to every operator who checks it, and delivers no unattended
+    // denial at all. Doctor emitted a WARN on this exact shape while 312
+    // denials went undelivered on one host — the product said it and the
+    // outcome did not change. Armed-and-lying is a failure, not advice.
     writeConfig({ actionGuard: { notify: { enabled: true, openclaw: true } } });
     const results = await checkActionGuard();
-    const warn = results.find((r) => r.status === 'warn' && /notify/i.test(r.label));
+    const warn = results.find((r) => r.status === 'fail' && /notify/i.test(r.label));
     expect(warn).toBeDefined();
     expect(warn!.message).toMatch(/openclaw only|denial-capable|webhookUrl/i);
     expect(warn!.message).not.toMatch(/native OpenClaw approval card reaches a human/i);
@@ -228,10 +233,30 @@ describe('doctor — Action Guard notify channel (#242)', () => {
     expect(results.find((r) => r.status === 'warn' && /notify/i.test(r.label))).toBeUndefined();
   });
 
-  it('does not warn about notify when the guard is not enforcing', async () => {
+  // #354 P3 (29 Aug 2026) — REVERSED DELIBERATELY. This used to assert that a
+  // non-enforcing host hears nothing about a missing denial sink. That gate is
+  // precisely how clawdbot1 went quiet the moment Action Guard was switched off:
+  // the operator deciding whether it is safe to switch back ON is exactly the
+  // person who needs to know there is no sink to deliver denials to. Measured
+  // across three hosts that day: 0 delivered out of 312 / 89 / 26.
+  it('still reports a missing denial sink when the guard is NOT enforcing', async () => {
     writeConfig({ actionGuard: { enforce: false } });
     const results = await checkActionGuard();
-    expect(results.find((r) => /webhookUrl/i.test(r.message))).toBeUndefined();
+    const notify = results.find((r) => /webhookUrl/i.test(r.message));
+    expect(notify).toBeDefined();
+    // Not currently lying to anyone, so it is a warning rather than a failure —
+    // but it is said, which is the whole point of un-gating.
+    expect(notify!.status).toBe('warn');
+    expect(notify!.message).toMatch(/warn-mode/i);
+  });
+
+  it('tells a DISABLED host it would have no denial sink once re-enabled', async () => {
+    writeConfig({ actionGuard: { enabled: false } });
+    const results = await checkActionGuard();
+    const notify = results.find((r) => /webhookUrl/i.test(r.message));
+    expect(notify).toBeDefined();
+    expect(notify!.status).toBe('warn');
+    expect(notify!.message).toMatch(/re-enabled/i);
   });
 });
 
@@ -242,9 +267,12 @@ describe('doctor — Action Guard notify channel (#242)', () => {
  * config.json, invalidated the `_sig` HMAC, and got forced into strict mode.
  */
 describe('doctor — Action Guard notify fix is a signed CLI command (#275)', () => {
+  // #354 P3: the armed openclaw-only shape is now a FAIL, not a WARN, so this
+  // helper matches either severity — the tests below assert the severity they
+  // expect explicitly rather than relying on the finder to filter it.
   const findNotifyWarn = async () => {
     const results = await checkActionGuard();
-    return results.find((r) => r.status === 'warn' && /notify/.test(r.label));
+    return results.find((r) => (r.status === 'warn' || r.status === 'fail') && /notify/.test(r.label));
   };
 
   it('prescribes `shieldcortex config` with a real flag, not bare key paths', async () => {
@@ -276,6 +304,10 @@ describe('doctor — Action Guard notify fix is a signed CLI command (#275)', ()
     handleCloudConfig(['--action-guard-notify-openclaw']);
     const warn = await findNotifyWarn();
     expect(warn).toBeDefined();
+    // #354 P3: armed + openclaw-only reads as configured to any operator who
+    // checks, and delivers no unattended denial at all. A WARN was emitted on
+    // this exact shape while 312 denials vanished — the severity was the defect.
+    expect(warn!.status).toBe('fail');
     expect(warn!.message).toMatch(/openclaw only|denial-capable|webhookUrl/i);
     const onDisk = JSON.parse(fs.readFileSync(configPath(), 'utf-8'));
     expect(typeof onDisk._sig).toBe('string');

--- a/src/cli/__tests__/doctor-action-guard.test.ts
+++ b/src/cli/__tests__/doctor-action-guard.test.ts
@@ -181,8 +181,13 @@ describe('doctor — Action Guard #209 alias resolution and migration', () => {
 
 /**
  * #242 Defect B / #260 — unattended enforcement with no notify channel is how
- * eight days of backups vanished while lastRunStatus stayed ok. Doctor must
- * WARN (not fail) when enforce is on and nothing can reach a human.
+ * eight days of backups vanished while lastRunStatus stayed ok.
+ *
+ * #354 (30 Aug 2026): the old rule here was "WARN, not fail". It is gone. The
+ * line is now honest-vs-lying, not misconfig-vs-evaluator — while armed,
+ * `notify.enabled: true` with no webhook FAILS, because it claims a delivery
+ * path it does not have. Notify that is off, or a host that is disabled or in
+ * warn-mode, still WARNs: under-configured is not the same as untruthful.
  */
 describe('doctor — Action Guard notify channel (#242)', () => {
   it('warns when enforce is on and notify.webhookUrl is unset (the default)', async () => {
@@ -217,6 +222,33 @@ describe('doctor — Action Guard notify channel (#242)', () => {
     expect(warn).toBeDefined();
     expect(warn!.message).toMatch(/openclaw only|denial-capable|webhookUrl/i);
     expect(warn!.message).not.toMatch(/native OpenClaw approval card reaches a human/i);
+  });
+
+  it('FAILS when armed with notify.enabled alone — no openclaw, no webhook (#354)', async () => {
+    // The sibling of the openclaw-only shape, and NOT the milder one. This is
+    // the `tars` host: notify says enabled, nothing can carry a headless denial,
+    // 0 delivered out of 89. Its rows are labelled `notify_not_configured`
+    // rather than `no_channel` — a different label on the same zero. Severity
+    // must not follow the label.
+    writeConfig({ actionGuard: { notify: { enabled: true } } });
+    const results = await checkActionGuard();
+    const found = results.find((r) => r.status === 'fail' && /notify/i.test(r.label));
+    expect(found).toBeDefined();
+    expect(found!.message).toMatch(/denial-capable|webhookUrl/i);
+    // It must NOT be described as the openclaw-card case — that is a different
+    // misconfiguration with a different fix.
+    expect(found!.message).not.toMatch(/openclaw only/i);
+  });
+
+  it('only WARNS when notify is off entirely — under-configured, not lying (#354)', async () => {
+    // The boundary of the FAIL rule. `notify.enabled` absent makes no claim, so
+    // doctor advises rather than fails; if this ever flips to `fail`, a stock
+    // host with no notify stanza starts exiting 1 on plain `doctor`.
+    writeConfig({ actionGuard: { notify: { enabled: false } } });
+    const results = await checkActionGuard();
+    const found = results.find((r) => /webhookUrl/i.test(r.message));
+    expect(found).toBeDefined();
+    expect(found!.status).toBe('warn');
   });
 
   it('does not warn when webhook denial sink is configured even if openclaw is also on', async () => {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2309,9 +2309,18 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
     }
 
     // #242 Defect B: enforce-on + no notify channel is how unattended denials
-    // vanished for eight days while lastRunStatus stayed ok. WARN, never fail
-    // — a missing webhook is a misconfiguration, not a broken evaluator.
+    // vanished for eight days while lastRunStatus stayed ok.
     // OpenClaw lastRunStatus is not ours to write (#242 Defect A / #260).
+    //
+    // NOTE (#354, 30 Aug 2026): this comment used to end "WARN, never fail — a
+    // missing webhook is a misconfiguration, not a broken evaluator." That rule
+    // is DEAD and must not be restored. It was the reason doctor emitted advice
+    // instead of a failure while 312 denials went undelivered on one host over
+    // seven days. The distinction that survives is not misconfig-vs-evaluator,
+    // it is honest-vs-lying: notify that says `enabled: true` while holding no
+    // denial-capable sink claims a delivery path it does not have, and it makes
+    // that claim to the operator who is deciding whether the host is safe. That
+    // is a failure. Notify that is simply off is not lying, and stays a warning.
     //
     // #354 / #310: `notify.openclaw` is NOT a DNP denial sink. It arms interactive
     // held-approval cards only. Headless denials are `denied_no_prompt_surface`
@@ -2334,14 +2343,23 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
       const armed = effective.enabled && effective.enforce;
       if (!denialSink) {
         const openclawOnly = notifyOn && openclaw && !webhook;
-        // FAIL, not WARN, for the armed-looking no-sink. `notify.enabled: true`
-        // + `openclaw: true` reads as configured to every operator who checks —
-        // and delivers no unattended denial at all. A WARN was emitted on this
-        // exact shape while 312 denials vanished; the product said it and the
-        // outcome did not change, so the severity was the defect. A host that is
-        // off or in warn-mode is not currently lying to anyone, so it stays WARN
-        // — but it is still told, which is the whole point of un-gating.
-        const status: CheckResult['status'] = armed && openclawOnly ? 'fail' : 'warn';
+        // FAIL, not WARN, for the armed no-sink that CLAIMS to be configured.
+        // The discriminator is `notify.enabled: true` without a webhook — that
+        // config asserts a delivery path it does not have, to the one operator
+        // who is deciding whether the host is safe. Both shapes measured on
+        // 29 Aug 2026 delivered nothing while enforcing:
+        //   notify.enabled + openclaw, no webhook  → clawdbot1, 0 of 312
+        //   notify.enabled alone,      no webhook  → tars,      0 of 89
+        // The second is not the milder case — `notify_not_configured` rows are
+        // just a different label on the same zero. Doctor WARNed on both and the
+        // outcome did not change, so severity was the defect, not coverage.
+        //
+        // `notify.enabled` false/absent stays WARN: a host that says notify is
+        // off and has it off is not lying, it is under-configured. Same for any
+        // host that is disabled or in warn-mode — not currently lying to anyone,
+        // but still told, which is the whole point of un-gating.
+        const claimsASink = notifyOn && !webhook;
+        const status: CheckResult['status'] = armed && claimsASink ? 'fail' : 'warn';
         const prefix = armed
           ? 'Action Guard is enforcing with'
           : effective.enabled

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2317,23 +2317,44 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
     // held-approval cards only. Headless denials are `denied_no_prompt_surface`
     // and travel via webhookUrl → denialChannel (or loud DNP digest on that sink).
     // Doctor must not treat openclaw:true alone as "unattended notify configured".
-    if (effective.enabled && effective.enforce) {
+    // #354 P3 (29 Aug 2026): this check used to sit inside
+    // `if (effective.enabled && effective.enforce)`. That gate is why clawdbot1
+    // went quiet the moment Action Guard was switched off: a disabled host hears
+    // only "AG is off" and never that it has no denial-capable sink, so the
+    // missing sink is invisible exactly when someone is deciding whether it is
+    // safe to switch back on. Measured across three hosts on 29 Aug 2026:
+    // 0 denials delivered out of 312 / 89 / 26. Un-gated deliberately.
+    {
       const notify = isBlock(merged.notify) ? merged.notify : {};
       const notifyOn = notify.enabled === true;
       const webhook = typeof notify.webhookUrl === 'string' ? notify.webhookUrl.trim() : '';
       const openclaw = notify.openclaw === true;
       // Denial-capable sink for unattended/DNP path = enabled notify + webhook URL.
       const denialSink = notifyOn && webhook.length > 0;
+      const armed = effective.enabled && effective.enforce;
       if (!denialSink) {
         const openclawOnly = notifyOn && openclaw && !webhook;
+        // FAIL, not WARN, for the armed-looking no-sink. `notify.enabled: true`
+        // + `openclaw: true` reads as configured to every operator who checks —
+        // and delivers no unattended denial at all. A WARN was emitted on this
+        // exact shape while 312 denials vanished; the product said it and the
+        // outcome did not change, so the severity was the defect. A host that is
+        // off or in warn-mode is not currently lying to anyone, so it stays WARN
+        // — but it is still told, which is the whole point of un-gating.
+        const status: CheckResult['status'] = armed && openclawOnly ? 'fail' : 'warn';
+        const prefix = armed
+          ? 'Action Guard is enforcing with'
+          : effective.enabled
+            ? 'Action Guard is in warn-mode and running with'
+            : 'Action Guard is disabled and, when re-enabled, would run with';
         results.push({
           label: `${label} notify`,
-          status: 'warn',
+          status,
           message: openclawOnly
-            ? `Action Guard is enforcing with notify.openclaw only — that arms interactive approval cards, ` +
+            ? `${prefix} notify.openclaw only — that arms interactive approval cards, ` +
               `not unattended denial delivery. Headless denials (denied_no_prompt_surface / cron) stay local ` +
               `unless actionGuard.notify.webhookUrl is set as the denial-capable sink (#354 / #310).`
-            : `Action Guard is enforcing with no denial-capable notify sink (actionGuard.notify.webhookUrl unset` +
+            : `${prefix} no denial-capable notify sink (actionGuard.notify.webhookUrl unset` +
               `${notifyOn ? '' : ', notify.enabled is not true'}) — unattended denials stay in the ` +
               `audit log and session-guard index only. The #242 cron incidents were this shape.`,
           fix:
@@ -2350,7 +2371,9 @@ export async function checkActionGuard(): Promise<CheckResult[]> {
       // disabled is the default, and a disabled broker does nothing at all.
       // Neither state removes the need for a notify channel: the broker can
       // harden or hold, but the human path is still the notify path.
-      const brokerBlock = isBlock(merged.broker) ? merged.broker : null;
+      // Broker reporting stays gated on armed, exactly as before this change —
+      // un-gating the DENIAL SINK check is the scope; the broker block is not.
+      const brokerBlock = armed && isBlock(merged.broker) ? merged.broker : null;
       if (brokerBlock) {
         results.push(
           brokerBlock.enabled === true


### PR DESCRIPTION
Two of the four P3 gaps from the Action Guard no-door work. Both measured on live hosts.

## 1. Un-gate the denial-sink check

It sat inside `if (effective.enabled && effective.enforce)`. That gate is exactly how a host goes quiet the moment Action Guard is switched off — it then reports only "AG is disabled" and never that it has **no sink to deliver denials to**.

The operator deciding whether it is safe to switch back **on** is precisely the person who needs that fact. Warn-mode and disabled hosts now hear it, worded for their state ("...when re-enabled, would run with...").

## 2. FAIL, not WARN, for the armed-looking no-sink

`notify.enabled: true` + `notify.openclaw: true` reads as configured to any operator who checks it, and delivers no unattended denial at all — `openclaw` arms interactive cards, which correctly refuse headless `denied_no_prompt_surface` events.

**Severity was the defect.** Doctor already emitted a correct WARN on this exact shape while **312 denials went undelivered on one host over 7 days**. The product said it; the outcome did not change. Armed-and-lying is a failure, not advice.

A host that is off or in warn-mode is not currently lying to anyone, so it stays WARN — but it is still told.

## Evidence (29 Aug 2026 — three hosts, unique `actionId`, final row only)

| host | delivered | row labels |
|---|---|---|
| clawdbot1 | **0 / 312** | `coalesced` + `no_channel` |
| tars | **0 / 89** | `notify_not_configured` |
| aiquant | **0 / 26** (15d) | `no_channel` |

Three configs, three different labels, zero delivery everywhere.

## Tests

The suite's "does not warn when not enforcing" case asserted the very gate being removed, so it is **reversed deliberately** and renamed, plus a new disabled-host case. 29/29 pass.

Verified by **observation**, not only tests: the built CLI against a synthetic config dir prints `[!]` for the disabled host and `[x]` for the armed one. That observation caught a grammar defect ("is enforcing running with") which every test happily passed over.

## Pre-existing, not introduced here

88 tests across 13 doctor suites fail on clean `origin/main` in this environment. Baselined by stashing and re-running: identical 88. This PR adds one passing test and breaks none.

## Not in this PR

The other two P3 gaps: doctor reading `dnp-digest.json` honesty, and the four audit buckets as the config-vs-code discriminator. P2 (the digest `notifiedForWindow` two-phase fix) is deliberately not started — it is a concurrency change to shared state and is gated behind review.