### PR TITLE
fix(guard): #439 map TaskOutput/TaskStop to closed shell-control schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+- **#439:** Claude Code `TaskOutput` / `TaskStop` now use the same closed shell-control schemas as `BashOutput` / `KillShell` / `KillBash`, and `evaluateToolCall` enforces that bag even though those names are not exec-family. Exact native names only — namespaced look-alikes still fail closed on `EXEC_KEYS`. Pins the #436 residual so a later Claude rename cannot reopen invalid-tool-input on legitimate control bags.
+
 ## [4.54.14] - 2026-08-29
 
 ### Security

--- a/src/defence/iron-dome/__tests__/shell-control-schema-436.test.ts
+++ b/src/defence/iron-dome/__tests__/shell-control-schema-436.test.ts
@@ -176,13 +176,26 @@ describe('#439 — TaskOutput/TaskStop use the native control schemas', () => {
     expect(v.signals).toEqual(expect.arrayContaining(['invalid-tool-input', 'unknown-keys']));
   });
 
+  it('non-string TaskStop handle fails closed without throwing', () => {
+    const v = evaluateToolCall('TaskStop', { shell_id: 1 });
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('dangerous');
+    expect(v.action).toBe('invalid_tool_input');
+  });
+
   it('does not leak the narrow schema to a namespaced TaskOutput look-alike', () => {
     const r = enforceToolInput('mcp__thirdparty__TaskOutput', { task_id: 'task_1' });
     expect(r.ok).toBe(false);
+    // If the native control bag leaked, evil_payload would be invalid_tool_input.
+    // Unknown-family annotate strips it and allows — that is the intended split.
+    const v = evaluateToolCall('mcp__thirdparty__TaskOutput', { task_id: 'task_1', evil_payload: 'x' });
+    expect(v.action).not.toBe('invalid_tool_input');
   });
 
   it('does not leak the narrow schema to a namespaced TaskStop look-alike', () => {
     const r = enforceToolInput('mcp__thirdparty__TaskStop', { shell_id: 'shell_1' });
     expect(r.ok).toBe(false);
+    const v = evaluateToolCall('mcp__thirdparty__TaskStop', { shell_id: 'shell_1', evil_payload: 'x' });
+    expect(v.action).not.toBe('invalid_tool_input');
   });
 });

--- a/src/defence/iron-dome/__tests__/shell-control-schema-436.test.ts
+++ b/src/defence/iron-dome/__tests__/shell-control-schema-436.test.ts
@@ -20,6 +20,12 @@ describe('#436 acceptance 1 — live control shapes are not invalid-tool-input',
     ['KillShell', { task_id: 'task_1' }],
     ['KillBash', { shell_id: 'shell_1' }],
     ['KillBash', { task_id: 'task_1' }],
+    // #439 — same closed bags, exact native names not previously mapped
+    ['TaskOutput', { task_id: 'task_1' }],
+    ['TaskOutput', { bash_id: 'bash_1', filter: 'ready' }],
+    ['TaskOutput', { agentId: 'agent_1' }],
+    ['TaskStop', { task_id: 'task_1' }],
+    ['TaskStop', { shell_id: 'shell_1' }],
   ];
 
   it.each(LIVE)('%s %j is not an invalid-tool-input hard block', (tool, args) => {
@@ -128,5 +134,55 @@ describe('#436 acceptance 2 — schema stays CLOSED', () => {
     expect(v.decision).toBe('block');
     expect(v.severity).toBe('catastrophic');
     expect(v.action).not.toBe('invalid_tool_input');
+  });
+});
+
+describe('#439 — TaskOutput/TaskStop use the native control schemas', () => {
+  it.each(['TaskOutput', 'TaskStop'] as const)(
+    'empty %s fails closed via evaluateToolCall (never throws)',
+    (tool) => {
+      const r = enforceToolInput(tool, {});
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.code).toBe('MISSING_HANDLE');
+      const v = evaluateToolCall(tool, {});
+      expect(v.decision).toBe('block');
+      expect(v.severity).toBe('dangerous');
+      expect(v.action).toBe('invalid_tool_input');
+    },
+  );
+
+  it('filter-only TaskOutput fails closed (no handle)', () => {
+    const v = evaluateToolCall('TaskOutput', { filter: 'ready' });
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('dangerous');
+    expect(v.action).toBe('invalid_tool_input');
+  });
+
+  it('non-string TaskOutput handle fails closed without throwing', () => {
+    const v = evaluateToolCall('TaskOutput', { task_id: 1 });
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('dangerous');
+    expect(v.action).toBe('invalid_tool_input');
+  });
+
+  it.each([
+    ['TaskOutput', { task_id: 'task_1', evil_payload: 'x' }],
+    ['TaskStop', { shell_id: 'shell_1', evil_payload: 'x' }],
+  ])('rejects an unknown field on %s via evaluateToolCall', (tool, args) => {
+    const v = evaluateToolCall(tool, args);
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('dangerous');
+    expect(v.action).toBe('invalid_tool_input');
+    expect(v.signals).toEqual(expect.arrayContaining(['invalid-tool-input', 'unknown-keys']));
+  });
+
+  it('does not leak the narrow schema to a namespaced TaskOutput look-alike', () => {
+    const r = enforceToolInput('mcp__thirdparty__TaskOutput', { task_id: 'task_1' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('does not leak the narrow schema to a namespaced TaskStop look-alike', () => {
+    const r = enforceToolInput('mcp__thirdparty__TaskStop', { shell_id: 'shell_1' });
+    expect(r.ok).toBe(false);
   });
 });

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -27,7 +27,7 @@
 
 import { lstatSync, realpathSync } from 'node:fs';
 import type { IronDomeConfig } from './config.js';
-import { validateToolInput, schemaFamilyForTool } from './tool-input-schema.js';
+import { validateToolInput, schemaFamilyForTool, isNativeShellControlTool } from './tool-input-schema.js';
 import { forEachWindow } from '../scan-windows.js';
 
 export type ToolGuardDecision = 'allow' | 'require_approval' | 'block';
@@ -4155,7 +4155,11 @@ export function evaluateToolCall(
     // which would fail-closed GitHub-API tools under EXEC_KEYS (title/labels).
     const schemaFam = schemaFamilyForTool(toolName);
     const guardFam = classifyFamily(toolName);
-    const mode = (schemaFam === 'exec' || schemaFam === 'git' || guardFam === 'exec')
+    // #439: TaskOutput/TaskStop are not exec-family by name (no bash/shell
+    // substring). Without this, validateToolInput annotates and strips unknown
+    // keys instead of failing closed — so mapping them in shellControlSchemaFor
+    // alone would not survive evaluateToolCall.
+    const mode = (schemaFam === 'exec' || schemaFam === 'git' || guardFam === 'exec' || isNativeShellControlTool(toolName))
       ? 'enforce'
       : 'annotate';
     const validated = validateToolInput(toolName, args, mode);

--- a/src/defence/iron-dome/tool-input-schema.ts
+++ b/src/defence/iron-dome/tool-input-schema.ts
@@ -131,11 +131,18 @@ const SHELL_CONTROL_STOP: ShellControlSchema = {
  */
 function shellControlSchemaFor(toolName: string): ShellControlSchema | null {
   switch (String(toolName ?? '').trim().toLowerCase()) {
-    case 'bashoutput': return SHELL_CONTROL_OUTPUT;
+    case 'bashoutput':
+    case 'taskoutput': return SHELL_CONTROL_OUTPUT;
     case 'killshell':
-    case 'killbash': return SHELL_CONTROL_STOP;
+    case 'killbash':
+    case 'taskstop': return SHELL_CONTROL_STOP;
     default: return null;
   }
+}
+
+/** #439: native control tools are not exec-family by name, but their bag is still closed. */
+export function isNativeShellControlTool(toolName: string): boolean {
+  return shellControlSchemaFor(toolName) != null;
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {


### PR DESCRIPTION
## Problem

`TaskOutput` and `TaskStop` sit in the hook `SAFE_TOOL_NAMES` set and the notify allowlist, and `SHELL_CONTROL_OUTPUT` / `SHELL_CONTROL_STOP` already document their Claude 2.1.233 shapes. `shellControlSchemaFor()` only mapped `BashOutput` / `KillShell` / `KillBash`.

Today those names are not exec-family, so there is no live denial. The next Claude build that classifies them as exec (or a rename of the handle) reopens the #436 class: legitimate control bags rejected as `invalid_tool_input`.

Mapping the schema was **not sufficient**. `evaluateToolCall` only enforces the bag when the schema/guard family is exec/git. `TaskOutput`/`TaskStop` have no bash/shell substring, so unknown keys were annotated (stripped) and the call allowed. `enforceToolInput` alone would have lied green.

Fixes #439.

## Approach

- Map exact whole-name case-insensitive `taskoutput` → output schema, `taskstop` → stop schema.
- `isNativeShellControlTool()` drives enforce-mode in `evaluateToolCall`.
- Do not add keys to `EXEC_KEYS`. Namespaced look-alikes (`mcp__thirdparty__TaskOutput`) still fail closed.

## Tests

- Live shapes via `evaluateToolCall` and `enforceToolInput`.
- Empty / filter-only / non-string handle: verdict, never throw.
- Unknown extra key: `block` / `dangerous` / `invalid_tool_input` + `unknown-keys`.
- Namespaced look-alikes do not inherit the narrow schema.
- Catastrophic Bash + extra unknown key stays catastrophic.

Sabotage: revert mapping + enforce-mode wire → **11 FAIL**. Restore → **47/47** plus #412 suites **74/74**.

## Not in this PR

- #438 dead-PID session-lease reap
- #441 dual_legacy remedy loop (Jarvis)
- #444 docstring `install-package-global` FP (Jarvis)
- Not merging. Independent review required (implementer is TARS/Grok).
