### PR TITLE
fix(doctor): carry a remedy's precondition to the terminal, structured (#441)

### DIFF
--- a/src/cli/__tests__/doctor-report-precondition-441.test.ts
+++ b/src/cli/__tests__/doctor-report-precondition-441.test.ts
@@ -1,0 +1,63 @@
+/**
+ * #441 renderer half — the precondition must reach the terminal, above the
+ * command, on both the plain and the collapsed path.
+ *
+ * The check-side fix (plane-remedy-441.test.ts) is worthless if the renderer
+ * drops `fixWhen` the same way it dropped the prose clause it replaces.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { formatDoctorReport, type DoctorReportItem } from '../doctor-report.js';
+
+const WARN: DoctorReportItem = {
+  label: 'Memory plane drift',
+  status: 'warn',
+  message: 'plane=dual_legacy: native agent SoT written inside the window — ~/clawd/memory/2026-08-29.md',
+  fix: 'Time-box dual_legacy: `shieldcortex config --memory-plane import_only` — dual_legacy is a migration escape, not steady state',
+  fixWhen: 'the host contract and defended import have landed — until then this command raises the same finding to FAIL',
+};
+
+// formatDoctorReport returns lines, not a blob.
+const renderLines = (items: DoctorReportItem[], opts = {}): string[] =>
+  formatDoctorReport(items, { color: false, ...opts });
+const render = (items: DoctorReportItem[], opts = {}): string =>
+  renderLines(items, opts).join('\n');
+
+describe('#441 — doctor prints the precondition, not just the command', () => {
+  it('renders the condition and the command together', () => {
+    const out = render([WARN]);
+    expect(out).toMatch(/only when:/);
+    expect(out).toMatch(/host contract and defended import/);
+    expect(out).toMatch(/\$ shieldcortex config --memory-plane import_only/);
+  });
+
+  it('puts the condition ABOVE the runnable command', () => {
+    // Order is the whole point: an operator copies the first bold `$` they see.
+    // A caveat underneath is read only by someone who already hesitated.
+    const lines = renderLines([WARN]);
+    const cond = lines.findIndex((l) => l.includes('only when:'));
+    const cmd = lines.findIndex((l) => l.includes('$ shieldcortex config --memory-plane import_only'));
+    expect(cond).toBeGreaterThanOrEqual(0);
+    expect(cmd).toBeGreaterThanOrEqual(0);
+    expect(cond).toBeLessThan(cmd);
+  });
+
+  it('keeps the condition when a group is collapsed', () => {
+    // Collapsing merges fixCommands across members; before #441 there was no
+    // fixWhen to merge, so this path is exactly where a precondition would
+    // silently vanish while the command it guards survived.
+    const sibling: DoctorReportItem = { ...WARN, message: WARN.message + ' (second signal)' };
+    const out = render([WARN, sibling], { collapse: true });
+    expect(out).toMatch(/only when:/);
+    expect(out).toMatch(/\$ shieldcortex config --memory-plane import_only/);
+  });
+
+  it('says nothing extra when a remedy has no precondition', () => {
+    const plain: DoctorReportItem = {
+      label: 'Hooks',
+      status: 'warn',
+      message: '1/4 installed',
+      fix: 'Run `shieldcortex setup` to install the hooks',
+    };
+    expect(render([plain])).not.toMatch(/only when:/);
+  });
+});

--- a/src/cli/doctor-report.ts
+++ b/src/cli/doctor-report.ts
@@ -15,6 +15,8 @@ export interface DoctorReportItem {
   status: DoctorStatus;
   message: string;
   fix?: string;
+  /** #441 — precondition for `fix`; rendered above the command, never inferred. */
+  fixWhen?: string;
 }
 
 export interface FormatDoctorReportOpts {
@@ -272,6 +274,8 @@ interface ThemeGroup {
   what: string;
   why: string;
   fixCommands: string[];
+  /** #441 — printed before the commands so the condition is read first. */
+  fixWhen?: string;
   count: number;
   labels: string[];
 }
@@ -284,6 +288,7 @@ function groupItems(items: DoctorReportItem[], collapse: boolean): ThemeGroup[] 
       what: shortWhat(it),
       why: it.message.replace(/\s+/g, ' ').trim(),
       fixCommands: extractFixCommands(it.fix),
+      ...(it.fixWhen ? { fixWhen: it.fixWhen } : {}),
       count: 1,
       labels: [it.label],
     }));
@@ -301,6 +306,7 @@ function groupItems(items: DoctorReportItem[], collapse: boolean): ThemeGroup[] 
         what: shortWhat(it),
         why: it.message.replace(/\s+/g, ' ').trim(),
         fixCommands: extractFixCommands(it.fix),
+        ...(it.fixWhen ? { fixWhen: it.fixWhen } : {}),
         count: 1,
         labels: [it.label],
       };
@@ -314,6 +320,10 @@ function groupItems(items: DoctorReportItem[], collapse: boolean): ThemeGroup[] 
       // Prefer a non-empty fix
       const cmds = extractFixCommands(it.fix);
       for (const c of cmds) if (!existing.fixCommands.includes(c)) existing.fixCommands.push(c);
+      // #441: collapsing must never drop a precondition. If either member of a
+      // collapsed group carries one, the group keeps it — dropping it here would
+      // reintroduce the unconditional-command bug through the grouping path.
+      if (!existing.fixWhen && it.fixWhen) existing.fixWhen = it.fixWhen;
       // Prefer the dedicated conversation-scanning label over plugin-loaded note
       if (/conversation scanning/i.test(it.label) && !/conversation scanning/i.test(existing.what)) {
         existing.what = shortWhat(it);
@@ -362,6 +372,17 @@ function renderIssueBlock(g: ThemeGroup, width: number, style: DoctorReportStyle
   // Why: full text, wrapped. Ellipsis here is what made full-screen doctor look "cut off".
   const why = cleanWhy(g.why);
   lines.push(...wrapLine(why, width, 4, 4).map((l) => `${style.dim}${l}${style.reset}`));
+  // #441 — the precondition goes ABOVE the command, not after it. An operator
+  // scanning for the bold `$` line copies the first runnable thing they see; a
+  // caveat printed underneath is read only by someone who already doubted it.
+  // `only when:` is a fixed prefix rather than prose so it cannot be mistaken
+  // for part of the command.
+  if (g.fixWhen) {
+    lines.push(
+      ...wrapLine(`only when: ${g.fixWhen}`, width, 4, 6)
+        .map((l) => `${style.yellow}${l}${style.reset}`),
+    );
+  }
   // Fix commands — all of them. `$` only on a real binary. English notes stay notes.
   if (g.fixCommands.length === 0) {
     lines.push(`${style.dim}    (no single copy-paste command)${style.reset}`);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -121,6 +121,16 @@ export interface CheckResult {
   message: string;
   fix?: string;
   /**
+   * #441 — a precondition on `fix`, kept OUT of the fix prose on purpose.
+   *
+   * The report renderer recovers copy-pasteable commands from `fix` with a
+   * backtick regex. Anything the sentence said about WHEN to run the command is
+   * dropped on the floor, so a conditional remedy reaches the operator as an
+   * unconditional one. Any check whose fix is only safe in some states must put
+   * that condition here, not in the sentence.
+   */
+  fixWhen?: string;
+  /**
    * Set when the check did not run because a prerequisite simply does not
    * exist yet on a fresh install. runDoctor() collapses these into a single
    * dim note instead of printing a line per dependent check — the cascade of
@@ -3211,6 +3221,7 @@ export async function checkMemoryPlaneDrift(): Promise<CheckResult> {
       status: verdict.status,
       message: verdict.message,
       ...(verdict.fix ? { fix: verdict.fix } : {}),
+      ...(verdict.fixWhen ? { fixWhen: verdict.fixWhen } : {}),
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/memory/__tests__/plane-remedy-441.test.ts
+++ b/src/memory/__tests__/plane-remedy-441.test.ts
@@ -1,0 +1,118 @@
+/**
+ * #441 — a remedy must not lose the condition that makes it safe.
+ *
+ * The dual_legacy drift WARN rendered a bold, copy-pasteable
+ * `$ shieldcortex config --memory-plane import_only`. Running it on the host
+ * that produced the WARN turned it into a FAIL, and the FAIL's own remedy
+ * pointed back at `--memory-plane dual_legacy` — a closed loop with nothing
+ * anywhere saying it was one.
+ *
+ * The command was never wrong. Its precondition ("land the host contract +
+ * defended import, THEN ...") lived in the fix sentence, and the renderer
+ * recovers commands from that sentence with a backtick regex — so the command
+ * reached the terminal and the condition did not.
+ *
+ * The invariant these tests pin is deliberately general, because the loop is a
+ * symptom: IF applying a check's own remedy to the same evidence raises the
+ * severity, THEN that remedy must carry a precondition. A future signal that
+ * offers a plane change without one fails here, not on someone's host.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { extractFixCommands } from '../../cli/doctor-report.js';
+import {
+  evaluatePlaneDrift,
+  type MemoryPlane,
+  type NativeSotEvidence,
+  type PlaneDriftCounts,
+} from '../plane-drift.js';
+
+/** The real clawdbot1 numbers from the #441 report, not constructed ones. */
+const native: NativeSotEvidence = {
+  touched7d: true,
+  bytes: 7834955,
+  touchedPaths: [
+    '~/clawd/memory/.dreams/events.jsonl',
+    '~/clawd/memory/2026-08-29.md',
+  ],
+  busActive: [],
+};
+const counts: PlaneDriftCounts = {
+  durableAdmits7d: 271,
+  activity7d: 7652,
+  injectable: null,
+  unscopedExcluded: 42,
+};
+
+const evaluate = (plane: MemoryPlane, over: Partial<NativeSotEvidence> = {}) =>
+  evaluatePlaneDrift({
+    plane,
+    counts,
+    native: { ...native, ...over },
+    requireScope: true,
+    nowMs: Date.parse('2026-08-30T07:00:00Z'),
+    planeSetAt: null,
+  });
+
+/** The plane a remedy command would move the host to, or null if it is not a plane change. */
+function planeAfter(commands: string[]): MemoryPlane | null {
+  for (const c of commands) {
+    const m = /--memory-plane\s+(dual_legacy|import_only|sc_canonical)\b/.exec(c);
+    if (m) return m[1] as MemoryPlane;
+  }
+  return null;
+}
+
+const RANK: Record<string, number> = { pass: 0, warn: 1, fail: 2 };
+
+describe('#441 — a remedy that raises severity must state its precondition', () => {
+  // The four drift signals that offer a dual_legacy host the same escape.
+  const signals: Array<{ name: string; over: Partial<NativeSotEvidence> }> = [
+    { name: 'native SoT written in window', over: {} },
+    { name: 'native memory bus still on', over: { touched7d: false, busActive: ['OpenClaw agents.defaults.memorySearch.enabled=true'] } },
+  ];
+
+  for (const { name, over } of signals) {
+    it(`carries a precondition on the dual_legacy remedy — ${name}`, () => {
+      const v = evaluate('dual_legacy', over);
+      expect(v.status).toBe('warn');
+      expect(extractFixCommands(v.fix)).toContain('shieldcortex config --memory-plane import_only');
+      expect(v.fixWhen).toBeDefined();
+      expect(v.fixWhen).toMatch(/host contract|defended import/i);
+      // The precondition must say what happens if you ignore it, or it reads as
+      // optional flavour text and gets ignored.
+      expect(v.fixWhen).toMatch(/FAIL/i);
+    });
+  }
+
+  it('THE INVARIANT: following the remedy must not raise severity without warning', () => {
+    // This is the general rule the loop broke. Take the verdict, read the plane
+    // its own remedy moves you to, re-evaluate against the SAME evidence, and
+    // compare. A remedy that makes things worse is allowed to exist — a host
+    // mid-migration genuinely has to pass through it — but it may not be
+    // offered as an unconditional command.
+    const before = evaluate('dual_legacy');
+    const target = planeAfter(extractFixCommands(before.fix));
+    expect(target).toBe('import_only');
+
+    const after = evaluate(target!);
+    expect(RANK[after.status]!).toBeGreaterThan(RANK[before.status]!);
+    // Severity goes UP, so the precondition is mandatory.
+    expect(before.fixWhen).toBeTruthy();
+  });
+
+  it('the loop is real and closes — the FAIL points back at the WARN state', () => {
+    // Named so nobody "fixes" the WARN side alone and believes the cycle is
+    // gone. import_only's remedy legitimately offers dual_legacy as the honest
+    // fallback; that is fine ONLY because the WARN side now states its
+    // condition. If this test ever fails, the two ends have drifted apart.
+    const failVerdict = evaluate('import_only');
+    expect(failVerdict.status).toBe('fail');
+    expect(planeAfter(extractFixCommands(failVerdict.fix))).toBe('dual_legacy');
+  });
+
+  it('a non-dual_legacy plane gets its own remedy and no plane-change precondition', () => {
+    const v = evaluate('sc_canonical');
+    expect(v.status).toBe('fail');
+    expect(v.fixWhen).toBeUndefined();
+  });
+});

--- a/src/memory/plane-drift.ts
+++ b/src/memory/plane-drift.ts
@@ -76,6 +76,20 @@ export interface PlaneDriftVerdict {
   status: 'pass' | 'warn' | 'fail';
   message: string;
   fix?: string;
+  /**
+   * #441 — the precondition a remedy must not lose on its way to the terminal.
+   *
+   * `fix` used to carry this as prose ("land the host contract + defended
+   * import, then `...`"), and the renderer extracts backticked commands out of
+   * `fix` with a regex. The command survived that trip; the clause saying WHEN
+   * to run it did not, so doctor printed an unconditional instruction where the
+   * source wrote a conditional one — and on a dual_legacy host, following it
+   * turned the WARN into a FAIL whose own remedy pointed back to dual_legacy.
+   *
+   * Keeping it as a separate field means the renderer never has to infer intent
+   * from a sentence, which is the thing it cannot reliably do.
+   */
+  fixWhen?: string;
 }
 
 /** dual_legacy is time-boxed: past this, the defect warning names the age. */
@@ -83,8 +97,23 @@ export const DUAL_LEGACY_GRACE_MS = 14 * 24 * 60 * 60 * 1000;
 
 const RESIDUAL_DOC = 'docs/design/2026-08-22-memory-sota-track-a-residual.md';
 const DUAL_LEGACY_FIX =
-  'Time-box dual_legacy: land the host contract + defended import, then '
-  + '`shieldcortex config --memory-plane import_only` — dual_legacy is a migration escape, not steady state';
+  'Time-box dual_legacy: `shieldcortex config --memory-plane import_only` — '
+  + 'dual_legacy is a migration escape, not steady state';
+/**
+ * #441 — the `then` in the old one-sentence form. Setting the plane flag does
+ * not stop the agent writing its native memory dir, so running this before the
+ * host contract and defended import have landed just re-raises the same
+ * evidence at `fail` severity (`severityFor()` returns fail for every non-
+ * dual_legacy plane while `native.touched7d` is still true).
+ */
+const DUAL_LEGACY_FIX_WHEN =
+  // Phrasing note: this is rendered after a fixed `only when: ` prefix, so it
+  // must NOT start with "only"/"when" itself. Observing the built CLI is what
+  // caught "only when: only once the host contract..." — every unit test passed
+  // straight over it, because they assert content, not readability.
+  'the host contract and defended import have landed — until then this command '
+  + 'raises the same finding to FAIL, because setting the plane does not stop '
+  + 'native memory writes';
 const NATIVE_SOT_FIX =
   'Stop native MEMORY.md / memory-store growth as the agent brain — import it through the defended path or '
   + `archive it, or drop back to \`shieldcortex config --memory-plane dual_legacy\` and be honest (${RESIDUAL_DOC})`;
@@ -102,6 +131,25 @@ const UNSCOPED_STORE_FIX =
 /** `warn` for the deprecated-but-tolerated plane, `fail` where canonicity is claimed. */
 function severityFor(plane: MemoryPlane): 'warn' | 'fail' {
   return plane === 'dual_legacy' ? 'warn' : 'fail';
+}
+
+/**
+ * The remedy pair for a drift signal. Every signal offers the SAME advice to a
+ * dual_legacy host — move off the escape hatch — and its own advice to any
+ * other plane, so this is one helper rather than four ternaries.
+ *
+ * #441: it exists to make the precondition unmissable. When the fix and its
+ * `fixWhen` were assembled per-signal, two of the four call sites were updated
+ * and two were not; a caller that forgets `fixWhen` emits a bare, unconditional
+ * `$ shieldcortex config --memory-plane import_only`, which is the whole bug.
+ * Returning both together means a new signal cannot half-adopt it.
+ */
+function remedyFor(
+  plane: MemoryPlane,
+  otherPlaneFix: string,
+): { fix: string; fixWhen?: string } {
+  if (plane !== 'dual_legacy') return { fix: otherPlaneFix };
+  return { fix: DUAL_LEGACY_FIX, fixWhen: DUAL_LEGACY_FIX_WHEN };
 }
 
 function headlineFor(plane: MemoryPlane): string {
@@ -162,7 +210,7 @@ export function evaluatePlaneDrift(input: PlaneDriftInput): PlaneDriftVerdict {
       message:
         `${headlineFor(plane)}: native agent SoT written inside the window — `
         + `${listPaths(native.touchedPaths)} (${detail})${aged}`,
-      fix: plane === 'dual_legacy' ? DUAL_LEGACY_FIX : NATIVE_SOT_FIX,
+      ...remedyFor(plane, NATIVE_SOT_FIX),
     };
   }
 
@@ -173,7 +221,7 @@ export function evaluatePlaneDrift(input: PlaneDriftInput): PlaneDriftVerdict {
       message:
         `${headlineFor(plane)}: native memory bus still switched on — `
         + `${native.busActive.join('; ')} (${detail})${aged}`,
-      fix: plane === 'dual_legacy' ? DUAL_LEGACY_FIX : NATIVE_BUS_FIX,
+      ...remedyFor(plane, NATIVE_BUS_FIX),
     };
   }
 
@@ -184,7 +232,7 @@ export function evaluatePlaneDrift(input: PlaneDriftInput): PlaneDriftVerdict {
       message:
         `${headlineFor(plane)}: activity bypasses SC — zero durable admits in the last 7d `
         + `for this host/agent scope (${detail})${aged}`,
-      fix: plane === 'dual_legacy' ? DUAL_LEGACY_FIX : EMPTY_SC_FIX,
+      ...remedyFor(plane, EMPTY_SC_FIX),
     };
   }
 
@@ -209,7 +257,7 @@ export function evaluatePlaneDrift(input: PlaneDriftInput): PlaneDriftVerdict {
       message:
         `${headlineFor(plane)}: scope gate excluded ${counts.unscopedExcluded} unscoped row(s) — `
         + `an unscoped/quiet store cannot prove this plane (${detail})${aged}`,
-      fix: plane === 'dual_legacy' ? DUAL_LEGACY_FIX : UNSCOPED_STORE_FIX,
+      ...remedyFor(plane, UNSCOPED_STORE_FIX),
     };
   }
 


### PR DESCRIPTION
Closes #441.

## What was wrong

The `dual_legacy` drift WARN rendered a bold, copy-pasteable `$ shieldcortex config --memory-plane import_only`. Running it on the host that produced the WARN turned it into a FAIL, whose own remedy pointed back at `--memory-plane dual_legacy`. A closed loop, with nothing anywhere saying it was one.

The command was never wrong — its **precondition** was lost. `DUAL_LEGACY_FIX` read "land the host contract + defended import, **then** `...`". `extractFixCommands()` pulls backticked commands out of that sentence with a regex, and `renderIssueBlock` prints `message` + extracted commands and never the fix prose. So the command reached the terminal and the condition did not.

## Approach

Option 1 from the issue — structured, not more sentence parsing:

- **`fixWhen?: string`** on `PlaneDriftVerdict`, `CheckResult` and `DoctorReportItem`. The renderer never has to infer intent from prose, which is the thing it cannot reliably do.
- **`remedyFor(plane, otherPlaneFix)`** replaces four identical ternaries in `plane-drift.ts`. My first cut was two ad-hoc spreads and missed two of the four call sites — a signal that forgets `fixWhen` emits exactly the bare command this issue is about, so returning the pair together is the safety property, not tidiness.
- **`only when: ...` renders ABOVE the `$` line.** An operator scanning for the bold `$` copies the first runnable thing they see; a caveat underneath is read only by someone who already hesitated.
- **The collapse path merges `fixWhen`.** That branch merges `fixCommands` across group members and previously had no precondition to lose — it is precisely where one would vanish while the command it guards survived.

## Tests — 9 new across two files

The load-bearing test is not the dual_legacy case, it is the general invariant the loop violated:

> IF applying a check's own remedy to the same evidence raises the severity, THEN that remedy must carry a precondition.

A future signal that offers a plane change without one fails in CI rather than on someone's host. The closed loop itself is also pinned, so nobody repairs the WARN side alone and believes the cycle is gone.

## Observed, not only asserted

Ran the issue's own repro against the built artifact with the real clawdbot1 numbers:

```
BEFORE   $ shieldcortex config --memory-plane import_only        ← no condition

AFTER    only when: the host contract and defended import have landed —
           until then this command raises the same finding to FAIL, because
           setting the plane does not stop native memory writes
         $ shieldcortex config --memory-plane import_only
```

That observation caught `only when: only once the host contract...` — a doubled qualifier from composing my string with the renderer's fixed prefix. All nine tests passed straight over it, because they assert content and not readability.

## Deliberately NOT in scope

Issue option 3 — withhold the command entirely when `memory.inject` is unconfigured — needs host-contract state plumbed into `plane-drift`, a wider change than making the existing remedy honest. The honest remedy is what stops the loop; the gate is worth doing separately.

## Verification

- `tsc -p tsconfig.build.json` clean
- 45/45 across the plane and doctor-report suites
- Built CLI observed on the repro above