### PR TITLE
fix(doctor): #441 stop dual_legacy plane-flip remedy loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **#441:** doctor no longer copy-pastes `--memory-plane import_only` / `--memory-plane dual_legacy` as `$` remedies while native SoT is still growing. That looped WARN → FAIL → WARN. The rendered command is now `shieldcortex memories import-native`; flipping the plane flag does not stop native writes.
+
 ## [4.54.14] - 2026-08-29
 
 ### Security

--- a/src/memory/__tests__/plane-drift-394.test.ts
+++ b/src/memory/__tests__/plane-drift-394.test.ts
@@ -16,6 +16,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { readMemoryPlane } from '../../cloud/config.js';
 import { readMemoryPlaneFromConfig } from '../../cli/doctor.js';
+import { extractFixCommands } from '../../cli/doctor-report.js';
 import {
   evaluatePlaneDrift,
   DUAL_LEGACY_GRACE_MS,
@@ -179,5 +180,40 @@ describe('evaluatePlaneDrift precedence', () => {
     expect(v.message).toMatch(/injectable=unknown/);
     expect(v.message).toMatch(/unscoped_excluded=unknown/);
     expect(v.message).toMatch(/activity_7d=unknown/);
+  });
+});
+
+describe('#441 plane-remedy commands must not loop WARN -> FAIL -> WARN', () => {
+  it('does not offer a copy-paste plane flip while native SoT is still growing', () => {
+    const native = {
+      touched7d: true,
+      bytes: 7834955,
+      touchedPaths: ['~/clawd/memory/2026-08-29.md'],
+      unattestable: [],
+      busActive: [],
+    };
+    const counts = {
+      durableAdmits7d: 271, durableRows: 400, injectable: null, unscopedExcluded: 42, activity7d: 7652,
+    };
+    const base = {
+      planeSetAt: null as string | null,
+      injectOn: false,
+      requireScope: true,
+      counts,
+      native,
+      nowMs: Date.parse('2026-08-30T12:00:00.000Z'),
+    };
+
+    const warn = evaluatePlaneDrift({ ...base, plane: 'dual_legacy' });
+    const fail = evaluatePlaneDrift({ ...base, plane: 'import_only' });
+    expect(warn.status).toBe('warn');
+    expect(fail.status).toBe('fail');
+
+    const warnCmds = extractFixCommands(warn.fix);
+    const failCmds = extractFixCommands(fail.fix);
+    expect(warnCmds.join(' ')).not.toMatch(/--memory-plane\s+import_only/);
+    expect(failCmds.join(' ')).not.toMatch(/--memory-plane\s+dual_legacy/);
+    expect(warnCmds).toEqual(['shieldcortex memories import-native']);
+    expect(failCmds).toEqual(['shieldcortex memories import-native']);
   });
 });

--- a/src/memory/plane-drift.ts
+++ b/src/memory/plane-drift.ts
@@ -83,11 +83,11 @@ export const DUAL_LEGACY_GRACE_MS = 14 * 24 * 60 * 60 * 1000;
 
 const RESIDUAL_DOC = 'docs/design/2026-08-22-memory-sota-track-a-residual.md';
 const DUAL_LEGACY_FIX =
-  'Time-box dual_legacy: land the host contract + defended import, then '
-  + '`shieldcortex config --memory-plane import_only` — dual_legacy is a migration escape, not steady state';
+  'Time-box dual_legacy: land the host contract and run `shieldcortex memories import-native` while native SoT is still growing. '
+  + 'Do not flip memory.plane to import_only until that growth has stopped — dual_legacy is a migration escape, not steady state';
 const NATIVE_SOT_FIX =
-  'Stop native MEMORY.md / memory-store growth as the agent brain — import it through the defended path or '
-  + `archive it, or drop back to \`shieldcortex config --memory-plane dual_legacy\` and be honest (${RESIDUAL_DOC})`;
+  'Stop native MEMORY.md / memory-store growth as the agent brain — import it through the defended path '
+  + `(\`shieldcortex memories import-native\`) or archive it. Flipping memory.plane does not stop native writes (${RESIDUAL_DOC})`;
 const NATIVE_BUS_FIX =
   'Turn the host native memory bus off (OpenClaw agents.defaults.memorySearch.enabled=false, '
   + 'Hermes memory.memory_enabled=false) — see the `Memory plane (host contract)` check for the per-runtime proof';


### PR DESCRIPTION
## Problem
`dual_legacy` plane-drift WARN rendered `$ shieldcortex config --memory-plane import_only`. On a host still writing native SoT that command FAILs, and the FAIL remedy is `$ --memory-plane dual_legacy` — a copy-paste loop (#221 family on the #394 surface).

## Approach
Stop backticking plane-flip commands in those fix strings. Render `shieldcortex memories import-native` instead. Flipping `memory.plane` does not stop native writes.

## Tests
- Repro from #441: dual_legacy WARN + import_only FAIL no longer extract `--memory-plane` flips
- Sabotage: restoring the old DUAL_LEGACY_FIX fails the new assertion
- `plane-drift-394` + `doctor-plane-drift-394`: 60 passed

## Risk
Doctor copy-paste text only. No host/soak mutation. TARS soak stays dual_legacy + inject off.

Closes #441