### PR TITLE
fix(guard): closed webrun/spawn contracts without false approval cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Action Guard P0 exact tool contracts:** reviewed `web.run`, OpenClaw `sessions_spawn`, and collaboration `spawn_agent` aliases now use closed schemas for their measured live fields before legacy run/spawn family inference, eliminating false approval cards without opening unknown payload bags. Schema rejection union-scans RAW command evidence (string, nested token arrays/objects, overlapping 8k windows over the full payload). A matched wipe is terminal; a scanned-clean oversize unknown-key call stays `dangerous` with a door — not an unappealable wall. Not Action Guard 2.0.
 - **#441:** doctor no longer copy-pastes `--memory-plane import_only` / `--memory-plane dual_legacy` as `$` remedies while native SoT is still growing. That looped WARN → FAIL → WARN. The rendered command is now `shieldcortex memories import-native`; flipping the plane flag does not stop native writes.
 
 ## [4.54.14] - 2026-08-29

--- a/src/defence/iron-dome/__tests__/tool-input-schema-412.test.ts
+++ b/src/defence/iron-dome/__tests__/tool-input-schema-412.test.ts
@@ -6,6 +6,7 @@ import { validateToolInput, enforceToolInput } from '../tool-input-schema.js';
 import { evaluateToolCall } from '../tool-action-guard.js';
 import { rememberSchema } from '../../../tools/remember.js';
 import { recallSchema } from '../../../tools/recall.js';
+import { createInterceptor, DEFAULT_CONFIG, type InterceptAuditEntry } from '../../../../plugins/openclaw/interceptor.js';
 
 describe('#412 tool input schema', () => {
   it('accepts canonical Bash command shape', () => {
@@ -75,6 +76,263 @@ describe('#412 tool input schema', () => {
   it('evaluateToolCall still allows clean Bash', () => {
     const v = evaluateToolCall('Bash', { command: 'git status' });
     expect(v.decision).toBe('allow');
+  });
+});
+
+describe('Action Guard P0 exact web/delegation contracts', () => {
+  const webFields: Record<string, unknown> = {
+    search_query: [{ q: 'ShieldCortex' }], open: [{ ref_id: 'turn0search0' }],
+    click: [{ ref_id: 'turn0fetch0', id: 1 }], find: [{ ref_id: 'turn0fetch0', pattern: 'guard' }],
+    image_query: [{ q: 'shield' }], calculator: [{ expression: '2+2' }],
+    weather: [{ location: 'London' }], finance: [{ ticker: 'AMD', type: 'equity', market: 'USA' }],
+    sports: [{ fn: 'standings', league: 'nfl' }], time: [{ utc_offset: '+00:00' }],
+    response_length: 'short',
+  };
+  const openClawFields: Record<string, unknown> = {
+    task: 'inspect tests', label: 'review', runtime: 'subagent', agentId: 'edith', model: 'default',
+    thinking: 'medium', cwd: '/workspace', runTimeoutSeconds: 60, timeoutSeconds: 90,
+    thread: true, mode: 'run', cleanup: 'delete', sandbox: 'inherit', attachments: [],
+    context: 'bounded context', taskName: 'review_tests',
+  };
+  const collaborationFields: Record<string, unknown> = {
+    task_name: 'review_tests', fork_turns: 'all', model: 'default',
+    reasoning_effort: 'medium', message: 'Inspect the tests',
+  };
+
+  it.each([
+    ['webrun', webFields], ['web.run', webFields], ['web__run', webFields], ['mcp__web__run', webFields],
+    ['sessions_spawn', openClawFields], ['openclawsessions_spawn', openClawFields],
+    ['openclaw.sessions_spawn', openClawFields], ['openclaw__sessions_spawn', openClawFields],
+    ['mcp__openclaw__sessions_spawn', openClawFields],
+    ['collaborationspawn_agent', collaborationFields], ['collaboration.spawn_agent', collaborationFields],
+    ['collaboration__spawn_agent', collaborationFields], ['mcp__collaboration__spawn_agent', collaborationFields],
+  ] as const)('allows every measured field, in forward and reverse insertion order: %s', (tool, fields) => {
+    for (const args of [fields, Object.fromEntries(Object.entries(fields).reverse())]) {
+      expect(enforceToolInput(tool, args)).toMatchObject({ ok: true });
+      expect(evaluateToolCall(tool, args)).toMatchObject({ decision: 'allow' });
+    }
+  });
+
+  it('keeps unknown third-party spawn/run names on the old fail-closed path', () => {
+    expect(evaluateToolCall('vendor_spawn_agent', { task: 'work' }).decision).toBe('block');
+    expect(evaluateToolCall('thirdparty_run', { search_query: [{ q: 'x' }] }).decision).toBe('block');
+  });
+
+  const BIN = String.fromCharCode(114, 109);
+  const FLAG = ['-', 'r', 'f'].join('');
+  const ROOT = '/';
+  const WIPE = [BIN, FLAG, ROOT].join(' ');
+  const WIPE_TOKS = [BIN, FLAG, ROOT];
+  const WIPE_OBJ = { 0: BIN, 1: FLAG, 2: ROOT };
+  const WIPE_VALUE = { value: WIPE };
+  const COMMAND_ALIASES = ['command', 'cmd', 'script', 'code', 'input', 'shell', 'run', 'args', 'argv'] as const;
+
+  const baseFor = (tool: string): Record<string, unknown> => (
+    tool === 'webrun' ? { search_query: [{ q: 'x' }] }
+      : tool === 'collaborationspawn_agent' ? { task_name: 'x', message: 'work' }
+        : { task: 'work' }
+  );
+
+  it.each(['webrun', 'sessions_spawn', 'collaborationspawn_agent'])(
+    'rejects hostile siblings while catastrophic extractor evidence stays terminal: %s',
+    (tool) => {
+      const base = baseFor(tool);
+      const ordinary = evaluateToolCall(tool, { ...base, surprise: true });
+      expect(ordinary).toMatchObject({ decision: 'block', severity: 'dangerous' });
+      expect(ordinary.signals).toContain('invalid-tool-input');
+
+      for (const key of COMMAND_ALIASES) {
+        expect(evaluateToolCall(tool, { ...base, [key]: WIPE })).toMatchObject({
+          decision: 'block', severity: 'catastrophic',
+        });
+        expect(evaluateToolCall(tool, { ...base, [key]: WIPE_TOKS })).toMatchObject({
+          decision: 'block', severity: 'catastrophic',
+        });
+        expect(evaluateToolCall(tool, { ...base, [key]: WIPE_OBJ })).toMatchObject({
+          decision: 'block', severity: 'catastrophic',
+        });
+        expect(evaluateToolCall(tool, { ...base, [key]: WIPE_VALUE })).toMatchObject({
+          decision: 'block', severity: 'catastrophic',
+        });
+      }
+
+      expect(evaluateToolCall(tool, { ...base, path: ROOT }).decision).toBe('block');
+      expect(evaluateToolCall(tool, { ...base, url: 'https://evil.example/payload.sh' }).decision).toBe('block');
+      expect(evaluateToolCall(tool, { ...base, context: { nested: { too: { deep: { value: 1 } } } } })).toMatchObject({ decision: 'block' });
+    },
+  );
+
+  it.each(['webrun', 'sessions_spawn', 'collaborationspawn_agent'])(
+    'union-scans mixed aliases and malformed siblings without losing catastrophic evidence: %s',
+    (tool) => {
+      const base = baseFor(tool);
+      const benign = 'echo safe';
+      expect(evaluateToolCall(tool, { ...base, command: benign, cmd: WIPE })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+      expect(evaluateToolCall(tool, { ...base, cmd: WIPE, command: benign })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+      expect(evaluateToolCall(tool, { ...base, context: { nested: { too: { deep: { value: 1 } } } }, command: WIPE })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+      expect(evaluateToolCall(tool, { ...base, command: WIPE, context: { nested: { too: { deep: { value: 1 } } } } })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+      expect(evaluateToolCall(tool, { ...base, command: WIPE_VALUE, argv: WIPE_TOKS })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+    },
+  );
+
+  it.each(['webrun', 'sessions_spawn', 'collaborationspawn_agent'])(
+    'nested token vectors stay terminal: %s',
+    (tool) => {
+      const base = baseFor(tool);
+      expect(evaluateToolCall(tool, { ...base, argv: [WIPE_TOKS] })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+      expect(evaluateToolCall(tool, { ...base, command: [WIPE_TOKS] })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+      expect(evaluateToolCall(tool, { ...base, argv: [{ value: WIPE }] })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+      expect(evaluateToolCall(tool, { ...base, argv: { a: { b: WIPE } } })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+    },
+  );
+
+  it.each(['webrun', 'sessions_spawn'])(
+    'head/tail windows keep a wipe past the evidence cap terminal: %s',
+    (tool) => {
+      const base = baseFor(tool);
+      const pad = 'z'.repeat(9000);
+      expect(evaluateToolCall(tool, { ...base, argv: [pad, ...WIPE_TOKS] })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+      expect(evaluateToolCall(tool, { ...base, command: pad + ' ' + WIPE })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+      expect(evaluateToolCall(tool, { ...base, argv: { 0: pad, 1: WIPE } })).toMatchObject({
+        decision: 'block', severity: 'catastrophic',
+      });
+    },
+  );
+
+  it('a long scanned-clean command with an unknown key keeps a door — not a terminal wall', () => {
+    const v = evaluateToolCall('Bash', { command: 'z'.repeat(9000), extra: true });
+    expect(v.decision).toBe('block');
+    expect(v.severity).toBe('dangerous');
+    expect(v.severity).not.toBe('catastrophic');
+  });
+
+  it('a wipe past 256 argv tokens stays terminal', () => {
+    const toks = Array(300).fill('ok');
+    toks.push(...WIPE_TOKS);
+    expect(evaluateToolCall('sessions_spawn', { ...baseFor('sessions_spawn'), argv: toks })).toMatchObject({
+      decision: 'block', severity: 'catastrophic',
+    });
+  });
+
+  it('a depth-4 nested wipe stays terminal', () => {
+    const nested = { a: { b: { c: { d: WIPE } } } };
+    expect(evaluateToolCall('webrun', { ...baseFor('webrun'), argv: nested })).toMatchObject({
+      decision: 'block', severity: 'catastrophic',
+    });
+  });
+
+  it('a wipe in the middle of 600 argv tokens stays terminal', () => {
+    const toks = Array(600).fill('ok');
+    toks[300] = BIN;
+    toks[301] = FLAG;
+    toks[302] = ROOT;
+    expect(evaluateToolCall('sessions_spawn', { ...baseFor('sessions_spawn'), argv: toks })).toMatchObject({
+      decision: 'block', severity: 'catastrophic',
+    });
+  });
+
+  it('a wipe in the middle of a 24k command stays terminal', () => {
+    const mid = 'x'.repeat(12000) + ' ' + WIPE + ' ' + 'y'.repeat(12000);
+    expect(evaluateToolCall('webrun', { ...baseFor('webrun'), extra: true, argv: mid })).toMatchObject({
+      decision: 'block', severity: 'catastrophic',
+    });
+  });
+
+  it('a wipe past the old 32-window ceiling stays terminal', () => {
+    const mid = 'x'.repeat(140000) + ' ' + WIPE + ' ' + 'y'.repeat(20000);
+    expect(evaluateToolCall('webrun', { ...baseFor('webrun'), extra: true, argv: mid })).toMatchObject({
+      decision: 'block', severity: 'catastrophic',
+    });
+  });
+
+  it('keeps near-collision names off the reviewed allow path', () => {
+    expect(evaluateToolCall('mcp__evil__sessions_spawn', { task: 'work' }).decision).toBe('block');
+    expect(evaluateToolCall('mcp__evil__web__run', { search_query: [{ q: 'x' }] }).decision).toBe('block');
+  });
+
+  const okPipeline = () => ({
+    allowed: true, firewall: { result: 'ALLOW' as const, reason: '', threatIndicators: [], anomalyScore: 0, blockedPatterns: [] },
+    trust: { score: 0.5 }, sensitivity: { level: 'INTERNAL' }, fragmentation: null, auditId: 1,
+  });
+
+  it('real OpenClaw interceptor gives measured calls a zero-card, zero-audit unattended path', async () => {
+    const audits: InterceptAuditEntry[] = [];
+    let prompts = 0;
+    const okPipeline = () => ({
+      allowed: true, firewall: { result: 'ALLOW' as const, reason: '', threatIndicators: [], anomalyScore: 0, blockedPatterns: [] },
+      trust: { score: 0.5 }, sensitivity: { level: 'INTERNAL' }, fragmentation: null, auditId: 1,
+    });
+    const interceptor = createInterceptor({ ...DEFAULT_CONFIG } as any, okPipeline as any, {
+      evaluateToolCall: evaluateToolCall as any, onAuditEntry: (entry) => audits.push(entry),
+    });
+    for (const [toolName, args] of [
+      ['webrun', webFields], ['sessions_spawn', openClawFields],
+      ['openclawsessions_spawn', openClawFields], ['collaborationspawn_agent', collaborationFields],
+    ] as const) {
+      await expect(interceptor.handleToolCall({
+        toolName, arguments: args, requireApproval: async () => { prompts++; return false; },
+      })).resolves.toBeUndefined();
+    }
+    expect(prompts).toBe(0);
+    expect(audits).toEqual([]);
+  });
+
+  it('tokenised catastrophic argv never becomes an approval card', async () => {
+    const audits: InterceptAuditEntry[] = [];
+    let prompts = 0;
+    const make = (actionGuard: Record<string, unknown>) => createInterceptor(
+      { ...DEFAULT_CONFIG, actionGuard: { ...DEFAULT_CONFIG.actionGuard, ...actionGuard } } as any,
+      okPipeline as any,
+      { evaluateToolCall: evaluateToolCall as any, onAuditEntry: (entry) => audits.push(entry) },
+    );
+    const payload = { ...baseFor('sessions_spawn'), argv: WIPE_TOKS };
+
+    const attended = make({ enabled: true, enforce: true, autoApprove: [] });
+    await expect(attended.handleToolCall({
+      toolName: 'sessions_spawn', arguments: payload,
+      requireApproval: async () => { prompts++; return true; },
+    })).rejects.toThrow(/blocked/);
+    expect(prompts).toBe(0);
+
+    const unattended = make({ enabled: true, enforce: true, autoApprove: [] });
+    await expect(unattended.handleToolCall({
+      toolName: 'sessions_spawn', arguments: payload,
+    })).rejects.toThrow(/blocked/);
+
+    const advisory = make({
+      enabled: true, enforce: false,
+      autoApprove: ['invalid_tool_input', 'invalid-tool-input', 'dangerous'],
+    });
+    await expect(advisory.handleToolCall({
+      toolName: 'webrun', arguments: { ...baseFor('webrun'), command: WIPE_TOKS },
+      requireApproval: async () => { prompts++; return true; },
+    })).rejects.toThrow(/blocked/);
+    expect(prompts).toBe(0);
+
+    expect(audits.some((row) => row.action === 'auto_deny' || row.outcome === 'auto_denied')).toBe(true);
+    expect(audits.some((row) => row.action === 'require_approval')).toBe(false);
   });
 });
 

--- a/src/defence/iron-dome/guard-precision-corpus.ts
+++ b/src/defence/iron-dome/guard-precision-corpus.ts
@@ -50,6 +50,12 @@ const sh = (command: string, expect: 'allow' | 'gate', why: string): GuardCorpus
  * positive. This is the surface an agent touches hundreds of times a session.
  */
 export const SAFE_CORPUS: GuardCorpusEntry[] = [
+  // Product-wide P0 exact host contracts: every row has a zero-card budget.
+  { tool: 'webrun', args: { search_query: [{ q: 'ShieldCortex' }], response_length: 'short' }, expect: 'allow', why: 'web.run search contract is network/read, not OS exec' },
+  { tool: 'web.run', args: { open: [{ ref_id: 'turn0search0' }] }, expect: 'allow', why: 'reviewed web.run namespace spelling' },
+  { tool: 'sessions_spawn', args: { task: 'inspect tests', label: 'review', runtime: 'subagent', agentId: 'edith', model: 'default', thinking: 'medium', cwd: '/workspace', runTimeoutSeconds: 60, timeoutSeconds: 90, thread: true, mode: 'run', cleanup: 'delete', sandbox: 'inherit', attachments: [], context: 'bounded', taskName: 'review_tests' }, expect: 'allow', why: 'measured OpenClaw delegation contract' },
+  { tool: 'openclawsessions_spawn', args: { task: 'inspect tests', runtime: 'subagent' }, expect: 'allow', why: 'measured bare OpenClaw host alias' },
+  { tool: 'collaborationspawn_agent', args: { task_name: 'review_tests', fork_turns: 'all', model: 'default', reasoning_effort: 'medium', message: 'Inspect the tests' }, expect: 'allow', why: 'measured collaboration delegation contract' },
   // ── git: everyday version control ──
   sh('git status --short', 'allow', 'read-only status'),
   sh('git add src/foo.ts src/bar.ts', 'allow', 'stage explicit paths'),

--- a/src/defence/iron-dome/tool-action-guard.ts
+++ b/src/defence/iron-dome/tool-action-guard.ts
@@ -27,7 +27,7 @@
 
 import { lstatSync, realpathSync } from 'node:fs';
 import type { IronDomeConfig } from './config.js';
-import { validateToolInput, schemaFamilyForTool } from './tool-input-schema.js';
+import { hasExactSpecialToolSchema, validateToolInput, schemaFamilyForTool } from './tool-input-schema.js';
 import { forEachWindow } from '../scan-windows.js';
 
 export type ToolGuardDecision = 'allow' | 'require_approval' | 'block';
@@ -101,6 +101,10 @@ const EXEC_TOOLS = /(bash|shell|exec|run|run_command|runcommand|command|terminal
 const GIT_TOOLS = /(^git$|git_|_git|github)/;
 
 export function classifyFamily(toolName: string): ToolFamily {
+  const specialFamily = schemaFamilyForTool(toolName);
+  if (hasExactSpecialToolSchema(toolName) && (specialFamily === 'read' || specialFamily === 'network')) {
+    return specialFamily;
+  }
   const n = normaliseToolName(toolName);
   if (MEMORY_TOOLS.test(n)) return 'memory';
   // Exec is checked early: a "Bash" tool can do anything, so its args drive risk.
@@ -125,6 +129,90 @@ function pickString(args: Record<string, unknown>, keys: string[]): string {
 
 export function extractCommand(args: Record<string, unknown>): string {
   return pickString(args, ['command', 'cmd', 'script', 'code', 'input', 'shell', 'run']);
+}
+
+/** Command-bearing aliases the schema-failure recovery pass must union-scan. */
+const COMMAND_EVIDENCE_KEYS = [
+  'command', 'cmd', 'script', 'code', 'input', 'shell', 'run', 'args', 'argv',
+] as const;
+
+const EXTRACTOR_EVIDENCE_CAP = 8192;
+
+const EXTRACTOR_WINDOW_STEP = 4096;
+const EXTRACTOR_MAX_DEPTH = 8;
+const EXTRACTOR_MAX_LEAVES = 16384;
+
+function stringElements(value: unknown, depth = 0, acc: string[] = []): string[] {
+  if (depth > EXTRACTOR_MAX_DEPTH || acc.length >= EXTRACTOR_MAX_LEAVES) return acc;
+  if (typeof value === 'string') {
+    if (value) acc.push(value);
+    return acc;
+  }
+  if (Array.isArray(value)) {
+    for (const el of value) {
+      stringElements(el, depth + 1, acc);
+      if (acc.length >= EXTRACTOR_MAX_LEAVES) break;
+    }
+    return acc;
+  }
+  if (value !== null && typeof value === 'object') {
+    for (const el of Object.values(value as Record<string, unknown>)) {
+      stringElements(el, depth + 1, acc);
+      if (acc.length >= EXTRACTOR_MAX_LEAVES) break;
+    }
+  }
+  return acc;
+}
+
+function slidingWindows(text: string, cap = EXTRACTOR_EVIDENCE_CAP): string[] {
+  if (!text) return [];
+  if (text.length <= cap) return [text];
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i += EXTRACTOR_WINDOW_STEP) {
+    out.push(text.slice(i, i + cap));
+  }
+  const tail = text.slice(-cap);
+  if (!out.includes(tail)) out.push(tail);
+  return out;
+}
+
+/**
+ * Overlapping windows over the full leaf join — not head+tail only.
+ * A wipe in the middle of a long string or a 600-token argv must still scan.
+ */
+function flattenScanWindows(value: unknown, cap = EXTRACTOR_EVIDENCE_CAP): string[] {
+  const parts = stringElements(value);
+  if (parts.length === 0) return [];
+  return slidingWindows(parts.join(' '), cap);
+}
+
+function pathUrlFromRaw(raw: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const k of ['path', 'file_path', 'filePath', 'file', 'target', 'destination', 'dir', 'directory']) {
+    if (typeof raw[k] === 'string' && raw[k]) out[k] = raw[k];
+  }
+  for (const k of ['url', 'uri', 'endpoint', 'href', 'host', 'to']) {
+    if (typeof raw[k] === 'string' && raw[k]) out[k] = raw[k];
+  }
+  return out;
+}
+
+/**
+ * Schema rejection used to scan a single first-wins string (or `{}` when
+ * annotate failed). Each command-bearing alias is its own surface: joining
+ * `echo safe` with a later wipe makes the tokeniser treat `echo` as the verb.
+ */
+function commandEvidenceSurfaces(raw: Record<string, unknown>): string[] {
+  const surfaces: string[] = [];
+  const seen = new Set<string>();
+  for (const k of COMMAND_EVIDENCE_KEYS) {
+    for (const text of flattenScanWindows(raw[k])) {
+      if (!text || seen.has(text)) continue;
+      seen.add(text);
+      surfaces.push(text);
+    }
+  }
+  return surfaces;
 }
 
 // `${IFS}`, `${IFS:0:1}`, `$IFS` all expand to whitespace at runtime and are used
@@ -4155,7 +4243,7 @@ export function evaluateToolCall(
     // which would fail-closed GitHub-API tools under EXEC_KEYS (title/labels).
     const schemaFam = schemaFamilyForTool(toolName);
     const guardFam = classifyFamily(toolName);
-    const mode = (schemaFam === 'exec' || schemaFam === 'git' || guardFam === 'exec')
+    const mode = (hasExactSpecialToolSchema(toolName) || schemaFam === 'exec' || schemaFam === 'git' || guardFam === 'exec')
       ? 'enforce'
       : 'annotate';
     const validated = validateToolInput(toolName, args, mode);
@@ -4165,14 +4253,22 @@ export function evaluateToolCall(
       // full evaluator with the schema gate skipped. If that is catastrophic,
       // keep it terminal. Otherwise the original schema failure stands.
       const annotated = validateToolInput(toolName, args, 'annotate');
-      const inner = evaluateToolCall(
-        toolName,
-        annotated.ok ? annotated.args : {},
-        config,
-        options,
-        true,
-      );
-      if (inner.severity === 'catastrophic') return inner;
+      const extras = pathUrlFromRaw(args);
+      const surfaces = commandEvidenceSurfaces(args);
+      if (surfaces.length === 0 && annotated.ok) {
+        const inner = evaluateToolCall(toolName, { ...annotated.args, ...extras }, config, options, true);
+        if (inner.severity === 'catastrophic') return inner;
+      }
+      for (const text of surfaces) {
+        const inner = evaluateToolCall(
+          toolName,
+          { ...extras, command: text },
+          config,
+          options,
+          true,
+        );
+        if (inner.severity === 'catastrophic') return inner;
+      }
       return verdict(
         'block',
         'dangerous',
@@ -4196,7 +4292,9 @@ export function evaluateToolCall(
   }
   // Read-only tools never execute their args — a search query or path that
   // merely *mentions* "rm -rf" is not an action. Short-circuit before scanning.
-  if (family === 'read') {
+  // A rejected exact special bag is rescanned with extractor evidence retained.
+  // Do not let its normal read-only classification hide a hostile sibling.
+  if (family === 'read' && !(skipSchema && hasExactSpecialToolSchema(toolName))) {
     return verdict('allow', 'benign', family, 'read_file', 'read-only operation', []);
   }
 

--- a/src/defence/iron-dome/tool-input-schema.ts
+++ b/src/defence/iron-dome/tool-input-schema.ts
@@ -111,6 +111,51 @@ interface ShellControlSchema {
   handles: string[];
 }
 
+/**
+ * P0 reviewed host contracts. These are exact spellings, not suffix/pattern
+ * matches: an unrelated third-party `*_spawn` / `*run*` tool must retain the
+ * old fail-closed family behaviour.
+ */
+interface ExactSpecialSchema {
+  allowed: Set<string>;
+  family: 'read' | 'network';
+}
+
+const WEB_RUN_KEYS = new Set([
+  'search_query', 'open', 'click', 'find', 'image_query', 'calculator',
+  'weather', 'finance', 'sports', 'time', 'response_length',
+]);
+
+const DELEGATION_KEYS = new Set([
+  'task', 'label', 'runtime', 'agentId', 'model', 'thinking', 'cwd',
+  'runTimeoutSeconds', 'timeoutSeconds', 'thread', 'mode', 'cleanup',
+  'sandbox', 'attachments', 'context', 'taskName',
+  'task_name', 'fork_turns', 'reasoning_effort', 'message',
+]);
+
+const WEB_RUN_ALIASES = new Set([
+  'webrun', 'web.run', 'web__run', 'mcp__web__run',
+]);
+
+const DELEGATION_ALIASES = new Set([
+  'sessions_spawn', 'openclawsessions_spawn',
+  'openclaw.sessions_spawn', 'openclaw__sessions_spawn', 'mcp__openclaw__sessions_spawn',
+  'collaborationspawn_agent', 'collaboration.spawn_agent', 'collaboration__spawn_agent',
+  'mcp__collaboration__spawn_agent',
+]);
+
+function exactSpecialSchemaFor(toolName: string): ExactSpecialSchema | null {
+  const exact = String(toolName ?? '').trim().toLowerCase();
+  if (WEB_RUN_ALIASES.has(exact)) return { allowed: WEB_RUN_KEYS, family: 'network' };
+  if (DELEGATION_ALIASES.has(exact)) return { allowed: DELEGATION_KEYS, family: 'read' };
+  return null;
+}
+
+/** Special contracts are enforced closed even though their effects are read/network. */
+export function hasExactSpecialToolSchema(toolName: string): boolean {
+  return exactSpecialSchemaFor(toolName) !== null;
+}
+
 /** Claude 2.1.233's TaskOutput reads `task_id ?? agentId ?? bash_id`; `filter` is an output regex — data, not a command. */
 const SHELL_CONTROL_OUTPUT: ShellControlSchema = {
   allowed: new Set(['bash_id', 'task_id', 'agentId', 'filter']),
@@ -147,6 +192,8 @@ export function schemaFamilyForTool(
   toolName: string,
 ): 'exec' | 'write' | 'read' | 'network' | 'memory' | 'git' | 'unknown' {
   const n = String(toolName || '').toLowerCase().trim();
+  const special = exactSpecialSchemaFor(n);
+  if (special) return special.family;
   const seg = n.split(/__|\.|:|\//).filter(Boolean).pop() ?? n;
   if (/(remember|recall|forget|memory|get_context|getcontext)/.test(seg) || /(remember|recall|forget|memory)/.test(n)) {
     return 'memory';
@@ -169,6 +216,8 @@ export function schemaFamilyForTool(
 }
 
 function allowedKeysFor(toolName: string): Set<string> {
+  const special = exactSpecialSchemaFor(toolName);
+  if (special) return special.allowed;
   // #436: the native control plane is narrower than its exec family, not wider.
   const control = shellControlSchemaFor(toolName);
   if (control) return control.allowed;
@@ -277,7 +326,8 @@ export function validateToolInput(
         continue;
       }
       // annotate: keep extractor-critical keys so unknown tool names are not blinded
-      if (!EXTRACTOR_KEYS.has(key)) {
+      const specialArgvEvidence = exactSpecialSchemaFor(toolName) && (key === 'args' || key === 'argv');
+      if (!EXTRACTOR_KEYS.has(key) && !specialArgvEvidence) {
         strippedKeys.push(key);
         continue;
       }


### PR DESCRIPTION
## What this is
Action Guard was treating real webrun / spawn work as an attack (false approval cards). Edith-class uninstall risk.

This PR gives those tools an exact closed contract for the fields they actually use. Ordinary calls stay silent. A real wipe still dies with no button. A scanned-clean extra field stays a normal denial with a door.

Not Action Guard 2.0. Not a re-enable. Not a cut.

## Review
Grok 4.6 + GPT-5.6 SOL Pro + Opus: **OK**. Uninstall risk **NO** on measured webrun/spawn/git/npm.

## Do not
- Re-enable Jarvis Action Guard from this PR
- Cut a release
- Touch the TARS memory soak

## Residuals (not blocking this land)
- Host adding one new field on these tools still cards (contract drift)
- MCP name-squat on exact `openclaw` / `collaboration` aliases
- Shared OpenClaw+collaboration key union
- Interceptor unattended extra-field doors (pre-existing)
