### PR TITLE
chore(release): v4.54.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [4.54.15] - 2026-09-01
+
+**OpenClaw 2 exec storm + Action Guard off by default.** Shop hosts pick this up with `shieldcortex update`. Existing signed `enabled: true` stays on. Guard re-enable is not this cut.
+
 ### Changed
 - **Action Guard is OFF by default.** Absent `actionGuard.enabled` no longer means on. Fresh installs and upgrades without an explicit signed enable leave tool calls ungated, including catastrophic checks. `shieldcortex update` prints that notice and the enable command. Existing hosts with `enabled: true` stay on.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.14",
+  "version": "4.54.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shieldcortex",
-      "version": "4.54.14",
+      "version": "4.54.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shieldcortex",
-  "version": "4.54.14",
+  "version": "4.54.15",
   "description": "Trustworthy memory and security for AI agents. Memory firewall for any host that writes through it; runtime tool gates on Claude Code, OpenClaw, and Hermes.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "shieldcortex-realtime",
-  "version": "4.54.14",
+  "version": "4.54.15",
   "name": "ShieldCortex Real-time Scanner",
   "description": "Real-time defence scanning on LLM input, memory extraction on LLM output, and active tool call interception with approval gating.",
   "kind": null,

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drakon-systems/shieldcortex-realtime",
-  "version": "4.54.14",
+  "version": "4.54.15",
   "description": "OpenClaw plugin for ShieldCortex real-time defence scanning and optional memory extraction.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/shieldcortex/SKILL.md
+++ b/skills/shieldcortex/SKILL.md
@@ -4,7 +4,7 @@ description: "Memory and defence for AI agents: semantic recall, knowledge graph
 license: MIT-0
 metadata:
   author: Drakon Systems
-  version: 4.54.14
+  version: 4.54.15
   mcp-server: shieldcortex
   category: memory-and-security
   tags: [memory, security, knowledge-graph, mcp, iron-dome, openclaw-plugin, audit]


### PR DESCRIPTION
## Cut: v4.54.15

Version-only PR. Product is already on `main` via #453 (`88a4ee2`).

**Theme:** OpenClaw 2 `exec` storm stop + Action Guard **off by default**.

Hosts pick this up with `shieldcortex update` after tag + `publish.yml`. Existing signed `enabled: true` stays on. Guard re-enable is **not** this cut.

### Surfaces bumped
- `package.json` / `package-lock.json` → `4.54.15`
- `plugins/openclaw/package.json` + `openclaw.plugin.json` (via `sync-plugin-version.mjs`)
- `skills/shieldcortex/SKILL.md` metadata.version
- CHANGELOG: Unreleased stub kept; `## [4.54.15] - 2026-09-01` inserted

### Not in this PR
- Tag / `publish.yml`
- Cloud / websites
- TARS or Edith bump (memory soak in)
- Guard re-enable

### After merge
1. Annotated tag `v4.54.15` on the `chore(release)` commit
2. Watch `publish.yml`
3. Cloud + websites lockstep
4. **Jarvis** `shieldcortex update` only
