### PR TITLE
fix(cli): survive the OpenClaw 2026.8.1 update — skills flag + cron schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **#456: OpenClaw 2026.8.1 removed `--acknowledge-clawhub-risk`,** so every hardcoded skills install (`shieldcortex openclaw skill install` and the `update` skill step) failed with an unrecognized-option error on updated hosts. Install args are now feature-detected against the installed binary's own `skills install --help`: legacy hosts keep the old flag, 2026.8.1+ hosts get `--force` plus `--acknowledge-install-policy-warning` when listed (so a policy warning cannot hang a quiet update), and a failed probe falls back to the new flag set rather than resurrecting the dead one. Prose hints no longer advertise the dead flag.
+- **#456: the OpenClaw 2026.8.1 cron store schema (measured live, 82 jobs) read as `schema_mismatch`,** so `allowlist scan` and `doctor` treated a healthy OpenClaw 2 host as cannot-look. The read-only cron store reader now recognises two generations: gen1 (legacy `payload_message`/`trigger_script` + `cron_run_logs`) unchanged, and gen2 (message inside `job_json` → `payload.message`; run outcomes in `cron_run_receipts` with `started_at_ms`/`finished_at_ms`, no `session_key`). Gen2 denial correlation joins by containment in the same job's run window — the run was in progress when the denial fired — never nearest-run; no containing receipt stays `unconfirmed`. A `cron_jobs` matching neither generation stays `schema_mismatch`, and a gen2 store missing `cron_run_receipts` is still cannot-look, so the #375 honesty rules hold on both generations.
+
 ## [4.54.15] - 2026-09-01
 
 **OpenClaw 2 exec storm + Action Guard off by default.** Shop hosts pick this up with `shieldcortex update`. Existing signed `enabled: true` stays on. Guard re-enable is not this cut.

--- a/src/cli/__tests__/allowlist-scan-cron-db-375.test.ts
+++ b/src/cli/__tests__/allowlist-scan-cron-db-375.test.ts
@@ -79,6 +79,43 @@ function buildStore(
 
 
 
+/**
+ * Writable ONLY here — the OC2 (gen2, #456) fixture: the measured 2026.8.1
+ * shape (no payload_message/trigger_script; cron_run_receipts, not
+ * cron_run_logs). Before #456 this exact live shape scanned as
+ * SCHEMA MISMATCH and exited 1 on an 82-job host.
+ */
+function buildGen2Store(
+  dbPath: string,
+  shape: { jobs?: Array<{ job_id: string; name?: string; enabled?: unknown; job_json?: string | null }> } = {},
+): void {
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  try {
+    db.prepare(
+      `CREATE TABLE cron_jobs (store_key TEXT, job_id TEXT, declaration_key TEXT,
+        owner_agent_id TEXT, name TEXT, description TEXT, enabled INTEGER, agent_id TEXT,
+        payload_kind TEXT, job_json TEXT, state_json TEXT, runtime_updated_at_ms INTEGER,
+        schedule_identity TEXT, sort_order INTEGER, updated_at INTEGER)`,
+    ).run();
+    for (const j of shape.jobs ?? []) {
+      db.prepare(
+        `INSERT INTO cron_jobs (store_key, job_id, owner_agent_id, name, enabled, agent_id,
+          payload_kind, job_json, state_json, runtime_updated_at_ms, sort_order, updated_at)
+         VALUES ('default', ?, 'main', ?, ?, 'main', 'agentTurn', ?, '{}', 0, 0, 0)`,
+      ).run(j.job_id, j.name ?? j.job_id, (j.enabled ?? 1) as never, j.job_json ?? null);
+    }
+    db.prepare(
+      `CREATE TABLE cron_run_receipts (receipt_id TEXT, store_key TEXT, job_id TEXT,
+        config_revision INTEGER, agent_id TEXT, request_run_id TEXT, status TEXT,
+        owner_pid INTEGER, owner_start_time INTEGER, started_at_ms INTEGER,
+        finished_at_ms INTEGER, error_text TEXT)`,
+    ).run();
+  } finally {
+    db.close();
+  }
+}
+
 /** Paths may soft/hard-wrap for 40-col TUI; assert against whitespace-collapsed logs.
  *  macOS realpath often adds a `/private` prefix — accept both forms. */
 function flatLogs(logs: string[]): string {
@@ -209,6 +246,32 @@ describe('allowlist scan: OpenClaw SQLite cron source (#375)', () => {
     // The live SQLite store is readable, so the scan is complete.
     const code = await runAllowlistScan([], deps());
     expect(code).toBe(3);
+  });
+
+  test('an OC2 (gen2, #456) store scans ok and its job_json scripts are discovered', async () => {
+    // The regression this pins: before #456 this measured live shape probed
+    // schema_mismatch, so a healthy 82-job OpenClaw 2 host exited 1 with an
+    // empty script list.
+    buildGen2Store(dbPath, {
+      jobs: [
+        {
+          job_id: JOB_A,
+          name: 'oc2 sentry',
+          job_json: JSON.stringify({ payload: { kind: 'agentTurn', message: `python3 ${scriptPath}` } }),
+        },
+      ],
+    });
+
+    const found = discoverScripts({ home: dir, openclawDbPath: dbPath });
+    expect(found.sources.openclawDb).toMatchObject({ path: dbPath, status: 'ok' });
+    expect(found.scripts.map((s) => s.path)).toContain(scriptPath);
+
+    const code = await runAllowlistScan([], deps());
+    expect(code).toBe(3);
+    expect(logs.join('\n')).toContain('openclaw-cron-db');
+    expect(logs.join('\n')).not.toContain('SCHEMA MISMATCH');
+    expectLogPath(logs, realpathSync(scriptPath));
+    expect(stored).toEqual([]);
   });
 
   // -- Visibility rule ------------------------------------------

--- a/src/cli/__tests__/cron-denial-audit-375.test.ts
+++ b/src/cli/__tests__/cron-denial-audit-375.test.ts
@@ -488,10 +488,12 @@ describe('cron denial correlation (#375 P2)', () => {
       const report = correlate();
       expect(report.jobs[0].denialCount).toBe(1);
       expect(report.jobs[0].silentCount).toBe(0);
-      expect(report.unconfirmedCount).toBe(0);
+      // The run demonstrably failed, so the denial is not silent — but a
+      // non-ok containment is not a clean ruling either: unconfirmed.
+      expect(report.unconfirmedCount).toBe(1);
     });
 
-    test('a still-running receipt (finished_at_ms NULL) contains the denial', () => {
+    test('a still-running receipt (finished_at_ms NULL) is never a silent claim', () => {
       buildGen2Store(dbPath, {
         jobs: [{ job_id: JOB_A, name: 'oc2 sweep' }],
         receipts: [{ job_id: JOB_A, status: 'running', started_at_ms: NOW - 90_000, finished_at_ms: null }],
@@ -499,9 +501,43 @@ describe('cron denial correlation (#375 P2)', () => {
       writeDenials([denial()]);
 
       const report = correlate();
-      // Row found (not unconfirmed); status is not ok (not silent).
-      expect(report.unconfirmedCount).toBe(0);
+      // An open window is a run still in flight: unconfirmed, never silent.
+      expect(report.unconfirmedCount).toBe(1);
       expect(report.silentCount).toBe(0);
+    });
+
+    test('an ok receipt with finished_at_ms NULL is an open window, never an infinite silent claim', () => {
+      buildGen2Store(dbPath, {
+        jobs: [{ job_id: JOB_A, name: 'oc2 sweep' }],
+        // Status already stamped ok but finish never recorded — a crashed
+        // writer could leave this forever. It must not become a permanent
+        // "every future denial is silent" verdict.
+        receipts: [{ job_id: JOB_A, status: 'ok', started_at_ms: NOW - 90_000, finished_at_ms: null }],
+      });
+      writeDenials([denial()]);
+
+      const report = correlate();
+      expect(report.silentCount).toBe(0);
+      expect(report.unconfirmedCount).toBe(1);
+    });
+
+    test('overlapping same-job receipts must be unanimously ok before silence is ruled', () => {
+      buildGen2Store(dbPath, {
+        jobs: [{ job_id: JOB_A, name: 'oc2 sweep' }],
+        receipts: [
+          // An earlier containing run errored…
+          { job_id: JOB_A, status: 'error', started_at_ms: NOW - 120_000, finished_at_ms: NOW - 30_000 },
+          // …and a later containing run reported ok. The ok must not outvote
+          // the failure: unconfirmed, not silent.
+          { job_id: JOB_A, status: 'ok', started_at_ms: NOW - 90_000, finished_at_ms: NOW - 20_000 },
+        ],
+      });
+      writeDenials([denial()]);
+
+      const report = correlate();
+      expect(report.silentCount).toBe(0);
+      expect(report.unconfirmedCount).toBe(1);
+      expect(report.jobs[0].denialCount).toBe(1);
     });
 
     test('a denial outside every run window of its job is unconfirmed, never silent', () => {

--- a/src/cli/__tests__/cron-denial-audit-375.test.ts
+++ b/src/cli/__tests__/cron-denial-audit-375.test.ts
@@ -87,6 +87,75 @@ function buildStore(
   }
 }
 
+interface Gen2JobSeed {
+  job_id: string;
+  name?: string;
+  enabled?: unknown;
+  job_json?: string | null;
+}
+interface ReceiptSeed {
+  job_id: string;
+  status: string;
+  started_at_ms: number;
+  finished_at_ms?: number | null;
+}
+
+/**
+ * Writable ONLY here — the OC2 (gen2, #456) fixture. The full measured
+ * 2026.8.1 column sets: cron_jobs has no payload_message/trigger_script, run
+ * outcomes live in cron_run_receipts (no session_key, no run_at_ms, and
+ * request_run_id NULL as sampled live).
+ */
+function buildGen2Store(
+  dbPath: string,
+  shape: { jobs?: Gen2JobSeed[]; receipts?: ReceiptSeed[]; omitReceipts?: boolean } = {},
+): void {
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  try {
+    db.prepare(
+      `CREATE TABLE cron_jobs (store_key TEXT, job_id TEXT, declaration_key TEXT,
+        owner_agent_id TEXT, name TEXT, description TEXT, enabled INTEGER, agent_id TEXT,
+        payload_kind TEXT, job_json TEXT, state_json TEXT, runtime_updated_at_ms INTEGER,
+        schedule_identity TEXT, sort_order INTEGER, updated_at INTEGER)`,
+    ).run();
+    for (const j of shape.jobs ?? []) {
+      db.prepare(
+        `INSERT INTO cron_jobs (store_key, job_id, owner_agent_id, name, enabled, agent_id,
+          payload_kind, job_json, state_json, runtime_updated_at_ms, sort_order, updated_at)
+         VALUES ('default', ?, 'main', ?, ?, 'main', 'agentTurn', ?, '{}', 0, 0, 0)`,
+      ).run(j.job_id, j.name ?? j.job_id, (j.enabled ?? 1) as never, j.job_json ?? null);
+    }
+    if (!shape.omitReceipts) {
+      db.prepare(
+        `CREATE TABLE cron_run_receipts (receipt_id TEXT, store_key TEXT, job_id TEXT,
+          config_revision INTEGER, agent_id TEXT, request_run_id TEXT, status TEXT,
+          owner_pid INTEGER, owner_start_time INTEGER, started_at_ms INTEGER,
+          finished_at_ms INTEGER, error_text TEXT)`,
+      ).run();
+      let n = 0;
+      for (const r of shape.receipts ?? []) {
+        db.prepare(
+          `INSERT INTO cron_run_receipts (receipt_id, store_key, job_id, config_revision,
+            agent_id, request_run_id, status, owner_pid, owner_start_time, started_at_ms,
+            finished_at_ms, error_text)
+           VALUES (?, 'default', ?, 1, 'main', NULL, ?, 4242, ?, ?, ?, NULL)`,
+        ).run(`receipt-${(n += 1)}`, r.job_id, r.status, r.started_at_ms, r.started_at_ms, r.finished_at_ms ?? null);
+      }
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/** The live gen2 payload shape: the message is a string leaf in job_json. */
+function gen2JobJson(message: string): string {
+  return JSON.stringify({
+    schedule: { kind: 'cron', expr: '0 9 * * *' },
+    payload: { kind: 'agentTurn', message },
+  });
+}
+
 describe('cron denial correlation (#375 P2)', () => {
   const NOW = 1_760_000_000_000;
   let home: string;
@@ -377,6 +446,114 @@ describe('cron denial correlation (#375 P2)', () => {
     });
     writeDenials([denial()]);
     expect([...deniedScriptPaths(correlate())]).toEqual([[scriptA, 'sweep']]);
+  });
+
+  // -- OC2 store (gen2, #456) -----------------------------------
+  // cron_run_receipts has no session_key, so the join is containment in the
+  // SAME job's run window — exact in time, never nearest-run.
+
+  describe('gen2 containment join', () => {
+    test('a denial inside a receipt window with status ok is silent', () => {
+      buildGen2Store(dbPath, {
+        jobs: [{ job_id: JOB_A, name: 'oc2 sweep', job_json: gen2JobJson(`python3 ${scriptA}`) }],
+        receipts: [
+          { job_id: JOB_A, status: 'ok', started_at_ms: NOW - 90_000, finished_at_ms: NOW - 30_000 },
+        ],
+      });
+      writeDenials([denial()]); // detectedAt NOW - 60s — inside the window
+
+      const report = correlate();
+      expect(report.cannotCorrelate).toBeNull();
+      expect(report.attributedCount).toBe(1);
+      expect(report.unconfirmedCount).toBe(0);
+      expect(report.silentCount).toBe(1);
+      expect(report.jobs[0]).toMatchObject({
+        jobId: JOB_A,
+        name: 'oc2 sweep',
+        denialCount: 1,
+        silentCount: 1,
+        pinnablePaths: [scriptA],
+      });
+    });
+
+    test('a containing receipt that reported its failure is not silent', () => {
+      buildGen2Store(dbPath, {
+        jobs: [{ job_id: JOB_A, name: 'oc2 sweep' }],
+        receipts: [
+          { job_id: JOB_A, status: 'error', started_at_ms: NOW - 90_000, finished_at_ms: NOW - 30_000 },
+        ],
+      });
+      writeDenials([denial()]);
+
+      const report = correlate();
+      expect(report.jobs[0].denialCount).toBe(1);
+      expect(report.jobs[0].silentCount).toBe(0);
+      expect(report.unconfirmedCount).toBe(0);
+    });
+
+    test('a still-running receipt (finished_at_ms NULL) contains the denial', () => {
+      buildGen2Store(dbPath, {
+        jobs: [{ job_id: JOB_A, name: 'oc2 sweep' }],
+        receipts: [{ job_id: JOB_A, status: 'running', started_at_ms: NOW - 90_000, finished_at_ms: null }],
+      });
+      writeDenials([denial()]);
+
+      const report = correlate();
+      // Row found (not unconfirmed); status is not ok (not silent).
+      expect(report.unconfirmedCount).toBe(0);
+      expect(report.silentCount).toBe(0);
+    });
+
+    test('a denial outside every run window of its job is unconfirmed, never silent', () => {
+      buildGen2Store(dbPath, {
+        jobs: [{ job_id: JOB_A, name: 'oc2 sweep' }, { job_id: JOB_B, name: 'other' }],
+        receipts: [
+          // This job's run finished before the denial fired…
+          { job_id: JOB_A, status: 'ok', started_at_ms: NOW - 300_000, finished_at_ms: NOW - 200_000 },
+          // …and ANOTHER job's run containing the timestamp must not match.
+          { job_id: JOB_B, status: 'ok', started_at_ms: NOW - 90_000, finished_at_ms: NOW - 30_000 },
+        ],
+      });
+      writeDenials([denial()]);
+
+      const report = correlate();
+      expect(report.attributedCount).toBe(1);
+      expect(report.unconfirmedCount).toBe(1);
+      expect(report.silentCount).toBe(0);
+      expect(report.jobs[0].denialCount).toBe(1);
+    });
+
+    test('gen2 cron_jobs with no cron_run_receipts is cannot-correlate naming the receipts table', () => {
+      buildGen2Store(dbPath, { jobs: [{ job_id: JOB_A, name: 'oc2 sweep' }], omitReceipts: true });
+      writeDenials([denial()]);
+
+      const report = correlate();
+      expect(report.cannotCorrelate).toContain('cron_run_receipts');
+      expect(report.silentCount).toBe(0);
+      expect(report.jobs[0].denialCount).toBe(1);
+      expect(report.jobs[0].silentCount).toBe(0);
+    });
+
+    test('a receipts query that dies mid-correlation drops every silence claim', () => {
+      buildGen2Store(dbPath, {
+        jobs: [{ job_id: JOB_A, name: 'oc2 sweep' }],
+        receipts: [
+          { job_id: JOB_A, status: 'ok', started_at_ms: NOW - 90_000, finished_at_ms: NOW - 30_000 },
+        ],
+      });
+      writeDenials([denial()]);
+      expect(correlate().silentCount).toBe(1); // sanity: clean without the injected failure
+
+      const report = correlate({
+        openStore: () => {
+          throw new Error('database disk image is malformed');
+        },
+      });
+      expect(report.cannotCorrelate).toContain('cron_run_receipts');
+      expect(report.storeStatus).toBe('unreadable');
+      expect(report.silentCount).toBe(0);
+      expect(report.jobs[0].silentCount).toBe(0);
+    });
   });
 
   // -- Tail cap -------------------------------------------------

--- a/src/cli/__tests__/openclaw-cron-store-375.test.ts
+++ b/src/cli/__tests__/openclaw-cron-store-375.test.ts
@@ -105,6 +105,145 @@ function buildCronStore(dbPath: string, shape: StoreShape = {}): void {
   }
 }
 
+// ── OC2 (gen2, #456) fixtures — the full measured live column sets ─────────
+
+interface Gen2JobSeed {
+  job_id: string;
+  name?: string;
+  enabled?: unknown;
+  job_json?: string | null;
+}
+interface ReceiptSeed {
+  job_id: string;
+  status: string;
+  started_at_ms: number;
+  finished_at_ms?: number | null;
+}
+
+// Exactly the columns measured on a live OpenClaw 2026.8.1 host (82 jobs):
+// no payload_message, no trigger_script, no cron_run_logs.
+const GEN2_JOB_COLUMNS: Record<string, string> = {
+  store_key: 'TEXT',
+  job_id: 'TEXT',
+  declaration_key: 'TEXT',
+  owner_agent_id: 'TEXT',
+  name: 'TEXT',
+  description: 'TEXT',
+  enabled: 'INTEGER',
+  agent_id: 'TEXT',
+  payload_kind: 'TEXT',
+  job_json: 'TEXT',
+  state_json: 'TEXT',
+  runtime_updated_at_ms: 'INTEGER',
+  schedule_identity: 'TEXT',
+  sort_order: 'INTEGER',
+  updated_at: 'INTEGER',
+};
+const RECEIPT_COLUMNS: Record<string, string> = {
+  receipt_id: 'TEXT',
+  store_key: 'TEXT',
+  job_id: 'TEXT',
+  config_revision: 'INTEGER',
+  agent_id: 'TEXT',
+  request_run_id: 'TEXT',
+  status: 'TEXT',
+  owner_pid: 'INTEGER',
+  owner_start_time: 'INTEGER',
+  started_at_ms: 'INTEGER',
+  finished_at_ms: 'INTEGER',
+  error_text: 'TEXT',
+};
+
+/** Writable ONLY here — the gen2 fixture build step. */
+function buildGen2CronStore(
+  dbPath: string,
+  shape: {
+    jobs?: Gen2JobSeed[];
+    receipts?: ReceiptSeed[];
+    omit?: Array<'cron_jobs' | 'cron_run_receipts'>;
+    dropJobColumn?: string;
+    /** Leave a legacy cron_run_logs table behind (a migration leftover must
+     *  not satisfy the gen2 run-outcome probe). */
+    legacyRunLogs?: boolean;
+  } = {},
+): void {
+  mkdirSync(join(dbPath, '..'), { recursive: true });
+  const db = new Database(dbPath);
+  try {
+    const omit = new Set(shape.omit ?? []);
+    if (!omit.has('cron_jobs')) {
+      const cols = Object.keys(GEN2_JOB_COLUMNS).filter((c) => c !== shape.dropJobColumn);
+      db.prepare(
+        `CREATE TABLE cron_jobs (${cols.map((c) => `${c} ${GEN2_JOB_COLUMNS[c]}`).join(', ')})`,
+      ).run();
+      for (const job of shape.jobs ?? []) {
+        const row: Record<string, unknown> = {
+          store_key: 'default',
+          declaration_key: null,
+          owner_agent_id: 'main',
+          description: null,
+          agent_id: 'main',
+          payload_kind: 'agentTurn',
+          state_json: '{}',
+          runtime_updated_at_ms: 0,
+          schedule_identity: 'cron:0 9 * * *',
+          sort_order: 0,
+          updated_at: 0,
+          name: job.name ?? job.job_id,
+          enabled: job.enabled ?? 1,
+          job_id: job.job_id,
+          job_json: job.job_json ?? null,
+        };
+        db.prepare(
+          `INSERT INTO cron_jobs (${cols.join(', ')}) VALUES (${cols.map(() => '?').join(', ')})`,
+        ).run(...(cols.map((c) => row[c] ?? null) as never[]));
+      }
+    }
+    if (!omit.has('cron_run_receipts')) {
+      const cols = Object.keys(RECEIPT_COLUMNS);
+      db.prepare(
+        `CREATE TABLE cron_run_receipts (${cols.map((c) => `${c} ${RECEIPT_COLUMNS[c]}`).join(', ')})`,
+      ).run();
+      let n = 0;
+      for (const r of shape.receipts ?? []) {
+        const row: Record<string, unknown> = {
+          receipt_id: `receipt-${(n += 1)}`,
+          store_key: 'default',
+          job_id: r.job_id,
+          config_revision: 1,
+          agent_id: 'main',
+          // NULL on every sampled live row — correlation must not key on it.
+          request_run_id: null,
+          status: r.status,
+          owner_pid: 4242,
+          owner_start_time: r.started_at_ms,
+          started_at_ms: r.started_at_ms,
+          finished_at_ms: r.finished_at_ms ?? null,
+          error_text: null,
+        };
+        db.prepare(
+          `INSERT INTO cron_run_receipts (${cols.join(', ')}) VALUES (${cols.map(() => '?').join(', ')})`,
+        ).run(...(cols.map((c) => row[c] ?? null) as never[]));
+      }
+    }
+    if (shape.legacyRunLogs) {
+      db.prepare(
+        'CREATE TABLE cron_run_logs (job_id TEXT, session_key TEXT, run_at_ms INTEGER, status TEXT)',
+      ).run();
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/** The live gen2 payload shape: the message is a string leaf in job_json. */
+function gen2JobJson(message: string): string {
+  return JSON.stringify({
+    schedule: { kind: 'cron', expr: '0 9 * * *' },
+    payload: { kind: 'agentTurn', message },
+  });
+}
+
 describe('openclaw-cron-store (#375)', () => {
   let dir: string;
   let dbPath: string;
@@ -333,6 +472,93 @@ describe('openclaw-cron-store (#375)', () => {
     const found = discoverDbCronScripts({ dbPath, home: dir });
     expect(found.status).toBe('absent');
     expect(found.scripts).toEqual([]);
+  });
+
+  // -- OC2 generation (#456) ---------------------------------
+
+  test('probe: a gen1 store reports its generation and legacy run table', () => {
+    buildCronStore(dbPath, { jobs: [], runs: [] });
+    expect(probeCronSource(dbPath)).toMatchObject({
+      generation: 'gen1',
+      runTable: 'cron_run_logs',
+    });
+  });
+
+  test('probe: an OC2 store is ok on both tables — this exact live shape read schema_mismatch before', () => {
+    buildGen2CronStore(dbPath, { jobs: [], receipts: [] });
+    const probe = probeCronSource(dbPath);
+    expect(probe).toMatchObject({
+      status: 'ok',
+      jobs: 'ok',
+      runLogs: 'ok',
+      generation: 'gen2',
+      runTable: 'cron_run_receipts',
+    });
+    expect(isIncomplete(probe.status)).toBe(false);
+  });
+
+  test('probe: gen2 cron_jobs with no cron_run_receipts is cannot-look on run outcomes', () => {
+    // A leftover legacy cron_run_logs must not satisfy the gen2 probe either.
+    buildGen2CronStore(dbPath, { omit: ['cron_run_receipts'], legacyRunLogs: true });
+    const probe = probeCronSource(dbPath);
+    expect(probe.jobs).toBe('ok');
+    expect(probe.generation).toBe('gen2');
+    expect(probe.runTable).toBe('cron_run_receipts');
+    expect(probe.runLogs).toBe('schema_mismatch');
+    expect(isIncomplete(probe.runLogs)).toBe(true);
+  });
+
+  test('probe: a cron_jobs matching NEITHER generation stays schema_mismatch', () => {
+    // gen2 columns minus job_json: not gen1 (no payload_message), not gen2.
+    buildGen2CronStore(dbPath, { dropJobColumn: 'job_json' });
+    const probe = probeCronSource(dbPath);
+    expect(probe.jobs).toBe('schema_mismatch');
+    expect(probe.generation).toBeNull();
+    expect(isIncomplete(probe.status)).toBe(true);
+  });
+
+  test('discovery: gen2 paths come from job_json payload.message', () => {
+    buildGen2CronStore(dbPath, {
+      jobs: [
+        {
+          job_id: 'b0000000-0000-4000-8000-000000000001',
+          name: 'oc2 sweep',
+          enabled: 1,
+          job_json: gen2JobJson(`run python3 ${join(dir, 'oc2-sweep.py')} now`),
+        },
+      ],
+      receipts: [],
+    });
+    const found = discoverDbCronScripts({ dbPath, home: dir });
+    expect(found.status).toBe('ok');
+    expect(found.scripts.map((s) => s.path)).toEqual([join(dir, 'oc2-sweep.py')]);
+    for (const s of found.scripts) expect(s.sources).toEqual([OPENCLAW_CRON_DB_SOURCE]);
+  });
+
+  test('discovery: a disabled gen2 job contributes no scripts but stays in jobsById', () => {
+    buildGen2CronStore(dbPath, {
+      jobs: [
+        {
+          job_id: 'b0000000-0000-4000-8000-000000000002',
+          name: 'oc2 off',
+          enabled: 0,
+          job_json: gen2JobJson(`python3 ${join(dir, 'oc2-off.py')}`),
+        },
+        {
+          job_id: 'b0000000-0000-4000-8000-000000000003',
+          name: 'oc2 on',
+          enabled: 1,
+          job_json: gen2JobJson(`python3 ${join(dir, 'oc2-on.py')}`),
+        },
+      ],
+      receipts: [],
+    });
+    const found = discoverDbCronScripts({ dbPath, home: dir });
+    expect(found.scripts.map((s) => s.path)).toEqual([join(dir, 'oc2-on.py')]);
+    expect(found.jobsById.get('b0000000-0000-4000-8000-000000000002')).toMatchObject({
+      enabled: false,
+      paths: [join(dir, 'oc2-off.py')],
+    });
   });
 
   // -- Walk + rendering hygiene ------------------------------

--- a/src/cli/cron-denial-audit.ts
+++ b/src/cli/cron-denial-audit.ts
@@ -17,10 +17,21 @@
  *     matching, and the hook lane (Match B) is deferred until denials carry a
  *     join key — guessing would print a job name next to someone else's
  *     denial.
- *   - **No nearest-run fallback.** The run row is found by EXACT session_key
- *     inside an SQL-bounded window, or not at all. A nearest-in-time fallback
- *     can glue a denial to an unrelated run that happened to succeed, and then
- *     print a green lie with more confidence than the lie it replaced.
+ *   - **No nearest-run fallback.** On a gen1 store the run row is found by
+ *     EXACT session_key inside an SQL-bounded window, or not at all. A
+ *     nearest-in-time fallback can glue a denial to an unrelated run that
+ *     happened to succeed, and then print a green lie with more confidence
+ *     than the lie it replaced.
+ *   - **gen2 (OpenClaw 2, #456) joins by containment, which is exact in
+ *     time.** `cron_run_receipts` has no `session_key` and its
+ *     `request_run_id` was NULL on every sampled live row, so the exact-key
+ *     join is impossible there. Instead a denial at time T is matched to a
+ *     receipt of the SAME job whose run window contains T
+ *     (`started_at_ms <= T` and `finished_at_ms` NULL-or-`>= T`): the run was
+ *     demonstrably in progress when the denial fired. That is containment,
+ *     not nearest-run fuzzy matching — a receipt that merely happened nearby
+ *     never matches. Denial attribution itself is unchanged: OC2 denial
+ *     session keys still carry the `agent:<agent>:cron:<uuid>:run:` shape.
  *   - **No row means unconfirmed, never silent and never a pass.** "We could
  *     not look" is reported as its own count.
  *   - **Nothing from the denial surface is ever surfaced.** Correlation reads
@@ -36,6 +47,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
   CRON_RUN_LOGS_TABLE,
+  CRON_RUN_RECEIPTS_TABLE,
   defaultOpenClawCronDbPath,
   discoverDbCronScripts,
   isIncomplete,
@@ -317,9 +329,11 @@ export function correlateCronDenials(opts: CorrelateCronDenialsOptions = {}): Cr
 
   // A cron store whose run log is present-but-wrong (or unreadable) is
   // cannot-look on its own terms, denials or not: reporting "0 silent" from a
-  // table we cannot read is the green lie in a new costume.
+  // table we cannot read is the green lie in a new costume. The probe names
+  // the table it actually looked at (gen1 cron_run_logs / gen2
+  // cron_run_receipts) so the operator is pointed at the right one.
   if (isIncomplete(discovery.probe.runLogs)) {
-    base.cannotCorrelate = `${CRON_RUN_LOGS_TABLE} ${discovery.probe.runLogs}`;
+    base.cannotCorrelate = `${discovery.probe.runTable} ${discovery.probe.runLogs}`;
   }
 
   if (log.status === 'absent') {
@@ -361,24 +375,37 @@ export function correlateCronDenials(opts: CorrelateCronDenialsOptions = {}): Cr
   // A run log we cannot read while denials ARE attributed is the fail-closed
   // case: count the denials, refuse to rule on silence.
   if (base.cannotCorrelate === null && discovery.probe.runLogs !== 'ok') {
-    base.cannotCorrelate = `${CRON_RUN_LOGS_TABLE} ${discovery.probe.runLogs}`;
+    base.cannotCorrelate = `${discovery.probe.runTable} ${discovery.probe.runLogs}`;
   }
 
   if (base.cannotCorrelate !== null) {
     return { ...base, jobs: renderJobs(aggregates, discovery.jobsById) };
   }
 
+  const gen2 = discovery.probe.generation === 'gen2';
   let db: SqliteDatabase | null = null;
   try {
     db = (opts.openStore ?? openCronStore)(dbPath);
-    const findRun = db.prepare(
-      `SELECT status FROM ${CRON_RUN_LOGS_TABLE}
-        WHERE job_id = ? AND run_at_ms BETWEEN ? AND ? AND session_key = ?
-        ORDER BY run_at_ms DESC LIMIT 1`,
-    );
+    // gen1: exact session_key match. gen2: containment — the receipt of the
+    // same job whose run window contains the denial timestamp (see module
+    // header). Both are exact joins; neither is nearest-run.
+    const findRun = gen2
+      ? db.prepare(
+          `SELECT status FROM ${CRON_RUN_RECEIPTS_TABLE}
+            WHERE job_id = ? AND started_at_ms <= ?
+              AND (finished_at_ms IS NULL OR finished_at_ms >= ?)
+            ORDER BY started_at_ms DESC LIMIT 1`,
+        )
+      : db.prepare(
+          `SELECT status FROM ${CRON_RUN_LOGS_TABLE}
+            WHERE job_id = ? AND run_at_ms BETWEEN ? AND ? AND session_key = ?
+            ORDER BY run_at_ms DESC LIMIT 1`,
+        );
     for (const a of attributed) {
       const agg = aggregates.get(a.jobId);
-      const row = findRun.get(a.jobId, windowStart, now, a.sessionKey) as { status?: unknown } | undefined;
+      const row = (
+        gen2 ? findRun.get(a.jobId, a.ts, a.ts) : findRun.get(a.jobId, windowStart, now, a.sessionKey)
+      ) as { status?: unknown } | undefined;
       if (!row) {
         // No exactly-matched run row. Not silent, not clean — unconfirmed.
         base.unconfirmedCount += 1;
@@ -398,7 +425,7 @@ export function correlateCronDenials(opts: CorrelateCronDenialsOptions = {}): Cr
     return {
       ...base,
       storeStatus: 'unreadable',
-      cannotCorrelate: `${CRON_RUN_LOGS_TABLE} unreadable`,
+      cannotCorrelate: `${discovery.probe.runTable} unreadable`,
       jobs: renderJobs(aggregates, discovery.jobsById),
     };
   } finally {

--- a/src/cli/cron-denial-audit.ts
+++ b/src/cli/cron-denial-audit.ts
@@ -386,15 +386,23 @@ export function correlateCronDenials(opts: CorrelateCronDenialsOptions = {}): Cr
   let db: SqliteDatabase | null = null;
   try {
     db = (opts.openStore ?? openCronStore)(dbPath);
-    // gen1: exact session_key match. gen2: containment — the receipt of the
+    // gen1: exact session_key match. gen2: containment — receipts of the
     // same job whose run window contains the denial timestamp (see module
     // header). Both are exact joins; neither is nearest-run.
+    //
+    // gen2 reads EVERY containing receipt, not the latest, and rules silent
+    // only when they unanimously finished `ok`:
+    //   - overlapping receipts where any containing row errored → not
+    //     silent (a later `ok` window must not outvote the failure), and
+    //   - a receipt with `finished_at_ms` NULL is a run still in flight —
+    //     an open window is never an infinite silent claim.
+    // Anything short of unanimous finished-ok is unconfirmed: fail toward
+    // the warning, never toward the green.
     const findRun = gen2
       ? db.prepare(
-          `SELECT status FROM ${CRON_RUN_RECEIPTS_TABLE}
+          `SELECT status, finished_at_ms FROM ${CRON_RUN_RECEIPTS_TABLE}
             WHERE job_id = ? AND started_at_ms <= ?
-              AND (finished_at_ms IS NULL OR finished_at_ms >= ?)
-            ORDER BY started_at_ms DESC LIMIT 1`,
+              AND (finished_at_ms IS NULL OR finished_at_ms >= ?)`,
         )
       : db.prepare(
           `SELECT status FROM ${CRON_RUN_LOGS_TABLE}
@@ -403,9 +411,31 @@ export function correlateCronDenials(opts: CorrelateCronDenialsOptions = {}): Cr
         );
     for (const a of attributed) {
       const agg = aggregates.get(a.jobId);
-      const row = (
-        gen2 ? findRun.get(a.jobId, a.ts, a.ts) : findRun.get(a.jobId, windowStart, now, a.sessionKey)
-      ) as { status?: unknown } | undefined;
+      if (gen2) {
+        const rows = findRun.all(a.jobId, a.ts, a.ts) as Array<{
+          status?: unknown;
+          finished_at_ms?: unknown;
+        }>;
+        if (rows.length === 0) {
+          // No containing receipt. Not silent, not clean — unconfirmed.
+          base.unconfirmedCount += 1;
+          continue;
+        }
+        const unanimousOk = rows.every(
+          (r) =>
+            String(r.status ?? '').toLowerCase() === 'ok' &&
+            r.finished_at_ms !== null &&
+            r.finished_at_ms !== undefined,
+        );
+        if (agg && unanimousOk) {
+          agg.silentCount += 1;
+          base.silentCount += 1;
+        } else if (!unanimousOk) {
+          base.unconfirmedCount += 1;
+        }
+        continue;
+      }
+      const row = findRun.get(a.jobId, windowStart, now, a.sessionKey) as { status?: unknown } | undefined;
       if (!row) {
         // No exactly-matched run row. Not silent, not clean — unconfirmed.
         base.unconfirmedCount += 1;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2491,7 +2491,8 @@ export function fixActionGuardConfig(): { changed: boolean; backupPath?: string;
  * loud — and it is deliberately harder to satisfy than most:
  *
  *   - It WARNs when denials landed inside runs that reported ok.
- *   - It WARNs when it could not look (denial log unreadable, `cron_run_logs`
+ *   - It WARNs when it could not look (denial log unreadable, the store's
+ *     run table — `cron_run_logs` gen1 / `cron_run_receipts` gen2 —
  *     missing/unreadable). Never `info`, never a pass with a zeroed count: a
  *     "0 silent denials" derived from a table we could not read is the same
  *     green lie in different handwriting.

--- a/src/cli/openclaw-cron-store.ts
+++ b/src/cli/openclaw-cron-store.ts
@@ -1,5 +1,5 @@
 /**
- * Read-only reader for OpenClaw's SQLite cron store (#375).
+ * Read-only reader for OpenClaw's SQLite cron store (#375, #456).
  *
  * OpenClaw migrated `~/.openclaw/cron/jobs.json` into
  * `~/.openclaw/state/openclaw.sqlite` (`cron_jobs`, `cron_run_logs`) and
@@ -8,6 +8,21 @@
  * gateway cron scripts and reported "all clear" — every new cron script broke
  * silently on its first run. This module is the single place that reads the
  * new store.
+ *
+ * OpenClaw 2026.8.1 changed the schema again (#456, measured on a live
+ * 82-job host), so the store now has two recognised generations:
+ *
+ *   - **gen1** (OpenClaw 1): `cron_jobs` with `payload_message` +
+ *     `trigger_script`, run outcomes in `cron_run_logs`
+ *     (`job_id`/`session_key`/`run_at_ms`/`status`).
+ *   - **gen2** (OpenClaw 2): `cron_jobs` WITHOUT those two columns — the
+ *     message lives at `job_json` → `payload.message` — and run outcomes in
+ *     `cron_run_receipts` (`job_id`/`status`/`started_at_ms`/`finished_at_ms`;
+ *     there is no `session_key` and no `run_at_ms`).
+ *
+ * A `cron_jobs` table matching NEITHER generation stays `schema_mismatch`:
+ * recognising gen2 must not soften the "unknown shape is cannot-look" rule
+ * that made the original bug visible.
  *
  * Two rules hold everywhere below:
  *
@@ -38,9 +53,14 @@ export function defaultOpenClawCronDbPath(home: string): string {
 
 export const CRON_JOBS_TABLE = 'cron_jobs';
 export const CRON_RUN_LOGS_TABLE = 'cron_run_logs';
+export const CRON_RUN_RECEIPTS_TABLE = 'cron_run_receipts';
 
-/** Columns P1 discovery reads. A store missing any of them is a shape we do
- *  not understand — reported, never silently skipped. */
+/** The two store shapes we know how to read (see module header). */
+export type CronStoreGeneration = 'gen1' | 'gen2';
+
+/** Columns P1 discovery reads on a gen1 store. A store missing any of them —
+ *  and not matching gen2 either — is a shape we do not understand: reported,
+ *  never silently skipped. */
 export const REQUIRED_CRON_JOB_COLUMNS = [
   'job_id',
   'name',
@@ -50,9 +70,25 @@ export const REQUIRED_CRON_JOB_COLUMNS = [
   'job_json',
 ] as const;
 
+/** Columns P1 discovery reads on a gen2 store. The message lives inside
+ *  `job_json` (payload.message); the two legacy columns must be ABSENT for a
+ *  store to classify as gen2 — their presence alongside a failed gen1 match
+ *  is an unknown shape, not a newer one. */
+export const REQUIRED_CRON_JOB_COLUMNS_GEN2 = ['job_id', 'name', 'enabled', 'job_json'] as const;
+
 /** Columns P2 correlation reads. The run log is the silent-source-of-truth:
  *  it is what says a run "reported ok" while the guard denied inside it. */
 export const REQUIRED_CRON_RUN_LOG_COLUMNS = ['job_id', 'session_key', 'run_at_ms', 'status'] as const;
+
+/** The gen2 run-outcome columns. `request_run_id` exists but was NULL on
+ *  every sampled live row, so correlation cannot key on it and we do not
+ *  require it. */
+export const REQUIRED_CRON_RUN_RECEIPT_COLUMNS = [
+  'job_id',
+  'status',
+  'started_at_ms',
+  'finished_at_ms',
+] as const;
 
 /**
  * The shared honesty enum.
@@ -88,16 +124,25 @@ export interface CronSourceProbe {
   /** Same as {@link CronSourceProbe.status}; named for the reader. */
   jobs: CronProbeStatus;
   /**
-   * `cron_run_logs` health — what P2 correlation keys off.
+   * Run-outcome table health — what P2 correlation keys off. Probed against
+   * {@link CronSourceProbe.runTable} for the detected generation.
    *
    * One deliberate promotion: when `cron_jobs` is `ok` the file demonstrably
-   * IS an OpenClaw cron store, so a missing `cron_run_logs` is not "not this
-   * shape" — it is a store we cannot read run outcomes from. That is
+   * IS an OpenClaw cron store, so a missing run-outcome table is not "not
+   * this shape" — it is a store we cannot read run outcomes from. That is
    * cannot-look, so it is reported `schema_mismatch` rather than `absent`;
    * otherwise a broken run log would collapse into a green `silentCount = 0`,
-   * which is the exact lie #375 exists to stop.
+   * which is the exact lie #375 exists to stop. Holds for both generations:
+   * a gen2 store missing `cron_run_receipts` is the same promotion.
    */
   runLogs: CronProbeStatus;
+  /** Which generation `cron_jobs` matched; null when it matched neither (or
+   *  could not be read at all). */
+  generation: CronStoreGeneration | null;
+  /** The run-outcome table {@link CronSourceProbe.runLogs} reports on —
+   *  `cron_run_logs` (gen1 / unknown) or `cron_run_receipts` (gen2). Callers
+   *  must name THIS table in cannot-look messages, not assume the legacy one. */
+  runTable: string;
 }
 
 /**
@@ -122,22 +167,44 @@ function fileState(dbPath: string): 'absent' | 'present' | 'unreadable' {
   }
 }
 
-/** Probed independently per table: a broken `cron_run_logs` must not make a
+/** Probed independently per table: a broken run-outcome table must not make a
  *  perfectly readable `cron_jobs` look unreadable, and vice versa. */
 function probeTable(db: SqliteDatabase, table: string, required: readonly string[]): CronProbeStatus {
   try {
-    const present = db
-      .prepare("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?")
-      .get(table) as { present?: number } | undefined;
-    if (!present) return 'absent';
-    // Table names here are module constants, never caller input.
-    const cols = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>;
-    const have = new Set(cols.map((c) => String(c?.name ?? '')));
-    for (const col of required) if (!have.has(col)) return 'schema_mismatch';
+    const cols = tableColumns(db, table);
+    if (cols === null) return 'absent';
+    for (const col of required) if (!cols.has(col)) return 'schema_mismatch';
     return 'ok';
   } catch {
     return 'unreadable';
   }
+}
+
+/** Column names of a table, or null when the table is not there. Throws on a
+ *  query failure — callers turn that into `unreadable`. */
+function tableColumns(db: SqliteDatabase, table: string): Set<string> | null {
+  const present = db
+    .prepare("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(table) as { present?: number } | undefined;
+  if (!present) return null;
+  // Table names here are module constants, never caller input.
+  const cols = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name?: string }>;
+  return new Set(cols.map((c) => String(c?.name ?? '')));
+}
+
+/** Which generation a `cron_jobs` column set matches, or null for neither.
+ *  gen1 is checked first; gen2 additionally requires the legacy columns to be
+ *  ABSENT, so a half-migrated hybrid cannot pass as either. */
+function classifyJobColumns(cols: Set<string>): CronStoreGeneration | null {
+  if (REQUIRED_CRON_JOB_COLUMNS.every((c) => cols.has(c))) return 'gen1';
+  if (
+    REQUIRED_CRON_JOB_COLUMNS_GEN2.every((c) => cols.has(c)) &&
+    !cols.has('payload_message') &&
+    !cols.has('trigger_script')
+  ) {
+    return 'gen2';
+  }
+  return null;
 }
 
 /**
@@ -147,23 +214,46 @@ function probeTable(db: SqliteDatabase, table: string, required: readonly string
  * would be caught somewhere upstream and turned back into silence.
  */
 export function probeCronSource(dbPath: string): CronSourceProbe {
+  const fail = (status: 'absent' | 'unreadable'): CronSourceProbe => ({
+    path: dbPath,
+    status,
+    jobs: status,
+    runLogs: status,
+    generation: null,
+    runTable: CRON_RUN_LOGS_TABLE,
+  });
   const state = fileState(dbPath);
-  if (state === 'absent') return { path: dbPath, status: 'absent', jobs: 'absent', runLogs: 'absent' };
-  if (state === 'unreadable') {
-    return { path: dbPath, status: 'unreadable', jobs: 'unreadable', runLogs: 'unreadable' };
-  }
+  if (state === 'absent') return fail('absent');
+  if (state === 'unreadable') return fail('unreadable');
 
   let db: SqliteDatabase | null = null;
   try {
     db = openCronStore(dbPath);
-    const jobs = probeTable(db, CRON_JOBS_TABLE, REQUIRED_CRON_JOB_COLUMNS);
-    let runLogs = probeTable(db, CRON_RUN_LOGS_TABLE, REQUIRED_CRON_RUN_LOG_COLUMNS);
-    // See CronSourceProbe.runLogs — a cron store with no run log is
-    // cannot-look, not "not a cron store".
+    let jobs: CronProbeStatus;
+    let generation: CronStoreGeneration | null = null;
+    try {
+      const cols = tableColumns(db, CRON_JOBS_TABLE);
+      if (cols === null) {
+        jobs = 'absent';
+      } else {
+        generation = classifyJobColumns(cols);
+        jobs = generation === null ? 'schema_mismatch' : 'ok';
+      }
+    } catch {
+      jobs = 'unreadable';
+    }
+    // An unknown/unreadable cron_jobs still probes the legacy run table, so
+    // the pre-gen2 statuses are unchanged on stores we never understood.
+    const runTable = generation === 'gen2' ? CRON_RUN_RECEIPTS_TABLE : CRON_RUN_LOGS_TABLE;
+    const runRequired =
+      generation === 'gen2' ? REQUIRED_CRON_RUN_RECEIPT_COLUMNS : REQUIRED_CRON_RUN_LOG_COLUMNS;
+    let runLogs = probeTable(db, runTable, runRequired);
+    // See CronSourceProbe.runLogs — a cron store with no run-outcome table is
+    // cannot-look, not "not a cron store". Both generations.
     if (jobs === 'ok' && runLogs === 'absent') runLogs = 'schema_mismatch';
-    return { path: dbPath, status: jobs, jobs, runLogs };
+    return { path: dbPath, status: jobs, jobs, runLogs, generation, runTable };
   } catch {
-    return { path: dbPath, status: 'unreadable', jobs: 'unreadable', runLogs: 'unreadable' };
+    return fail('unreadable');
   } finally {
     try {
       db?.close();
@@ -300,11 +390,14 @@ export function discoverDbCronScripts(opts: { dbPath: string; home: string }): D
   let db: SqliteDatabase | null = null;
   try {
     db = openCronStore(opts.dbPath);
-    const rows = db
-      .prepare(
-        `SELECT job_id, name, enabled, payload_message, trigger_script, job_json FROM ${CRON_JOBS_TABLE}`,
-      )
-      .all() as CronJobRow[];
+    // gen2 has no payload_message/trigger_script columns to read; its message
+    // lives at job_json → payload.message, which the structural walk below
+    // already visits as a string leaf.
+    const columns =
+      probe.generation === 'gen2'
+        ? 'job_id, name, enabled, job_json'
+        : 'job_id, name, enabled, payload_message, trigger_script, job_json';
+    const rows = db.prepare(`SELECT ${columns} FROM ${CRON_JOBS_TABLE}`).all() as CronJobRow[];
 
     const jobsById = new Map<string, DiscoveredCronJob>();
     const enabledPaths = new Set<string>();

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -541,9 +541,11 @@ async function stepOpenClawSkill(home: string): Promise<StepResult> {
   // binary cancelled), skipped silently when no copy existed, and reported
   // "@latest installed" off the exit code without reading what landed. The
   // measured result: a box carrying a skill 21 releases stale with every
-  // surface green. Now: resolved binary, acknowledge flag, verify-by-reading,
+  // surface green. Now: resolved binary, feature-detected acknowledge flag
+  // (#456 — OpenClaw 2026.8.1 removed `--acknowledge-clawhub-risk`, so a
+  // hardcoded flag is a bet against the installed binary), verify-by-reading,
   // and the skip names the command that installs.
-  const { resolveOpenClawBinary, findInstalledSkillDirs, readInstalledSkillVersion } =
+  const { resolveOpenClawBinary, resolveSkillInstallArgs, findInstalledSkillDirs, readInstalledSkillVersion } =
     await import('../setup/openclaw.js');
   if (findInstalledSkillDirs(home).length === 0) {
     return await step('OpenClaw skill', async () => ({
@@ -555,7 +557,7 @@ async function stepOpenClawSkill(home: string): Promise<StepResult> {
     const bin = resolveOpenClawBinary(home);
     if (!bin) return { status: 'warn' as const, summary: 'openclaw binary not found — run `shieldcortex openclaw skill install`' };
     try {
-      await runQuiet(bin, ['skills', 'install', 'shieldcortex', '--force', '--acknowledge-clawhub-risk'], {
+      await runQuiet(bin, resolveSkillInstallArgs(bin, { home }), {
         timeout: 120000,
         env: { ...process.env, HOME: home },
       });

--- a/src/setup/__tests__/skill-install-179.test.ts
+++ b/src/setup/__tests__/skill-install-179.test.ts
@@ -17,8 +17,11 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import {
   resolveOpenClawBinary,
+  resolveSkillInstallArgs,
   findInstalledSkillDirs,
   readInstalledSkillVersion,
+  LEGACY_CLAWHUB_ACK_FLAG,
+  INSTALL_POLICY_ACK_FLAG,
 } from '../openclaw.js';
 import { checkOpenClawSkillVersion } from '../../cli/doctor.js';
 
@@ -118,10 +121,48 @@ describe('#179 — the command the operator typed now exists', () => {
     expect(src).toMatch(/openclaw <install\|uninstall\|status\|repair\|inspect-runtime\|skill install>/);
   });
 
-  it('update wires the resolved binary + acknowledge flag, and its skip names the install command', () => {
+  it('update wires the resolved binary + feature-detected args, and its skip names the install command', () => {
     const src = fs.readFileSync(path.join(repoRoot, 'src', 'cli', 'update.ts'), 'utf-8');
     expect(src).toMatch(/resolveOpenClawBinary/);
-    expect(src).toMatch(/--acknowledge-clawhub-risk/);
+    expect(src).toMatch(/resolveSkillInstallArgs/);
     expect(src).toMatch(/shieldcortex openclaw skill install/);
+    // The dead OpenClaw 1 flag must never be hardcoded as an argument again
+    // (#456) — prose/comments may still name it, a string literal may not.
+    expect(src).not.toMatch(/'--acknowledge-clawhub-risk'/);
+  });
+});
+
+describe('#456 — skills install args are feature-detected, never a bet on a version', () => {
+  // OpenClaw 2026.8.1 removed --acknowledge-clawhub-risk; passing it fails
+  // every install. The helper probes the installed binary's own help.
+  const BASE = ['skills', 'install', 'shieldcortex', '--force'];
+  const args = (help: string | null): string[] =>
+    resolveSkillInstallArgs('/fake/openclaw', { home: '/fake/home', probe: () => help });
+
+  it('legacy help (lists the clawhub ack) → legacy args, current behaviour', () => {
+    expect(args(`Options:\n  --force\n  ${LEGACY_CLAWHUB_ACK_FLAG}  acknowledge\n`)).toEqual([
+      ...BASE,
+      LEGACY_CLAWHUB_ACK_FLAG,
+    ]);
+  });
+
+  it('2026.8.1 help (policy ack, no clawhub ack) → new args with the policy ack', () => {
+    const help = `Options:\n  ${INSTALL_POLICY_ACK_FLAG}\n  --force\n  --force-install\n  --global\n`;
+    expect(args(help)).toEqual([...BASE, INSTALL_POLICY_ACK_FLAG]);
+  });
+
+  it('help listing neither ack flag → bare --force', () => {
+    expect(args('Options:\n  --force\n  --global\n')).toEqual(BASE);
+  });
+
+  it('probe failure → the 2026.8.1 args, never the dead legacy flag', () => {
+    const resolved = args(null);
+    expect(resolved).toEqual([...BASE, INSTALL_POLICY_ACK_FLAG]);
+    expect(resolved).not.toContain(LEGACY_CLAWHUB_ACK_FLAG);
+  });
+
+  it('a real spawn probe against a missing binary falls back rather than throwing', () => {
+    const resolved = resolveSkillInstallArgs('/nonexistent/openclaw-bin', { home: os.tmpdir() });
+    expect(resolved).toEqual([...BASE, INSTALL_POLICY_ACK_FLAG]);
   });
 });

--- a/src/setup/__tests__/skill-install-179.test.ts
+++ b/src/setup/__tests__/skill-install-179.test.ts
@@ -155,6 +155,17 @@ describe('#456 — skills install args are feature-detected, never a bet on a ve
     expect(args('Options:\n  --force\n  --global\n')).toEqual(BASE);
   });
 
+  it('a PROSE mention of the removed flag must not resurrect it', () => {
+    // 2026.8.1-style help that only names the legacy flag in a sentence.
+    const help = `Options:\n  ${INSTALL_POLICY_ACK_FLAG}  Acknowledge warnings\n  --force\nNote: ${LEGACY_CLAWHUB_ACK_FLAG} was removed; use ${INSTALL_POLICY_ACK_FLAG}.\n`;
+    expect(args(help)).toEqual([...BASE, INSTALL_POLICY_ACK_FLAG]);
+  });
+
+  it('a transitional help offering BOTH acks prefers the new one', () => {
+    const help = `Options:\n  ${LEGACY_CLAWHUB_ACK_FLAG}  deprecated\n  ${INSTALL_POLICY_ACK_FLAG}  acknowledge\n`;
+    expect(args(help)).toEqual([...BASE, INSTALL_POLICY_ACK_FLAG]);
+  });
+
   it('probe failure → the 2026.8.1 args, never the dead legacy flag', () => {
     const resolved = args(null);
     expect(resolved).toEqual([...BASE, INSTALL_POLICY_ACK_FLAG]);

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -2402,6 +2402,58 @@ export function readInstalledSkillVersion(skillDir: string): string | null {
   }
 }
 
+/** The ClawHub acknowledge flag OpenClaw 1 gen required (#179). Removed in
+ *  OpenClaw 2026.8.1 — passing it there fails every install with
+ *  `OpenClaw does not recognize option "--acknowledge-clawhub-risk"`. */
+export const LEGACY_CLAWHUB_ACK_FLAG = '--acknowledge-clawhub-risk';
+
+/** Its 2026.8.1 successor. Passed when the installed binary lists it, so a
+ *  policy warning cannot hang a quiet, non-interactive update step. */
+export const INSTALL_POLICY_ACK_FLAG = '--acknowledge-install-policy-warning';
+
+/** Probe `openclaw skills install --help` for flag support. Null when the
+ *  probe itself failed (missing binary, timeout, non-zero exit). */
+function probeSkillInstallHelp(bin: string, home: string): string | null {
+  try {
+    const r = spawnSync(bin, ['skills', 'install', '--help'], {
+      encoding: 'utf-8',
+      timeout: 15000,
+      env: { ...process.env, HOME: home },
+    });
+    if (r.error || r.status !== 0) return null;
+    return `${r.stdout ?? ''}${r.stderr ?? ''}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The one arg vector for `openclaw skills install shieldcortex` (#456).
+ *
+ * OpenClaw 2026.8.1 removed `--acknowledge-clawhub-risk`, so the hardcoded
+ * legacy vector made every skills install fail on updated hosts. Feature-
+ * detect against the installed binary's own help instead of betting on a
+ * version:
+ *
+ *   - help lists the legacy flag        → legacy args (OpenClaw 1 gen).
+ *   - help lists the policy-warning ack → new args + that ack.
+ *   - help lists neither                → bare `--force`.
+ *   - the probe itself fails            → the 2026.8.1 args. New OpenClaw is
+ *     the present; a probe we could not run must not resurrect a dead flag.
+ */
+export function resolveSkillInstallArgs(
+  bin: string,
+  opts: { home?: string; probe?: (bin: string, home: string) => string | null } = {},
+): string[] {
+  const home = opts.home ?? os.homedir();
+  const help = (opts.probe ?? probeSkillInstallHelp)(bin, home);
+  const base = ['skills', 'install', 'shieldcortex', '--force'];
+  if (help === null) return [...base, INSTALL_POLICY_ACK_FLAG];
+  if (help.includes(LEGACY_CLAWHUB_ACK_FLAG)) return [...base, LEGACY_CLAWHUB_ACK_FLAG];
+  if (help.includes(INSTALL_POLICY_ACK_FLAG)) return [...base, INSTALL_POLICY_ACK_FLAG];
+  return base;
+}
+
 /**
  * `shieldcortex openclaw skill install|update` (#179).
  *
@@ -2419,10 +2471,10 @@ export async function installOpenClawSkill(home: string = os.homedir()): Promise
   const bin = resolveOpenClawBinary(home);
   if (!bin) {
     console.log('✗ Could not find the `openclaw` binary (PATH or known install locations).');
-    console.log('  Install OpenClaw first, or run: openclaw skills install shieldcortex --force --acknowledge-clawhub-risk');
+    console.log('  Install OpenClaw first, or run: openclaw skills install shieldcortex --force');
     return false;
   }
-  const r = spawnSync(bin, ['skills', 'install', 'shieldcortex', '--force', '--acknowledge-clawhub-risk'], {
+  const r = spawnSync(bin, resolveSkillInstallArgs(bin, { home }), {
     encoding: 'utf-8',
     timeout: 120000,
     env: { ...process.env, HOME: home },

--- a/src/setup/openclaw.ts
+++ b/src/setup/openclaw.ts
@@ -2435,12 +2435,25 @@ function probeSkillInstallHelp(bin: string, home: string): string | null {
  * detect against the installed binary's own help instead of betting on a
  * version:
  *
- *   - help lists the legacy flag        → legacy args (OpenClaw 1 gen).
- *   - help lists the policy-warning ack → new args + that ack.
- *   - help lists neither                → bare `--force`.
+ *   - help OFFERS the legacy flag       → legacy args (OpenClaw 1 gen).
+ *   - help offers the policy-warning ack → new args + that ack.
+ *   - help offers neither               → bare `--force`.
  *   - the probe itself fails            → the 2026.8.1 args. New OpenClaw is
  *     the present; a probe we could not run must not resurrect a dead flag.
+ *
+ * "Offers" is an option-shaped match (the flag at the start of a help line),
+ * not a substring: 2026.8.1's help mentioning the removed flag in prose
+ * ("--acknowledge-clawhub-risk was removed") must not resurrect it. And when
+ * a transitional help lists BOTH flags, the new ack wins — the legacy flag is
+ * the one with a known removal date.
  */
+function helpOffersFlag(help: string, flag: string): boolean {
+  // Option rows in commander-style help start with optional short aliases
+  // then the long flag: `  --force  Overwrite ...`. Prose mentions sit
+  // mid-sentence and fail the line-start anchor.
+  return new RegExp(`^\\s*(?:-\\w,\\s*)?${flag}(?:\\s|=|$)`, 'm').test(help);
+}
+
 export function resolveSkillInstallArgs(
   bin: string,
   opts: { home?: string; probe?: (bin: string, home: string) => string | null } = {},
@@ -2449,8 +2462,8 @@ export function resolveSkillInstallArgs(
   const help = (opts.probe ?? probeSkillInstallHelp)(bin, home);
   const base = ['skills', 'install', 'shieldcortex', '--force'];
   if (help === null) return [...base, INSTALL_POLICY_ACK_FLAG];
-  if (help.includes(LEGACY_CLAWHUB_ACK_FLAG)) return [...base, LEGACY_CLAWHUB_ACK_FLAG];
-  if (help.includes(INSTALL_POLICY_ACK_FLAG)) return [...base, INSTALL_POLICY_ACK_FLAG];
+  if (helpOffersFlag(help, INSTALL_POLICY_ACK_FLAG)) return [...base, INSTALL_POLICY_ACK_FLAG];
+  if (helpOffersFlag(help, LEGACY_CLAWHUB_ACK_FLAG)) return [...base, LEGACY_CLAWHUB_ACK_FLAG];
   return base;
 }
 


### PR DESCRIPTION
## Fix: survive the OpenClaw 2026.8.1 update (#456)

Two OpenClaw 2 breakages seen on live hosts during `shieldcortex update`, both fixed:

### 1. Skills install used a removed flag

OpenClaw 2026.8.1 removed `--acknowledge-clawhub-risk`, so every skill reinstall failed:

```
!  OpenClaw skill: reinstall failed — OpenClaw does not recognize option "--acknowledge-clawhub-risk".
```

New exported `resolveSkillInstallArgs(bin, { home, probe })` feature-detects via `openclaw skills install --help`:
- help lists `--acknowledge-clawhub-risk` → legacy args (old hosts unchanged)
- help lists `--acknowledge-install-policy-warning` → new args including that ack (a policy warning must not hang a quiet update step)
- neither → bare `--force`
- probe failure → the 2026.8.1 arg set (the present), never the dead flag

Both `installOpenClawSkill` and update's `stepOpenClawSkill` use it; the "Install OpenClaw first" hint no longer advertises the dead flag.

### 2. Cron reader didn't know the OC2 schema

Live OC2 host (82 jobs) reported `cron source incomplete (…openclaw.sqlite:schema_mismatch)`. OpenClaw 2:
- dropped `payload_message`/`trigger_script` from `cron_jobs` (message now in `job_json` → `payload.message`)
- replaced `cron_run_logs` with `cron_run_receipts` (`job_id`,`status`,`started_at_ms`,`finished_at_ms`; no `session_key`, `request_run_id` NULL in practice)

`probeCronSource` now classifies gen1 (legacy) / gen2 (OC2) / `schema_mismatch` for anything else, and reports `generation` + `runTable`. Discovery on gen2 reads `job_id,name,enabled,job_json`; paths come from the existing structural walk of `job_json`. Correlation on gen2 joins by containment in the same job's receipt window (`started_at_ms <= T <= finished_at_ms`) — exact-in-time, not nearest-run fuzzy matching; no containing receipt stays `unconfirmed`, never silent, never a pass. The missing-run-table → `schema_mismatch` promotion holds on both generations. #375 honesty doctrine intact: read-only sqlite, "cannot-look is never all-clear".

### Proof (run, not claimed)

- Focused gates: **93/93 pass** (openclaw-cron-store-375, cron-denial-audit-375, allowlist-scan-cron-db-375, skill-install-179, doctor-blocked-fix-tagging), incl. the schema_mismatch→ok regression pin and all four flag-detect branches
- `npm run build:ts` clean · `npm run test:dist` clean
- Schemas in fixtures are the measured live column sets from an OpenClaw 2026.8.1 host (82 jobs) and a legacy host, verbatim
- Skipped gate (disclosed): direct live readback against the production OC2 sqlite copy — approval expired; fixtures carry the identical measured schema

### Not in this PR

No version bump (not a cut). No Guard changes. No dependency changes.
Closes #456.
