### PR TITLE
fix: worker mode aborts on Node 24 — better-sqlite3 13 (Node-API)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        # Node 24 is a required leg, not a nice-to-have: better-sqlite3 <=12
+        # subclassed the raw `node::ObjectWrap`, whose Node 24 destructor calls
+        # RemoveEnvironmentCleanupHook and aborts when a Statement is collected
+        # in a GC weak callback with no current Environment. That crash-looped
+        # worker mode on a Node 24 host and CI could not see it. Node 20 is
+        # dropped — it went EOL in April 2026 and better-sqlite3 13 requires >=22.
+        node-version: [22, 24]
 
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "better-sqlite3": "^12.0.0",
+        "better-sqlite3": "^13.0.0",
         "cors": "^2.8.5",
         "express": "^4.21.0",
         "safe-regex2": "^5.0.0",
@@ -36,7 +36,7 @@
         "typescript": "^5.6.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "@huggingface/transformers": "^3.7.2"
@@ -3313,26 +3313,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.18.tgz",
@@ -3344,37 +3324,15 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
-      "hasInstallScript": true,
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "license": "MIT",
       "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
+        "node-addon-api": "^8.0.0"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "node": ">=22"
       }
     },
     "node_modules/body-parser": {
@@ -3516,30 +3474,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3652,12 +3586,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.3.1",
@@ -3884,21 +3812,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
@@ -3912,15 +3825,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deepmerge": {
@@ -3993,6 +3897,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4075,15 +3980,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -4293,15 +4189,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
@@ -4447,12 +4334,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4532,12 +4413,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -4662,12 +4537,6 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -4882,26 +4751,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -4948,12 +4797,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -6042,18 +5885,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -6074,6 +5905,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6102,22 +5934,10 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -6159,16 +5979,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
       "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-int64": {
@@ -6484,32 +6301,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
@@ -6575,16 +6366,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -6642,41 +6423,12 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -7108,51 +6860,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7211,15 +6918,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -7383,15 +7081,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7436,34 +7125,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tar/node_modules/chownr": {
@@ -7669,18 +7330,6 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -7826,12 +7475,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -134,11 +134,11 @@
     "url": "https://github.com/Drakon-Systems-Ltd/ShieldCortex/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "better-sqlite3": "^12.0.0",
+    "better-sqlite3": "^13.0.0",
     "cors": "^2.8.5",
     "express": "^4.21.0",
     "safe-regex2": "^5.0.0",

--- a/src/database/__tests__/better-sqlite3-node-api.test.ts
+++ b/src/database/__tests__/better-sqlite3-node-api.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression guard for the Node 24 worker crash-loop.
+ *
+ * better-sqlite3 <= 12 subclassed the RAW `node::ObjectWrap` from
+ * `node_object_wrap.h`. Node 24 changed that header: the constructor now calls
+ * `AddEnvironmentCleanupHook` and the destructor calls
+ *
+ *     RemoveEnvironmentCleanupHook(v8::Isolate::GetCurrent(), CleanupHook, this)
+ *
+ * and `node::RemoveEnvironmentCleanupHook` does `CHECK_NOT_NULL(env)`. A
+ * `Statement` is destroyed from a V8 GC weak callback, where there may be no
+ * current Environment — so a garbage-collected prepared statement aborts the
+ * whole process:
+ *
+ *     Assertion failed: (env) != nullptr
+ *     node::RemoveEnvironmentCleanupHook <- Statement::~Statement()
+ *
+ * That crash-looped `shieldcortex --mode worker` on a Node 24 host, ~10s in,
+ * the moment BrainWorker's predictive consolidation churned prepared
+ * statements. better-sqlite3 13 fixed it by moving to Node-API
+ * (`Napi::ObjectWrap`), which touches no `node::` C++ symbol at all.
+ *
+ * Nothing in ShieldCortex's JS can prevent this — `db.close()` does not destroy
+ * the C++ wrapper, GC does. So the dependency floor IS the fix, and this test
+ * is what holds it: a resolution back to 12.x would reintroduce a crash that
+ * only shows up on a Node 24 host under GC pressure.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+function major(version: string): number {
+  return Number(version.split('.')[0]);
+}
+
+describe('better-sqlite3 must be Node-API based (Node 24 worker crash-loop)', () => {
+  it('declares a >=13 floor in package.json', () => {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8'));
+    const range: string = pkg.dependencies['better-sqlite3'];
+    // Any range that can resolve a 12.x is a range that can resurrect the abort.
+    const floor = range.replace(/^[\^~>=]+/, '');
+    expect(major(floor)).toBeGreaterThanOrEqual(13);
+  });
+
+  it('has an installed version >=13', () => {
+    const installed: string = require('better-sqlite3/package.json').version;
+    expect(major(installed)).toBeGreaterThanOrEqual(13);
+  });
+
+  it('resolves a native binding that links no node::ObjectWrap cleanup hooks', () => {
+    // better-sqlite3 13 exposes its own resolver; fall back to the node-gyp
+    // location for a locally compiled build (`shieldcortex repair`).
+    let bindingPath: string | null = null;
+    try {
+      bindingPath = (require('better-sqlite3/lib/binding') as {
+        getPrebuildPath(): string | null;
+      }).getPrebuildPath();
+    } catch {
+      bindingPath = null;
+    }
+    if (!bindingPath) {
+      const built = join(repoRoot, 'node_modules', 'better-sqlite3', 'build', 'Release', 'better_sqlite3.node');
+      bindingPath = existsSync(built) ? built : null;
+    }
+    if (!bindingPath) {
+      // No binding on disk to inspect (e.g. a dependency-less checkout). The
+      // two version assertions above still hold the floor.
+      return;
+    }
+
+    // Dynamic symbol names live as plain ASCII in the binary on every platform
+    // we ship, so this needs no nm/objdump and works on Linux, macOS and Windows.
+    const bytes = readFileSync(bindingPath).toString('latin1');
+    expect(bytes).not.toContain('RemoveEnvironmentCleanupHook');
+    expect(bytes).not.toContain('AddEnvironmentCleanupHook');
+    // Positive control: it really is a Node-API addon, not just a stripped one.
+    expect(bytes).toContain('napi_');
+  });
+});

--- a/src/database/better-sqlite3-guard.ts
+++ b/src/database/better-sqlite3-guard.ts
@@ -1,11 +1,13 @@
 /**
  * Guarded loader for the better-sqlite3 native module.
  *
- * better-sqlite3 ships prebuilt binaries per Node ABI. On a Node version
- * newer than the installed better-sqlite3's prebuilds (and with no C++
- * toolchain to compile from source), the native load fails — historically
- * with a bare `libc++abi: terminating ... Napi::Error` crash-loop and zero
- * guidance. This module is the single place better-sqlite3 is loaded at
+ * better-sqlite3 13 ships Node-API prebuilt binaries per PLATFORM (not per
+ * Node ABI), so a Node upgrade no longer strands the binding — that was the
+ * 12.x failure mode, where a Node version newer than the installed prebuilds
+ * (and with no C++ toolchain to compile from source) failed to load with a
+ * bare `libc++abi: terminating ... Napi::Error` crash-loop and zero guidance.
+ * An unsupported platform, a stripped install or a half-finished local build
+ * can still fail. This module is the single place better-sqlite3 is loaded at
  * runtime: it turns that failure into one actionable, catchable error
  * instead of an opaque abort.
  *
@@ -53,15 +55,16 @@ export function formatNativeLoadError(
   return [
     'ShieldCortex could not load its database engine (better-sqlite3).',
     '',
-    `Node ${nodeVersion} (ABI ${abi}) has no matching prebuilt binary and`,
-    'the module was not compiled locally.',
+    `Node ${nodeVersion} (ABI ${abi}) could not load the better-sqlite3 binding.`,
+    'The shipped prebuilt binary is missing for this platform, or the module',
+    'was not compiled locally.',
     '',
     'Fix one of these:',
     '  • Run `shieldcortex repair` (compiles better-sqlite3 from source + re-verifies)',
     '  • Or recompile manually in the better-sqlite3 package dir:  npm run build-release',
     '    (requires a C/C++ toolchain — Xcode CLT / build-essential; a plain `npm rebuild` can silently no-op)',
-    '  • Or run ShieldCortex on a supported Node LTS (20.x or 22.x),',
-    '    which ship prebuilt binaries — no compiler needed.',
+    '  • Or reinstall ShieldCortex on Node 22+ (`npm i -g shieldcortex`) so the',
+    '    Node-API prebuilt binary is restored — no compiler needed.',
     '',
     `Underlying error: ${detail}`,
   ].join('\n');

--- a/src/setup/native-binding.ts
+++ b/src/setup/native-binding.ts
@@ -15,13 +15,18 @@
  *
  * The second trap (proven on clawdbot1): even in the right dir, `npm rebuild
  * better-sqlite3` — AND `npm rebuild … --build-from-source` — can report "rebuilt
- * dependencies successfully" while the binary never built. better-sqlite3's
- * install runs prebuild-install, which on a platform with no matching prebuilt
- * exits 0 WITHOUT building (the `--build-from-source` flag does not reliably force
- * it). So when a plain rebuild doesn't heal, we escalate to better-sqlite3's own
- * `npm run build-release` (= `node-gyp rebuild --release`) IN its package dir,
- * which bypasses prebuild-install and actually compiles — surfacing the real
- * build error (almost always a missing C/C++ toolchain) if it can't.
+ * dependencies successfully" while the binary never built. On 12.x that was
+ * prebuild-install exiting 0 without building; on 13.x npm's implicit node-gyp
+ * rebuild is a deliberate no-op whenever the package already carries a prebuilt
+ * for the host. Either way, when a plain rebuild doesn't heal, we escalate to
+ * better-sqlite3's own `npm run build-release` (= `node-gyp rebuild --release
+ * --force_build=1`) IN its package dir, which actually compiles — surfacing the
+ * real build error (almost always a missing C/C++ toolchain) if it can't.
+ *
+ * The third trap, new in 13.x: `lib/binding.js` resolves `prebuilds/` BEFORE
+ * `build/Release/`, so a from-source build is invisible while an unloadable
+ * prebuilt is still sitting there. {@link shelvePrebuild} moves it aside for the
+ * duration of a forced build, and puts it back if that build fails.
  *
  * Used by: `shieldcortex update` (verify+heal step), `shieldcortex repair`,
  * `shieldcortex doctor` (correct remediation text), and the postinstall guidance.
@@ -29,6 +34,7 @@
 
 import path from 'path';
 import { spawn } from 'child_process';
+import { existsSync, renameSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 
@@ -127,11 +133,21 @@ export function rebuildNativeBinding(
   installDir: string,
   opts: { fromSource?: boolean } = {},
 ): Promise<{ ok: boolean; output: string }> {
-  const { cmd, args, cwd } = nativeRebuildCommand(installDir, opts.fromSource ?? false);
+  const fromSource = opts.fromSource ?? false;
+  const { cmd, args, cwd } = nativeRebuildCommand(installDir, fromSource);
+  const shadowing = fromSource ? shelvePrebuild(installDir) : null;
   return new Promise((resolve) => {
     let output = '';
     let settled = false;
-    const finish = (ok: boolean) => { if (!settled) { settled = true; resolve({ ok, output }); } };
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      // A failed source build must not leave the install with NO binding at
+      // all: put the shelved prebuilt back, since it is still the best
+      // available binary.
+      if (shadowing && !ok) restorePrebuild(shadowing);
+      resolve({ ok, output });
+    };
 
     let child;
     try {
@@ -158,6 +174,51 @@ export function rebuildNativeBinding(
     child.on('error', (err) => { clearTimeout(timer); output += String(err?.message ?? err); finish(false); });
     child.on('close', (code) => { clearTimeout(timer); finish(code === 0); });
   });
+}
+
+interface ShelvedPrebuild {
+  from: string;
+  to: string;
+}
+
+/**
+ * Move better-sqlite3 13's shipped prebuilt binary aside before a from-source
+ * compile, and remember where it went.
+ *
+ * Why this is needed: 13.x resolves its binding as
+ * `prebuilds/<platform>-<arch>.node` FIRST and only falls back to the node-gyp
+ * output in `build/Release/`. So on a box where the shipped prebuilt exists but
+ * cannot load (unsupported glibc, a truncated download, a hardened mount),
+ * `npm run build-release` would compile a perfectly good binary that nothing
+ * ever loads — the exact silent no-op this module exists to prevent, one layer
+ * down. Shelving the prebuilt makes the fresh build the resolved binding.
+ *
+ * Best-effort by design: on 12.x (no `lib/binding`, no `prebuilds/`) and on any
+ * fs error this returns null and the build proceeds unchanged.
+ */
+function shelvePrebuild(installDir: string): ShelvedPrebuild | null {
+  try {
+    const pkgDir = path.join(installDir, 'node_modules', 'better-sqlite3');
+    const { getPrebuildPath } = require(path.join(pkgDir, 'lib', 'binding.js')) as {
+      getPrebuildPath(): string | null;
+    };
+    const from = getPrebuildPath();
+    if (!from || !existsSync(from)) return null;
+    const to = `${from}.shelved-for-source-build`;
+    renameSync(from, to);
+    return { from, to };
+  } catch {
+    return null;
+  }
+}
+
+/** Undo {@link shelvePrebuild} when the source build did not produce a binding. */
+function restorePrebuild(shelved: ShelvedPrebuild): void {
+  try {
+    if (existsSync(shelved.to) && !existsSync(shelved.from)) renameSync(shelved.to, shelved.from);
+  } catch {
+    // Best-effort: the source build's own output is the remediation path now.
+  }
 }
 
 /**


### PR DESCRIPTION
## Symptom

`shieldcortex --mode worker` crash-loops on a Node 24 host. It aborts ~10s after boot, the moment BrainWorker logs `Predictive consolidation triggered`, and systemd restarts it into the same crash (restart counter hit 33 on clawdbot1):

```
[BrainWorker] Predictive consolidation triggered: STM at 99% (critical threshold)
  #  /usr/bin/node[287369]: void node::RemoveEnvironmentCleanupHook(v8::Isolate*, CleanupHook, void*) at ../src/api/hooks.cc:142
  #  Assertion failed: (env) != nullptr
 1: node::Assert(node::AssertionInfo const&) [/usr/bin/node]
 2: node::RemoveEnvironmentCleanupHook(...) [/usr/bin/node]
 3: Statement::~Statement() [.../better-sqlite3/build/Release/better_sqlite3.node]
```

Triggered on this host by the Node upgrade 22.23.2 -> 24.20.0 (openclaw@2026.9.3 requires Node >=24.16).

## Root cause

Not a ShieldCortex bug, and not a teardown/leak bug.

Node 24 changed `node_object_wrap.h`. The raw `node::ObjectWrap` constructor now registers an environment cleanup hook, and its destructor removes one:

```cpp
void RemoveCleanupHook() {
  RemoveEnvironmentCleanupHook(v8::Isolate::GetCurrent(), CleanupHook, this);
}
```

`node::RemoveEnvironmentCleanupHook` does `CHECK_NOT_NULL(Environment::GetCurrent(isolate))`.

better-sqlite3 <= 12 subclasses that raw `node::ObjectWrap` (`class Statement : public node::ObjectWrap`). A `Statement` is destroyed from a **V8 GC weak callback**, where there may be no current Environment — so `env` is null and the `CHECK` aborts the whole process.

That means **any** garbage-collected prepared statement is a crash candidate. Predictive consolidation is not special; it is simply the first thing that churns enough `db.prepare()` calls to provoke a GC.

Symbol-level confirmation:

| binary | imports `node::RemoveEnvironmentCleanupHook` |
|---|---|
| better-sqlite3 12.11.1, node-gyp-built against Node 24.20 headers | yes -> aborts |
| better-sqlite3 13.0.3 Node-API prebuild | no (`napi_*` only) -> clean |

<details>
<summary>Why this looked intermittent / why CI never saw it</summary>

The upstream 12.10.0 ABI-137 prebuild happens to have been compiled against older Node 24 headers, before the `ObjectWrap` change, so it does **not** import the symbol and does **not** crash. Any local `npm rebuild` / `shieldcortex repair` against current Node 24 headers reintroduces the crash. CI ran Node 20 and 22 only, neither of which has the new `ObjectWrap`.
</details>

### What this is *not*

The original hypothesis was unclosed `Database`/`Statement` handles at worker teardown. That is not the cause, and I could not find such a leak:

- `db.close()` closes the SQLite handle; it does **not** destroy the C++ wrapper. GC does. So closing handles cannot prevent this abort.
- BrainWorker is not a `worker_threads` worker at all — it is `setInterval`/`setTimeout` on the main thread. The two real worker threads (`src/embeddings/worker.ts`, `src/defence/judge/worker.ts`) never open SQLite.
- I audited every `new Database(...)` / `new BetterSqlite3(...)` site outside tests. `doctor`, `openclaw-cron-store`, `cron-denial-audit`, `migrate-legacy`, `embed-backfill`, `setup/*` and `integrations/*` all close in a `finally`. The long-lived singleton in `database/init.ts` is closed by `closeDatabase()` (WAL checkpoint + `close()`) from `process.on('exit'|'SIGINT'|'SIGTERM')`, registered on the init path at `init.ts:706`.

The dependency floor is the fix.

## Fix

better-sqlite3 13 moved to Node-API (`Napi::ObjectWrap`) and links no `node::` C++ symbol at all, so the crash cannot occur. Bonus: 13.x ships per-**platform** Node-API prebuilts inside the npm tarball — ABI-independent, and they install fine under `ignore-scripts=true`. That removes the entire "no prebuilt for this Node ABI" class of install failure this repo has fought repeatedly.

- `better-sqlite3` `^12.0.0` -> `^13.0.0`. Drops the `bindings` + `prebuild-install` dependency trees (-371 lockfile lines).
- `engines.node` `>=20` -> `>=22`, matching better-sqlite3 13's own floor. Node 20 went EOL in April 2026.
- CI matrix `[20, 22]` -> `[22, 24]`. **A Node 24 leg is the point** — CI structurally could not have caught this.
- New regression guard (`src/database/__tests__/better-sqlite3-node-api.test.ts`): asserts the resolved native binding links no `ObjectWrap` cleanup hooks and is Node-API. Verified it **fails** against the 12.11.1 binary and **passes** against 13.0.3, so it is a real guard, not a tautology.
- `native-binding.ts`: shelve the shipped prebuilt during a forced from-source build. 13.x resolves `prebuilds/` **before** `build/Release/`, so without this a `shieldcortex repair` compile would be invisible while an unloadable prebuilt sat in front of it — the same silent no-op that module exists to prevent, one layer down. Restored if the build fails.
- Refresh now-stale `prebuild-install` / "run on Node LTS 20.x or 22.x" text in the native-load error path.

## Verification

All on clawdbot1, Node **v24.20.0** aarch64, with an isolated `HOME` throughout (the live `~/.shieldcortex` and the running worker service were never touched).

**1. A/B on identical `dist/` — only the dependency differs**

```
$ HOME=$ISOLATED node dist/index.js --mode worker     # better-sqlite3 12.11.1
[BrainWorker] Predictive consolidation triggered: STM at 240% (critical threshold)
  #  Assertion failed: (env) != nullptr
 2: node::RemoveEnvironmentCleanupHook(...) [/usr/bin/node]
 3: Statement::~Statement() [.../better_sqlite3.node]
exit=134   (SIGABRT, core dumped)

$ HOME=$ISOLATED node dist/index.js --mode worker     # better-sqlite3 13.0.3
[BrainWorker] Predictive consolidation triggered: STM at 240% (critical threshold)
[BrainWorker] Light tick: pruned 0 activations, consolidated 0
exit=124   (90s timeout reached — process alive the whole time)
### assertion/abort occurrences: 0
```

Consolidation was forced by seeding 240 `short_term` rows into the isolated DB, so the exact crashing code path ran in both arms.

**2. Minimal repro isolating the mechanism** — 200k `prepare()`/collect cycles under `--expose-gc`:

```
=== bs12.11.1 === exit=134, same RemoveEnvironmentCleanupHook <- Statement::~Statement() stack
=== bs13.0.3  === "survived 200k prepare/collect cycles"   exit=0
```

**3. CLI + hooks exit cleanly, no assert**

```
doctor              exit=1  assert_hits=0   (the 1 failure is my fixture's 644 file modes — PERM check)
pre-tool-hook       exit=0  assert_hits=0
prompt-recall-hook  exit=0  assert_hits=0
session-start-hook  exit=0  assert_hits=0
stop-hook           exit=0  assert_hits=0
```

**4. Test suite**

```
Test Suites: 530 passed, 530 total
Tests:       7 skipped, 7639 passed, 7646 total
```

Isolation verified before running: `defaultRunCommand`/gateway-restart gated on `JEST_WORKER_ID`, and `scripts/jest-config-sandbox.mjs` sandboxes `SHIELDCORTEX_CONFIG_DIR` + `SHIELDCORTEX_AUDIT_DIR` per worker. `~/.shieldcortex/memories.db` checksummed identical immediately before and after the run; the gateway and worker service PIDs were unchanged.

## Follow-up on clawdbot1 (after this ships in a release)

Once a release carrying this is installed globally, the Node 22 workarounds can all be removed:

- the drop-in `~/.config/systemd/user/shieldcortex-dashboard.service.d/10-node22-pin.conf`
- `/opt/node-22`
- the dual-ABI better-sqlite3 layout in the global install (`lib/binding/node-v127-*` + `node-v137-*` and the `build/Release/better_sqlite3.node.single-abi-disabled` rename, described in that package's `MULTI-ABI-README.txt`)

The worker then runs on PATH node like every other ShieldCortex process. Not done here — this PR is code only, nothing published and nothing merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
